### PR TITLE
Refactor AddPlayerSheet to remove tabs and simplify player creation

### DIFF
--- a/apps/web/src/live-sessions/components/__tests__/add-player-sheet.test.tsx
+++ b/apps/web/src/live-sessions/components/__tests__/add-player-sheet.test.tsx
@@ -6,13 +6,19 @@ import { AddPlayerSheet } from "../add-player-sheet";
 
 const ALICE_NAME_PATTERN = /alice/i;
 const BOB_NAME_PATTERN = /bob/i;
-const NAME_LABEL_PATTERN = /name/i;
+const CREATE_NEW_HERO_PATTERN = /create "new hero"/i;
 
 const mocks = vi.hoisted(() => ({
-	players: [] as Array<{ id: string; memo: string | null; name: string }>,
+	players: [] as Array<{
+		id: string;
+		memo: string | null;
+		name: string;
+		tags: Array<{ color: string; id: string; name: string }>;
+	}>,
 }));
 
 vi.mock("@tanstack/react-query", () => ({
+	keepPreviousData: (prev: unknown) => prev,
 	useQuery: () => ({
 		data: mocks.players,
 	}),
@@ -46,33 +52,33 @@ vi.mock("@/utils/trpc", () => ({
 	},
 }));
 
-vi.mock("@/shared/components/ui/rich-text-editor", () => ({
-	RichTextEditor: ({
-		onChange,
-	}: {
-		initialContent?: string | null;
-		onChange: (html: string) => void;
-	}) => (
-		<textarea aria-label="Memo" onChange={(e) => onChange(e.target.value)} />
-	),
-}));
-
 vi.mock("@/players/components/player-tag-input", () => ({
 	PlayerTagInput: () => null,
 }));
 
+vi.mock("@/players/components/player-avatar", () => ({
+	PlayerAvatar: ({ name }: { name: string }) => (
+		<div data-testid="player-avatar">{name.slice(0, 2).toUpperCase()}</div>
+	),
+}));
+
+vi.mock("@/players/components/color-badge", () => ({
+	ColorBadge: ({ children }: { children: React.ReactNode; color: string }) => (
+		<span>{children}</span>
+	),
+}));
+
 describe("AddPlayerSheet", () => {
-	it("filters existing players by search text", async () => {
-		const user = userEvent.setup();
+	it("excludes already-seated players from the list", () => {
 		mocks.players = [
-			{ id: "p1", memo: "Aggro", name: "Alice" },
-			{ id: "p2", memo: "Tight", name: "Bob" },
+			{ id: "p1", memo: "Aggro", name: "Alice", tags: [] },
+			{ id: "p2", memo: "Tight", name: "Bob", tags: [] },
 		];
 
 		render(
 			<AddPlayerSheet
 				availableTags={[]}
-				excludePlayerIds={[]}
+				excludePlayerIds={["p1"]}
 				onAddExisting={vi.fn()}
 				onAddNew={vi.fn()}
 				onCreateTag={vi.fn()}
@@ -80,8 +86,6 @@ describe("AddPlayerSheet", () => {
 				open
 			/>
 		);
-
-		await user.type(screen.getByLabelText("Search players"), "bo");
 
 		expect(
 			screen.queryByRole("button", { name: ALICE_NAME_PATTERN })
@@ -92,7 +96,7 @@ describe("AddPlayerSheet", () => {
 	});
 
 	it("shows the empty state when no selectable players remain", () => {
-		mocks.players = [{ id: "p1", memo: null, name: "Alice" }];
+		mocks.players = [{ id: "p1", memo: null, name: "Alice", tags: [] }];
 
 		render(
 			<AddPlayerSheet
@@ -113,7 +117,7 @@ describe("AddPlayerSheet", () => {
 		const user = userEvent.setup();
 		const onAddExisting = vi.fn();
 		const onOpenChange = vi.fn();
-		mocks.players = [{ id: "p1", memo: "Aggro", name: "Alice" }];
+		mocks.players = [{ id: "p1", memo: "Aggro", name: "Alice", tags: [] }];
 
 		render(
 			<AddPlayerSheet
@@ -133,7 +137,7 @@ describe("AddPlayerSheet", () => {
 		expect(onOpenChange).toHaveBeenCalledWith(false);
 	});
 
-	it("submits a new player with memo text", async () => {
+	it("creates a new player via the create option", async () => {
 		const user = userEvent.setup();
 		const onAddNew = vi.fn();
 		const onOpenChange = vi.fn();
@@ -151,16 +155,44 @@ describe("AddPlayerSheet", () => {
 			/>
 		);
 
-		await user.click(screen.getByRole("tab", { name: "New Player" }));
-		await user.type(screen.getByLabelText(NAME_LABEL_PATTERN), "New Hero");
-		await user.type(screen.getByLabelText("Memo"), "Late reg");
-		await user.click(screen.getByRole("button", { name: "Save" }));
+		await user.type(screen.getByLabelText("Search players"), "New Hero");
+		await user.click(
+			screen.getByRole("button", { name: CREATE_NEW_HERO_PATTERN })
+		);
 
 		expect(onAddNew).toHaveBeenCalledWith({
-			memo: "Late reg",
 			name: "New Hero",
 			tagIds: undefined,
 		});
 		expect(onOpenChange).toHaveBeenCalledWith(false);
+	});
+
+	it("displays tags on player items", () => {
+		mocks.players = [
+			{
+				id: "p1",
+				memo: null,
+				name: "Alice",
+				tags: [
+					{ color: "red", id: "t1", name: "Regular" },
+					{ color: "blue", id: "t2", name: "Aggressive" },
+				],
+			},
+		];
+
+		render(
+			<AddPlayerSheet
+				availableTags={[]}
+				excludePlayerIds={[]}
+				onAddExisting={vi.fn()}
+				onAddNew={vi.fn()}
+				onCreateTag={vi.fn()}
+				onOpenChange={vi.fn()}
+				open
+			/>
+		);
+
+		expect(screen.getByText("Regular")).toBeInTheDocument();
+		expect(screen.getByText("Aggressive")).toBeInTheDocument();
 	});
 });

--- a/apps/web/src/live-sessions/components/add-player-sheet.tsx
+++ b/apps/web/src/live-sessions/components/add-player-sheet.tsx
@@ -1,13 +1,13 @@
 import { IconPlus, IconSearch } from "@tabler/icons-react";
-import { useQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
-import type { PlayerFormValues } from "@/players/components/player-form";
-import { PlayerForm } from "@/players/components/player-form";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useDeferredValue, useEffect, useState } from "react";
+import { ColorBadge } from "@/players/components/color-badge";
+import { PlayerAvatar } from "@/players/components/player-avatar";
+import { PlayerTagInput } from "@/players/components/player-tag-input";
 import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { Input } from "@/shared/components/ui/input";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
-import { Tabs, TabsList, TabsTrigger } from "@/shared/components/ui/tabs";
 import { trpc } from "@/utils/trpc";
 
 interface TagWithColor {
@@ -39,40 +39,46 @@ export function AddPlayerSheet({
 	onOpenChange,
 	open,
 }: AddPlayerSheetProps) {
-	const [tab, setTab] = useState<"existing" | "new">("existing");
 	const [search, setSearch] = useState("");
+	const [selectedTags, setSelectedTags] = useState<TagWithColor[]>([]);
 
 	useEffect(() => {
 		if (open) {
-			setTab("existing");
 			setSearch("");
+			setSelectedTags([]);
 		}
 	}, [open]);
 
+	const deferredSearch = useDeferredValue(search);
+	const selectedTagIds = selectedTags.map((t) => t.id);
+	const queryInput = {
+		...(deferredSearch ? { search: deferredSearch } : {}),
+		...(selectedTagIds.length > 0 ? { tagIds: selectedTagIds } : {}),
+	};
+
 	const playersQuery = useQuery({
-		...trpc.player.list.queryOptions({}),
+		...trpc.player.list.queryOptions(queryInput),
 		enabled: open,
+		placeholderData: keepPreviousData,
 	});
 
 	const allPlayers = playersQuery.data ?? [];
 	const excludeSet = new Set(excludePlayerIds);
-	const availablePlayers = allPlayers.filter((p) => !excludeSet.has(p.id));
-	const filteredPlayers = search
-		? availablePlayers.filter((p) =>
-				p.name.toLowerCase().includes(search.toLowerCase())
-			)
-		: availablePlayers;
+	const filteredPlayers = allPlayers.filter((p) => !excludeSet.has(p.id));
 
 	const handleAddExisting = (playerId: string, playerName: string) => {
 		onAddExisting(playerId, playerName);
 		onOpenChange(false);
 	};
 
-	const handleAddNew = (values: PlayerFormValues) => {
+	const handleCreateNew = () => {
+		const trimmed = search.trim();
+		if (!trimmed) {
+			return;
+		}
 		onAddNew({
-			memo: values.memo,
-			name: values.name,
-			tagIds: values.tagIds,
+			name: trimmed,
+			tagIds: selectedTagIds.length > 0 ? selectedTagIds : undefined,
 		});
 		onOpenChange(false);
 	};
@@ -85,89 +91,86 @@ export function AddPlayerSheet({
 			title="Add Player"
 		>
 			<div className="flex flex-col gap-3">
-				<Tabs
-					onValueChange={(value) => setTab(value as "existing" | "new")}
-					value={tab}
-				>
-					<TabsList className="grid w-full grid-cols-2">
-						<TabsTrigger value="existing">Existing</TabsTrigger>
-						<TabsTrigger value="new">New Player</TabsTrigger>
-					</TabsList>
-				</Tabs>
-
-				{tab === "existing" && (
-					<div className="flex flex-col gap-2">
-						<div className="relative">
-							<IconSearch
-								className="absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground"
-								size={16}
-							/>
-							<Input
-								aria-label="Search players"
-								className="pl-9"
-								id="add-player-search"
-								onChange={(e) => setSearch(e.target.value)}
-								placeholder="Search players..."
-								value={search}
-							/>
-						</div>
-
-						<div className="max-h-[40vh] overflow-y-auto">
-							{filteredPlayers.length === 0 && (
-								<EmptyState
-									className="border-none bg-transparent px-0 py-4"
-									description={search ? "Try a different name." : undefined}
-									heading={
-										search ? "No matching players" : "No available players"
-									}
-								/>
-							)}
-							{filteredPlayers.map((p) => (
-								<Button
-									className="h-auto w-full justify-start gap-3 rounded-lg px-3 py-2.5 text-left"
-									key={p.id}
-									onClick={() => handleAddExisting(p.id, p.name)}
-									type="button"
-									variant="ghost"
-								>
-									<div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 font-bold text-primary text-xs">
-										{p.name.slice(0, 2).toUpperCase()}
-									</div>
-									<div className="min-w-0 flex-1">
-										<p className="truncate font-medium text-sm">{p.name}</p>
-										{p.memo && (
-											<p className="truncate text-muted-foreground text-xs">
-												{p.memo}
-											</p>
-										)}
-									</div>
-									<IconPlus
-										className="shrink-0 text-muted-foreground"
-										size={16}
-									/>
-								</Button>
-							))}
-						</div>
-					</div>
-				)}
-
-				{tab === "new" && (
-					<PlayerForm
-						availableTags={availableTags}
-						key={String(open)}
-						leadingActions={
-							<Button
-								onClick={() => onOpenChange(false)}
-								type="button"
-								variant="outline"
-							>
-								Cancel
-							</Button>
-						}
-						onCreateTag={onCreateTag}
-						onSubmit={handleAddNew}
+				<div className="relative">
+					<IconSearch
+						className="absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground"
+						size={16}
 					/>
-				)}
+					<Input
+						aria-label="Search players"
+						className="pl-9"
+						id="add-player-search"
+						onChange={(e) => setSearch(e.target.value)}
+						placeholder="Search players..."
+						value={search}
+					/>
+				</div>
+
+				<PlayerTagInput
+					availableTags={availableTags}
+					onAdd={(tag) => setSelectedTags((prev) => [...prev, tag])}
+					onCreateTag={onCreateTag}
+					onRemove={(tag) =>
+						setSelectedTags((prev) => prev.filter((t) => t.id !== tag.id))
+					}
+					placeholder="Filter by tags..."
+					selectedTags={selectedTags}
+				/>
+
+				<div className="max-h-[40vh] overflow-y-auto">
+					{search.trim() && (
+						<Button
+							className="h-auto w-full justify-start gap-3 rounded-lg px-3 py-2.5 text-left"
+							onClick={handleCreateNew}
+							type="button"
+							variant="ghost"
+						>
+							<div className="flex size-9 shrink-0 items-center justify-center rounded-full border-2 border-muted-foreground/30 border-dashed text-muted-foreground">
+								<IconPlus size={16} />
+							</div>
+							<p className="font-medium text-sm">
+								Create &quot;{search.trim()}&quot;
+							</p>
+						</Button>
+					)}
+					{filteredPlayers.map((p) => (
+						<Button
+							className="h-auto w-full justify-start gap-3 rounded-lg px-3 py-2.5 text-left"
+							key={p.id}
+							onClick={() => handleAddExisting(p.id, p.name)}
+							type="button"
+							variant="ghost"
+						>
+							<PlayerAvatar className="shrink-0" name={p.name} />
+							<div className="min-w-0 flex-1">
+								<p className="truncate font-medium text-sm">{p.name}</p>
+								{p.tags.length > 0 && (
+									<div className="mt-0.5 flex flex-wrap gap-1">
+										{p.tags.map((tag) => (
+											<ColorBadge color={tag.color} key={tag.id}>
+												{tag.name}
+											</ColorBadge>
+										))}
+									</div>
+								)}
+								{p.memo && (
+									<p className="truncate text-muted-foreground text-xs">
+										{p.memo}
+									</p>
+								)}
+							</div>
+							<IconPlus className="shrink-0 text-muted-foreground" size={16} />
+						</Button>
+					))}
+					{filteredPlayers.length === 0 &&
+						!search.trim() &&
+						selectedTagIds.length === 0 && (
+							<EmptyState
+								className="border-none bg-transparent px-0 py-4"
+								heading="No available players"
+							/>
+						)}
+				</div>
 			</div>
 		</ResponsiveDialog>
 	);

--- a/apps/web/src/live-sessions/components/poker-table.tsx
+++ b/apps/web/src/live-sessions/components/poker-table.tsx
@@ -1,10 +1,8 @@
 import { IconPlus, IconUser } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
+import { PlayerAvatar } from "@/players/components/player-avatar";
 
 const MAX_SEATS = 9;
-
-/** Uniform color for non-hero player avatars. */
-const PLAYER_COLOR = "bg-slate-500";
 
 /**
  * Seat positions around a stadium-shaped (racetrack) poker table (0-8).
@@ -110,18 +108,7 @@ function SeatSlot({
 			)}
 
 			{/* Occupied seat */}
-			{isOccupied && (
-				<div
-					className={cn(
-						"flex size-9 items-center justify-center rounded-full border-2 font-bold text-[11px] text-white shadow-md",
-						isHero
-							? "border-amber-400 bg-amber-500/80"
-							: `border-white/30 ${PLAYER_COLOR}`
-					)}
-				>
-					{player.player.name.slice(0, 2).toUpperCase()}
-				</div>
-			)}
+			{isOccupied && <PlayerAvatar isHero={isHero} name={player.player.name} />}
 
 			{/* Name label */}
 			<span

--- a/apps/web/src/players/components/player-avatar.tsx
+++ b/apps/web/src/players/components/player-avatar.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+
+interface PlayerAvatarProps {
+	className?: string;
+	isHero?: boolean;
+	name: string;
+}
+
+export function PlayerAvatar({
+	className,
+	isHero = false,
+	name,
+}: PlayerAvatarProps) {
+	return (
+		<div
+			className={cn(
+				"flex size-9 items-center justify-center rounded-full border-2 font-bold text-[11px] text-white shadow-md",
+				isHero
+					? "border-amber-400 bg-amber-500/80"
+					: "border-white/30 bg-slate-500",
+				className
+			)}
+		>
+			{name.slice(0, 2).toUpperCase()}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
Refactored the AddPlayerSheet component to remove the tab-based UI for switching between existing and new player modes. The component now displays both existing players and a create-new option in a unified interface, with improved search and filtering capabilities.

## Key Changes
- **Removed tab navigation**: Eliminated the "Existing" / "New Player" tabs, consolidating both modes into a single view
- **Simplified player creation**: Replaced the full PlayerForm with an inline "Create" button that appears when search text is entered
- **Enhanced search and filtering**: 
  - Integrated `useDeferredValue` for debounced search input
  - Added tag-based filtering via the new `PlayerTagInput` component
  - Moved search logic to the query layer using `trpc.player.list` with search and tagIds parameters
- **Extracted PlayerAvatar component**: Created a reusable `PlayerAvatar` component to standardize player avatar rendering across the app
- **Improved player display**: 
  - Now displays player tags using the `ColorBadge` component
  - Uses the new `PlayerAvatar` component for consistent styling
  - Removed memo field from new player creation (simplified to name + tags only)
- **Updated poker-table.tsx**: Refactored to use the new `PlayerAvatar` component, removing inline avatar styling

## Implementation Details
- The create button only appears when search text is non-empty and trimmed
- Tag filtering is applied at the query level with `keepPreviousData` for better UX during searches
- Empty state now only shows when no filters are applied and no players are available
- Test suite updated to reflect the new unified UI and removed tab-based interactions

https://claude.ai/code/session_01BXTmXS7aZHEvsEXtPbtPeJ