### PR TITLE
Prevent event propagation in bottom sheet form submissions

### DIFF
--- a/apps/web/src/live-sessions/components/addon-bottom-sheet.tsx
+++ b/apps/web/src/live-sessions/components/addon-bottom-sheet.tsx
@@ -32,6 +32,7 @@ export function AddonBottomSheet({
 
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
+		e.stopPropagation();
 		onSubmit({ amount });
 	};
 

--- a/apps/web/src/live-sessions/components/all-in-bottom-sheet.tsx
+++ b/apps/web/src/live-sessions/components/all-in-bottom-sheet.tsx
@@ -62,6 +62,7 @@ export function AllInBottomSheet({
 
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
+		e.stopPropagation();
 		onSubmit({ potSize, trials, equity, wins });
 	};
 


### PR DESCRIPTION
## Summary
Added `stopPropagation()` calls to form submission handlers in bottom sheet components to prevent events from bubbling up to parent elements.

## Key Changes
- **AddonBottomSheet**: Added `e.stopPropagation()` in `handleSubmit` handler
- **AllInBottomSheet**: Added `e.stopPropagation()` in `handleSubmit` handler

## Implementation Details
Both components now call `stopPropagation()` immediately after `preventDefault()` in their form submission handlers. This ensures that form submission events are contained within the bottom sheet component and do not propagate to parent elements, preventing potential unintended side effects or event handling conflicts in the component hierarchy.

https://claude.ai/code/session_01JX8ctNPCN3PZcc1WUC87LN