### PR TITLE
Display session duration in decimal hours format

### DIFF
--- a/apps/web/src/sessions/components/session-card.tsx
+++ b/apps/web/src/sessions/components/session-card.tsx
@@ -1,6 +1,7 @@
 import {
 	IconBolt,
 	IconCalendar,
+	IconClock,
 	IconList,
 	IconMapPin,
 	IconPlayerPlay,
@@ -117,15 +118,8 @@ function formatBBBI(value: number, unit: "BB" | "BI"): string {
 
 function formatDuration(startedAt: string, endedAt: string): string {
 	const diffMs = new Date(endedAt).getTime() - new Date(startedAt).getTime();
-	const hours = Math.floor(diffMs / (1000 * 60 * 60));
-	const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-	if (hours > 0 && minutes > 0) {
-		return `${hours}h ${minutes}m`;
-	}
-	if (hours > 0) {
-		return `${hours}h`;
-	}
-	return `${minutes}m`;
+	const hours = diffMs / (1000 * 60 * 60);
+	return `${hours.toFixed(1)}h`;
 }
 
 function DetailRow({ label, value }: { label: string; value: string }) {
@@ -382,6 +376,12 @@ function SessionHeader({
 						<IconCalendar className="shrink-0" size={12} />
 						{formatSessionDate(session.sessionDate)}
 					</span>
+					{session.startedAt && session.endedAt && (
+						<span className="flex items-center gap-0.5">
+							<IconClock className="shrink-0" size={12} />
+							{formatDuration(session.startedAt, session.endedAt)}
+						</span>
+					)}
 				</div>
 			</div>
 			<div className="flex shrink-0 flex-col items-end">

--- a/apps/web/src/sessions/components/session-card.tsx
+++ b/apps/web/src/sessions/components/session-card.tsx
@@ -366,16 +366,16 @@ function SessionHeader({
 					))}
 				</div>
 				<div className="mt-1 flex items-center gap-3 text-muted-foreground text-xs">
+					<span className="flex items-center gap-0.5">
+						<IconCalendar className="shrink-0" size={12} />
+						{formatSessionDate(session.sessionDate)}
+					</span>
 					{session.storeName && (
 						<span className="flex max-w-[120px] items-center gap-0.5">
 							<IconMapPin className="shrink-0" size={12} />
 							<span className="truncate">{session.storeName}</span>
 						</span>
 					)}
-					<span className="flex items-center gap-0.5">
-						<IconCalendar className="shrink-0" size={12} />
-						{formatSessionDate(session.sessionDate)}
-					</span>
 					{session.startedAt && session.endedAt && (
 						<span className="flex items-center gap-0.5">
 							<IconClock className="shrink-0" size={12} />


### PR DESCRIPTION
## Summary
Updated the session duration display to show time in a simplified decimal hours format (e.g., "2.5h") instead of the previous hours and minutes breakdown (e.g., "2h 30m").

## Key Changes
- Simplified `formatDuration()` function to calculate and display duration as decimal hours with one decimal place using `toFixed(1)`
- Added `IconClock` import to support the new duration display
- Added duration display to the SessionHeader component, showing next to the session date with a clock icon
- Duration is only displayed when both `startedAt` and `endedAt` timestamps are available

## Implementation Details
- The duration calculation remains the same (millisecond difference between end and start times), but the formatting is now more concise
- The new duration display is conditionally rendered in the session header metadata section alongside the existing session date
- Uses the same icon sizing and spacing patterns as other metadata items in the header

https://claude.ai/code/session_01SK3xzwfM1f5aBohXKo5w68