### PR TITLE
Validate initial buy-in against ring game bounds

### DIFF
--- a/apps/web/src/live-sessions/components/create-cash-game-session-form.tsx
+++ b/apps/web/src/live-sessions/components/create-cash-game-session-form.tsx
@@ -1,3 +1,4 @@
+import { useForm } from "@tanstack/react-form";
 import { useState } from "react";
 import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
@@ -50,11 +51,38 @@ export function CreateCashGameSessionForm({
 	const [selectedCurrencyId, setSelectedCurrencyId] = useState<
 		string | undefined
 	>(undefined);
-	const [initialBuyIn, setInitialBuyIn] = useState<string>("");
+
+	const selectedRingGame = selectedRingGameId
+		? ringGames.find((g) => g.id === selectedRingGameId)
+		: null;
+
+	const isCurrencyLocked =
+		selectedRingGame?.currencyId !== null &&
+		selectedRingGame?.currencyId !== undefined;
+
+	const form = useForm({
+		defaultValues: {
+			initialBuyIn: "",
+			memo: "",
+		},
+		onSubmit: ({ value }) => {
+			if (!(selectedStoreId && selectedRingGameId)) {
+				return;
+			}
+			onSubmit({
+				storeId: selectedStoreId,
+				ringGameId: selectedRingGameId,
+				currencyId: selectedCurrencyId,
+				initialBuyIn: Number(value.initialBuyIn),
+				memo: value.memo || undefined,
+			});
+		},
+	});
 
 	const handleStoreChange = (value: string) => {
 		setSelectedStoreId(value);
 		setSelectedRingGameId(undefined);
+		form.setFieldValue("initialBuyIn", "");
 		onStoreChange?.(value);
 	};
 
@@ -62,7 +90,7 @@ export function CreateCashGameSessionForm({
 		setSelectedRingGameId(value);
 		const ringGame = ringGames.find((g) => g.id === value);
 		if (ringGame) {
-			setInitialBuyIn(ringGame.maxBuyIn?.toString() ?? "");
+			form.setFieldValue("initialBuyIn", ringGame.maxBuyIn?.toString() ?? "");
 			setSelectedCurrencyId(ringGame.currencyId ?? undefined);
 		}
 	};
@@ -71,37 +99,18 @@ export function CreateCashGameSessionForm({
 		setSelectedCurrencyId(value);
 	};
 
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		if (!(selectedStoreId && selectedRingGameId)) {
-			return;
-		}
-		const formData = new FormData(e.currentTarget);
-		const memo = (formData.get("memo") as string) || undefined;
-
-		onSubmit({
-			storeId: selectedStoreId,
-			ringGameId: selectedRingGameId,
-			currencyId: selectedCurrencyId,
-			initialBuyIn: Number(initialBuyIn),
-			memo,
-		});
-	};
-
 	const hasRingGames = ringGames.length > 0;
-
-	// Determine which fields are locked by the selected ring game
-	const selectedRingGame = selectedRingGameId
-		? ringGames.find((g) => g.id === selectedRingGameId)
-		: null;
-	const isCurrencyLocked =
-		selectedRingGame?.currencyId !== null &&
-		selectedRingGame?.currencyId !== undefined;
-
 	const canSubmit = !!selectedStoreId && !!selectedRingGameId;
 
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
 			<Field label="Store" required>
 				{stores.length > 0 ? (
 					<Select onValueChange={handleStoreChange} value={selectedStoreId}>
@@ -176,31 +185,84 @@ export function CreateCashGameSessionForm({
 						</Field>
 					)}
 
-					<Field htmlFor="initialBuyIn" label="Initial Buy-in">
-						<Input
-							id="initialBuyIn"
-							max={selectedRingGame?.maxBuyIn ?? undefined}
-							min={selectedRingGame?.minBuyIn ?? 0}
-							onChange={(e) => setInitialBuyIn(e.target.value)}
-							required
-							type="number"
-							value={initialBuyIn}
-						/>
-					</Field>
+					<form.Field
+						name="initialBuyIn"
+						validators={{
+							onChange: ({ value }) => {
+								if (value === "") {
+									return "Buy-in is required";
+								}
+								const numValue = Number(value);
+								if (Number.isNaN(numValue)) {
+									return "Must be a number";
+								}
+								if (numValue < 0) {
+									return "Must be 0 or greater";
+								}
+								if (
+									selectedRingGame?.minBuyIn != null &&
+									numValue < selectedRingGame.minBuyIn
+								) {
+									return `Must be at least ${selectedRingGame.minBuyIn}`;
+								}
+								if (
+									selectedRingGame?.maxBuyIn != null &&
+									numValue > selectedRingGame.maxBuyIn
+								) {
+									return `Must be at most ${selectedRingGame.maxBuyIn}`;
+								}
+								return undefined;
+							},
+						}}
+					>
+						{(field) => (
+							<Field
+								error={field.state.meta.errors[0]}
+								htmlFor={field.name}
+								label="Initial Buy-in"
+							>
+								<Input
+									id={field.name}
+									max={selectedRingGame?.maxBuyIn ?? undefined}
+									min={selectedRingGame?.minBuyIn ?? 0}
+									onBlur={field.handleBlur}
+									onChange={(e) => field.handleChange(e.target.value)}
+									type="number"
+									value={field.state.value}
+								/>
+							</Field>
+						)}
+					</form.Field>
 
-					<Field htmlFor="memo" label="Memo">
-						<Textarea
-							id="memo"
-							name="memo"
-							placeholder="Notes about this session"
-						/>
-					</Field>
+					<form.Field name="memo">
+						{(field) => (
+							<Field htmlFor={field.name} label="Memo">
+								<Textarea
+									id={field.name}
+									onBlur={field.handleBlur}
+									onChange={(e) => field.handleChange(e.target.value)}
+									placeholder="Notes about this session"
+									value={field.state.value}
+								/>
+							</Field>
+						)}
+					</form.Field>
 				</>
 			)}
 
-			<Button className="mt-2" disabled={isLoading || !canSubmit} type="submit">
-				{isLoading ? "Starting..." : "Start Session"}
-			</Button>
+			<form.Subscribe>
+				{(state) => (
+					<Button
+						className="mt-2"
+						disabled={
+							isLoading || !canSubmit || !state.canSubmit || state.isSubmitting
+						}
+						type="submit"
+					>
+						{isLoading ? "Starting..." : "Start Session"}
+					</Button>
+				)}
+			</form.Subscribe>
 		</form>
 	);
 }

--- a/apps/web/src/live-sessions/components/create-cash-game-session-form.tsx
+++ b/apps/web/src/live-sessions/components/create-cash-game-session-form.tsx
@@ -26,6 +26,7 @@ interface CreateCashGameSessionFormProps {
 	ringGames: Array<{
 		id: string;
 		name: string;
+		minBuyIn: number | null;
 		maxBuyIn: number | null;
 		currencyId: string | null;
 	}>;
@@ -93,9 +94,6 @@ export function CreateCashGameSessionForm({
 	const selectedRingGame = selectedRingGameId
 		? ringGames.find((g) => g.id === selectedRingGameId)
 		: null;
-	const isBuyInLocked =
-		selectedRingGame?.maxBuyIn !== null &&
-		selectedRingGame?.maxBuyIn !== undefined;
 	const isCurrencyLocked =
 		selectedRingGame?.currencyId !== null &&
 		selectedRingGame?.currencyId !== undefined;
@@ -180,9 +178,9 @@ export function CreateCashGameSessionForm({
 
 					<Field htmlFor="initialBuyIn" label="Initial Buy-in">
 						<Input
-							disabled={isBuyInLocked}
 							id="initialBuyIn"
-							min={0}
+							max={selectedRingGame?.maxBuyIn ?? undefined}
+							min={selectedRingGame?.minBuyIn ?? 0}
 							onChange={(e) => setInitialBuyIn(e.target.value)}
 							required
 							type="number"

--- a/apps/web/src/live-sessions/hooks/use-create-session.ts
+++ b/apps/web/src/live-sessions/hooks/use-create-session.ts
@@ -11,6 +11,7 @@ function useStoreRingGames(storeId: string | undefined) {
 	return (ringGamesQuery.data ?? []).map((g) => ({
 		id: g.id,
 		name: g.name,
+		minBuyIn: g.minBuyIn,
 		maxBuyIn: g.maxBuyIn,
 		currencyId: g.currencyId,
 	}));

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -321,6 +321,38 @@ export const liveCashGameSessionRouter = router({
 				});
 			}
 
+			// Validate initialBuyIn against ring game bounds
+			if (input.ringGameId) {
+				const [foundRingGame] = await ctx.db
+					.select({
+						minBuyIn: ringGame.minBuyIn,
+						maxBuyIn: ringGame.maxBuyIn,
+					})
+					.from(ringGame)
+					.where(eq(ringGame.id, input.ringGameId));
+
+				if (foundRingGame) {
+					if (
+						foundRingGame.minBuyIn !== null &&
+						input.initialBuyIn < foundRingGame.minBuyIn
+					) {
+						throw new TRPCError({
+							code: "BAD_REQUEST",
+							message: `Initial buy-in must be at least ${foundRingGame.minBuyIn}`,
+						});
+					}
+					if (
+						foundRingGame.maxBuyIn !== null &&
+						input.initialBuyIn > foundRingGame.maxBuyIn
+					) {
+						throw new TRPCError({
+							code: "BAD_REQUEST",
+							message: `Initial buy-in must be at most ${foundRingGame.maxBuyIn}`,
+						});
+					}
+				}
+			}
+
 			const id = crypto.randomUUID();
 
 			await ctx.db.insert(liveCashGameSession).values({


### PR DESCRIPTION
## Summary
This PR adds validation for the initial buy-in amount against the minimum and maximum buy-in bounds defined on ring games. Previously, only the maximum buy-in was considered for UI purposes, but now both bounds are enforced on the server and reflected in the form.

## Key Changes
- **Server-side validation**: Added validation in the live cash game session router to check that the initial buy-in falls within the ring game's `minBuyIn` and `maxBuyIn` bounds, returning appropriate error messages if violated
- **Form updates**: Removed the `isBuyInLocked` logic that disabled the buy-in input field and replaced it with proper min/max HTML attributes that reflect the selected ring game's bounds
- **Data flow**: Updated the `useStoreRingGames` hook to include `minBuyIn` in the mapped ring game data, and updated the form component's interface to accept this field

## Implementation Details
- The server validation only runs if a `ringGameId` is provided and checks both bounds only if they are not null
- The form now uses HTML5 `min` and `max` attributes for client-side validation, with sensible defaults (0 for min if not set)
- The buy-in input field is no longer disabled based on bounds; users can attempt to enter any value, but the form will validate against the constraints

https://claude.ai/code/session_01GP5fbbh6Edp8KvwvwTzN3d