### PR TITLE
Refactor mobile navigation to use resources popover menu

### DIFF
--- a/apps/web/src/__tests__/mobile-nav.test.tsx
+++ b/apps/web/src/__tests__/mobile-nav.test.tsx
@@ -38,6 +38,7 @@ function createTestRouter(initialPath: string) {
 	const routes = [
 		"/",
 		"/dashboard",
+		"/resources",
 		"/stores",
 		"/currencies",
 		"/sessions",
@@ -70,15 +71,15 @@ describe("MobileNav - Normal Mode (no active session)", () => {
 		});
 	});
 
-	it("renders 4 nav links and 1 center button", async () => {
+	it("renders 3 nav links, 1 resources popover button, and 1 center button", async () => {
 		const router = createTestRouter("/sessions");
 		render(<RouterProvider router={router} />);
 
 		const links = await screen.findAllByRole("link");
-		expect(links).toHaveLength(4);
+		expect(links).toHaveLength(3);
 
-		const centerButton = screen.getByRole("button");
-		expect(centerButton).toBeInTheDocument();
+		const buttons = screen.getAllByRole("button");
+		expect(buttons).toHaveLength(2);
 	});
 
 	it("displays normal mode labels", async () => {
@@ -86,8 +87,8 @@ describe("MobileNav - Normal Mode (no active session)", () => {
 		render(<RouterProvider router={router} />);
 
 		await screen.findByText("Sessions");
-		expect(screen.getByText("Stores")).toBeInTheDocument();
-		expect(screen.getByText("Players")).toBeInTheDocument();
+		expect(screen.getByText("Dashboard")).toBeInTheDocument();
+		expect(screen.getByText("Resources")).toBeInTheDocument();
 		expect(screen.getByText("Settings")).toBeInTheDocument();
 		expect(screen.getByText("New")).toBeInTheDocument();
 	});
@@ -106,9 +107,9 @@ describe("MobileNav - Normal Mode (no active session)", () => {
 		render(<RouterProvider router={router} />);
 
 		await screen.findByText("Sessions");
-		const storesLink = screen.getByText("Stores");
-		const anchor = storesLink.closest("a");
-		expect(anchor?.className).toContain("text-sidebar-foreground");
+		const resourcesButton = screen.getByText("Resources");
+		const button = resourcesButton.closest("button");
+		expect(button?.className).toContain("text-sidebar-foreground");
 	});
 });
 

--- a/apps/web/src/shared/components/__tests__/sidebar-nav.test.tsx
+++ b/apps/web/src/shared/components/__tests__/sidebar-nav.test.tsx
@@ -23,7 +23,14 @@ function createTestRouter(initialPath: string) {
 		component: () => <SidebarNav />,
 	});
 
-	const routes = ["/sessions", "/stores", "/players", "/settings"].map((path) =>
+	const routes = [
+		"/dashboard",
+		"/sessions",
+		"/stores",
+		"/players",
+		"/currencies",
+		"/settings",
+	].map((path) =>
 		createRoute({
 			component: () => <div>{path}</div>,
 			getParentRoute: () => rootRoute,
@@ -43,8 +50,10 @@ describe("SidebarNav", () => {
 		render(<RouterProvider router={router} />);
 
 		expect(await screen.findByText("Sessions")).toBeInTheDocument();
+		expect(screen.getByText("Dashboard")).toBeInTheDocument();
 		expect(screen.getByText("Stores")).toBeInTheDocument();
 		expect(screen.getByText("Players")).toBeInTheDocument();
+		expect(screen.getByText("Currencies")).toBeInTheDocument();
 		expect(screen.getByText("Settings")).toBeInTheDocument();
 		expect(screen.getByText("User Menu")).toBeInTheDocument();
 		expect(screen.getByText("Mode Toggle")).toBeInTheDocument();

--- a/apps/web/src/shared/components/app-navigation.tsx
+++ b/apps/web/src/shared/components/app-navigation.tsx
@@ -2,6 +2,8 @@ import {
 	type IconBolt,
 	IconBuildingStore,
 	IconCards,
+	IconCategory,
+	IconCoins,
 	IconLayoutDashboard,
 	IconList,
 	type IconPlus,
@@ -17,6 +19,7 @@ export interface NavigationItem {
 	exact?: boolean;
 	icon: ComponentType<{ size?: number; stroke?: number; className?: string }>;
 	label: string;
+	matchPaths?: string[];
 	to: string;
 }
 
@@ -27,20 +30,35 @@ export interface NavigationCenterAction {
 	tone: "accent" | "live";
 }
 
+export const RESOURCE_ITEMS: readonly NavigationItem[] = [
+	{ to: "/stores", label: "Stores", icon: IconBuildingStore },
+	{ to: "/players", label: "Players", icon: IconUsers },
+	{ to: "/currencies", label: "Currencies", icon: IconCoins },
+] as const;
+
 export const SIDEBAR_ITEMS: readonly NavigationItem[] = [
+	{ to: "/dashboard", label: "Dashboard", icon: IconLayoutDashboard },
 	{ to: "/sessions", label: "Sessions", icon: IconCards },
 	{ to: "/stores", label: "Stores", icon: IconBuildingStore },
 	{ to: "/players", label: "Players", icon: IconUsers },
+	{ to: "/currencies", label: "Currencies", icon: IconCoins },
 	{ to: "/settings", label: "Settings", icon: IconSettings },
 ] as const;
 
 const NORMAL_LEFT_ITEMS: readonly NavigationItem[] = [
+	{ to: "/dashboard", label: "Dashboard", icon: IconLayoutDashboard },
 	{ to: "/sessions", label: "Sessions", icon: IconCards },
-	{ to: "/stores", label: "Stores", icon: IconBuildingStore },
 ] as const;
 
+const RESOURCES_NAV_ITEM: NavigationItem = {
+	to: "/resources",
+	label: "Resources",
+	icon: IconCategory,
+	matchPaths: ["/stores", "/players", "/currencies"],
+};
+
 const NORMAL_RIGHT_ITEMS: readonly NavigationItem[] = [
-	{ to: "/players", label: "Players", icon: IconUsers },
+	RESOURCES_NAV_ITEM,
 	{ to: "/settings", label: "Settings", icon: IconSettings },
 ] as const;
 
@@ -73,6 +91,19 @@ export function isActive(
 		return currentPath === itemPath;
 	}
 	return currentPath === itemPath || currentPath.startsWith(`${itemPath}/`);
+}
+
+export function isActiveItem(
+	currentPath: string,
+	item: NavigationItem
+): boolean {
+	if (isActive(currentPath, item.to, item.exact)) {
+		return true;
+	}
+	if (item.matchPaths) {
+		return item.matchPaths.some((p) => isActive(currentPath, p));
+	}
+	return false;
 }
 
 export function getMobileNavigationItems(hasActive: boolean): {

--- a/apps/web/src/shared/components/mobile-nav.tsx
+++ b/apps/web/src/shared/components/mobile-nav.tsx
@@ -1,15 +1,72 @@
 import { IconBolt, IconPlus } from "@tabler/icons-react";
-import { useRouterState } from "@tanstack/react-router";
+import { Link, useRouterState } from "@tanstack/react-router";
 import { useState } from "react";
+import { cn } from "@/lib/utils";
 import { CreateSessionDialog } from "@/live-sessions/components/create-session-dialog";
 import { useActiveSession } from "@/live-sessions/hooks/use-active-session";
 import { useStackSheet } from "@/live-sessions/hooks/use-stack-sheet";
 import {
 	getMobileNavigationItems,
-	isActive,
+	isActiveItem,
 	MobileNavItem,
 	NavigationCenterButton,
+	type NavigationItem,
+	RESOURCE_ITEMS,
 } from "@/shared/components/app-navigation";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/shared/components/ui/popover";
+
+function MobileNavPopoverItem({
+	active,
+	item,
+	children,
+}: {
+	active: boolean;
+	item: NavigationItem;
+	children: readonly NavigationItem[];
+}) {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<li className="flex-1">
+			<Popover onOpenChange={setOpen} open={open}>
+				<PopoverTrigger asChild>
+					<button
+						className={cn(
+							"flex w-full flex-col items-center gap-0.5 py-1.5 text-xs transition-colors",
+							active
+								? "font-semibold text-sidebar-primary"
+								: "text-sidebar-foreground/60"
+						)}
+						type="button"
+					>
+						<item.icon size={22} stroke={active ? 2.5 : 1.5} />
+						<span>{item.label}</span>
+					</button>
+				</PopoverTrigger>
+				<PopoverContent className="w-48 p-1" side="top" sideOffset={12}>
+					<ul className="flex flex-col gap-0.5">
+						{children.map((child) => (
+							<li key={child.to}>
+								<Link
+									className="flex items-center gap-3 rounded-md px-3 py-2.5 text-sm transition-colors hover:bg-accent"
+									onClick={() => setOpen(false)}
+									to={child.to}
+								>
+									<child.icon size={18} stroke={1.5} />
+									<span>{child.label}</span>
+								</Link>
+							</li>
+						))}
+					</ul>
+				</PopoverContent>
+			</Popover>
+		</li>
+	);
+}
 
 export function MobileNav() {
 	const pathname = useRouterState({
@@ -39,7 +96,7 @@ export function MobileNav() {
 				<ul className="grid h-16 grid-cols-5 items-center">
 					{leftItems.map((item) => (
 						<MobileNavItem
-							active={isActive(pathname, item.to, item.exact)}
+							active={isActiveItem(pathname, item)}
 							item={item}
 							key={item.to}
 						/>
@@ -49,13 +106,23 @@ export function MobileNav() {
 						<NavigationCenterButton action={centerAction} />
 					</li>
 
-					{rightItems.map((item) => (
-						<MobileNavItem
-							active={isActive(pathname, item.to, item.exact)}
-							item={item}
-							key={item.to}
-						/>
-					))}
+					{rightItems.map((item) =>
+						item.matchPaths ? (
+							<MobileNavPopoverItem
+								active={isActiveItem(pathname, item)}
+								item={item}
+								key={item.to}
+							>
+								{RESOURCE_ITEMS}
+							</MobileNavPopoverItem>
+						) : (
+							<MobileNavItem
+								active={isActiveItem(pathname, item)}
+								item={item}
+								key={item.to}
+							/>
+						)
+					)}
 				</ul>
 			</nav>
 

--- a/apps/web/src/shared/components/sidebar-nav.tsx
+++ b/apps/web/src/shared/components/sidebar-nav.tsx
@@ -1,6 +1,6 @@
 import { useRouterState } from "@tanstack/react-router";
 import {
-	isActive,
+	isActiveItem,
 	SIDEBAR_ITEMS,
 	SidebarNavItem,
 } from "@/shared/components/app-navigation";
@@ -17,7 +17,7 @@ export function SidebarNav() {
 			<div className="flex-1 overflow-y-auto px-3 py-4">
 				<ul className="flex flex-col gap-1">
 					{SIDEBAR_ITEMS.map((item) => {
-						const active = isActive(pathname, item.to);
+						const active = isActiveItem(pathname, item);
 						return <SidebarNavItem active={active} item={item} key={item.to} />;
 					})}
 				</ul>


### PR DESCRIPTION
## Summary
Restructured the mobile navigation to consolidate resource-related links (Stores, Players, Currencies) into a collapsible popover menu under a new "Resources" navigation item, improving mobile UX by reducing navigation clutter.

## Key Changes
- **New MobileNavPopoverItem component**: Created a reusable popover-based navigation item that displays child navigation items in a dropdown menu triggered from the mobile nav bar
- **Navigation restructuring**: 
  - Moved Stores, Players, and Currencies into a new `RESOURCE_ITEMS` constant
  - Created a `RESOURCES_NAV_ITEM` that groups these items with `matchPaths` configuration
  - Updated `NORMAL_RIGHT_ITEMS` to use the Resources popover instead of individual Players link
  - Added Dashboard to left navigation items
- **Enhanced NavigationItem interface**: Added optional `matchPaths` property to support items that should be marked active when any of their child paths are visited
- **New `isActiveItem` function**: Refactored active state detection to handle both direct route matching and `matchPaths` matching, replacing direct `isActive` calls throughout
- **Updated imports**: Added Popover components and Link from react-router for the new popover functionality
- **Test updates**: Updated mobile nav and sidebar nav tests to reflect the new navigation structure and verify popover functionality

## Implementation Details
- The popover closes automatically when a child link is clicked via `onClick={() => setOpen(false)}`
- Active state styling applies to the Resources button when any of its child paths (/stores, /players, /currencies) are active
- Sidebar navigation continues to display all items individually while mobile nav consolidates them
- The `matchPaths` property enables flexible active state detection without duplicating route logic

https://claude.ai/code/session_012Upa22vyESLwop4zw4iEiH