### PR TITLE
Add player management system with tagging support

### DIFF
--- a/apps/web/src/__tests__/mobile-nav.test.tsx
+++ b/apps/web/src/__tests__/mobile-nav.test.tsx
@@ -44,6 +44,18 @@ function createTestRouter(initialPath: string) {
 		component: () => <div>Currencies</div>,
 	});
 
+	const sessionsRoute = createRoute({
+		getParentRoute: () => rootRoute,
+		path: "/sessions",
+		component: () => <div>Sessions</div>,
+	});
+
+	const playersRoute = createRoute({
+		getParentRoute: () => rootRoute,
+		path: "/players",
+		component: () => <div>Players</div>,
+	});
+
 	const settingsRoute = createRoute({
 		getParentRoute: () => rootRoute,
 		path: "/settings",
@@ -55,6 +67,8 @@ function createTestRouter(initialPath: string) {
 		dashboardRoute,
 		storesRoute,
 		currenciesRoute,
+		sessionsRoute,
+		playersRoute,
 		searchRoute,
 		settingsRoute,
 	]);
@@ -66,12 +80,12 @@ function createTestRouter(initialPath: string) {
 }
 
 describe("MobileNav", () => {
-	it("renders 6 navigation items", async () => {
+	it("renders 8 navigation items", async () => {
 		const router = createTestRouter("/");
 		render(<RouterProvider router={router} />);
 
 		const links = await screen.findAllByRole("link");
-		expect(links).toHaveLength(7);
+		expect(links).toHaveLength(8);
 	});
 
 	it("displays labels for all navigation items", async () => {

--- a/apps/web/src/components/mobile-nav.tsx
+++ b/apps/web/src/components/mobile-nav.tsx
@@ -6,6 +6,7 @@ import {
 	IconLayoutDashboard,
 	IconSearch,
 	IconSettings,
+	IconUsers,
 } from "@tabler/icons-react";
 import { Link, useRouterState } from "@tanstack/react-router";
 import type { ComponentType } from "react";
@@ -22,6 +23,7 @@ export const NAVIGATION_ITEMS: readonly NavigationItem[] = [
 	{ to: "/stores", label: "Stores", icon: IconBuildingStore },
 	{ to: "/currencies", label: "Currencies", icon: IconCoins },
 	{ to: "/sessions", label: "Sessions", icon: IconCards },
+	{ to: "/players", label: "Players", icon: IconUsers },
 	{ to: "/search", label: "Search", icon: IconSearch },
 	{ to: "/settings", label: "Settings", icon: IconSettings },
 ] as const;

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -2,6 +2,8 @@ import { protectedProcedure, publicProcedure, router } from "../index";
 import { blindLevelRouter } from "./blind-level";
 import { currencyRouter } from "./currency";
 import { currencyTransactionRouter } from "./currency-transaction";
+import { playerRouter } from "./player";
+import { playerTagRouter } from "./player-tag";
 import { ringGameRouter } from "./ring-game";
 import { sessionRouter } from "./session";
 import { sessionTagRouter } from "./session-tag";
@@ -28,5 +30,7 @@ export const appRouter = router({
 	blindLevel: blindLevelRouter,
 	session: sessionRouter,
 	sessionTag: sessionTagRouter,
+	player: playerRouter,
+	playerTag: playerTagRouter,
 });
 export type AppRouter = typeof appRouter;

--- a/packages/api/src/routers/player-tag.ts
+++ b/packages/api/src/routers/player-tag.ts
@@ -1,0 +1,103 @@
+import { TAG_COLOR_NAMES } from "@sapphire2/db/constants/player-tag-colors";
+import { playerTag, playerToPlayerTag } from "@sapphire2/db/schema/player";
+import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { protectedProcedure, router } from "../index";
+
+const colorSchema = z.enum(TAG_COLOR_NAMES);
+
+export const playerTagRouter = router({
+	list: protectedProcedure.query(async ({ ctx }) => {
+		const userId = ctx.session.user.id;
+		return await ctx.db
+			.select()
+			.from(playerTag)
+			.where(eq(playerTag.userId, userId));
+	}),
+
+	create: protectedProcedure
+		.input(
+			z.object({
+				name: z.string().min(1).max(50),
+				color: colorSchema.default("gray"),
+			})
+		)
+		.mutation(async ({ ctx, input }) => {
+			const userId = ctx.session.user.id;
+			const id = crypto.randomUUID();
+			await ctx.db.insert(playerTag).values({
+				id,
+				userId,
+				name: input.name,
+				color: input.color,
+				updatedAt: new Date(),
+			});
+			const [created] = await ctx.db
+				.select()
+				.from(playerTag)
+				.where(eq(playerTag.id, id));
+			return created;
+		}),
+
+	update: protectedProcedure
+		.input(
+			z.object({
+				id: z.string(),
+				name: z.string().min(1).max(50).optional(),
+				color: colorSchema.optional(),
+			})
+		)
+		.mutation(async ({ ctx, input }) => {
+			const userId = ctx.session.user.id;
+			const [found] = await ctx.db
+				.select()
+				.from(playerTag)
+				.where(eq(playerTag.id, input.id));
+			if (!found) {
+				throw new TRPCError({ code: "NOT_FOUND", message: "Tag not found" });
+			}
+			if (found.userId !== userId) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "You do not own this tag",
+				});
+			}
+			await ctx.db
+				.update(playerTag)
+				.set({
+					...(input.name !== undefined ? { name: input.name } : {}),
+					...(input.color !== undefined ? { color: input.color } : {}),
+				})
+				.where(eq(playerTag.id, input.id));
+			const [updated] = await ctx.db
+				.select()
+				.from(playerTag)
+				.where(eq(playerTag.id, input.id));
+			return updated;
+		}),
+
+	delete: protectedProcedure
+		.input(z.object({ id: z.string() }))
+		.mutation(async ({ ctx, input }) => {
+			const userId = ctx.session.user.id;
+			const [found] = await ctx.db
+				.select()
+				.from(playerTag)
+				.where(eq(playerTag.id, input.id));
+			if (!found) {
+				throw new TRPCError({ code: "NOT_FOUND", message: "Tag not found" });
+			}
+			if (found.userId !== userId) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "You do not own this tag",
+				});
+			}
+			await ctx.db
+				.delete(playerToPlayerTag)
+				.where(eq(playerToPlayerTag.playerTagId, input.id));
+			await ctx.db.delete(playerTag).where(eq(playerTag.id, input.id));
+			return { success: true };
+		}),
+});

--- a/packages/api/src/routers/player.ts
+++ b/packages/api/src/routers/player.ts
@@ -1,0 +1,286 @@
+import {
+	player,
+	playerTag,
+	playerToPlayerTag,
+} from "@sapphire2/db/schema/player";
+import { TRPCError } from "@trpc/server";
+import { and, eq, inArray, like } from "drizzle-orm";
+import { z } from "zod";
+import { protectedProcedure, router } from "../index";
+
+export const playerRouter = router({
+	list: protectedProcedure
+		.input(
+			z
+				.object({
+					search: z.string().optional(),
+					tagIds: z.array(z.string()).optional(),
+				})
+				.optional()
+		)
+		.query(async ({ ctx, input }) => {
+			const userId = ctx.session.user.id;
+
+			let playerIds: string[] | undefined;
+
+			if (input?.tagIds && input.tagIds.length > 0) {
+				const tagLinks = await ctx.db
+					.select({ playerId: playerToPlayerTag.playerId })
+					.from(playerToPlayerTag)
+					.where(inArray(playerToPlayerTag.playerTagId, input.tagIds));
+				playerIds = [...new Set(tagLinks.map((l) => l.playerId))];
+				if (playerIds.length === 0) {
+					return [];
+				}
+			}
+
+			const conditions = [eq(player.userId, userId)];
+			if (input?.search) {
+				conditions.push(like(player.name, `%${input.search}%`));
+			}
+			if (playerIds) {
+				conditions.push(inArray(player.id, playerIds));
+			}
+
+			const players = await ctx.db
+				.select()
+				.from(player)
+				.where(and(...conditions));
+
+			const allPlayerIds = players.map((p) => p.id);
+			if (allPlayerIds.length === 0) {
+				return [];
+			}
+
+			const tagLinks = await ctx.db
+				.select({
+					playerId: playerToPlayerTag.playerId,
+					tagId: playerTag.id,
+					tagName: playerTag.name,
+					tagColor: playerTag.color,
+				})
+				.from(playerToPlayerTag)
+				.innerJoin(playerTag, eq(playerToPlayerTag.playerTagId, playerTag.id))
+				.where(inArray(playerToPlayerTag.playerId, allPlayerIds));
+
+			const tagsByPlayer = new Map<
+				string,
+				Array<{ id: string; name: string; color: string }>
+			>();
+			for (const link of tagLinks) {
+				const tags = tagsByPlayer.get(link.playerId) ?? [];
+				tags.push({
+					id: link.tagId,
+					name: link.tagName,
+					color: link.tagColor,
+				});
+				tagsByPlayer.set(link.playerId, tags);
+			}
+
+			return players.map((p) => ({
+				...p,
+				tags: tagsByPlayer.get(p.id) ?? [],
+			}));
+		}),
+
+	getById: protectedProcedure
+		.input(z.object({ id: z.string() }))
+		.query(async ({ ctx, input }) => {
+			const userId = ctx.session.user.id;
+			const [found] = await ctx.db
+				.select()
+				.from(player)
+				.where(eq(player.id, input.id));
+
+			if (!found) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Player not found",
+				});
+			}
+
+			if (found.userId !== userId) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "You do not own this player",
+				});
+			}
+
+			const tagLinks = await ctx.db
+				.select({
+					tagId: playerTag.id,
+					tagName: playerTag.name,
+					tagColor: playerTag.color,
+				})
+				.from(playerToPlayerTag)
+				.innerJoin(playerTag, eq(playerToPlayerTag.playerTagId, playerTag.id))
+				.where(eq(playerToPlayerTag.playerId, found.id));
+
+			return {
+				...found,
+				tags: tagLinks.map((t) => ({
+					id: t.tagId,
+					name: t.tagName,
+					color: t.tagColor,
+				})),
+			};
+		}),
+
+	create: protectedProcedure
+		.input(
+			z.object({
+				name: z.string().min(1).max(100),
+				memo: z.string().max(50_000).optional(),
+				tagIds: z.array(z.string()).optional(),
+			})
+		)
+		.mutation(async ({ ctx, input }) => {
+			const userId = ctx.session.user.id;
+			const id = crypto.randomUUID();
+
+			await ctx.db.insert(player).values({
+				id,
+				userId,
+				name: input.name,
+				memo: input.memo ?? null,
+				updatedAt: new Date(),
+			});
+
+			if (input.tagIds && input.tagIds.length > 0) {
+				await ctx.db.insert(playerToPlayerTag).values(
+					input.tagIds.map((tagId) => ({
+						playerId: id,
+						playerTagId: tagId,
+					}))
+				);
+			}
+
+			const [created] = await ctx.db
+				.select()
+				.from(player)
+				.where(eq(player.id, id));
+
+			const tagLinks = await ctx.db
+				.select({
+					tagId: playerTag.id,
+					tagName: playerTag.name,
+					tagColor: playerTag.color,
+				})
+				.from(playerToPlayerTag)
+				.innerJoin(playerTag, eq(playerToPlayerTag.playerTagId, playerTag.id))
+				.where(eq(playerToPlayerTag.playerId, id));
+
+			return {
+				...created,
+				tags: tagLinks.map((t) => ({
+					id: t.tagId,
+					name: t.tagName,
+					color: t.tagColor,
+				})),
+			};
+		}),
+
+	update: protectedProcedure
+		.input(
+			z.object({
+				id: z.string(),
+				name: z.string().min(1).max(100).optional(),
+				memo: z.string().max(50_000).optional().nullable(),
+				tagIds: z.array(z.string()).optional(),
+			})
+		)
+		.mutation(async ({ ctx, input }) => {
+			const userId = ctx.session.user.id;
+			const [found] = await ctx.db
+				.select()
+				.from(player)
+				.where(eq(player.id, input.id));
+
+			if (!found) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Player not found",
+				});
+			}
+
+			if (found.userId !== userId) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "You do not own this player",
+				});
+			}
+
+			await ctx.db
+				.update(player)
+				.set({
+					...(input.name !== undefined ? { name: input.name } : {}),
+					...(input.memo !== undefined ? { memo: input.memo } : {}),
+				})
+				.where(eq(player.id, input.id));
+
+			if (input.tagIds !== undefined) {
+				await ctx.db
+					.delete(playerToPlayerTag)
+					.where(eq(playerToPlayerTag.playerId, input.id));
+				if (input.tagIds.length > 0) {
+					await ctx.db.insert(playerToPlayerTag).values(
+						input.tagIds.map((tagId) => ({
+							playerId: input.id,
+							playerTagId: tagId,
+						}))
+					);
+				}
+			}
+
+			const [updated] = await ctx.db
+				.select()
+				.from(player)
+				.where(eq(player.id, input.id));
+
+			const tagLinks = await ctx.db
+				.select({
+					tagId: playerTag.id,
+					tagName: playerTag.name,
+					tagColor: playerTag.color,
+				})
+				.from(playerToPlayerTag)
+				.innerJoin(playerTag, eq(playerToPlayerTag.playerTagId, playerTag.id))
+				.where(eq(playerToPlayerTag.playerId, input.id));
+
+			return {
+				...updated,
+				tags: tagLinks.map((t) => ({
+					id: t.tagId,
+					name: t.tagName,
+					color: t.tagColor,
+				})),
+			};
+		}),
+
+	delete: protectedProcedure
+		.input(z.object({ id: z.string() }))
+		.mutation(async ({ ctx, input }) => {
+			const userId = ctx.session.user.id;
+			const [found] = await ctx.db
+				.select()
+				.from(player)
+				.where(eq(player.id, input.id));
+
+			if (!found) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Player not found",
+				});
+			}
+
+			if (found.userId !== userId) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "You do not own this player",
+				});
+			}
+
+			await ctx.db.delete(player).where(eq(player.id, input.id));
+			return { success: true };
+		}),
+});

--- a/packages/db/src/migrations/0005_colorful_sabretooth.sql
+++ b/packages/db/src/migrations/0005_colorful_sabretooth.sql
@@ -1,0 +1,29 @@
+CREATE TABLE `player` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`name` text NOT NULL,
+	`memo` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `player_userId_idx` ON `player` (`user_id`);--> statement-breakpoint
+CREATE TABLE `player_tag` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`name` text NOT NULL,
+	`color` text DEFAULT 'gray' NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `playerTag_userId_idx` ON `player_tag` (`user_id`);--> statement-breakpoint
+CREATE TABLE `player_to_player_tag` (
+	`player_id` text NOT NULL,
+	`player_tag_id` text NOT NULL,
+	PRIMARY KEY(`player_id`, `player_tag_id`),
+	FOREIGN KEY (`player_id`) REFERENCES `player`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`player_tag_id`) REFERENCES `player_tag`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/packages/db/src/migrations/meta/0005_snapshot.json
+++ b/packages/db/src/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1681 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "570c349c-ef65-4195-867e-031ea3989b3a",
+  "prevId": "a4e0cb60-8aa1-4821-8b99-8287e161ba77",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": ["identifier"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player": {
+      "name": "player",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "player_userId_idx": {
+          "name": "player_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_user_id_user_id_fk": {
+          "name": "player_user_id_user_id_fk",
+          "tableFrom": "player",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_tag": {
+      "name": "player_tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gray'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "playerTag_userId_idx": {
+          "name": "playerTag_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_tag_user_id_user_id_fk": {
+          "name": "player_tag_user_id_user_id_fk",
+          "tableFrom": "player_tag",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_to_player_tag": {
+      "name": "player_to_player_tag",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_tag_id": {
+          "name": "player_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_to_player_tag_player_id_player_id_fk": {
+          "name": "player_to_player_tag_player_id_player_id_fk",
+          "tableFrom": "player_to_player_tag",
+          "tableTo": "player",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_to_player_tag_player_tag_id_player_tag_id_fk": {
+          "name": "player_to_player_tag_player_tag_id_player_tag_id_fk",
+          "tableFrom": "player_to_player_tag",
+          "tableTo": "player_tag",
+          "columnsFrom": ["player_tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_to_player_tag_player_id_player_tag_id_pk": {
+          "columns": ["player_id", "player_tag_id"],
+          "name": "player_to_player_tag_player_id_player_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ring_game": {
+      "name": "ring_game",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'nlh'"
+        },
+        "blind1": {
+          "name": "blind1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind2": {
+          "name": "blind2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind3": {
+          "name": "blind3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante": {
+          "name": "ante",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante_type": {
+          "name": "ante_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_buy_in": {
+          "name": "min_buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_buy_in": {
+          "name": "max_buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "table_size": {
+          "name": "table_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency_id": {
+          "name": "currency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ringGame_storeId_idx": {
+          "name": "ringGame_storeId_idx",
+          "columns": ["store_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ring_game_store_id_store_id_fk": {
+          "name": "ring_game_store_id_store_id_fk",
+          "tableFrom": "ring_game",
+          "tableTo": "store",
+          "columnsFrom": ["store_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ring_game_currency_id_currency_id_fk": {
+          "name": "ring_game_currency_id_currency_id_fk",
+          "tableFrom": "ring_game",
+          "tableTo": "currency",
+          "columnsFrom": ["currency_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_tag": {
+      "name": "session_tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "sessionTag_userId_idx": {
+          "name": "sessionTag_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_tag_user_id_user_id_fk": {
+          "name": "session_tag_user_id_user_id_fk",
+          "tableFrom": "session_tag",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_to_session_tag": {
+      "name": "session_to_session_tag",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_tag_id": {
+          "name": "session_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_to_session_tag_session_id_poker_session_id_fk": {
+          "name": "session_to_session_tag_session_id_poker_session_id_fk",
+          "tableFrom": "session_to_session_tag",
+          "tableTo": "poker_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_to_session_tag_session_tag_id_session_tag_id_fk": {
+          "name": "session_to_session_tag_session_tag_id_session_tag_id_fk",
+          "tableFrom": "session_to_session_tag",
+          "tableTo": "session_tag",
+          "columnsFrom": ["session_tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_to_session_tag_session_id_session_tag_id_pk": {
+          "columns": ["session_id", "session_tag_id"],
+          "name": "session_to_session_tag_session_id_session_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "poker_session": {
+      "name": "poker_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_date": {
+          "name": "session_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ring_game_id": {
+          "name": "ring_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency_id": {
+          "name": "currency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "buy_in": {
+          "name": "buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cash_out": {
+          "name": "cash_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ev_cash_out": {
+          "name": "ev_cash_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tournament_buy_in": {
+          "name": "tournament_buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_entries": {
+          "name": "total_entries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prize_money": {
+          "name": "prize_money",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rebuy_count": {
+          "name": "rebuy_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rebuy_cost": {
+          "name": "rebuy_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "addon_cost": {
+          "name": "addon_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bounty_prizes": {
+          "name": "bounty_prizes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pokerSession_userId_idx": {
+          "name": "pokerSession_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "pokerSession_sessionDate_idx": {
+          "name": "pokerSession_sessionDate_idx",
+          "columns": ["session_date"],
+          "isUnique": false
+        },
+        "pokerSession_storeId_idx": {
+          "name": "pokerSession_storeId_idx",
+          "columns": ["store_id"],
+          "isUnique": false
+        },
+        "pokerSession_currencyId_idx": {
+          "name": "pokerSession_currencyId_idx",
+          "columns": ["currency_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "poker_session_user_id_user_id_fk": {
+          "name": "poker_session_user_id_user_id_fk",
+          "tableFrom": "poker_session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "poker_session_store_id_store_id_fk": {
+          "name": "poker_session_store_id_store_id_fk",
+          "tableFrom": "poker_session",
+          "tableTo": "store",
+          "columnsFrom": ["store_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "poker_session_ring_game_id_ring_game_id_fk": {
+          "name": "poker_session_ring_game_id_ring_game_id_fk",
+          "tableFrom": "poker_session",
+          "tableTo": "ring_game",
+          "columnsFrom": ["ring_game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "poker_session_tournament_id_tournament_id_fk": {
+          "name": "poker_session_tournament_id_tournament_id_fk",
+          "tableFrom": "poker_session",
+          "tableTo": "tournament",
+          "columnsFrom": ["tournament_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "poker_session_currency_id_currency_id_fk": {
+          "name": "poker_session_currency_id_currency_id_fk",
+          "tableFrom": "poker_session",
+          "tableTo": "currency",
+          "columnsFrom": ["currency_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "currency": {
+      "name": "currency",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "currency_userId_idx": {
+          "name": "currency_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "currency_user_id_user_id_fk": {
+          "name": "currency_user_id_user_id_fk",
+          "tableFrom": "currency",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "currency_transaction": {
+      "name": "currency_transaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency_id": {
+          "name": "currency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transaction_type_id": {
+          "name": "transaction_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transacted_at": {
+          "name": "transacted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "currencyTransaction_currencyId_idx": {
+          "name": "currencyTransaction_currencyId_idx",
+          "columns": ["currency_id"],
+          "isUnique": false
+        },
+        "currencyTransaction_sessionId_idx": {
+          "name": "currencyTransaction_sessionId_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "currency_transaction_currency_id_currency_id_fk": {
+          "name": "currency_transaction_currency_id_currency_id_fk",
+          "tableFrom": "currency_transaction",
+          "tableTo": "currency",
+          "columnsFrom": ["currency_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "currency_transaction_transaction_type_id_transaction_type_id_fk": {
+          "name": "currency_transaction_transaction_type_id_transaction_type_id_fk",
+          "tableFrom": "currency_transaction",
+          "tableTo": "transaction_type",
+          "columnsFrom": ["transaction_type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "currency_transaction_session_id_poker_session_id_fk": {
+          "name": "currency_transaction_session_id_poker_session_id_fk",
+          "tableFrom": "currency_transaction",
+          "tableTo": "poker_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "store": {
+      "name": "store",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "store_userId_idx": {
+          "name": "store_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "store_user_id_user_id_fk": {
+          "name": "store_user_id_user_id_fk",
+          "tableFrom": "store",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_type": {
+      "name": "transaction_type",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactionType_userId_idx": {
+          "name": "transactionType_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_type_user_id_user_id_fk": {
+          "name": "transaction_type_user_id_user_id_fk",
+          "tableFrom": "transaction_type",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tournament_tag": {
+      "name": "tournament_tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "tournamentTag_tournamentId_idx": {
+          "name": "tournamentTag_tournamentId_idx",
+          "columns": ["tournament_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tournament_tag_tournament_id_tournament_id_fk": {
+          "name": "tournament_tag_tournament_id_tournament_id_fk",
+          "tableFrom": "tournament_tag",
+          "tableTo": "tournament",
+          "columnsFrom": ["tournament_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blind_level": {
+      "name": "blind_level",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_break": {
+          "name": "is_break",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "blind1": {
+          "name": "blind1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind2": {
+          "name": "blind2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind3": {
+          "name": "blind3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante": {
+          "name": "ante",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "minutes": {
+          "name": "minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blindLevel_tournamentId_idx": {
+          "name": "blindLevel_tournamentId_idx",
+          "columns": ["tournament_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blind_level_tournament_id_tournament_id_fk": {
+          "name": "blind_level_tournament_id_tournament_id_fk",
+          "tableFrom": "blind_level",
+          "tableTo": "tournament",
+          "columnsFrom": ["tournament_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tournament": {
+      "name": "tournament",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'nlh'"
+        },
+        "buy_in": {
+          "name": "buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "starting_stack": {
+          "name": "starting_stack",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rebuy_allowed": {
+          "name": "rebuy_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rebuy_cost": {
+          "name": "rebuy_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rebuy_chips": {
+          "name": "rebuy_chips",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "addon_allowed": {
+          "name": "addon_allowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "addon_cost": {
+          "name": "addon_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "addon_chips": {
+          "name": "addon_chips",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bounty_amount": {
+          "name": "bounty_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "table_size": {
+          "name": "table_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency_id": {
+          "name": "currency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tournament_storeId_idx": {
+          "name": "tournament_storeId_idx",
+          "columns": ["store_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tournament_store_id_store_id_fk": {
+          "name": "tournament_store_id_store_id_fk",
+          "tableFrom": "tournament",
+          "tableTo": "store",
+          "columnsFrom": ["store_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tournament_currency_id_currency_id_fk": {
+          "name": "tournament_currency_id_currency_id_fk",
+          "tableFrom": "tournament",
+          "tableTo": "currency",
+          "columnsFrom": ["currency_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1774315829906,
       "tag": "0004_large_masque",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1774780415564,
+      "tag": "0005_colorful_sabretooth",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -7,6 +7,14 @@ import {
 	userRelations,
 	verification,
 } from "./schema/auth";
+import {
+	player,
+	playerRelations,
+	playerTag,
+	playerTagRelations,
+	playerToPlayerTag,
+	playerToPlayerTagRelations,
+} from "./schema/player";
 import { ringGame, ringGameRelations } from "./schema/ring-game";
 import { pokerSession, pokerSessionRelations } from "./schema/session";
 import {
@@ -63,4 +71,10 @@ export const schema = {
 	sessionTagRelations,
 	sessionToSessionTag,
 	sessionToSessionTagRelations,
+	player,
+	playerRelations,
+	playerTag,
+	playerTagRelations,
+	playerToPlayerTag,
+	playerToPlayerTagRelations,
 };

--- a/packages/db/src/schema/player.ts
+++ b/packages/db/src/schema/player.ts
@@ -1,0 +1,90 @@
+import { relations, sql } from "drizzle-orm";
+import {
+	index,
+	integer,
+	primaryKey,
+	sqliteTable,
+	text,
+} from "drizzle-orm/sqlite-core";
+import { user } from "./auth";
+
+export const player = sqliteTable(
+	"player",
+	{
+		id: text("id").primaryKey(),
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		name: text("name").notNull(),
+		memo: text("memo"),
+		createdAt: integer("created_at", { mode: "timestamp" })
+			.default(sql`(unixepoch())`)
+			.notNull(),
+		updatedAt: integer("updated_at", { mode: "timestamp" })
+			.$onUpdate(() => new Date())
+			.notNull(),
+	},
+	(table) => [index("player_userId_idx").on(table.userId)]
+);
+
+export const playerTag = sqliteTable(
+	"player_tag",
+	{
+		id: text("id").primaryKey(),
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		name: text("name").notNull(),
+		color: text("color").notNull().default("gray"),
+		createdAt: integer("created_at", { mode: "timestamp" })
+			.default(sql`(unixepoch())`)
+			.notNull(),
+		updatedAt: integer("updated_at", { mode: "timestamp" })
+			.$onUpdate(() => new Date())
+			.notNull(),
+	},
+	(table) => [index("playerTag_userId_idx").on(table.userId)]
+);
+
+export const playerToPlayerTag = sqliteTable(
+	"player_to_player_tag",
+	{
+		playerId: text("player_id")
+			.notNull()
+			.references(() => player.id, { onDelete: "cascade" }),
+		playerTagId: text("player_tag_id")
+			.notNull()
+			.references(() => playerTag.id, { onDelete: "cascade" }),
+	},
+	(table) => [primaryKey({ columns: [table.playerId, table.playerTagId] })]
+);
+
+export const playerRelations = relations(player, ({ one, many }) => ({
+	user: one(user, {
+		fields: [player.userId],
+		references: [user.id],
+	}),
+	tagLinks: many(playerToPlayerTag),
+}));
+
+export const playerTagRelations = relations(playerTag, ({ one, many }) => ({
+	user: one(user, {
+		fields: [playerTag.userId],
+		references: [user.id],
+	}),
+	playerLinks: many(playerToPlayerTag),
+}));
+
+export const playerToPlayerTagRelations = relations(
+	playerToPlayerTag,
+	({ one }) => ({
+		player: one(player, {
+			fields: [playerToPlayerTag.playerId],
+			references: [player.id],
+		}),
+		tag: one(playerTag, {
+			fields: [playerToPlayerTag.playerTagId],
+			references: [playerTag.id],
+		}),
+	})
+);

--- a/specs/005-player-notes/tasks.md
+++ b/specs/005-player-notes/tasks.md
@@ -28,14 +28,14 @@
 
 **CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T003 Create Player, PlayerTag, and PlayerToPlayerTag tables with relations and indexes in packages/db/src/schema/player.ts following the patterns in packages/db/src/schema/store.ts and packages/db/src/schema/session-tag.ts. Player has: id, userId, name, memo (nullable text), createdAt, updatedAt. PlayerTag has: id, userId, name, color (default "gray"), createdAt, updatedAt. PlayerToPlayerTag is a junction table with composite PK (playerId, playerTagId), both FK cascade delete.
-- [ ] T004 Export new tables and relations from packages/db/src/schema.ts by adding player, playerRelations, playerTag, playerTagRelations, playerToPlayerTag, playerToPlayerTagRelations to the schema object
-- [ ] T005 Generate database migration by running `bun run drizzle-kit generate` in packages/db
-- [ ] T006 [P] Create playerTag tRPC router in packages/api/src/routers/player-tag.ts with list, create (name + color with Zod enum validation), update (name and/or color), delete (cascade cleanup of playerToPlayerTag) procedures. Follow the pattern in packages/api/src/routers/session-tag.ts.
-- [ ] T007 [P] Create player tRPC router in packages/api/src/routers/player.ts with list (search + tagIds filter), getById (with tags), create (name + optional memo + optional tagIds), update (name, memo, tagIds replacement), delete procedures. Follow the pattern in packages/api/src/routers/store.ts. Player list must JOIN playerToPlayerTag and playerTag to return tags with color.
-- [ ] T008 Register player and playerTag routers in packages/api/src/routers/index.ts by importing and adding them to the appRouter object
-- [ ] T009 [P] Add "Players" navigation item to apps/web/src/components/sidebar-nav.tsx in the NAVIGATION_ITEMS array with path "/players" and IconUsers icon from @tabler/icons-react
-- [ ] T010 [P] Add "Players" navigation item to apps/web/src/components/mobile-nav.tsx (uses same NAVIGATION_ITEMS from sidebar-nav.tsx, so this may already be covered if shared)
+- [x] T003 Create Player, PlayerTag, and PlayerToPlayerTag tables with relations and indexes in packages/db/src/schema/player.ts following the patterns in packages/db/src/schema/store.ts and packages/db/src/schema/session-tag.ts. Player has: id, userId, name, memo (nullable text), createdAt, updatedAt. PlayerTag has: id, userId, name, color (default "gray"), createdAt, updatedAt. PlayerToPlayerTag is a junction table with composite PK (playerId, playerTagId), both FK cascade delete.
+- [x] T004 Export new tables and relations from packages/db/src/schema.ts by adding player, playerRelations, playerTag, playerTagRelations, playerToPlayerTag, playerToPlayerTagRelations to the schema object
+- [x] T005 Generate database migration by running `bun run drizzle-kit generate` in packages/db
+- [x] T006 [P] Create playerTag tRPC router in packages/api/src/routers/player-tag.ts with list, create (name + color with Zod enum validation), update (name and/or color), delete (cascade cleanup of playerToPlayerTag) procedures. Follow the pattern in packages/api/src/routers/session-tag.ts.
+- [x] T007 [P] Create player tRPC router in packages/api/src/routers/player.ts with list (search + tagIds filter), getById (with tags), create (name + optional memo + optional tagIds), update (name, memo, tagIds replacement), delete procedures. Follow the pattern in packages/api/src/routers/store.ts. Player list must JOIN playerToPlayerTag and playerTag to return tags with color.
+- [x] T008 Register player and playerTag routers in packages/api/src/routers/index.ts by importing and adding them to the appRouter object
+- [x] T009 [P] Add "Players" navigation item to apps/web/src/components/sidebar-nav.tsx in the NAVIGATION_ITEMS array with path "/players" and IconUsers icon from @tabler/icons-react
+- [x] T010 [P] Add "Players" navigation item to apps/web/src/components/mobile-nav.tsx (uses same NAVIGATION_ITEMS from sidebar-nav.tsx, so this may already be covered if shared)
 
 **Checkpoint**: Database schema, API routers, and navigation ready. User story implementation can begin.
 


### PR DESCRIPTION
## Summary
This PR implements a complete player management system with support for organizing players through customizable tags. It includes database schema, API endpoints, and UI navigation updates to enable users to create, manage, and organize poker players.

## Key Changes

### Database Schema & Migrations
- Added `player` table to store player information with user association
- Added `playerTag` table for user-defined player tags with color support
- Added `playerToPlayerTag` junction table for many-to-many player-tag relationships
- Created migration `0005_colorful_sabretooth.sql` with proper foreign keys and indexes
- Updated schema exports to include new player-related tables and relations

### API Endpoints
- **Player Router** (`packages/api/src/routers/player.ts`):
  - `list`: Query players with optional search and tag filtering
  - `getById`: Retrieve individual player with associated tags
  - `create`: Create new player with optional tag assignments
  - `update`: Update player details and tag associations
  - `delete`: Remove player (implementation truncated in diff)

- **Player Tag Router** (`packages/api/src/routers/player-tag.ts`):
  - `list`: Retrieve all tags for authenticated user
  - `create`: Create new tag with color selection
  - `update`: Modify tag name and color
  - `delete`: Remove tag (implementation truncated in diff)

### UI Updates
- Added `IconUsers` import to mobile navigation
- Updated mobile navigation test to include sessions and players routes
- Added players route navigation component

### Implementation Details
- All endpoints use `protectedProcedure` for authentication
- Tag colors are validated against predefined `TAG_COLOR_NAMES` enum
- Player-tag relationships use composite primary keys for data integrity
- Proper authorization checks ensure users can only access their own data
- Cascade delete configured for data consistency when users/players are removed
- Search functionality supports partial name matching
- Tag filtering returns players matching any of the provided tag IDs

https://claude.ai/code/session_01GjnxKBtvTQBbBhXtcTk5jg