### PR TITLE
fix: restore seated player state from event history (#132)

### DIFF
--- a/packages/api/src/routers/session-table-player.ts
+++ b/packages/api/src/routers/session-table-player.ts
@@ -1,3 +1,7 @@
+import {
+	playerJoinPayload,
+	playerLeavePayload,
+} from "@sapphire2/db/constants/session-event-types";
 import { liveCashGameSession } from "@sapphire2/db/schema/live-cash-game-session";
 import { liveTournamentSession } from "@sapphire2/db/schema/live-tournament-session";
 import { player, playerToPlayerTag } from "@sapphire2/db/schema/player";
@@ -142,6 +146,70 @@ async function insertPlayerLeaveEvent(
 	});
 }
 
+interface RecoveredSeatState {
+	isActive: boolean;
+	lastJoinedAt: Date | null;
+	lastLeftAt: Date | null;
+}
+
+async function recoverSeatStateFromEvents(
+	db: DbInstance,
+	liveCashGameSessionId: string | undefined,
+	liveTournamentSessionId: string | undefined
+) {
+	const sessionCond = liveCashGameSessionId
+		? eq(sessionEvent.liveCashGameSessionId, liveCashGameSessionId)
+		: eq(
+				sessionEvent.liveTournamentSessionId,
+				liveTournamentSessionId as string
+			);
+
+	const events = await db
+		.select({
+			eventType: sessionEvent.eventType,
+			payload: sessionEvent.payload,
+			occurredAt: sessionEvent.occurredAt,
+			sortOrder: sessionEvent.sortOrder,
+		})
+		.from(sessionEvent)
+		.where(sessionCond)
+		.orderBy(asc(sessionEvent.occurredAt), asc(sessionEvent.sortOrder));
+
+	const stateByPlayerId = new Map<string, RecoveredSeatState>();
+
+	for (const event of events) {
+		if (event.eventType === "player_join") {
+			const parsed = playerJoinPayload.safeParse(JSON.parse(event.payload));
+			const playerId = parsed.success ? parsed.data.playerId : undefined;
+			if (!playerId) {
+				continue;
+			}
+			stateByPlayerId.set(playerId, {
+				isActive: true,
+				lastJoinedAt: event.occurredAt,
+				lastLeftAt: null,
+			});
+			continue;
+		}
+
+		if (event.eventType === "player_leave") {
+			const parsed = playerLeavePayload.safeParse(JSON.parse(event.payload));
+			const playerId = parsed.success ? parsed.data.playerId : undefined;
+			if (!playerId) {
+				continue;
+			}
+			const current = stateByPlayerId.get(playerId);
+			stateByPlayerId.set(playerId, {
+				isActive: false,
+				lastJoinedAt: current?.lastJoinedAt ?? null,
+				lastLeftAt: event.occurredAt,
+			});
+		}
+	}
+
+	return stateByPlayerId;
+}
+
 export const sessionTablePlayerRouter = router({
 	list: protectedProcedure
 		.input(
@@ -174,10 +242,6 @@ export const sessionTablePlayerRouter = router({
 						liveTournamentSessionId as string
 					);
 
-			const conditions = activeOnly
-				? and(sessionCond, eq(sessionTablePlayer.isActive, 1))
-				: sessionCond;
-
 			const rows = await ctx.db
 				.select({
 					id: sessionTablePlayer.id,
@@ -191,22 +255,35 @@ export const sessionTablePlayerRouter = router({
 				})
 				.from(sessionTablePlayer)
 				.innerJoin(player, eq(player.id, sessionTablePlayer.playerId))
-				.where(conditions)
+				.where(sessionCond)
 				.orderBy(asc(sessionTablePlayer.joinedAt));
 
-			return {
-				items: rows.map((row) => ({
+			const recoveredSeatState = await recoverSeatStateFromEvents(
+				ctx.db,
+				liveCashGameSessionId,
+				liveTournamentSessionId
+			);
+
+			const items = rows.map((row) => {
+				const recovered = recoveredSeatState.get(row.playerId);
+				const isActive = recovered?.isActive ?? row.isActive === 1;
+
+				return {
 					id: row.id,
 					player: {
 						id: row.playerId,
 						name: row.playerName,
 						memo: row.playerMemo,
 					},
-					isActive: row.isActive === 1,
-					joinedAt: row.joinedAt,
-					leftAt: row.leftAt ?? null,
+					isActive,
+					joinedAt: recovered?.lastJoinedAt ?? row.joinedAt,
+					leftAt: recovered?.lastLeftAt ?? row.leftAt ?? null,
 					seatPosition: row.seatPosition ?? null,
-				})),
+				};
+			});
+
+			return {
+				items: activeOnly ? items.filter((item) => item.isActive) : items,
 			};
 		}),
 
@@ -260,7 +337,15 @@ export const sessionTablePlayerRouter = router({
 				.from(sessionTablePlayer)
 				.where(and(sessionCond, eq(sessionTablePlayer.playerId, playerId)));
 
-			if (existing?.isActive === 1) {
+			const recoveredSeatState = await recoverSeatStateFromEvents(
+				ctx.db,
+				liveCashGameSessionId,
+				liveTournamentSessionId
+			);
+			const isActiveByEvent =
+				recoveredSeatState.get(playerId)?.isActive ?? false;
+
+			if (isActiveByEvent) {
 				throw new TRPCError({
 					code: "BAD_REQUEST",
 					message: "Player is already active in this session",
@@ -471,7 +556,15 @@ export const sessionTablePlayerRouter = router({
 					message: "Player not found in session",
 				});
 			}
-			if (existing.isActive === 0) {
+			const recoveredSeatState = await recoverSeatStateFromEvents(
+				ctx.db,
+				liveCashGameSessionId,
+				liveTournamentSessionId
+			);
+			const isActiveByEvent =
+				recoveredSeatState.get(playerId)?.isActive ?? false;
+
+			if (!isActiveByEvent) {
 				throw new TRPCError({
 					code: "BAD_REQUEST",
 					message: "Player is not active in this session",


### PR DESCRIPTION
### Motivation
- Ensure seated player state is reconstructed deterministically from ordered `player_join` / `player_leave` events to avoid divergence with the `session_table_player.isActive` column.
- Fix incorrect behavior when the middle-table active flag is stale by basing active/seat state on event history.
- Support the requirement in Issue #132 to treat event history as the source of truth for seated players.

### Description
- Added `recoverSeatStateFromEvents` which scans ordered `session_event` rows and derives per-player `isActive`, `lastJoinedAt`, and `lastLeftAt` values using `player_join`/`player_leave` payload parsing with `playerJoinPayload`/`playerLeavePayload`.
- Imported payload validators from `@sapphire2/db/constants/session-event-types` and ignored join/leave events without `playerId` (e.g. hero-only events) when reconstructing state.
- Updated `sessionTablePlayer.list` to merge recovered state into returned items and apply the `activeOnly` filter based on the recovered `isActive` instead of the DB `isActive` flag.
- Updated `sessionTablePlayer.add` and `sessionTablePlayer.remove` validations to use the recovered event-derived state to decide whether a player is already active or not before proceeding.

### Testing
- Ran formatter/lint autofix for the modified file with `bun x ultracite fix packages/api/src/routers/session-table-player.ts` and verified `bun x ultracite check packages/api/src/routers/session-table-player.ts` completed successfully.
- Executed the full test suite via the pre-commit hook (`vitest run`) which reported all tests passing: `78 files / 461 tests passed`.
- Attempted global type check with `bun run check-types` which failed due to an unrelated frontend type error in `apps/web/src/shared/components/mobile-nav.tsx` and is not caused by these changes.
- Performed local TypeScript and formatting checks for the modified file and confirmed no remaining issues for this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc8342714832dbc692d2a42c1f7a1)