### PR TITLE
Add mobile-accessible sign out in Settings

### DIFF
--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -1,11 +1,12 @@
 import { IconCheck, IconPencil, IconTrash, IconX } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { LinkedAccounts } from "@/components/linked-accounts";
 import { TransactionTypeManager } from "@/components/stores/transaction-type-manager";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { authClient } from "@/lib/auth-client";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 export const Route = createFileRoute("/settings")({
@@ -167,9 +168,39 @@ function SessionTagManager() {
 }
 
 function SettingsComponent() {
+	const navigate = useNavigate();
+	const { data: session } = authClient.useSession();
+
 	return (
 		<div className="container mx-auto max-w-3xl px-4 py-2">
 			<h1 className="font-bold text-2xl">Settings</h1>
+
+			{session ? (
+				<section className="mt-6">
+					<h2 className="mb-3 font-semibold text-lg">Account</h2>
+					<div className="flex flex-col gap-2 rounded-md border p-4">
+						<p className="text-muted-foreground text-sm">{session.user.email}</p>
+						<div>
+							<Button
+								onClick={() => {
+									authClient.signOut({
+										fetchOptions: {
+											onSuccess: () => {
+												navigate({
+													to: "/",
+												});
+											},
+										},
+									});
+								}}
+								variant="destructive"
+							>
+								Sign Out
+							</Button>
+						</div>
+					</div>
+				</section>
+			) : null}
 
 			<section className="mt-6">
 				<h2 className="mb-3 font-semibold text-lg">Linked Accounts</h2>


### PR DESCRIPTION
### Motivation
- Mobile users could not sign out from the app because the desktop user menu is not available on small screens, so a settings-based sign out is needed.

### Description
- Added `useNavigate` and `authClient` imports and wired `authClient.useSession()` into the Settings component in `apps/web/src/routes/settings.tsx`.
- Added an `Account` section that displays the signed-in email and a destructive `Sign Out` `Button` for mobile access.
- The `Sign Out` button calls `authClient.signOut()` and redirects to `/` on success using `useNavigate`.

### Testing
- Ran `bun run check-types`, which failed in this environment due to missing workspace/type dependencies (`@cloudflare/workers-types`, `bun`, and workspace tsconfig files).
- Ran the targeted test invocation `bun run test -- apps/web/src/__tests__/mobile-nav.test.tsx`, which failed here because the `vitest` binary is unavailable in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfa5c91de8832d89e080e3506a3cd0)