### PR TITLE
feat: implement Phase 7 — EV adjusted result tracking for cash game sessions (T032-T035)

### DIFF
--- a/apps/web/src/components/sessions/session-card.tsx
+++ b/apps/web/src/components/sessions/session-card.tsx
@@ -13,6 +13,7 @@ interface SessionCardProps {
 		sessionDate: string;
 		buyIn: number | null;
 		cashOut: number | null;
+		evCashOut: number | null;
 		tournamentBuyIn: number | null;
 		entryFee: number | null;
 		placement: number | null;
@@ -23,6 +24,8 @@ interface SessionCardProps {
 		addonCost: number | null;
 		bountyPrizes: number | null;
 		profitLoss: number | null;
+		evProfitLoss: number | null;
+		evDiff: number | null;
 		startedAt: string | null;
 		endedAt: string | null;
 		memo: string | null;
@@ -72,20 +75,97 @@ function formatTournamentCost(session: SessionCardProps["session"]): string {
 	return formatCompactNumber(total);
 }
 
+function plColorClass(value: number): string {
+	if (value > 0) {
+		return "text-green-500";
+	}
+	if (value < 0) {
+		return "text-red-500";
+	}
+	return "";
+}
+
+function EvDisplay({
+	evDiff,
+	evProfitLoss,
+}: {
+	evDiff: number;
+	evProfitLoss: number;
+}) {
+	return (
+		<div className="mt-0.5 flex items-center gap-2 text-xs">
+			<span className="text-muted-foreground">
+				EV{" "}
+				<span className={plColorClass(evProfitLoss)}>
+					{evProfitLoss > 0 ? "+" : ""}
+					{formatCompactNumber(evProfitLoss)}
+				</span>
+			</span>
+			<span className="text-muted-foreground">
+				Diff{" "}
+				<span className={plColorClass(evDiff)}>
+					{evDiff > 0 ? "+" : ""}
+					{formatCompactNumber(evDiff)}
+				</span>
+			</span>
+		</div>
+	);
+}
+
+function SessionInfo({ session }: { session: SessionCardProps["session"] }) {
+	const isTournament = session.type === "tournament";
+	const gameName = isTournament ? session.tournamentName : session.ringGameName;
+
+	return (
+		<>
+			{isTournament && (
+				<div className="mt-0.5 flex items-center gap-2 text-muted-foreground text-xs">
+					{session.placement !== null && (
+						<span>
+							{session.placement}
+							{session.totalEntries !== null ? `/${session.totalEntries}` : ""}
+						</span>
+					)}
+					<span>Cost: {formatTournamentCost(session)}</span>
+				</div>
+			)}
+			{gameName && <p className="text-muted-foreground text-xs">{gameName}</p>}
+			{(session.storeName || session.currencyName) && (
+				<div className="flex items-center gap-2 text-muted-foreground text-xs">
+					{session.storeName && <span>{session.storeName}</span>}
+					{session.storeName && session.currencyName && <span>·</span>}
+					{session.currencyName && <span>{session.currencyName}</span>}
+				</div>
+			)}
+			{session.startedAt && session.endedAt && (
+				<p className="text-muted-foreground text-xs">
+					{formatDuration(session.startedAt, session.endedAt)}
+				</p>
+			)}
+			{session.memo && (
+				<p className="max-w-[200px] truncate text-muted-foreground text-xs">
+					{session.memo}
+				</p>
+			)}
+			{session.tags.length > 0 && (
+				<div className="mt-1 flex flex-wrap gap-1">
+					{session.tags.map((tag) => (
+						<Badge key={tag.id} variant="outline">
+							{tag.name}
+						</Badge>
+					))}
+				</div>
+			)}
+		</>
+	);
+}
+
 export function SessionCard({ session, onEdit, onDelete }: SessionCardProps) {
 	const [confirmingDelete, setConfirmingDelete] = useState(false);
 
 	const profitLoss = session.profitLoss ?? 0;
-	const isProfitPositive = profitLoss > 0;
-	const isProfitNegative = profitLoss < 0;
 	const isTournament = session.type === "tournament";
-
-	let profitColorClass = "text-foreground";
-	if (isProfitPositive) {
-		profitColorClass = "text-green-500";
-	} else if (isProfitNegative) {
-		profitColorClass = "text-red-500";
-	}
+	const profitColorClass = plColorClass(profitLoss) || "text-foreground";
 
 	return (
 		<div className="rounded-lg border bg-card">
@@ -99,59 +179,17 @@ export function SessionCard({ session, onEdit, onDelete }: SessionCardProps) {
 							{isTournament ? "Tournament" : "Cash Game"}
 						</span>
 						<span className={`font-semibold text-sm ${profitColorClass}`}>
-							{isProfitPositive ? "+" : ""}
+							{profitLoss > 0 ? "+" : ""}
 							{formatCompactNumber(profitLoss)}
 						</span>
 					</div>
-					{isTournament && (
-						<div className="mt-0.5 flex items-center gap-2 text-muted-foreground text-xs">
-							{session.placement !== null && (
-								<span>
-									{session.placement}
-									{session.totalEntries !== null
-										? `/${session.totalEntries}`
-										: ""}
-								</span>
-							)}
-							<span>Cost: {formatTournamentCost(session)}</span>
-						</div>
+					{session.evProfitLoss !== null && session.evDiff !== null && (
+						<EvDisplay
+							evDiff={session.evDiff}
+							evProfitLoss={session.evProfitLoss}
+						/>
 					)}
-					{!isTournament && session.ringGameName && (
-						<p className="text-muted-foreground text-xs">
-							{session.ringGameName}
-						</p>
-					)}
-					{isTournament && session.tournamentName && (
-						<p className="text-muted-foreground text-xs">
-							{session.tournamentName}
-						</p>
-					)}
-					{(session.storeName || session.currencyName) && (
-						<div className="flex items-center gap-2 text-muted-foreground text-xs">
-							{session.storeName && <span>{session.storeName}</span>}
-							{session.storeName && session.currencyName && <span>·</span>}
-							{session.currencyName && <span>{session.currencyName}</span>}
-						</div>
-					)}
-					{session.startedAt && session.endedAt && (
-						<p className="text-muted-foreground text-xs">
-							{formatDuration(session.startedAt, session.endedAt)}
-						</p>
-					)}
-					{session.memo && (
-						<p className="max-w-[200px] truncate text-muted-foreground text-xs">
-							{session.memo}
-						</p>
-					)}
-					{session.tags.length > 0 && (
-						<div className="mt-1 flex flex-wrap gap-1">
-							{session.tags.map((tag) => (
-								<Badge key={tag.id} variant="outline">
-									{tag.name}
-								</Badge>
-							))}
-						</div>
-					)}
+					<SessionInfo session={session} />
 				</div>
 
 				<div className="flex items-center gap-1">

--- a/apps/web/src/components/sessions/session-form.tsx
+++ b/apps/web/src/components/sessions/session-form.tsx
@@ -18,6 +18,7 @@ interface CashGameFormValues {
 	cashOut: number;
 	currencyId?: string;
 	endTime?: string;
+	evCashOut?: number;
 	memo?: string;
 	ringGameId?: string;
 	sessionDate: string;
@@ -87,6 +88,7 @@ interface SessionFormDefaults {
 	currencyId?: string;
 	endTime?: string;
 	entryFee?: number;
+	evCashOut?: number;
 	memo?: string;
 	placement?: number;
 	prizeMoney?: number;
@@ -145,6 +147,7 @@ function parseCashGameFields(
 		type: "cash_game",
 		buyIn: Number(formData.get("buyIn")),
 		cashOut: Number(formData.get("cashOut")),
+		evCashOut: parseOptionalInt(formData.get("evCashOut") as string),
 		variant: (formData.get("variant") as string) || "nlh",
 		blind1: parseOptionalInt(formData.get("blind1") as string),
 		blind2: parseOptionalInt(formData.get("blind2") as string),
@@ -343,38 +346,56 @@ function SessionFormFields({
 
 				{/* Buy-in / Cash-out (cash game only) */}
 				{isCashGame && (
-					<div className="grid grid-cols-2 gap-3">
-						<div className="flex flex-col gap-2">
-							<Label htmlFor="buyIn">
-								Buy-in <span className="text-destructive">*</span>
-							</Label>
-							<Input
-								defaultValue={defaultValues?.buyIn}
-								id="buyIn"
-								inputMode="numeric"
-								min={0}
-								name="buyIn"
-								placeholder="0"
-								required
-								type="number"
-							/>
+					<>
+						<div className="grid grid-cols-2 gap-3">
+							<div className="flex flex-col gap-2">
+								<Label htmlFor="buyIn">
+									Buy-in <span className="text-destructive">*</span>
+								</Label>
+								<Input
+									defaultValue={defaultValues?.buyIn}
+									id="buyIn"
+									inputMode="numeric"
+									min={0}
+									name="buyIn"
+									placeholder="0"
+									required
+									type="number"
+								/>
+							</div>
+							<div className="flex flex-col gap-2">
+								<Label htmlFor="cashOut">
+									Cash-out <span className="text-destructive">*</span>
+								</Label>
+								<Input
+									defaultValue={defaultValues?.cashOut}
+									id="cashOut"
+									inputMode="numeric"
+									min={0}
+									name="cashOut"
+									placeholder="0"
+									required
+									type="number"
+								/>
+							</div>
 						</div>
 						<div className="flex flex-col gap-2">
-							<Label htmlFor="cashOut">
-								Cash-out <span className="text-destructive">*</span>
-							</Label>
+							<Label htmlFor="evCashOut">EV Cash-out</Label>
 							<Input
-								defaultValue={defaultValues?.cashOut}
-								id="cashOut"
+								defaultValue={defaultValues?.evCashOut}
+								id="evCashOut"
 								inputMode="numeric"
 								min={0}
-								name="cashOut"
+								name="evCashOut"
 								placeholder="0"
-								required
 								type="number"
 							/>
+							<p className="text-muted-foreground text-xs">
+								Expected value cash-out based on all-in equity. Used to separate
+								skill from variance.
+							</p>
 						</div>
-					</div>
+					</>
 				)}
 			</div>
 

--- a/apps/web/src/routes/sessions/index.tsx
+++ b/apps/web/src/routes/sessions/index.tsx
@@ -22,6 +22,7 @@ interface CashGameFormValues {
 	cashOut: number;
 	currencyId?: string;
 	endTime?: string;
+	evCashOut?: number;
 	memo?: string;
 	ringGameId?: string;
 	sessionDate: string;
@@ -66,6 +67,9 @@ interface SessionItem {
 	currencyName: string | null;
 	endedAt: string | null;
 	entryFee: number | null;
+	evCashOut: number | null;
+	evDiff: number | null;
+	evProfitLoss: number | null;
 	id: string;
 	memo: string | null;
 	placement: number | null;
@@ -160,6 +164,33 @@ function formatTimeFromDate(date: string | null): string | undefined {
 	return `${hours}:${minutes}`;
 }
 
+function buildEditDefaults(session: SessionItem) {
+	return {
+		type: session.type as "cash_game" | "tournament",
+		sessionDate: formatDateForInput(session.sessionDate),
+		buyIn: session.buyIn ?? 0,
+		cashOut: session.cashOut ?? 0,
+		evCashOut: session.evCashOut ?? undefined,
+		tournamentBuyIn: session.tournamentBuyIn ?? 0,
+		entryFee: session.entryFee ?? undefined,
+		placement: session.placement ?? undefined,
+		totalEntries: session.totalEntries ?? undefined,
+		prizeMoney: session.prizeMoney ?? undefined,
+		rebuyCount: session.rebuyCount ?? undefined,
+		rebuyCost: session.rebuyCost ?? undefined,
+		addonCost: session.addonCost ?? undefined,
+		bountyPrizes: session.bountyPrizes ?? undefined,
+		startTime: formatTimeFromDate(session.startedAt),
+		endTime: formatTimeFromDate(session.endedAt),
+		memo: session.memo ?? undefined,
+		tagIds: session.tags.map((t) => t.id),
+		storeId: session.storeId ?? undefined,
+		ringGameId: session.ringGameId ?? undefined,
+		tournamentId: session.tournamentId ?? undefined,
+		currencyId: session.currencyId ?? undefined,
+	};
+}
+
 function SessionsPage() {
 	const [isCreateOpen, setIsCreateOpen] = useState(false);
 	const [editingSession, setEditingSession] = useState<SessionItem | null>(
@@ -215,6 +246,7 @@ function SessionsPage() {
 					type: "cash_game",
 					buyIn: values.buyIn,
 					cashOut: values.cashOut,
+					evCashOut: values.evCashOut,
 					variant: values.variant,
 					blind1: values.blind1,
 					blind2: values.blind2,
@@ -253,6 +285,9 @@ function SessionsPage() {
 					sessionDate: newSession.sessionDate,
 					buyIn: null,
 					cashOut: null,
+					evCashOut: null,
+					evProfitLoss: null,
+					evDiff: null,
 					tournamentBuyIn: null,
 					entryFee: null,
 					placement: null,
@@ -322,6 +357,7 @@ function SessionsPage() {
 					...common,
 					buyIn: values.buyIn,
 					cashOut: values.cashOut,
+					evCashOut: values.evCashOut ?? null,
 					variant: values.variant,
 					blind1: values.blind1,
 					blind2: values.blind2,
@@ -496,29 +532,7 @@ function SessionsPage() {
 				{editingSession && (
 					<SessionForm
 						currencies={currencies}
-						defaultValues={{
-							type: editingSession.type as "cash_game" | "tournament",
-							sessionDate: formatDateForInput(editingSession.sessionDate),
-							buyIn: editingSession.buyIn ?? 0,
-							cashOut: editingSession.cashOut ?? 0,
-							tournamentBuyIn: editingSession.tournamentBuyIn ?? 0,
-							entryFee: editingSession.entryFee ?? undefined,
-							placement: editingSession.placement ?? undefined,
-							totalEntries: editingSession.totalEntries ?? undefined,
-							prizeMoney: editingSession.prizeMoney ?? undefined,
-							rebuyCount: editingSession.rebuyCount ?? undefined,
-							rebuyCost: editingSession.rebuyCost ?? undefined,
-							addonCost: editingSession.addonCost ?? undefined,
-							bountyPrizes: editingSession.bountyPrizes ?? undefined,
-							startTime: formatTimeFromDate(editingSession.startedAt),
-							endTime: formatTimeFromDate(editingSession.endedAt),
-							memo: editingSession.memo ?? undefined,
-							tagIds: editingSession.tags.map((t) => t.id),
-							storeId: editingSession.storeId ?? undefined,
-							ringGameId: editingSession.ringGameId ?? undefined,
-							tournamentId: editingSession.tournamentId ?? undefined,
-							currencyId: editingSession.currencyId ?? undefined,
-						}}
+						defaultValues={buildEditDefaults(editingSession)}
 						isLoading={updateMutation.isPending}
 						onCreateTag={handleCreateTag}
 						onStoreChange={setEditStoreId}

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -311,6 +311,7 @@ const cashGameCreateSchema = z.object({
 	ante: z.number().int().optional(),
 	anteType: z.enum(["none", "all", "bb"]).optional(),
 	tableSize: z.number().int().optional(),
+	evCashOut: z.number().int().min(0).optional(),
 	// Time + memo
 	startedAt: z.number().optional(),
 	endedAt: z.number().optional(),
@@ -367,6 +368,7 @@ function buildCashGameSessionValues(
 	return {
 		buyIn: input.buyIn,
 		cashOut: input.cashOut,
+		evCashOut: input.evCashOut ?? null,
 		ringGameId,
 	};
 }
@@ -403,6 +405,7 @@ function nullableTimestampToDate(
 const SESSION_UPDATE_FIELDS = [
 	"buyIn",
 	"cashOut",
+	"evCashOut",
 	"tournamentBuyIn",
 	"entryFee",
 	"placement",
@@ -585,6 +588,7 @@ export const sessionRouter = router({
 					sessionDate: pokerSession.sessionDate,
 					buyIn: pokerSession.buyIn,
 					cashOut: pokerSession.cashOut,
+					evCashOut: pokerSession.evCashOut,
 					tournamentBuyIn: pokerSession.tournamentBuyIn,
 					entryFee: pokerSession.entryFee,
 					placement: pokerSession.placement,
@@ -622,12 +626,18 @@ export const sessionRouter = router({
 
 			const itemsWithPL = items.map((item) => {
 				let profitLoss: number | null = null;
+				let evProfitLoss: number | null = null;
+				let evDiff: number | null = null;
 				if (
 					item.type === "cash_game" &&
 					item.buyIn !== null &&
 					item.cashOut !== null
 				) {
 					profitLoss = computeCashGamePL(item.buyIn, item.cashOut);
+					if (item.evCashOut !== null) {
+						evProfitLoss = item.evCashOut - item.buyIn;
+						evDiff = evProfitLoss - profitLoss;
+					}
 				} else if (item.type === "tournament") {
 					profitLoss = computeTournamentPL(
 						item.tournamentBuyIn,
@@ -639,7 +649,7 @@ export const sessionRouter = router({
 						item.bountyPrizes
 					);
 				}
-				return { ...item, profitLoss };
+				return { ...item, profitLoss, evProfitLoss, evDiff };
 			});
 
 			const sessionIds = itemsWithPL.map((item) => item.id);
@@ -690,6 +700,7 @@ export const sessionRouter = router({
 				// Cash game fields
 				buyIn: z.number().int().min(0).optional(),
 				cashOut: z.number().int().min(0).optional(),
+				evCashOut: z.number().int().min(0).nullable().optional(),
 				// Tournament fields
 				tournamentBuyIn: z.number().int().min(0).optional(),
 				entryFee: z.number().int().min(0).optional(),


### PR DESCRIPTION
Add optional EV cash-out recording for cash games to separate skill from variance.
Backend: evCashOut in Zod create/update schemas, evProfitLoss/evDiff computed in list query.
Frontend: EV Cash-out field in session form (cash game only), EV P&L and EV diff on session card.
Refactor session card into extracted sub-components to reduce cognitive complexity.

https://claude.ai/code/session_01CXYiEeq4NMkog72jE4yLG8