### PR TITLE
Hide left content on mobile and remove footer notes from auth forms

### DIFF
--- a/apps/web/src/shared/components/public-page-shell.tsx
+++ b/apps/web/src/shared/components/public-page-shell.tsx
@@ -29,7 +29,7 @@ export function PublicPageShell({
 				)}
 			>
 				<div className="grid gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(360px,440px)] lg:items-center">
-					<div className="space-y-6">
+					<div className="hidden space-y-6 lg:block">
 						<div className="space-y-3">
 							{eyebrow ? (
 								<p className="font-medium text-primary text-xs uppercase tracking-[0.28em]">

--- a/apps/web/src/shared/components/sign-in-form.tsx
+++ b/apps/web/src/shared/components/sign-in-form.tsx
@@ -91,7 +91,6 @@ export default function SignInForm({
 		<AuthFormShell
 			description="Use your email and password or continue with a linked provider."
 			eyebrow="Welcome Back"
-			footerNote="You will be redirected to the dashboard after signing in."
 			onSwitchMode={onSwitchToSignUp}
 			providerActions={providerActions}
 			switchLabel="Need an account? Sign Up"

--- a/apps/web/src/shared/components/sign-up-form.tsx
+++ b/apps/web/src/shared/components/sign-up-form.tsx
@@ -94,7 +94,6 @@ export default function SignUpForm({
 		<AuthFormShell
 			description="Create your account to start tracking sessions, players, and stores."
 			eyebrow="New Account"
-			footerNote="By continuing, you can also connect Google or Discord after sign up."
 			onSwitchMode={onSwitchToSignIn}
 			providerActions={providerActions}
 			switchLabel="Already have an account? Sign In"


### PR DESCRIPTION
## Summary
This PR updates the public page shell layout and simplifies the authentication forms by removing redundant footer notes and improving mobile responsiveness.

## Key Changes
- **PublicPageShell**: Added `hidden lg:block` classes to the left content section to hide it on mobile devices and only display on large screens
- **SignInForm**: Removed the `footerNote` prop that displayed "You will be redirected to the dashboard after signing in."
- **SignUpForm**: Removed the `footerNote` prop that displayed "By continuing, you can also connect Google or Discord after sign up."

## Implementation Details
The layout change ensures better mobile UX by hiding the left column content on smaller viewports, allowing the form to take up more space. The removal of footer notes simplifies the auth form UI and reduces visual clutter while maintaining clarity about the sign-in/sign-up process.

https://claude.ai/code/session_01C6rHdAyHQFJCx2aL8FjDu3