### PR TITLE
feat(006-session-recording): add specification for real-time session recording

### DIFF
--- a/apps/web/src/components/players/player-tag-manager.tsx
+++ b/apps/web/src/components/players/player-tag-manager.tsx
@@ -94,6 +94,33 @@ export function PlayerTagManager() {
 	const createMutation = useMutation({
 		mutationFn: (values: TagFormValues) =>
 			trpcClient.playerTag.create.mutate(values),
+		onMutate: async (newTag) => {
+			await queryClient.cancelQueries({ queryKey: tagListKey });
+			const previous = queryClient.getQueryData(tagListKey);
+			queryClient.setQueryData(tagListKey, (old) => {
+				if (!old) {
+					return old;
+				}
+				const now = new Date().toISOString();
+				return [
+					...old,
+					{
+						id: `temp-${Date.now()}`,
+						name: newTag.name,
+						color: newTag.color,
+						createdAt: now,
+						updatedAt: now,
+						userId: "",
+					},
+				];
+			});
+			return { previous };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previous) {
+				queryClient.setQueryData(tagListKey, context.previous);
+			}
+		},
 		onSettled: () => {
 			queryClient.invalidateQueries({ queryKey: tagListKey });
 		},
@@ -105,6 +132,23 @@ export function PlayerTagManager() {
 	const updateMutation = useMutation({
 		mutationFn: (values: TagFormValues & { id: string }) =>
 			trpcClient.playerTag.update.mutate(values),
+		onMutate: async (updated) => {
+			await queryClient.cancelQueries({ queryKey: tagListKey });
+			const previous = queryClient.getQueryData(tagListKey);
+			queryClient.setQueryData(tagListKey, (old) =>
+				old?.map((t) =>
+					t.id === updated.id
+						? { ...t, name: updated.name, color: updated.color }
+						: t
+				)
+			);
+			return { previous };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previous) {
+				queryClient.setQueryData(tagListKey, context.previous);
+			}
+		},
 		onSettled: () => {
 			queryClient.invalidateQueries({ queryKey: tagListKey });
 			queryClient.invalidateQueries({
@@ -118,6 +162,19 @@ export function PlayerTagManager() {
 
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => trpcClient.playerTag.delete.mutate({ id }),
+		onMutate: async (id) => {
+			await queryClient.cancelQueries({ queryKey: tagListKey });
+			const previous = queryClient.getQueryData(tagListKey);
+			queryClient.setQueryData(tagListKey, (old) =>
+				old?.filter((t) => t.id !== id)
+			);
+			return { previous };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previous) {
+				queryClient.setQueryData(tagListKey, context.previous);
+			}
+		},
 		onSettled: () => {
 			queryClient.invalidateQueries({ queryKey: tagListKey });
 			queryClient.invalidateQueries({

--- a/apps/web/src/components/stores/ring-game-tab.tsx
+++ b/apps/web/src/components/stores/ring-game-tab.tsx
@@ -471,6 +471,45 @@ export function RingGameTab({
 	const createMutation = useMutation({
 		mutationFn: (values: RingGameFormValues) =>
 			trpcClient.ringGame.create.mutate({ storeId, ...values }),
+		onMutate: async (newGame) => {
+			await queryClient.cancelQueries({
+				queryKey: activeQueryOptions.queryKey,
+			});
+			const previous = queryClient.getQueryData(activeQueryOptions.queryKey);
+			queryClient.setQueryData(activeQueryOptions.queryKey, (old) => {
+				if (!old) {
+					return old;
+				}
+				return [
+					...old,
+					{
+						id: `temp-${Date.now()}`,
+						name: newGame.name,
+						variant: newGame.variant,
+						blind1: newGame.blind1 ?? null,
+						blind2: newGame.blind2 ?? null,
+						blind3: newGame.blind3 ?? null,
+						ante: newGame.ante ?? null,
+						anteType: newGame.anteType ?? null,
+						tableSize: newGame.tableSize ?? null,
+						minBuyIn: newGame.minBuyIn ?? null,
+						maxBuyIn: newGame.maxBuyIn ?? null,
+						currencyId: newGame.currencyId ?? null,
+						memo: newGame.memo ?? null,
+						storeId,
+						archivedAt: null,
+						createdAt: new Date().toISOString(),
+						updatedAt: new Date().toISOString(),
+					},
+				];
+			});
+			return { previous };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previous) {
+				queryClient.setQueryData(activeQueryOptions.queryKey, context.previous);
+			}
+		},
 		onSettled: () => {
 			queryClient.invalidateQueries({ queryKey: activeQueryOptions.queryKey });
 		},
@@ -482,6 +521,59 @@ export function RingGameTab({
 	const updateMutation = useMutation({
 		mutationFn: (values: RingGameFormValues & { id: string }) =>
 			trpcClient.ringGame.update.mutate(values),
+		onMutate: async (updated) => {
+			await queryClient.cancelQueries({
+				queryKey: activeQueryOptions.queryKey,
+			});
+			await queryClient.cancelQueries({
+				queryKey: archivedQueryOptions.queryKey,
+			});
+			const previousActive = queryClient.getQueryData(
+				activeQueryOptions.queryKey
+			);
+			const previousArchived = queryClient.getQueryData(
+				archivedQueryOptions.queryKey
+			);
+			const mapGame = <T extends { id: string }>(g: T) =>
+				g.id === updated.id
+					? {
+							...g,
+							name: updated.name,
+							variant: updated.variant,
+							blind1: updated.blind1 ?? null,
+							blind2: updated.blind2 ?? null,
+							blind3: updated.blind3 ?? null,
+							ante: updated.ante ?? null,
+							anteType: updated.anteType ?? null,
+							tableSize: updated.tableSize ?? null,
+							minBuyIn: updated.minBuyIn ?? null,
+							maxBuyIn: updated.maxBuyIn ?? null,
+							currencyId: updated.currencyId ?? null,
+							memo: updated.memo ?? null,
+						}
+					: g;
+			queryClient.setQueryData(activeQueryOptions.queryKey, (old) =>
+				old?.map(mapGame)
+			);
+			queryClient.setQueryData(archivedQueryOptions.queryKey, (old) =>
+				old?.map(mapGame)
+			);
+			return { previousActive, previousArchived };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previousActive) {
+				queryClient.setQueryData(
+					activeQueryOptions.queryKey,
+					context.previousActive
+				);
+			}
+			if (context?.previousArchived) {
+				queryClient.setQueryData(
+					archivedQueryOptions.queryKey,
+					context.previousArchived
+				);
+			}
+		},
 		onSettled: invalidateBoth,
 		onSuccess: () => {
 			setEditingGame(null);
@@ -490,16 +582,91 @@ export function RingGameTab({
 
 	const archiveMutation = useMutation({
 		mutationFn: (id: string) => trpcClient.ringGame.archive.mutate({ id }),
+		onMutate: async (id) => {
+			await queryClient.cancelQueries({
+				queryKey: activeQueryOptions.queryKey,
+			});
+			const previousActive = queryClient.getQueryData(
+				activeQueryOptions.queryKey
+			);
+			queryClient.setQueryData(activeQueryOptions.queryKey, (old) =>
+				old?.filter((g) => g.id !== id)
+			);
+			return { previousActive };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previousActive) {
+				queryClient.setQueryData(
+					activeQueryOptions.queryKey,
+					context.previousActive
+				);
+			}
+		},
 		onSettled: invalidateBoth,
 	});
 
 	const restoreMutation = useMutation({
 		mutationFn: (id: string) => trpcClient.ringGame.restore.mutate({ id }),
+		onMutate: async (id) => {
+			await queryClient.cancelQueries({
+				queryKey: archivedQueryOptions.queryKey,
+			});
+			const previousArchived = queryClient.getQueryData(
+				archivedQueryOptions.queryKey
+			);
+			queryClient.setQueryData(archivedQueryOptions.queryKey, (old) =>
+				old?.filter((g) => g.id !== id)
+			);
+			return { previousArchived };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previousArchived) {
+				queryClient.setQueryData(
+					archivedQueryOptions.queryKey,
+					context.previousArchived
+				);
+			}
+		},
 		onSettled: invalidateBoth,
 	});
 
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => trpcClient.ringGame.delete.mutate({ id }),
+		onMutate: async (id) => {
+			await queryClient.cancelQueries({
+				queryKey: activeQueryOptions.queryKey,
+			});
+			await queryClient.cancelQueries({
+				queryKey: archivedQueryOptions.queryKey,
+			});
+			const previousActive = queryClient.getQueryData(
+				activeQueryOptions.queryKey
+			);
+			const previousArchived = queryClient.getQueryData(
+				archivedQueryOptions.queryKey
+			);
+			queryClient.setQueryData(activeQueryOptions.queryKey, (old) =>
+				old?.filter((g) => g.id !== id)
+			);
+			queryClient.setQueryData(archivedQueryOptions.queryKey, (old) =>
+				old?.filter((g) => g.id !== id)
+			);
+			return { previousActive, previousArchived };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previousActive) {
+				queryClient.setQueryData(
+					activeQueryOptions.queryKey,
+					context.previousActive
+				);
+			}
+			if (context?.previousArchived) {
+				queryClient.setQueryData(
+					archivedQueryOptions.queryKey,
+					context.previousArchived
+				);
+			}
+		},
 		onSettled: invalidateBoth,
 	});
 

--- a/apps/web/src/components/stores/tournament-tab.tsx
+++ b/apps/web/src/components/stores/tournament-tab.tsx
@@ -719,16 +719,91 @@ export function TournamentTab({
 
 	const archiveMutation = useMutation({
 		mutationFn: (id: string) => trpcClient.tournament.archive.mutate({ id }),
+		onMutate: async (id) => {
+			await queryClient.cancelQueries({
+				queryKey: activeQueryOptions.queryKey,
+			});
+			const previousActive = queryClient.getQueryData(
+				activeQueryOptions.queryKey
+			);
+			queryClient.setQueryData(activeQueryOptions.queryKey, (old) =>
+				old?.filter((t) => t.id !== id)
+			);
+			return { previousActive };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previousActive) {
+				queryClient.setQueryData(
+					activeQueryOptions.queryKey,
+					context.previousActive
+				);
+			}
+		},
 		onSettled: invalidateBoth,
 	});
 
 	const restoreMutation = useMutation({
 		mutationFn: (id: string) => trpcClient.tournament.restore.mutate({ id }),
+		onMutate: async (id) => {
+			await queryClient.cancelQueries({
+				queryKey: archivedQueryOptions.queryKey,
+			});
+			const previousArchived = queryClient.getQueryData(
+				archivedQueryOptions.queryKey
+			);
+			queryClient.setQueryData(archivedQueryOptions.queryKey, (old) =>
+				old?.filter((t) => t.id !== id)
+			);
+			return { previousArchived };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previousArchived) {
+				queryClient.setQueryData(
+					archivedQueryOptions.queryKey,
+					context.previousArchived
+				);
+			}
+		},
 		onSettled: invalidateBoth,
 	});
 
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => trpcClient.tournament.delete.mutate({ id }),
+		onMutate: async (id) => {
+			await queryClient.cancelQueries({
+				queryKey: activeQueryOptions.queryKey,
+			});
+			await queryClient.cancelQueries({
+				queryKey: archivedQueryOptions.queryKey,
+			});
+			const previousActive = queryClient.getQueryData(
+				activeQueryOptions.queryKey
+			);
+			const previousArchived = queryClient.getQueryData(
+				archivedQueryOptions.queryKey
+			);
+			queryClient.setQueryData(activeQueryOptions.queryKey, (old) =>
+				old?.filter((t) => t.id !== id)
+			);
+			queryClient.setQueryData(archivedQueryOptions.queryKey, (old) =>
+				old?.filter((t) => t.id !== id)
+			);
+			return { previousActive, previousArchived };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previousActive) {
+				queryClient.setQueryData(
+					activeQueryOptions.queryKey,
+					context.previousActive
+				);
+			}
+			if (context?.previousArchived) {
+				queryClient.setQueryData(
+					archivedQueryOptions.queryKey,
+					context.previousArchived
+				);
+			}
+		},
 		onSettled: invalidateBoth,
 	});
 

--- a/apps/web/src/components/stores/transaction-type-manager.tsx
+++ b/apps/web/src/components/stores/transaction-type-manager.tsx
@@ -46,7 +46,18 @@ export function TransactionTypeManager() {
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) =>
 			trpcClient.transactionType.delete.mutate({ id }),
-		onError: (err: unknown) => {
+		onMutate: async (id) => {
+			await queryClient.cancelQueries({ queryKey: typeListKey });
+			const previous = queryClient.getQueryData(typeListKey);
+			queryClient.setQueryData(typeListKey, (old) =>
+				old?.filter((t) => t.id !== id)
+			);
+			return { previous };
+		},
+		onError: (err: unknown, _vars, context) => {
+			if (context?.previous) {
+				queryClient.setQueryData(typeListKey, context.previous);
+			}
 			if (
 				err &&
 				typeof err === "object" &&

--- a/apps/web/src/routes/currencies/index.tsx
+++ b/apps/web/src/routes/currencies/index.tsx
@@ -100,15 +100,17 @@ function CurrenciesPage() {
 				if (!old) {
 					return old;
 				}
-				const base = old[0];
+				const now = new Date().toISOString();
 				return [
 					...old,
 					{
-						...base,
 						id: `temp-${Date.now()}`,
 						name: newCurrency.name,
 						unit: newCurrency.unit ?? null,
 						balance: 0,
+						createdAt: now,
+						updatedAt: now,
+						userId: "",
 					},
 				];
 			});

--- a/apps/web/src/routes/stores/index.tsx
+++ b/apps/web/src/routes/stores/index.tsx
@@ -42,14 +42,16 @@ function StoresPage() {
 				if (!old) {
 					return old;
 				}
-				const base = old[0];
+				const now = new Date().toISOString();
 				return [
 					...old,
 					{
-						...base,
 						id: `temp-${Date.now()}`,
 						name: newStore.name,
 						memo: newStore.memo ?? null,
+						createdAt: now,
+						updatedAt: now,
+						userId: "",
 					},
 				];
 			});


### PR DESCRIPTION
Define event-sourced session recording feature including cash game and
tournament tracking, session pause/resume, table player management,
and event history viewing.

https://claude.ai/code/session_01VkgM9fxTNnoAZJs9e9m8PS