### PR TITLE
Update CI workflow to target main branch instead of master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary
Updated the GitHub Actions CI workflow configuration to use `main` as the default branch target instead of `master`.

## Changes
- Modified `.github/workflows/ci.yml` to trigger pull request checks against the `main` branch rather than `master`

## Details
This change aligns the CI workflow with the repository's current default branch naming convention. The workflow will now run on pull requests targeting `main`, ensuring continuous integration checks are properly executed on the correct branch.

https://claude.ai/code/session_014Rjqbxd7EoFjkTSa2Yxdwn