### PR TITLE
Fix social auth to email/password account linking

### DIFF
--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -134,7 +134,7 @@ export function createAuth(
 		account: {
 			accountLinking: {
 				enabled: true,
-				trustedProviders: ["google", "discord"],
+				trustedProviders: ["google", "discord", "credential"],
 			},
 		},
 		plugins: [],


### PR DESCRIPTION
Add "credential" to trustedProviders so users who signed up via
Google or Discord can later add email/password login to their account.

https://claude.ai/code/session_01Vx1Xaw9iymFvDT7hysB51Y