### PR TITLE
Fix EV calculation formula for all-in equity with multiple trials

### DIFF
--- a/apps/web/src/live-sessions/components/all-in-bottom-sheet.tsx
+++ b/apps/web/src/live-sessions/components/all-in-bottom-sheet.tsx
@@ -56,8 +56,8 @@ export function AllInBottomSheet({
 
 	const isEditMode = initialValues !== undefined;
 
-	const evAmount = potSize * (equity / 100) * trials;
-	const actual = potSize * wins;
+	const evAmount = potSize * (equity / 100);
+	const actual = (potSize / trials) * wins;
 	const evDiff = evAmount - actual;
 
 	const handleSubmit = (e: React.FormEvent) => {

--- a/packages/api/src/__tests__/live-session-pl.test.ts
+++ b/packages/api/src/__tests__/live-session-pl.test.ts
@@ -144,8 +144,8 @@ describe("computeCashGamePLFromEvents", () => {
 	});
 
 	it("computes evCashOut correctly using allIn equity data", () => {
-		// EV diff = potSize * (equity / 100) * trials - potSize * wins
-		// potSize=400, equity=75, trials=1, wins=0 => 400 * 0.75 * 1 - 400 * 0 = 300
+		// EV diff = potSize * (equity / 100) - (potSize / trials) * wins
+		// potSize=400, equity=75, trials=1, wins=0 => 400 * 0.75 - (400 / 1) * 0 = 300
 		const allIn = { potSize: 400, equity: 75, trials: 1, wins: 0 };
 		const events = [
 			{
@@ -161,6 +161,28 @@ describe("computeCashGamePLFromEvents", () => {
 		expect(result.cashOut).toBe(0);
 		expect(result.profitLoss).toBe(-200);
 		// evCashOut = 0 + 300 = 300
+		expect(result.evCashOut).toBe(300);
+	});
+
+	it("computes evCashOut correctly with multiple trials", () => {
+		// EV diff = potSize * (equity / 100) - (potSize / trials) * wins
+		// potSize=600, equity=50, trials=3, wins=2
+		// => 600 * 0.50 - (600 / 3) * 2 = 300 - 400 = -100
+		const allIn = { potSize: 600, equity: 50, trials: 3, wins: 2 };
+		const events = [
+			{
+				eventType: "chip_add",
+				payload: JSON.stringify({ amount: 500 }),
+			},
+			{
+				eventType: "stack_record",
+				payload: JSON.stringify({ stackAmount: 400, allIns: [allIn] }),
+			},
+		];
+		const result = computeCashGamePLFromEvents(events);
+		expect(result.cashOut).toBe(400);
+		expect(result.profitLoss).toBe(-100);
+		// evCashOut = 400 + (-100) = 300
 		expect(result.evCashOut).toBe(300);
 	});
 

--- a/packages/api/src/services/live-session-pl.ts
+++ b/packages/api/src/services/live-session-pl.ts
@@ -114,8 +114,8 @@ export function computeCashGamePLFromEvents(
 			cashOut = data.stackAmount;
 			for (const allIn of data.allIns) {
 				totalEvDiff +=
-					allIn.potSize * (allIn.equity / 100) * allIn.trials -
-					allIn.potSize * allIn.wins;
+					allIn.potSize * (allIn.equity / 100) -
+					(allIn.potSize / allIn.trials) * allIn.wins;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Corrects the expected value (EV) calculation formula for all-in situations when multiple trials are involved. The previous formula incorrectly scaled the EV by the number of trials, which doesn't align with how equity and wins should be weighted.

## Changes
- **Formula correction**: Changed EV diff calculation from `potSize * (equity / 100) * trials - potSize * wins` to `potSize * (equity / 100) - (potSize / trials) * wins`
  - The equity-based EV is now calculated once (not multiplied by trials)
  - The actual winnings are now normalized per trial by dividing potSize by trials before multiplying by wins
  
- **Updated files**:
  - `packages/api/src/services/live-session-pl.ts`: Core EV calculation logic
  - `apps/web/src/live-sessions/components/all-in-bottom-sheet.tsx`: UI calculation for displaying EV
  - `packages/api/src/__tests__/live-session-pl.test.ts`: Updated existing test comments and added new test case for multiple trials scenario

## Implementation Details
The corrected formula properly handles cases where a player goes all-in multiple times:
- `evAmount = potSize * (equity / 100)` - Expected value based on equity percentage
- `actual = (potSize / trials) * wins` - Actual value normalized across trials
- `evDiff = evAmount - actual` - The difference between expected and actual outcomes

A new test case validates the formula with `potSize=600, equity=50%, trials=3, wins=2`, expecting an EV diff of -100.

https://claude.ai/code/session_011ZxLDyyh1tb1BwjYZk7vXP