### PR TITLE
Fix time validation and sort order for session events

### DIFF
--- a/apps/web/src/live-sessions/components/add-player-sheet.tsx
+++ b/apps/web/src/live-sessions/components/add-player-sheet.tsx
@@ -5,7 +5,6 @@ import type { PlayerFormValues } from "@/players/components/player-form";
 import { PlayerForm } from "@/players/components/player-form";
 import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
-import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/components/ui/tabs";
@@ -21,7 +20,11 @@ interface AddPlayerSheetProps {
 	availableTags: TagWithColor[];
 	excludePlayerIds: string[];
 	onAddExisting: (playerId: string, playerName: string) => void;
-	onAddNew: (values: { memo?: string | null; name: string; tagIds?: string[] }) => void;
+	onAddNew: (values: {
+		memo?: string | null;
+		name: string;
+		tagIds?: string[];
+	}) => void;
 	onCreateTag: (name: string) => Promise<TagWithColor>;
 	onOpenChange: (open: boolean) => void;
 	open: boolean;
@@ -150,8 +153,8 @@ export function AddPlayerSheet({
 
 				{tab === "new" && (
 					<PlayerForm
-						key={String(open)}
 						availableTags={availableTags}
+						key={String(open)}
 						leadingActions={
 							<Button
 								onClick={() => onOpenChange(false)}

--- a/apps/web/src/live-sessions/components/player-detail-sheet.tsx
+++ b/apps/web/src/live-sessions/components/player-detail-sheet.tsx
@@ -43,12 +43,12 @@ export function PlayerDetailSheet({
 			title={player?.name ?? "Player"}
 		>
 			<PlayerForm
-				key={player?.id ?? "empty"}
 				availableTags={availableTags}
 				defaultMemo={player?.memo}
 				defaultTags={player?.tags ?? []}
 				defaultValues={{ name: player?.name ?? "" }}
 				isLoading={isSaving}
+				key={player?.id ?? "empty"}
 				leadingActions={
 					<Button
 						className="border-destructive text-destructive hover:bg-destructive/10"

--- a/apps/web/src/live-sessions/components/session-events-scene.tsx
+++ b/apps/web/src/live-sessions/components/session-events-scene.tsx
@@ -70,7 +70,7 @@ function formatTime(value: string | Date) {
 function applyTimeToDate(original: string | Date, timeStr: string) {
 	const date = new Date(typeof original === "string" ? original : original);
 	const [h, m] = timeStr.split(":").map(Number);
-	date.setHours(h ?? 0, m ?? 0, 0, 0);
+	date.setHours(h ?? 0, m ?? 0);
 	return date;
 }
 
@@ -81,11 +81,19 @@ function validateTime(
 	maxTime: Date | null
 ) {
 	const newDate = applyTimeToDate(original, timeStr);
-	if (minTime && newDate.getTime() < minTime.getTime()) {
-		return `Must be after ${formatTime(minTime)}`;
+	if (minTime) {
+		const minMinute = new Date(minTime);
+		minMinute.setSeconds(0, 0);
+		if (newDate.getTime() < minMinute.getTime()) {
+			return `Must be after ${formatTime(minTime)}`;
+		}
 	}
-	if (maxTime && newDate.getTime() > maxTime.getTime()) {
-		return `Must be before ${formatTime(maxTime)}`;
+	if (maxTime) {
+		const maxMinute = new Date(maxTime);
+		maxMinute.setSeconds(0, 0);
+		if (newDate.getTime() > maxMinute.getTime()) {
+			return `Must be before ${formatTime(maxTime)}`;
+		}
 	}
 	return null;
 }

--- a/apps/web/src/live-sessions/components/session-events-scene.tsx
+++ b/apps/web/src/live-sessions/components/session-events-scene.tsx
@@ -81,17 +81,19 @@ function validateTime(
 	maxTime: Date | null
 ) {
 	const newDate = applyTimeToDate(original, timeStr);
+	const newMinute = new Date(newDate);
+	newMinute.setSeconds(0, 0);
 	if (minTime) {
 		const minMinute = new Date(minTime);
 		minMinute.setSeconds(0, 0);
-		if (newDate.getTime() < minMinute.getTime()) {
+		if (newMinute.getTime() < minMinute.getTime()) {
 			return `Must be after ${formatTime(minTime)}`;
 		}
 	}
 	if (maxTime) {
 		const maxMinute = new Date(maxTime);
 		maxMinute.setSeconds(0, 0);
-		if (newDate.getTime() > maxMinute.getTime()) {
+		if (newMinute.getTime() > maxMinute.getTime()) {
 			return `Must be before ${formatTime(maxTime)}`;
 		}
 	}

--- a/apps/web/src/live-sessions/components/stack-editor-time.ts
+++ b/apps/web/src/live-sessions/components/stack-editor-time.ts
@@ -20,11 +20,19 @@ export function validateOccurredAtTime(
 	maxTime: Date | null | undefined
 ): string | null {
 	const nextDate = applyTimeToDate(original, timeStr);
-	if (minTime && nextDate.getTime() < minTime.getTime()) {
-		return `Must be after ${toTimeInputValue(minTime)}`;
+	if (minTime) {
+		const minMinute = new Date(minTime);
+		minMinute.setSeconds(0, 0);
+		if (nextDate.getTime() < minMinute.getTime()) {
+			return `Must be after ${toTimeInputValue(minTime)}`;
+		}
 	}
-	if (maxTime && nextDate.getTime() > maxTime.getTime()) {
-		return `Must be before ${toTimeInputValue(maxTime)}`;
+	if (maxTime) {
+		const maxMinute = new Date(maxTime);
+		maxMinute.setSeconds(0, 0);
+		if (nextDate.getTime() > maxMinute.getTime()) {
+			return `Must be before ${toTimeInputValue(maxTime)}`;
+		}
 	}
 	return null;
 }

--- a/apps/web/src/live-sessions/components/stack-editor-time.ts
+++ b/apps/web/src/live-sessions/components/stack-editor-time.ts
@@ -20,17 +20,19 @@ export function validateOccurredAtTime(
 	maxTime: Date | null | undefined
 ): string | null {
 	const nextDate = applyTimeToDate(original, timeStr);
+	const nextMinute = new Date(nextDate);
+	nextMinute.setSeconds(0, 0);
 	if (minTime) {
 		const minMinute = new Date(minTime);
 		minMinute.setSeconds(0, 0);
-		if (nextDate.getTime() < minMinute.getTime()) {
+		if (nextMinute.getTime() < minMinute.getTime()) {
 			return `Must be after ${toTimeInputValue(minTime)}`;
 		}
 	}
 	if (maxTime) {
 		const maxMinute = new Date(maxTime);
 		maxMinute.setSeconds(0, 0);
-		if (nextDate.getTime() > maxMinute.getTime()) {
+		if (nextMinute.getTime() > maxMinute.getTime()) {
 			return `Must be before ${toTimeInputValue(maxTime)}`;
 		}
 	}

--- a/apps/web/src/players/components/player-form.tsx
+++ b/apps/web/src/players/components/player-form.tsx
@@ -33,7 +33,10 @@ interface PlayerFormProps {
 
 const playerFormSchema = z.object({
 	memo: z.string().max(50_000).nullable().optional(),
-	name: z.string().min(1, "Name is required").max(100, "Name must be 100 characters or less"),
+	name: z
+		.string()
+		.min(1, "Name is required")
+		.max(100, "Name must be 100 characters or less"),
 	tags: z
 		.array(z.object({ color: z.string(), id: z.string(), name: z.string() }))
 		.optional(),
@@ -51,16 +54,15 @@ export function PlayerForm({
 }: PlayerFormProps) {
 	const form = useForm({
 		defaultValues: {
-			memo: defaultMemo ?? null as string | null,
+			memo: defaultMemo ?? (null as string | null),
 			name: defaultValues?.name ?? "",
-			tags: defaultTags ?? [] as TagWithColor[],
+			tags: defaultTags ?? ([] as TagWithColor[]),
 		},
 		onSubmit: ({ value }) => {
 			onSubmit({
 				memo: value.memo,
 				name: value.name,
-				tagIds:
-					value.tags.length > 0 ? value.tags.map((t) => t.id) : undefined,
+				tagIds: value.tags.length > 0 ? value.tags.map((t) => t.id) : undefined,
 			});
 		},
 		validators: {
@@ -103,9 +105,7 @@ export function PlayerForm({
 						<Field label="Tags">
 							<PlayerTagInput
 								availableTags={availableTags}
-								onAdd={(tag) =>
-									field.handleChange([...field.state.value, tag])
-								}
+								onAdd={(tag) => field.handleChange([...field.state.value, tag])}
 								onCreateTag={onCreateTag}
 								onRemove={(tag) =>
 									field.handleChange(

--- a/packages/api/src/routers/session-event.ts
+++ b/packages/api/src/routers/session-event.ts
@@ -369,13 +369,19 @@ export const sessionEventRouter = router({
 			const updates: Record<string, unknown> = { updatedAt: new Date() };
 			if (input.occurredAt !== undefined) {
 				const newOccurredAt = new Date(input.occurredAt * 1000);
-				updates.occurredAt = newOccurredAt;
-				updates.sortOrder = await computeNextSortOrder(
-					ctx.db,
-					event.liveCashGameSessionId ?? undefined,
-					event.liveTournamentSessionId ?? undefined,
-					newOccurredAt
+				const oldOccurredAtUnix = Math.floor(
+					new Date(event.occurredAt).getTime() / 1000
 				);
+				const newOccurredAtUnix = Math.floor(newOccurredAt.getTime() / 1000);
+				updates.occurredAt = newOccurredAt;
+				if (newOccurredAtUnix !== oldOccurredAtUnix) {
+					updates.sortOrder = await computeNextSortOrder(
+						ctx.db,
+						event.liveCashGameSessionId ?? undefined,
+						event.liveTournamentSessionId ?? undefined,
+						newOccurredAt
+					);
+				}
 			}
 			if (input.payload !== undefined) {
 				updates.payload = JSON.stringify(

--- a/packages/api/src/routers/session-event.ts
+++ b/packages/api/src/routers/session-event.ts
@@ -368,7 +368,14 @@ export const sessionEventRouter = router({
 			const eventType = event.eventType as SessionEventType;
 			const updates: Record<string, unknown> = { updatedAt: new Date() };
 			if (input.occurredAt !== undefined) {
-				updates.occurredAt = new Date(input.occurredAt * 1000);
+				const newOccurredAt = new Date(input.occurredAt * 1000);
+				updates.occurredAt = newOccurredAt;
+				updates.sortOrder = await computeNextSortOrder(
+					ctx.db,
+					event.liveCashGameSessionId ?? undefined,
+					event.liveTournamentSessionId ?? undefined,
+					newOccurredAt
+				);
 			}
 			if (input.payload !== undefined) {
 				updates.payload = JSON.stringify(

--- a/packages/api/src/routers/session-table-player.ts
+++ b/packages/api/src/routers/session-table-player.ts
@@ -1,9 +1,6 @@
 import { liveCashGameSession } from "@sapphire2/db/schema/live-cash-game-session";
 import { liveTournamentSession } from "@sapphire2/db/schema/live-tournament-session";
-import {
-	player,
-	playerToPlayerTag,
-} from "@sapphire2/db/schema/player";
+import { player, playerToPlayerTag } from "@sapphire2/db/schema/player";
 import { sessionEvent } from "@sapphire2/db/schema/session-event";
 import { sessionTablePlayer } from "@sapphire2/db/schema/session-table-player";
 import { TRPCError } from "@trpc/server";


### PR DESCRIPTION
## Summary
This PR fixes time validation logic for session events and ensures the sort order is recalculated when an event's timestamp is updated.

## Key Changes

- **Time validation precision**: Updated time validation in both `session-events-scene.tsx` and `stack-editor-time.ts` to compare times at minute-level precision by zeroing out seconds and milliseconds. This prevents validation errors caused by sub-minute time differences.

- **Removed unnecessary time components**: Simplified `applyTimeToDate()` to only set hours and minutes, removing the explicit setting of seconds and milliseconds to 0 (which is now handled in validation).

- **Sort order recalculation**: Modified the session event update endpoint to recalculate and update the `sortOrder` field whenever the `occurredAt` timestamp changes. This ensures events remain properly ordered when their timestamps are modified.

## Implementation Details

- Time validation now creates normalized copies of min/max times with seconds/milliseconds zeroed before comparison
- The sort order computation uses the new `occurredAt` timestamp and respects the event's session context (live cash game or tournament)
- This prevents edge cases where events with the same minute but different seconds could fail validation

https://claude.ai/code/session_01EUoC6PhQZavFjd7HxbWPbX