### PR TITLE
Fix live session event cache invalidation and complete session event redesign

### DIFF
--- a/apps/web/src/__tests__/mobile-nav.test.tsx
+++ b/apps/web/src/__tests__/mobile-nav.test.tsx
@@ -32,6 +32,46 @@ vi.mock("@/live-sessions/hooks/use-stack-sheet", () => ({
 
 // Mock trpc to avoid env validation
 vi.mock("@/utils/trpc", () => ({
+	trpc: {
+		liveCashGameSession: {
+			getById: {
+				queryOptions: ({ id }: { id: string }) => ({
+					queryKey: ["cash-session", id],
+				}),
+			},
+			list: {
+				queryOptions: (input: Record<string, unknown>) => ({
+					queryKey: ["cash-session-list", input],
+				}),
+			},
+		},
+		liveTournamentSession: {
+			getById: {
+				queryOptions: ({ id }: { id: string }) => ({
+					queryKey: ["tournament-session", id],
+				}),
+			},
+			list: {
+				queryOptions: (input: Record<string, unknown>) => ({
+					queryKey: ["tournament-session-list", input],
+				}),
+			},
+		},
+		sessionEvent: {
+			list: {
+				queryOptions: (input: Record<string, unknown>) => ({
+					queryKey: ["session-events", input],
+				}),
+			},
+		},
+		sessionTablePlayer: {
+			list: {
+				queryOptions: (input: Record<string, unknown>) => ({
+					queryKey: ["session-players", input],
+				}),
+			},
+		},
+	},
 	trpcClient: {
 		sessionEvent: {
 			create: { mutate: vi.fn() },
@@ -178,5 +218,20 @@ describe("MobileNav - Live Session Mode (active session)", () => {
 		const centerButton = screen.getByRole("button");
 		const greenDiv = centerButton.querySelector("div");
 		expect(greenDiv?.className).toContain("bg-green");
+	});
+
+	it("shows the resume action when the active session is paused", async () => {
+		mockUseActiveSession.mockReturnValue({
+			activeSession: { id: "session-123", type: "cash_game", status: "paused" },
+			hasActive: true,
+			isLoading: false,
+		});
+		const router = createTestRouter(
+			"/live-sessions/cash-game/session-123/events"
+		);
+		render(<RouterProvider router={router} />);
+
+		await screen.findByText("Resume");
+		expect(screen.queryByText("Stack")).not.toBeInTheDocument();
 	});
 });

--- a/apps/web/src/__tests__/tournament-lifecycle.test.tsx
+++ b/apps/web/src/__tests__/tournament-lifecycle.test.tsx
@@ -130,11 +130,43 @@ vi.mock("@/utils/trpc", () => ({
 				}),
 			},
 		},
+		currency: {
+			list: {
+				queryOptions: () => ({
+					queryKey: ["currency-list"],
+					queryFn: () => mockQuery("currency-list"),
+				}),
+			},
+		},
+		currencyTransaction: {
+			listByCurrency: {
+				queryOptions: (args: { currencyId: string }) => ({
+					queryKey: ["currency-transaction", args.currencyId],
+					queryFn: () => mockQuery("currency-transaction", args),
+				}),
+			},
+		},
+		session: {
+			list: {
+				queryOptions: () => ({
+					queryKey: ["session-list"],
+					queryFn: () => mockQuery("session-list"),
+				}),
+			},
+		},
 		sessionEvent: {
 			list: {
 				queryOptions: (args?: unknown) => ({
 					queryKey: ["events", args],
 					queryFn: () => mockQuery("events", args),
+				}),
+			},
+		},
+		sessionTablePlayer: {
+			list: {
+				queryOptions: (args?: unknown) => ({
+					queryKey: ["session-table-players", args],
+					queryFn: () => mockQuery("session-table-players", args),
 				}),
 			},
 		},

--- a/apps/web/src/live-sessions/components/__tests__/active-session-scene.test.tsx
+++ b/apps/web/src/live-sessions/components/__tests__/active-session-scene.test.tsx
@@ -163,6 +163,7 @@ describe("ActiveSessionScene", () => {
 				isDiscardPending={false}
 				onDiscard={vi.fn()}
 				state={createState()}
+				status="active"
 				summary={<div>Cash summary</div>}
 				title="Cash Game"
 			/>
@@ -181,6 +182,7 @@ describe("ActiveSessionScene", () => {
 				isDiscardPending={false}
 				onDiscard={onDiscard}
 				state={createState()}
+				status="active"
 				summary={<div>Tournament summary</div>}
 				title="Tournament"
 			/>
@@ -224,6 +226,7 @@ describe("ActiveSessionScene", () => {
 				isDiscardPending={false}
 				onDiscard={vi.fn()}
 				state={state}
+				status="active"
 				summary={<div>Scene summary</div>}
 				title="Cash Game"
 			/>
@@ -242,5 +245,20 @@ describe("ActiveSessionScene", () => {
 			}),
 			1
 		);
+	});
+
+	it("renders the paused badge when the session is paused", () => {
+		render(
+			<ActiveSessionScene
+				isDiscardPending={false}
+				onDiscard={vi.fn()}
+				state={createState()}
+				status="paused"
+				summary={<div>Paused summary</div>}
+				title="Cash Game"
+			/>
+		);
+
+		expect(screen.getByText("Paused")).toBeInTheDocument();
 	});
 });

--- a/apps/web/src/live-sessions/components/__tests__/live-stack-form-sheet.test.tsx
+++ b/apps/web/src/live-sessions/components/__tests__/live-stack-form-sheet.test.tsx
@@ -44,7 +44,10 @@ vi.mock("@tanstack/react-query", () => ({
 		return { data: undefined };
 	},
 	useQueryClient: () => ({
+		cancelQueries: vi.fn(),
+		getQueryData: vi.fn(),
 		invalidateQueries: vi.fn(),
+		setQueryData: vi.fn(),
 	}),
 }));
 
@@ -137,6 +140,30 @@ vi.mock("@/utils/trpc", () => ({
 			list: {
 				queryOptions: (input: Record<string, string>) => ({
 					queryKey: ["sessionEvent.list", input],
+				}),
+			},
+		},
+		sessionTablePlayer: {
+			list: {
+				queryOptions: (input: Record<string, string>) => ({
+					queryKey: ["sessionTablePlayer.list", input],
+				}),
+			},
+		},
+		session: {
+			list: {
+				queryOptions: () => ({ queryKey: ["session.list"] }),
+			},
+		},
+		currency: {
+			list: {
+				queryOptions: () => ({ queryKey: ["currency.list"] }),
+			},
+		},
+		currencyTransaction: {
+			listByCurrency: {
+				queryOptions: ({ currencyId }: { currencyId: string }) => ({
+					queryKey: ["currencyTransaction.listByCurrency", currencyId],
 				}),
 			},
 		},

--- a/apps/web/src/live-sessions/components/__tests__/session-events-scene.test.tsx
+++ b/apps/web/src/live-sessions/components/__tests__/session-events-scene.test.tsx
@@ -1,10 +1,14 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionEventsScene } from "../session-events-scene";
 
 const mocks = vi.hoisted(() => ({
+	cashSession: null as null | {
+		currencyId: string | null;
+		summary?: Record<string, unknown>;
+	},
 	deleteMutate: vi.fn(async () => undefined),
 	events: [] as Array<{
 		eventType: string;
@@ -12,7 +16,12 @@ const mocks = vi.hoisted(() => ({
 		occurredAt: string;
 		payload: Record<string, unknown>;
 	}>,
+	getQueryData: vi.fn(),
 	invalidateQueries: vi.fn(),
+	tournamentSession: null as null | {
+		currencyId: string | null;
+		summary?: Record<string, unknown>;
+	},
 	updateMutate: vi.fn(async () => undefined),
 }));
 
@@ -28,14 +37,26 @@ vi.mock("@tanstack/react-query", () => ({
 		};
 		return {
 			isPending: false,
-			mutate,
+			mutate: vi.fn(),
 			mutateAsync: mutate,
 		};
 	},
-	useQuery: () => ({ data: mocks.events }),
+	useQuery: (options: { queryKey?: unknown[] }) => {
+		const scope = options.queryKey?.[0];
+		if (scope === "events") {
+			return { data: mocks.events };
+		}
+		if (scope === "cash-session") {
+			return { data: mocks.cashSession };
+		}
+		if (scope === "tournament-session") {
+			return { data: mocks.tournamentSession };
+		}
+		return { data: undefined };
+	},
 	useQueryClient: () => ({
 		cancelQueries: vi.fn(),
-		getQueryData: vi.fn(),
+		getQueryData: mocks.getQueryData,
 		invalidateQueries: mocks.invalidateQueries,
 		setQueryData: vi.fn(),
 	}),
@@ -53,6 +74,20 @@ vi.mock("@/shared/components/ui/responsive-dialog", () => ({
 
 vi.mock("@/utils/trpc", () => ({
 	trpc: {
+		currency: {
+			list: {
+				queryOptions: () => ({
+					queryKey: ["currency-list"],
+				}),
+			},
+		},
+		currencyTransaction: {
+			listByCurrency: {
+				queryOptions: ({ currencyId }: { currencyId: string }) => ({
+					queryKey: ["currency-transaction-list", currencyId],
+				}),
+			},
+		},
 		liveCashGameSession: {
 			getById: {
 				queryOptions: ({ id }: { id: string }) => ({
@@ -64,6 +99,13 @@ vi.mock("@/utils/trpc", () => ({
 			getById: {
 				queryOptions: ({ id }: { id: string }) => ({
 					queryKey: ["tournament-session", id],
+				}),
+			},
+		},
+		session: {
+			list: {
+				queryOptions: () => ({
+					queryKey: ["session-list"],
 				}),
 			},
 		},
@@ -83,9 +125,20 @@ vi.mock("@/utils/trpc", () => ({
 	},
 }));
 
+beforeEach(() => {
+	mocks.cashSession = null;
+	mocks.tournamentSession = null;
+	mocks.events = [];
+	mocks.deleteMutate.mockClear();
+	mocks.getQueryData.mockReset();
+	mocks.invalidateQueries.mockClear();
+	mocks.updateMutate.mockClear();
+});
+
 describe("SessionEventsScene", () => {
-	it("updates a chips add/remove event from the shared scene", async () => {
+	it("invalidates dependent session and currency queries after cash event updates", async () => {
 		const user = userEvent.setup();
+		mocks.cashSession = { currencyId: "currency-1", summary: {} };
 		mocks.events = [
 			{
 				eventType: "chips_add_remove",
@@ -112,10 +165,27 @@ describe("SessionEventsScene", () => {
 				})
 			);
 		});
+
+		await waitFor(() => {
+			const queryKeys = [
+				["events", { liveCashGameSessionId: "session-1" }],
+				["cash-session", "session-1"],
+				["session-list"],
+				["currency-list"],
+				["currency-transaction-list", "currency-1"],
+			];
+			expect(mocks.invalidateQueries).toHaveBeenCalledTimes(queryKeys.length);
+			for (const [index, queryKey] of queryKeys.entries()) {
+				expect(mocks.invalidateQueries).toHaveBeenNthCalledWith(index + 1, {
+					queryKey,
+				});
+			}
+		});
 	});
 
-	it("updates a purchase chips event from the shared scene", async () => {
+	it("invalidates dependent session and currency queries after tournament event updates", async () => {
 		const user = userEvent.setup();
+		mocks.tournamentSession = { currencyId: "currency-2", summary: {} };
 		mocks.events = [
 			{
 				eventType: "purchase_chips",
@@ -147,6 +217,61 @@ describe("SessionEventsScene", () => {
 					}),
 				})
 			);
+		});
+
+		await waitFor(() => {
+			const queryKeys = [
+				["events", { liveTournamentSessionId: "session-2" }],
+				["tournament-session", "session-2"],
+				["session-list"],
+				["currency-list"],
+				["currency-transaction-list", "currency-2"],
+			];
+			expect(mocks.invalidateQueries).toHaveBeenCalledTimes(queryKeys.length);
+			for (const [index, queryKey] of queryKeys.entries()) {
+				expect(mocks.invalidateQueries).toHaveBeenNthCalledWith(index + 1, {
+					queryKey,
+				});
+			}
+		});
+	});
+
+	it("skips currency transaction invalidation when deleting an event from a session without currency", async () => {
+		const user = userEvent.setup();
+		mocks.cashSession = { currencyId: null, summary: {} };
+		mocks.events = [
+			{
+				eventType: "memo",
+				id: "event-3",
+				occurredAt: "2026-04-03T14:00:00.000Z",
+				payload: { text: "note" },
+			},
+		];
+
+		render(
+			<SessionEventsScene sessionId="session-3" sessionType="cash_game" />
+		);
+
+		await user.click(screen.getByLabelText("Delete Memo"));
+		await user.click(screen.getByLabelText("Confirm delete"));
+
+		await waitFor(() => {
+			expect(mocks.deleteMutate).toHaveBeenCalledWith({ id: "event-3" });
+		});
+
+		await waitFor(() => {
+			const queryKeys = [
+				["events", { liveCashGameSessionId: "session-3" }],
+				["cash-session", "session-3"],
+				["session-list"],
+				["currency-list"],
+			];
+			expect(mocks.invalidateQueries).toHaveBeenCalledTimes(queryKeys.length);
+			for (const [index, queryKey] of queryKeys.entries()) {
+				expect(mocks.invalidateQueries).toHaveBeenNthCalledWith(index + 1, {
+					queryKey,
+				});
+			}
 		});
 	});
 });

--- a/apps/web/src/live-sessions/components/__tests__/session-events-scene.test.tsx
+++ b/apps/web/src/live-sessions/components/__tests__/session-events-scene.test.tsx
@@ -94,11 +94,21 @@ vi.mock("@/utils/trpc", () => ({
 					queryKey: ["cash-session", id],
 				}),
 			},
+			list: {
+				queryOptions: (input: Record<string, unknown>) => ({
+					queryKey: ["cash-session-list", input],
+				}),
+			},
 		},
 		liveTournamentSession: {
 			getById: {
 				queryOptions: ({ id }: { id: string }) => ({
 					queryKey: ["tournament-session", id],
+				}),
+			},
+			list: {
+				queryOptions: (input: Record<string, unknown>) => ({
+					queryKey: ["tournament-session-list", input],
 				}),
 			},
 		},
@@ -113,6 +123,13 @@ vi.mock("@/utils/trpc", () => ({
 			list: {
 				queryOptions: (input: unknown) => ({
 					queryKey: ["events", input],
+				}),
+			},
+		},
+		sessionTablePlayer: {
+			list: {
+				queryOptions: (input: unknown) => ({
+					queryKey: ["players", input],
 				}),
 			},
 		},
@@ -134,6 +151,12 @@ beforeEach(() => {
 	mocks.invalidateQueries.mockClear();
 	mocks.updateMutate.mockClear();
 });
+
+function hasInvalidationFor(queryKey: unknown[]) {
+	return mocks.invalidateQueries.mock.calls.some(
+		([args]) => JSON.stringify(args) === JSON.stringify({ queryKey })
+	);
+}
 
 describe("SessionEventsScene", () => {
 	it("invalidates dependent session and currency queries after cash event updates", async () => {
@@ -170,15 +193,15 @@ describe("SessionEventsScene", () => {
 			const queryKeys = [
 				["events", { liveCashGameSessionId: "session-1" }],
 				["cash-session", "session-1"],
+				["cash-session-list", {}],
+				["cash-session-list", { status: "active", limit: 1 }],
+				["cash-session-list", { status: "paused", limit: 1 }],
 				["session-list"],
 				["currency-list"],
 				["currency-transaction-list", "currency-1"],
 			];
-			expect(mocks.invalidateQueries).toHaveBeenCalledTimes(queryKeys.length);
-			for (const [index, queryKey] of queryKeys.entries()) {
-				expect(mocks.invalidateQueries).toHaveBeenNthCalledWith(index + 1, {
-					queryKey,
-				});
+			for (const queryKey of queryKeys) {
+				expect(hasInvalidationFor(queryKey)).toBe(true);
 			}
 		});
 	});
@@ -223,15 +246,15 @@ describe("SessionEventsScene", () => {
 			const queryKeys = [
 				["events", { liveTournamentSessionId: "session-2" }],
 				["tournament-session", "session-2"],
+				["tournament-session-list", {}],
+				["tournament-session-list", { status: "active", limit: 1 }],
+				["tournament-session-list", { status: "paused", limit: 1 }],
 				["session-list"],
 				["currency-list"],
 				["currency-transaction-list", "currency-2"],
 			];
-			expect(mocks.invalidateQueries).toHaveBeenCalledTimes(queryKeys.length);
-			for (const [index, queryKey] of queryKeys.entries()) {
-				expect(mocks.invalidateQueries).toHaveBeenNthCalledWith(index + 1, {
-					queryKey,
-				});
+			for (const queryKey of queryKeys) {
+				expect(hasInvalidationFor(queryKey)).toBe(true);
 			}
 		});
 	});
@@ -263,15 +286,18 @@ describe("SessionEventsScene", () => {
 			const queryKeys = [
 				["events", { liveCashGameSessionId: "session-3" }],
 				["cash-session", "session-3"],
+				["cash-session-list", {}],
+				["cash-session-list", { status: "active", limit: 1 }],
+				["cash-session-list", { status: "paused", limit: 1 }],
 				["session-list"],
 				["currency-list"],
 			];
-			expect(mocks.invalidateQueries).toHaveBeenCalledTimes(queryKeys.length);
-			for (const [index, queryKey] of queryKeys.entries()) {
-				expect(mocks.invalidateQueries).toHaveBeenNthCalledWith(index + 1, {
-					queryKey,
-				});
+			for (const queryKey of queryKeys) {
+				expect(hasInvalidationFor(queryKey)).toBe(true);
 			}
+			expect(mocks.invalidateQueries).not.toHaveBeenCalledWith({
+				queryKey: ["currency-transaction-list", expect.any(String)],
+			});
 		});
 	});
 });

--- a/apps/web/src/live-sessions/components/active-session-scene.tsx
+++ b/apps/web/src/live-sessions/components/active-session-scene.tsx
@@ -8,6 +8,7 @@ import {
 	type TableGameInfo,
 	type TablePlayer,
 } from "@/live-sessions/components/poker-table";
+import type { LiveSessionStatus } from "@/live-sessions/lib/live-session-cache";
 import type { PlayerFormValues } from "@/players/components/player-form";
 import type {
 	PlayerDetailData,
@@ -28,6 +29,7 @@ interface ActiveSessionSceneProps {
 	memo?: string | null;
 	onDiscard: () => void;
 	state: ActiveSessionSceneState;
+	status: Extract<LiveSessionStatus, "active" | "paused">;
 	summary: ReactNode;
 	title: string;
 }
@@ -207,6 +209,7 @@ export function ActiveSessionScene({
 	isDiscardPending,
 	memo,
 	onDiscard,
+	status,
 	state,
 	summary,
 	title,
@@ -219,10 +222,14 @@ export function ActiveSessionScene({
 				<div className="flex items-center gap-2">
 					<h1 className="font-bold text-lg">{title}</h1>
 					<Badge
-						className="border-green-200 bg-green-50 text-[10px] text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400"
+						className={
+							status === "paused"
+								? "border-amber-200 bg-amber-50 text-[10px] text-amber-700 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-400"
+								: "border-green-200 bg-green-50 text-[10px] text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400"
+						}
 						variant="outline"
 					>
-						Active
+						{status === "paused" ? "Paused" : "Active"}
 					</Badge>
 				</div>
 				<Button

--- a/apps/web/src/live-sessions/hooks/use-cash-game-session.ts
+++ b/apps/web/src/live-sessions/hooks/use-cash-game-session.ts
@@ -1,10 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import {
+	getLiveSessionCacheRefs,
+	invalidateLiveSessionCaches,
+} from "@/live-sessions/lib/live-session-cache";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 export function useCashGameSession(sessionId: string) {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
+	const refs = getLiveSessionCacheRefs({
+		sessionId,
+		sessionType: "cash_game",
+	});
 
 	const sessionQuery = useQuery({
 		...trpc.liveCashGameSession.getById.queryOptions({ id: sessionId }),
@@ -24,14 +32,9 @@ export function useCashGameSession(sessionId: string) {
 		mutationFn: () =>
 			trpcClient.liveCashGameSession.discard.mutate({ id: sessionId }),
 		onSuccess: async () => {
-			await Promise.all([
-				queryClient.invalidateQueries({
-					queryKey: trpc.liveCashGameSession.list.queryOptions({}).queryKey,
-				}),
-				queryClient.invalidateQueries({
-					queryKey: trpc.session.list.queryOptions({}).queryKey,
-				}),
-			]);
+			await invalidateLiveSessionCaches(queryClient, refs, {
+				includeHistorical: true,
+			});
 			await navigate({ to: "/sessions" });
 		},
 	});

--- a/apps/web/src/live-sessions/hooks/use-cash-game-stack.ts
+++ b/apps/web/src/live-sessions/hooks/use-cash-game-stack.ts
@@ -1,99 +1,68 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { trpc, trpcClient } from "@/utils/trpc";
+import {
+	applyOptimisticLiveSessionEvent,
+	cancelLiveSessionCaches,
+	getLiveSessionCacheRefs,
+	invalidateLiveSessionCaches,
+	type LiveSessionEvent,
+	type LiveSessionEventType,
+	restoreLiveSessionCaches,
+	snapshotLiveSessionCaches,
+} from "@/live-sessions/lib/live-session-cache";
+import { trpcClient } from "@/utils/trpc";
+
+function buildOptimisticEvent(
+	eventType: LiveSessionEventType,
+	payload: unknown
+): LiveSessionEvent {
+	return {
+		eventType,
+		id: `optimistic-${Date.now()}`,
+		occurredAt: new Date().toISOString(),
+		payload,
+	};
+}
 
 export function useCashGameStack({ sessionId }: { sessionId: string }) {
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
-
-	const sessionKey = trpc.liveCashGameSession.getById.queryOptions({
-		id: sessionId,
-	}).queryKey;
-	const eventsKey = trpc.sessionEvent.list.queryOptions({
-		liveCashGameSessionId: sessionId,
-	}).queryKey;
-	const listKey = trpc.liveCashGameSession.list.queryOptions({}).queryKey;
-
-	const invalidateSession = async () => {
-		await Promise.all([
-			queryClient.invalidateQueries({ queryKey: sessionKey }),
-			queryClient.invalidateQueries({ queryKey: eventsKey }),
-		]);
-	};
-
-	const stackMutation = useMutation({
-		mutationFn: (values: { stackAmount: number }) =>
-			trpcClient.sessionEvent.create.mutate({
-				liveCashGameSessionId: sessionId,
-				eventType: "update_stack",
-				payload: { stackAmount: values.stackAmount },
-			}),
-		onSuccess: invalidateSession,
+	const refs = getLiveSessionCacheRefs({
+		sessionId,
+		sessionType: "cash_game",
 	});
 
-	const chipAddMutation = useMutation({
-		mutationFn: (amount: number) =>
-			trpcClient.sessionEvent.create.mutate({
-				liveCashGameSessionId: sessionId,
-				eventType: "chips_add_remove",
-				payload: { amount, type: "add" },
-			}),
-		onSuccess: invalidateSession,
-	});
-
-	const chipRemoveMutation = useMutation({
-		mutationFn: (amount: number) =>
-			trpcClient.sessionEvent.create.mutate({
-				liveCashGameSessionId: sessionId,
-				eventType: "chips_add_remove",
-				payload: { amount, type: "remove" },
-			}),
-		onSuccess: invalidateSession,
-	});
-
-	const allInMutation = useMutation({
-		mutationFn: (values: {
-			potSize: number;
-			trials: number;
-			equity: number;
-			wins: number;
+	const applyCreateEventMutation = useMutation({
+		mutationFn: ({
+			eventType,
+			payload,
+		}: {
+			eventType: LiveSessionEventType;
+			payload: unknown;
 		}) =>
 			trpcClient.sessionEvent.create.mutate({
 				liveCashGameSessionId: sessionId,
-				eventType: "all_in",
-				payload: values,
+				eventType,
+				payload,
 			}),
-		onSuccess: invalidateSession,
-	});
+		onMutate: async ({ eventType, payload }) => {
+			await cancelLiveSessionCaches(queryClient, refs);
+			const snapshot = snapshotLiveSessionCaches(queryClient, refs);
 
-	const memoMutation = useMutation({
-		mutationFn: (text: string) =>
-			trpcClient.sessionEvent.create.mutate({
-				liveCashGameSessionId: sessionId,
-				eventType: "memo",
-				payload: { text },
-			}),
-		onSuccess: invalidateSession,
-	});
+			applyOptimisticLiveSessionEvent(queryClient, refs, {
+				event: buildOptimisticEvent(eventType, payload),
+				eventType,
+				payload,
+			});
 
-	const pauseMutation = useMutation({
-		mutationFn: () =>
-			trpcClient.sessionEvent.create.mutate({
-				liveCashGameSessionId: sessionId,
-				eventType: "session_pause",
-				payload: {},
-			}),
-		onSuccess: invalidateSession,
-	});
-
-	const resumeMutation = useMutation({
-		mutationFn: () =>
-			trpcClient.sessionEvent.create.mutate({
-				liveCashGameSessionId: sessionId,
-				eventType: "session_resume",
-				payload: {},
-			}),
-		onSuccess: invalidateSession,
+			return { snapshot };
+		},
+		onError: (_error, _variables, context) => {
+			restoreLiveSessionCaches(queryClient, context?.snapshot);
+		},
+		onSettled: async () => {
+			await invalidateLiveSessionCaches(queryClient, refs);
+		},
 	});
 
 	const completeMutation = useMutation({
@@ -103,33 +72,57 @@ export function useCashGameStack({ sessionId }: { sessionId: string }) {
 				finalStack: values.finalStack,
 			}),
 		onSuccess: async () => {
-			await Promise.all([
-				queryClient.invalidateQueries({ queryKey: listKey }),
-				queryClient.invalidateQueries({
-					queryKey: trpc.session.list.queryOptions({}).queryKey,
-				}),
-			]);
+			await invalidateLiveSessionCaches(queryClient, refs, {
+				includeHistorical: true,
+			});
 			await navigate({ to: "/sessions" });
 		},
 	});
 
 	return {
 		recordStack: (values: { stackAmount: number }) =>
-			stackMutation.mutate(values),
-		addChip: (amount: number) => chipAddMutation.mutate(amount),
-		removeChip: (amount: number) => chipRemoveMutation.mutate(amount),
+			applyCreateEventMutation.mutate({
+				eventType: "update_stack",
+				payload: { stackAmount: values.stackAmount },
+			}),
+		addChip: (amount: number) =>
+			applyCreateEventMutation.mutate({
+				eventType: "chips_add_remove",
+				payload: { amount, type: "add" },
+			}),
+		removeChip: (amount: number) =>
+			applyCreateEventMutation.mutate({
+				eventType: "chips_add_remove",
+				payload: { amount, type: "remove" },
+			}),
 		addAllIn: (values: {
 			potSize: number;
 			trials: number;
 			equity: number;
 			wins: number;
-		}) => allInMutation.mutate(values),
-		addMemo: (text: string) => memoMutation.mutate(text),
-		pause: () => pauseMutation.mutate(),
-		resume: () => resumeMutation.mutate(),
+		}) =>
+			applyCreateEventMutation.mutate({
+				eventType: "all_in",
+				payload: values,
+			}),
+		addMemo: (text: string) =>
+			applyCreateEventMutation.mutate({
+				eventType: "memo",
+				payload: { text },
+			}),
+		pause: () =>
+			applyCreateEventMutation.mutate({
+				eventType: "session_pause",
+				payload: {},
+			}),
+		resume: () =>
+			applyCreateEventMutation.mutate({
+				eventType: "session_resume",
+				payload: {},
+			}),
 		complete: (values: { finalStack: number }) =>
 			completeMutation.mutate(values),
-		isStackPending: stackMutation.isPending,
+		isStackPending: applyCreateEventMutation.isPending,
 		isCompletePending: completeMutation.isPending,
 	};
 }

--- a/apps/web/src/live-sessions/hooks/use-create-session.ts
+++ b/apps/web/src/live-sessions/hooks/use-create-session.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
+import {
+	getLiveSessionCacheRefs,
+	invalidateLiveSessionCaches,
+} from "@/live-sessions/lib/live-session-cache";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 function useStoreRingGames(storeId: string | undefined) {
@@ -55,13 +59,6 @@ export function useCreateSession({ onClose }: { onClose: () => void }) {
 	const ringGames = useStoreRingGames(selectedStoreId);
 	const tournaments = useStoreTournaments(selectedStoreId);
 
-	const cashListKey = trpc.liveCashGameSession.list.queryOptions({}).queryKey;
-	const tournamentListKey = trpc.liveTournamentSession.list.queryOptions(
-		{}
-	).queryKey;
-
-	const sessionListKey = trpc.session.list.queryOptions({}).queryKey;
-
 	const createCashMutation = useMutation({
 		mutationFn: (values: {
 			currencyId?: string;
@@ -70,11 +67,17 @@ export function useCreateSession({ onClose }: { onClose: () => void }) {
 			ringGameId?: string;
 			storeId?: string;
 		}) => trpcClient.liveCashGameSession.create.mutate(values),
-		onSuccess: async () => {
-			await Promise.all([
-				queryClient.invalidateQueries({ queryKey: cashListKey }),
-				queryClient.invalidateQueries({ queryKey: sessionListKey }),
-			]);
+		onSuccess: async (result) => {
+			await invalidateLiveSessionCaches(
+				queryClient,
+				getLiveSessionCacheRefs({
+					sessionId: result.id,
+					sessionType: "cash_game",
+				}),
+				{
+					includeHistorical: true,
+				}
+			);
 			onClose();
 			await navigate({ to: "/active-session" });
 		},
@@ -103,11 +106,17 @@ export function useCreateSession({ onClose }: { onClose: () => void }) {
 			});
 			return result;
 		},
-		onSuccess: async () => {
-			await Promise.all([
-				queryClient.invalidateQueries({ queryKey: tournamentListKey }),
-				queryClient.invalidateQueries({ queryKey: sessionListKey }),
-			]);
+		onSuccess: async (result) => {
+			await invalidateLiveSessionCaches(
+				queryClient,
+				getLiveSessionCacheRefs({
+					sessionId: result.id,
+					sessionType: "tournament",
+				}),
+				{
+					includeHistorical: true,
+				}
+			);
 			onClose();
 			await navigate({ to: "/active-session" });
 		},

--- a/apps/web/src/live-sessions/hooks/use-session-events.ts
+++ b/apps/web/src/live-sessions/hooks/use-session-events.ts
@@ -1,156 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-	cancelTargets,
-	invalidateTargets,
-	type OptimisticTarget,
-	restoreSnapshots,
-	snapshotQuery,
-} from "@/utils/optimistic-update";
+	applyOptimisticLiveSessionEvent,
+	cancelLiveSessionCaches,
+	getLiveSessionCacheRefs,
+	invalidateLiveSessionCaches,
+	type LiveSessionEvent,
+	type LiveSessionType,
+	patchLiveSessionEvents,
+	restoreLiveSessionCaches,
+	snapshotLiveSessionCaches,
+} from "@/live-sessions/lib/live-session-cache";
 import { trpc, trpcClient } from "@/utils/trpc";
 
-export interface SessionEvent {
-	eventType: string;
-	id: string;
-	occurredAt: string | Date;
-	payload: unknown;
-}
-
-interface SessionSummaryData {
-	summary?: Record<string, unknown>;
-	[key: string]: unknown;
-}
-
-interface LiveSessionData extends SessionSummaryData {
-	currencyId?: string | null;
-}
-
-type SessionType = "cash_game" | "tournament";
-
-function applyUpdateStackSummary(
-	summary: Record<string, unknown>,
-	payload: Record<string, unknown>
-) {
-	if (typeof payload.stackAmount === "number") {
-		summary.currentStack = payload.stackAmount;
-	}
-}
-
-function applyUpdateTournamentInfoSummary(
-	summary: Record<string, unknown>,
-	payload: Record<string, unknown>
-) {
-	const typedPayload = payload as {
-		remainingPlayers?: number | null;
-		totalEntries?: number | null;
-	};
-
-	if (typeof typedPayload.remainingPlayers === "number") {
-		summary.remainingPlayers = typedPayload.remainingPlayers;
-	}
-
-	if (typeof typedPayload.totalEntries === "number") {
-		summary.totalEntries = typedPayload.totalEntries;
-	}
-}
-
-function applySessionStartSummary(
-	summary: Record<string, unknown>,
-	payload: Record<string, unknown>
-) {
-	if (typeof payload.buyInAmount === "number") {
-		summary.totalBuyIn = payload.buyInAmount;
-	}
-}
-
-function applySessionEndSummary(
-	summary: Record<string, unknown>,
-	payload: Record<string, unknown>
-) {
-	// Cash game end: cashOutAmount drives profitLoss
-	if (typeof payload.cashOutAmount === "number") {
-		summary.cashOut = payload.cashOutAmount;
-		const totalBuyIn =
-			typeof summary.totalBuyIn === "number" ? summary.totalBuyIn : 0;
-		summary.profitLoss = payload.cashOutAmount - totalBuyIn;
-	}
-
-	// Tournament end (not before deadline): placement + prizes
-	if (payload.beforeDeadline === false) {
-		const typedPayload = payload as {
-			placement?: number;
-			totalEntries?: number;
-			prizeMoney?: number;
-			bountyPrizes?: number;
-		};
-
-		if (typeof typedPayload.placement === "number") {
-			summary.placement = typedPayload.placement;
-		}
-
-		if (typeof typedPayload.totalEntries === "number") {
-			summary.totalEntries = typedPayload.totalEntries;
-		}
-
-		if (typeof typedPayload.prizeMoney === "number") {
-			summary.profitLoss =
-				typedPayload.prizeMoney +
-				(typeof typedPayload.bountyPrizes === "number"
-					? typedPayload.bountyPrizes
-					: 0);
-		}
-	}
-
-	// Tournament end before deadline: only prizes
-	if (payload.beforeDeadline === true) {
-		const typedPayload = payload as {
-			prizeMoney?: number;
-			bountyPrizes?: number;
-		};
-
-		if (typeof typedPayload.prizeMoney === "number") {
-			summary.profitLoss =
-				typedPayload.prizeMoney +
-				(typeof typedPayload.bountyPrizes === "number"
-					? typedPayload.bountyPrizes
-					: 0);
-		}
-	}
-}
-
-function buildOptimisticSessionSummary(
-	summary: Record<string, unknown>,
-	eventType: string,
-	payload: Record<string, unknown>,
-	occurredAt?: number
-) {
-	const nextSummary = { ...summary };
-
-	switch (eventType) {
-		case "session_start":
-			applySessionStartSummary(nextSummary, payload);
-			break;
-		case "session_end":
-			applySessionEndSummary(nextSummary, payload);
-			break;
-		case "update_stack":
-			applyUpdateStackSummary(nextSummary, payload);
-			break;
-		case "update_tournament_info":
-			applyUpdateTournamentInfoSummary(nextSummary, payload);
-			break;
-		// chips_add_remove affects totalBuyIn server-side; skip optimistic stack update
-		// all_in, memo, session_pause, session_resume, purchase_chips, player_join,
-		// player_leave: no summary fields to update optimistically
-		default:
-			break;
-	}
-
-	if (occurredAt) {
-		nextSummary.lastUpdatedAt = occurredAt;
-	}
-
-	return nextSummary;
-}
+export interface SessionEvent extends LiveSessionEvent {}
 
 export function useSessionEvents({
 	sessionId,
@@ -158,10 +20,11 @@ export function useSessionEvents({
 	refetchInterval,
 }: {
 	sessionId: string;
-	sessionType: SessionType;
+	sessionType: LiveSessionType;
 	refetchInterval?: number;
 }) {
 	const queryClient = useQueryClient();
+	const refs = getLiveSessionCacheRefs({ sessionId, sessionType });
 
 	const eventQueryInput =
 		sessionType === "tournament"
@@ -176,72 +39,23 @@ export function useSessionEvents({
 	});
 	const events = (eventsQuery.data ?? []) as SessionEvent[];
 
-	const cashSessionQueryOptions = trpc.liveCashGameSession.getById.queryOptions(
-		{
-			id: sessionId,
-		}
-	);
-	const tournamentSessionQueryOptions =
-		trpc.liveTournamentSession.getById.queryOptions({
-			id: sessionId,
-		});
 	const cashSessionQuery = useQuery({
-		...cashSessionQueryOptions,
+		...trpc.liveCashGameSession.getById.queryOptions({
+			id: sessionId,
+		}),
 		enabled: !!sessionId && sessionType === "cash_game",
 	});
 	const tournamentSessionQuery = useQuery({
-		...tournamentSessionQueryOptions,
+		...trpc.liveTournamentSession.getById.queryOptions({
+			id: sessionId,
+		}),
 		enabled: !!sessionId && sessionType === "tournament",
 	});
-	const sessionKey =
-		sessionType === "tournament"
-			? tournamentSessionQueryOptions.queryKey
-			: cashSessionQueryOptions.queryKey;
 
-	const applyEventSummaryToSession = (
-		event: SessionEvent,
-		payload: unknown,
-		occurredAt?: number
-	) => {
-		queryClient.setQueryData<LiveSessionData>(sessionKey, (old) => {
-			if (!(old?.summary && payload) || typeof payload !== "object") {
-				return old;
-			}
-
-			return {
-				...old,
-				summary: buildOptimisticSessionSummary(
-					old.summary,
-					event.eventType,
-					payload as Record<string, unknown>,
-					occurredAt
-				),
-			};
-		});
-	};
-
-	const invalidateAll = async () => {
-		const currentSession =
-			(sessionType === "tournament"
-				? (tournamentSessionQuery.data as LiveSessionData | undefined)
-				: (cashSessionQuery.data as LiveSessionData | undefined)) ??
-			queryClient.getQueryData<LiveSessionData>(sessionKey);
-		const targets: OptimisticTarget[] = [
-			{ queryKey: eventsQueryOptions.queryKey },
-			{ queryKey: sessionKey },
-			{ queryKey: trpc.session.list.queryOptions({}).queryKey },
-			{ queryKey: trpc.currency.list.queryOptions().queryKey },
-		];
-		const currencyId = currentSession?.currencyId;
-		if (currencyId) {
-			targets.push({
-				queryKey: trpc.currencyTransaction.listByCurrency.queryOptions({
-					currencyId,
-				}).queryKey,
-			});
-		}
-		await invalidateTargets(queryClient, targets);
-	};
+	const currencyId =
+		sessionType === "cash_game"
+			? (cashSessionQuery.data?.currencyId ?? null)
+			: (tournamentSessionQuery.data?.currencyId ?? null);
 
 	const updateMutation = useMutation({
 		mutationFn: (args: {
@@ -250,73 +64,60 @@ export function useSessionEvents({
 			payload?: unknown;
 		}) => trpcClient.sessionEvent.update.mutate(args),
 		onMutate: async (args) => {
-			await cancelTargets(queryClient, [
-				{ queryKey: eventsQueryOptions.queryKey },
-				{ queryKey: sessionKey },
-			]);
-			const previousEvents = snapshotQuery(
-				queryClient,
-				eventsQueryOptions.queryKey
-			);
-			const previousSession = snapshotQuery(queryClient, sessionKey);
+			await cancelLiveSessionCaches(queryClient, refs, {
+				includeLists: false,
+				includePlayers: false,
+			});
+			const snapshot = snapshotLiveSessionCaches(queryClient, refs);
 			const targetEvent = events.find((event) => event.id === args.id);
-			queryClient.setQueryData<SessionEvent[]>(
-				eventsQueryOptions.queryKey,
-				(old) =>
-					old?.map((event) =>
-						event.id === args.id
-							? {
-									...event,
-									occurredAt: args.occurredAt
-										? new Date(args.occurredAt * 1000).toISOString()
-										: event.occurredAt,
-									payload: args.payload ?? event.payload,
-								}
-							: event
-					) ?? []
-			);
-			if (targetEvent && args.payload) {
-				applyEventSummaryToSession(targetEvent, args.payload, args.occurredAt);
+
+			if (targetEvent) {
+				applyOptimisticLiveSessionEvent(queryClient, refs, {
+					event: targetEvent,
+					eventType: targetEvent.eventType,
+					occurredAt: args.occurredAt,
+					payload: args.payload ?? targetEvent.payload,
+				});
 			}
-			return { previousEvents, previousSession };
+
+			return { snapshot };
 		},
 		onError: (_error, _variables, context) => {
-			restoreSnapshots(queryClient, [
-				context?.previousEvents,
-				context?.previousSession,
-			]);
+			restoreLiveSessionCaches(queryClient, context?.snapshot);
 		},
 		onSuccess: async () => {
-			await invalidateAll();
+			await invalidateLiveSessionCaches(queryClient, refs, {
+				currencyId,
+				includeHistorical: true,
+				includePlayers: false,
+			});
 		},
 	});
 
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => trpcClient.sessionEvent.delete.mutate({ id }),
 		onMutate: async (id) => {
-			await cancelTargets(queryClient, [
-				{ queryKey: eventsQueryOptions.queryKey },
-				{ queryKey: sessionKey },
-			]);
-			const previousEvents = snapshotQuery(
-				queryClient,
-				eventsQueryOptions.queryKey
+			await cancelLiveSessionCaches(queryClient, refs, {
+				includeLists: false,
+				includePlayers: false,
+			});
+			const snapshot = snapshotLiveSessionCaches(queryClient, refs);
+
+			patchLiveSessionEvents(queryClient, refs, (currentEvents) =>
+				currentEvents.filter((event) => event.id !== id)
 			);
-			const previousSession = snapshotQuery(queryClient, sessionKey);
-			queryClient.setQueryData<SessionEvent[]>(
-				eventsQueryOptions.queryKey,
-				(old) => old?.filter((event) => event.id !== id) ?? []
-			);
-			return { previousEvents, previousSession };
+
+			return { snapshot };
 		},
 		onError: (_error, _variables, context) => {
-			restoreSnapshots(queryClient, [
-				context?.previousEvents,
-				context?.previousSession,
-			]);
+			restoreLiveSessionCaches(queryClient, context?.snapshot);
 		},
 		onSuccess: async () => {
-			await invalidateAll();
+			await invalidateLiveSessionCaches(queryClient, refs, {
+				currencyId,
+				includeHistorical: true,
+				includePlayers: false,
+			});
 		},
 	});
 

--- a/apps/web/src/live-sessions/hooks/use-session-events.ts
+++ b/apps/web/src/live-sessions/hooks/use-session-events.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
 	cancelTargets,
 	invalidateTargets,
+	type OptimisticTarget,
 	restoreSnapshots,
 	snapshotQuery,
 } from "@/utils/optimistic-update";
@@ -17,6 +18,10 @@ export interface SessionEvent {
 interface SessionSummaryData {
 	summary?: Record<string, unknown>;
 	[key: string]: unknown;
+}
+
+interface LiveSessionData extends SessionSummaryData {
+	currencyId?: string | null;
 }
 
 type SessionType = "cash_game" | "tournament";
@@ -171,19 +176,34 @@ export function useSessionEvents({
 	});
 	const events = (eventsQuery.data ?? []) as SessionEvent[];
 
+	const cashSessionQueryOptions = trpc.liveCashGameSession.getById.queryOptions(
+		{
+			id: sessionId,
+		}
+	);
+	const tournamentSessionQueryOptions =
+		trpc.liveTournamentSession.getById.queryOptions({
+			id: sessionId,
+		});
+	const cashSessionQuery = useQuery({
+		...cashSessionQueryOptions,
+		enabled: !!sessionId && sessionType === "cash_game",
+	});
+	const tournamentSessionQuery = useQuery({
+		...tournamentSessionQueryOptions,
+		enabled: !!sessionId && sessionType === "tournament",
+	});
 	const sessionKey =
 		sessionType === "tournament"
-			? trpc.liveTournamentSession.getById.queryOptions({ id: sessionId })
-					.queryKey
-			: trpc.liveCashGameSession.getById.queryOptions({ id: sessionId })
-					.queryKey;
+			? tournamentSessionQueryOptions.queryKey
+			: cashSessionQueryOptions.queryKey;
 
 	const applyEventSummaryToSession = (
 		event: SessionEvent,
 		payload: unknown,
 		occurredAt?: number
 	) => {
-		queryClient.setQueryData<SessionSummaryData>(sessionKey, (old) => {
+		queryClient.setQueryData<LiveSessionData>(sessionKey, (old) => {
 			if (!(old?.summary && payload) || typeof payload !== "object") {
 				return old;
 			}
@@ -201,10 +221,26 @@ export function useSessionEvents({
 	};
 
 	const invalidateAll = async () => {
-		await invalidateTargets(queryClient, [
+		const currentSession =
+			(sessionType === "tournament"
+				? (tournamentSessionQuery.data as LiveSessionData | undefined)
+				: (cashSessionQuery.data as LiveSessionData | undefined)) ??
+			queryClient.getQueryData<LiveSessionData>(sessionKey);
+		const targets: OptimisticTarget[] = [
 			{ queryKey: eventsQueryOptions.queryKey },
 			{ queryKey: sessionKey },
-		]);
+			{ queryKey: trpc.session.list.queryOptions({}).queryKey },
+			{ queryKey: trpc.currency.list.queryOptions().queryKey },
+		];
+		const currencyId = currentSession?.currencyId;
+		if (currencyId) {
+			targets.push({
+				queryKey: trpc.currencyTransaction.listByCurrency.queryOptions({
+					currencyId,
+				}).queryKey,
+			});
+		}
+		await invalidateTargets(queryClient, targets);
 	};
 
 	const updateMutation = useMutation({

--- a/apps/web/src/live-sessions/hooks/use-tournament-session.ts
+++ b/apps/web/src/live-sessions/hooks/use-tournament-session.ts
@@ -1,10 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import {
+	getLiveSessionCacheRefs,
+	invalidateLiveSessionCaches,
+} from "@/live-sessions/lib/live-session-cache";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 export function useTournamentSession(sessionId: string) {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
+	const refs = getLiveSessionCacheRefs({
+		sessionId,
+		sessionType: "tournament",
+	});
 
 	const sessionQuery = useQuery({
 		...trpc.liveTournamentSession.getById.queryOptions({ id: sessionId }),
@@ -17,14 +25,9 @@ export function useTournamentSession(sessionId: string) {
 		mutationFn: () =>
 			trpcClient.liveTournamentSession.discard.mutate({ id: sessionId }),
 		onSuccess: async () => {
-			await Promise.all([
-				queryClient.invalidateQueries({
-					queryKey: trpc.liveTournamentSession.list.queryOptions({}).queryKey,
-				}),
-				queryClient.invalidateQueries({
-					queryKey: trpc.session.list.queryOptions({}).queryKey,
-				}),
-			]);
+			await invalidateLiveSessionCaches(queryClient, refs, {
+				includeHistorical: true,
+			});
 			await navigate({ to: "/sessions" });
 		},
 	});

--- a/apps/web/src/live-sessions/hooks/use-tournament-stack.ts
+++ b/apps/web/src/live-sessions/hooks/use-tournament-stack.ts
@@ -1,10 +1,36 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import {
+	applyOptimisticLiveSessionEvent,
+	cancelLiveSessionCaches,
+	getLiveSessionCacheRefs,
+	invalidateLiveSessionCaches,
+	type LiveSessionEvent,
+	type LiveSessionEventType,
+	restoreLiveSessionCaches,
+	snapshotLiveSessionCaches,
+} from "@/live-sessions/lib/live-session-cache";
 import { trpc, trpcClient } from "@/utils/trpc";
+
+function buildOptimisticEvent(
+	eventType: LiveSessionEventType,
+	payload: unknown
+): LiveSessionEvent {
+	return {
+		eventType,
+		id: `optimistic-${Date.now()}`,
+		occurredAt: new Date().toISOString(),
+		payload,
+	};
+}
 
 export function useTournamentStack({ sessionId }: { sessionId: string }) {
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
+	const refs = getLiveSessionCacheRefs({
+		sessionId,
+		sessionType: "tournament",
+	});
 
 	const sessionQuery = useQuery({
 		...trpc.liveTournamentSession.getById.queryOptions({ id: sessionId }),
@@ -24,94 +50,37 @@ export function useTournamentStack({ sessionId }: { sessionId: string }) {
 		chips: t.chips,
 	}));
 
-	const sessionKey = trpc.liveTournamentSession.getById.queryOptions({
-		id: sessionId,
-	}).queryKey;
-	const eventsKey = trpc.sessionEvent.list.queryOptions({
-		liveTournamentSessionId: sessionId,
-	}).queryKey;
-	const listKey = trpc.liveTournamentSession.list.queryOptions({}).queryKey;
-
-	const invalidateSession = async () => {
-		await Promise.all([
-			queryClient.invalidateQueries({ queryKey: sessionKey }),
-			queryClient.invalidateQueries({ queryKey: eventsKey }),
-		]);
-	};
-
-	const stackMutation = useMutation({
-		mutationFn: (values: { stackAmount: number }) =>
-			trpcClient.sessionEvent.create.mutate({
-				liveTournamentSessionId: sessionId,
-				eventType: "update_stack",
-				payload: {
-					stackAmount: values.stackAmount,
-				},
-			}),
-		onSuccess: invalidateSession,
-	});
-
-	const purchaseChipsMutation = useMutation({
-		mutationFn: (values: { name: string; cost: number; chips: number }) =>
-			trpcClient.sessionEvent.create.mutate({
-				liveTournamentSessionId: sessionId,
-				eventType: "purchase_chips",
-				payload: values,
-			}),
-		onSuccess: invalidateSession,
-	});
-
-	const updateTournamentInfoMutation = useMutation({
-		mutationFn: (values: {
-			remainingPlayers: number | null;
-			totalEntries: number | null;
-			chipPurchaseCounts: Array<{
-				name: string;
-				count: number;
-				chipsPerUnit: number;
-			}>;
+	const applyCreateEventMutation = useMutation({
+		mutationFn: ({
+			eventType,
+			payload,
+		}: {
+			eventType: LiveSessionEventType;
+			payload: unknown;
 		}) =>
 			trpcClient.sessionEvent.create.mutate({
 				liveTournamentSessionId: sessionId,
-				eventType: "update_tournament_info",
-				payload: {
-					remainingPlayers: values.remainingPlayers,
-					totalEntries: values.totalEntries,
-					averageStack: null,
-					chipPurchaseCounts: values.chipPurchaseCounts,
-				},
+				eventType,
+				payload,
 			}),
-		onSuccess: invalidateSession,
-	});
+		onMutate: async ({ eventType, payload }) => {
+			await cancelLiveSessionCaches(queryClient, refs);
+			const snapshot = snapshotLiveSessionCaches(queryClient, refs);
 
-	const memoMutation = useMutation({
-		mutationFn: (text: string) =>
-			trpcClient.sessionEvent.create.mutate({
-				liveTournamentSessionId: sessionId,
-				eventType: "memo",
-				payload: { text },
-			}),
-		onSuccess: invalidateSession,
-	});
+			applyOptimisticLiveSessionEvent(queryClient, refs, {
+				event: buildOptimisticEvent(eventType, payload),
+				eventType,
+				payload,
+			});
 
-	const pauseMutation = useMutation({
-		mutationFn: () =>
-			trpcClient.sessionEvent.create.mutate({
-				liveTournamentSessionId: sessionId,
-				eventType: "session_pause",
-				payload: {},
-			}),
-		onSuccess: invalidateSession,
-	});
-
-	const resumeMutation = useMutation({
-		mutationFn: () =>
-			trpcClient.sessionEvent.create.mutate({
-				liveTournamentSessionId: sessionId,
-				eventType: "session_resume",
-				payload: {},
-			}),
-		onSuccess: invalidateSession,
+			return { snapshot };
+		},
+		onError: (_error, _variables, context) => {
+			restoreLiveSessionCaches(queryClient, context?.snapshot);
+		},
+		onSettled: async () => {
+			await invalidateLiveSessionCaches(queryClient, refs);
+		},
 	});
 
 	const completeMutation = useMutation({
@@ -135,12 +104,9 @@ export function useTournamentStack({ sessionId }: { sessionId: string }) {
 				...values,
 			}),
 		onSuccess: async () => {
-			await Promise.all([
-				queryClient.invalidateQueries({ queryKey: listKey }),
-				queryClient.invalidateQueries({
-					queryKey: trpc.session.list.queryOptions({}).queryKey,
-				}),
-			]);
+			await invalidateLiveSessionCaches(queryClient, refs, {
+				includeHistorical: true,
+			});
 			await navigate({ to: "/sessions" });
 		},
 	});
@@ -148,9 +114,17 @@ export function useTournamentStack({ sessionId }: { sessionId: string }) {
 	return {
 		chipPurchaseTypes,
 		recordStack: (values: { stackAmount: number }) =>
-			stackMutation.mutate(values),
+			applyCreateEventMutation.mutate({
+				eventType: "update_stack",
+				payload: {
+					stackAmount: values.stackAmount,
+				},
+			}),
 		purchaseChips: (values: { name: string; cost: number; chips: number }) =>
-			purchaseChipsMutation.mutate(values),
+			applyCreateEventMutation.mutate({
+				eventType: "purchase_chips",
+				payload: values,
+			}),
 		updateTournamentInfo: (values: {
 			remainingPlayers: number | null;
 			totalEntries: number | null;
@@ -159,7 +133,16 @@ export function useTournamentStack({ sessionId }: { sessionId: string }) {
 				count: number;
 				chipsPerUnit: number;
 			}>;
-		}) => updateTournamentInfoMutation.mutate(values),
+		}) =>
+			applyCreateEventMutation.mutate({
+				eventType: "update_tournament_info",
+				payload: {
+					remainingPlayers: values.remainingPlayers,
+					totalEntries: values.totalEntries,
+					averageStack: null,
+					chipPurchaseCounts: values.chipPurchaseCounts,
+				},
+			}),
 		complete: (
 			values:
 				| {
@@ -175,10 +158,22 @@ export function useTournamentStack({ sessionId }: { sessionId: string }) {
 						prizeMoney: number;
 				  }
 		) => completeMutation.mutate(values),
-		addMemo: (text: string) => memoMutation.mutate(text),
-		pause: () => pauseMutation.mutate(),
-		resume: () => resumeMutation.mutate(),
-		isStackPending: stackMutation.isPending,
+		addMemo: (text: string) =>
+			applyCreateEventMutation.mutate({
+				eventType: "memo",
+				payload: { text },
+			}),
+		pause: () =>
+			applyCreateEventMutation.mutate({
+				eventType: "session_pause",
+				payload: {},
+			}),
+		resume: () =>
+			applyCreateEventMutation.mutate({
+				eventType: "session_resume",
+				payload: {},
+			}),
+		isStackPending: applyCreateEventMutation.isPending,
 		isCompletePending: completeMutation.isPending,
 	};
 }

--- a/apps/web/src/live-sessions/lib/__tests__/live-session-cache.test.ts
+++ b/apps/web/src/live-sessions/lib/__tests__/live-session-cache.test.ts
@@ -1,0 +1,282 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import {
+	applyOptimisticLiveSessionEvent,
+	getHistoricalInvalidationTargets,
+	getLiveSessionCacheRefs,
+	invalidateLiveSessionCaches,
+	type LiveSessionDetailData,
+	type LiveSessionListData,
+	type LiveSessionPlayersData,
+	restoreLiveSessionCaches,
+	snapshotLiveSessionCaches,
+	transitionLiveSessionStatus,
+} from "../live-session-cache";
+
+vi.mock("@/utils/trpc", () => ({
+	trpc: {
+		currency: {
+			list: {
+				queryOptions: () => ({
+					queryKey: ["currency-list"],
+				}),
+			},
+		},
+		currencyTransaction: {
+			listByCurrency: {
+				queryOptions: ({ currencyId }: { currencyId: string }) => ({
+					queryKey: ["currency-transaction-list", currencyId],
+				}),
+			},
+		},
+		liveCashGameSession: {
+			getById: {
+				queryOptions: ({ id }: { id: string }) => ({
+					queryKey: ["cash-detail", id],
+				}),
+			},
+			list: {
+				queryOptions: (input: Record<string, unknown>) => ({
+					queryKey: ["cash-list", input],
+				}),
+			},
+		},
+		liveTournamentSession: {
+			getById: {
+				queryOptions: ({ id }: { id: string }) => ({
+					queryKey: ["tournament-detail", id],
+				}),
+			},
+			list: {
+				queryOptions: (input: Record<string, unknown>) => ({
+					queryKey: ["tournament-list", input],
+				}),
+			},
+		},
+		session: {
+			list: {
+				queryOptions: () => ({
+					queryKey: ["session-list"],
+				}),
+			},
+		},
+		sessionEvent: {
+			list: {
+				queryOptions: (input: Record<string, unknown>) => ({
+					queryKey: ["session-events", input],
+				}),
+			},
+		},
+		sessionTablePlayer: {
+			list: {
+				queryOptions: (input: Record<string, unknown>) => ({
+					queryKey: ["session-players", input],
+				}),
+			},
+		},
+	},
+}));
+
+function createQueryClientMock(initialData: Record<string, unknown> = {}) {
+	const data = new Map<string, unknown>(Object.entries(initialData));
+
+	const queryClient = {
+		cancelQueries: vi.fn(async () => undefined),
+		getQueryData: vi.fn((queryKey: QueryKey) =>
+			data.get(JSON.stringify(queryKey))
+		),
+		invalidateQueries: vi.fn(async () => undefined),
+		setQueryData: vi.fn(
+			(
+				queryKey: QueryKey,
+				updater: unknown | ((previousData: unknown) => unknown)
+			) => {
+				const key = JSON.stringify(queryKey);
+				const previousData = data.get(key);
+				const nextData =
+					typeof updater === "function"
+						? (updater as (previousData: unknown) => unknown)(previousData)
+						: updater;
+				data.set(key, nextData);
+				return nextData;
+			}
+		),
+	} as unknown as QueryClient;
+
+	return {
+		data,
+		queryClient,
+	};
+}
+
+describe("live-session-cache", () => {
+	it("transitions cash session status and restores from snapshot", () => {
+		const refs = getLiveSessionCacheRefs({
+			sessionId: "cash-1",
+			sessionType: "cash_game",
+		});
+		const { queryClient } = createQueryClientMock({
+			[JSON.stringify(refs.detailKey)]: {
+				currencyId: "currency-1",
+				status: "active",
+			} satisfies LiveSessionDetailData,
+			[JSON.stringify(refs.listKeys.active)]: {
+				items: [{ id: "cash-1", status: "active" }],
+			} satisfies LiveSessionListData,
+			[JSON.stringify(refs.listKeys.all)]: {
+				items: [{ id: "cash-1", status: "active" }],
+			} satisfies LiveSessionListData,
+			[JSON.stringify(refs.listKeys.paused)]: {
+				items: [],
+			} satisfies LiveSessionListData,
+			[JSON.stringify(refs.eventsKey)]: [],
+			[JSON.stringify(refs.playersKey)]: {
+				items: [],
+			} satisfies LiveSessionPlayersData,
+		});
+
+		const snapshot = snapshotLiveSessionCaches(queryClient, refs);
+
+		transitionLiveSessionStatus(queryClient, refs, "paused");
+
+		expect(queryClient.getQueryData(refs.detailKey)).toEqual(
+			expect.objectContaining({ status: "paused" })
+		);
+		expect(queryClient.getQueryData(refs.listKeys.all)).toEqual({
+			items: [{ id: "cash-1", status: "paused" }],
+		});
+		expect(queryClient.getQueryData(refs.listKeys.active)).toEqual({
+			items: [],
+		});
+		expect(queryClient.getQueryData(refs.listKeys.paused)).toEqual({
+			items: [{ id: "cash-1", status: "paused" }],
+		});
+
+		restoreLiveSessionCaches(queryClient, snapshot);
+
+		expect(queryClient.getQueryData(refs.detailKey)).toEqual(
+			expect.objectContaining({ status: "active" })
+		);
+		expect(queryClient.getQueryData(refs.listKeys.active)).toEqual({
+			items: [{ id: "cash-1", status: "active" }],
+		});
+	});
+
+	it("transitions tournament sessions back to active", () => {
+		const refs = getLiveSessionCacheRefs({
+			sessionId: "tournament-1",
+			sessionType: "tournament",
+		});
+		const { queryClient } = createQueryClientMock({
+			[JSON.stringify(refs.detailKey)]: {
+				status: "paused",
+			} satisfies LiveSessionDetailData,
+			[JSON.stringify(refs.listKeys.active)]: {
+				items: [],
+			} satisfies LiveSessionListData,
+			[JSON.stringify(refs.listKeys.all)]: {
+				items: [{ id: "tournament-1", status: "paused" }],
+			} satisfies LiveSessionListData,
+			[JSON.stringify(refs.listKeys.paused)]: {
+				items: [{ id: "tournament-1", status: "paused" }],
+			} satisfies LiveSessionListData,
+			[JSON.stringify(refs.eventsKey)]: [],
+			[JSON.stringify(refs.playersKey)]: {
+				items: [],
+			} satisfies LiveSessionPlayersData,
+		});
+
+		transitionLiveSessionStatus(queryClient, refs, "active");
+
+		expect(queryClient.getQueryData(refs.detailKey)).toEqual(
+			expect.objectContaining({ status: "active" })
+		);
+		expect(queryClient.getQueryData(refs.listKeys.active)).toEqual({
+			items: [{ id: "tournament-1", status: "active" }],
+		});
+		expect(queryClient.getQueryData(refs.listKeys.paused)).toEqual({
+			items: [],
+		});
+	});
+
+	it("applies optimistic event updates to summary and list data", () => {
+		const refs = getLiveSessionCacheRefs({
+			sessionId: "cash-2",
+			sessionType: "cash_game",
+		});
+		const { queryClient } = createQueryClientMock({
+			[JSON.stringify(refs.detailKey)]: {
+				summary: { addonCount: 0, currentStack: 100, totalBuyIn: 500 },
+			} satisfies LiveSessionDetailData,
+			[JSON.stringify(refs.eventsKey)]: [],
+			[JSON.stringify(refs.listKeys.all)]: {
+				items: [{ id: "cash-2", latestStackAmount: 100, status: "active" }],
+			} satisfies LiveSessionListData,
+		});
+
+		applyOptimisticLiveSessionEvent(queryClient, refs, {
+			eventType: "update_stack",
+			payload: { stackAmount: 250 },
+		});
+		applyOptimisticLiveSessionEvent(queryClient, refs, {
+			eventType: "chips_add_remove",
+			payload: { amount: 50, type: "add" },
+		});
+
+		expect(queryClient.getQueryData(refs.detailKey)).toEqual(
+			expect.objectContaining({
+				summary: expect.objectContaining({
+					addonCount: 1,
+					currentStack: 250,
+					totalBuyIn: 550,
+				}),
+			})
+		);
+		expect(queryClient.getQueryData(refs.listKeys.all)).toEqual({
+			items: [{ id: "cash-2", latestStackAmount: 250, status: "active" }],
+		});
+	});
+
+	it("builds historical invalidation targets only when currency exists", async () => {
+		const refs = getLiveSessionCacheRefs({
+			sessionId: "cash-3",
+			sessionType: "cash_game",
+		});
+		const withCurrency = createQueryClientMock({
+			[JSON.stringify(refs.detailKey)]: {
+				currencyId: "currency-9",
+			} satisfies LiveSessionDetailData,
+		}).queryClient;
+		const withoutCurrency = createQueryClientMock({
+			[JSON.stringify(refs.detailKey)]: {
+				currencyId: null,
+			} satisfies LiveSessionDetailData,
+		}).queryClient;
+
+		expect(getHistoricalInvalidationTargets(withCurrency, refs)).toEqual([
+			{ queryKey: ["session-list"] },
+			{ queryKey: ["currency-list"] },
+			{ queryKey: ["currency-transaction-list", "currency-9"] },
+		]);
+		expect(getHistoricalInvalidationTargets(withoutCurrency, refs)).toEqual([
+			{ queryKey: ["session-list"] },
+			{ queryKey: ["currency-list"] },
+		]);
+
+		await invalidateLiveSessionCaches(withCurrency, refs, {
+			includeHistorical: true,
+			includeLists: false,
+			includePlayers: false,
+		});
+
+		expect(withCurrency.invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["session-list"],
+		});
+		expect(withCurrency.invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["currency-list"],
+		});
+		expect(withCurrency.invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["currency-transaction-list", "currency-9"],
+		});
+	});
+});

--- a/apps/web/src/live-sessions/lib/live-session-cache.ts
+++ b/apps/web/src/live-sessions/lib/live-session-cache.ts
@@ -1,0 +1,754 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import {
+	cancelTargets,
+	invalidateTargets,
+	type OptimisticTarget,
+	type QuerySnapshot,
+	restoreSnapshots,
+	snapshotQuery,
+} from "@/utils/optimistic-update";
+import { trpc } from "@/utils/trpc";
+
+export type LiveSessionType = "cash_game" | "tournament";
+export type LiveSessionStatus = "active" | "paused" | "completed";
+export type LiveSessionEventType =
+	| "all_in"
+	| "chips_add_remove"
+	| "memo"
+	| "player_join"
+	| "player_leave"
+	| "purchase_chips"
+	| "session_end"
+	| "session_pause"
+	| "session_resume"
+	| "session_start"
+	| "update_stack"
+	| "update_tournament_info";
+
+export interface LiveSessionEvent {
+	eventType: LiveSessionEventType;
+	id: string;
+	occurredAt: string | Date;
+	payload: unknown;
+}
+
+export interface LiveSessionTablePlayerItem {
+	id: string;
+	isActive: boolean;
+	joinedAt: string | Date;
+	leftAt: string | Date | null;
+	player: {
+		id: string;
+		memo: string | null;
+		name: string;
+	};
+	seatPosition: number | null;
+}
+
+export interface LiveSessionPlayersData {
+	items: LiveSessionTablePlayerItem[];
+}
+
+export interface LiveSessionSummaryData {
+	summary?: Record<string, unknown>;
+	[key: string]: unknown;
+}
+
+export interface LiveSessionDetailData extends LiveSessionSummaryData {
+	currencyId?: string | null;
+	events?: LiveSessionEvent[];
+	heroSeatPosition?: number | null;
+	id?: string;
+	status?: LiveSessionStatus;
+	tablePlayers?: LiveSessionTablePlayerItem[];
+}
+
+export interface LiveSessionListItem {
+	averageStack?: number | null;
+	eventCount?: number;
+	id: string;
+	latestStackAmount?: number | null;
+	remainingPlayers?: number | null;
+	status: LiveSessionStatus;
+	updatedAt?: string | Date;
+	[key: string]: unknown;
+}
+
+export interface LiveSessionListData<
+	TItem extends LiveSessionListItem = LiveSessionListItem,
+> {
+	items: TItem[];
+	nextCursor?: string;
+}
+
+export interface LiveSessionCacheRefs {
+	detailKey: QueryKey;
+	eventsKey: QueryKey;
+	historicalTargets: {
+		currencyList: OptimisticTarget;
+		sessionList: OptimisticTarget;
+	};
+	listKeys: {
+		active: QueryKey;
+		all: QueryKey;
+		paused: QueryKey;
+	};
+	playersKey: QueryKey;
+	sessionId: string;
+	sessionType: LiveSessionType;
+}
+
+export interface LiveSessionCacheSnapshot {
+	detail: QuerySnapshot;
+	events: QuerySnapshot;
+	listActive: QuerySnapshot;
+	listAll: QuerySnapshot;
+	listPaused: QuerySnapshot;
+	players: QuerySnapshot;
+}
+
+interface InvalidateLiveSessionCacheOptions {
+	includeDetail?: boolean;
+	includeEvents?: boolean;
+	includeHistorical?: boolean;
+	includeLists?: boolean;
+	includePlayers?: boolean;
+}
+
+function getSessionEventQueryInput(
+	sessionId: string,
+	sessionType: LiveSessionType
+) {
+	return sessionType === "cash_game"
+		? { liveCashGameSessionId: sessionId }
+		: { liveTournamentSessionId: sessionId };
+}
+
+function getTablePlayersQueryInput(
+	sessionId: string,
+	sessionType: LiveSessionType
+) {
+	return sessionType === "cash_game"
+		? { liveCashGameSessionId: sessionId }
+		: { liveTournamentSessionId: sessionId };
+}
+
+function getDetailKey(
+	sessionId: string,
+	sessionType: LiveSessionType
+): QueryKey {
+	return sessionType === "cash_game"
+		? trpc.liveCashGameSession.getById.queryOptions({
+				id: sessionId,
+			}).queryKey
+		: trpc.liveTournamentSession.getById.queryOptions({
+				id: sessionId,
+			}).queryKey;
+}
+
+function getListKeys(sessionType: LiveSessionType) {
+	return sessionType === "cash_game"
+		? {
+				active: trpc.liveCashGameSession.list.queryOptions({
+					status: "active",
+					limit: 1,
+				}).queryKey,
+				all: trpc.liveCashGameSession.list.queryOptions({}).queryKey,
+				paused: trpc.liveCashGameSession.list.queryOptions({
+					status: "paused",
+					limit: 1,
+				}).queryKey,
+			}
+		: {
+				active: trpc.liveTournamentSession.list.queryOptions({
+					status: "active",
+					limit: 1,
+				}).queryKey,
+				all: trpc.liveTournamentSession.list.queryOptions({}).queryKey,
+				paused: trpc.liveTournamentSession.list.queryOptions({
+					status: "paused",
+					limit: 1,
+				}).queryKey,
+			};
+}
+
+export function getLiveSessionCacheRefs({
+	sessionId,
+	sessionType,
+}: {
+	sessionId: string;
+	sessionType: LiveSessionType;
+}): LiveSessionCacheRefs {
+	return {
+		detailKey: getDetailKey(sessionId, sessionType),
+		eventsKey: trpc.sessionEvent.list.queryOptions(
+			getSessionEventQueryInput(sessionId, sessionType)
+		).queryKey,
+		historicalTargets: {
+			currencyList: {
+				queryKey: trpc.currency.list.queryOptions().queryKey,
+			},
+			sessionList: {
+				queryKey: trpc.session.list.queryOptions({}).queryKey,
+			},
+		},
+		listKeys: getListKeys(sessionType),
+		playersKey: trpc.sessionTablePlayer.list.queryOptions(
+			getTablePlayersQueryInput(sessionId, sessionType)
+		).queryKey,
+		sessionId,
+		sessionType,
+	};
+}
+
+function getOptimisticTargets(
+	refs: LiveSessionCacheRefs,
+	{
+		includeDetail = true,
+		includeEvents = true,
+		includeLists = true,
+		includePlayers = true,
+	}: InvalidateLiveSessionCacheOptions = {}
+): OptimisticTarget[] {
+	const targets: OptimisticTarget[] = [];
+
+	if (includeDetail) {
+		targets.push({ queryKey: refs.detailKey });
+	}
+	if (includeEvents) {
+		targets.push({ queryKey: refs.eventsKey });
+	}
+	if (includePlayers) {
+		targets.push({ queryKey: refs.playersKey });
+	}
+	if (includeLists) {
+		targets.push(
+			{ queryKey: refs.listKeys.all },
+			{ queryKey: refs.listKeys.active },
+			{ queryKey: refs.listKeys.paused }
+		);
+	}
+
+	return targets;
+}
+
+function buildHistoricalTargets(
+	refs: LiveSessionCacheRefs,
+	currencyId: string | null | undefined
+): OptimisticTarget[] {
+	const targets = [
+		refs.historicalTargets.sessionList,
+		refs.historicalTargets.currencyList,
+	];
+
+	if (currencyId) {
+		targets.push({
+			queryKey: trpc.currencyTransaction.listByCurrency.queryOptions({
+				currencyId,
+			}).queryKey,
+		});
+	}
+
+	return targets;
+}
+
+function updateArrayItem<T extends { id: string }>(
+	items: T[],
+	id: string,
+	updater: (item: T) => T
+) {
+	return items.map((item) => (item.id === id ? updater(item) : item));
+}
+
+function resolveCurrencyId(
+	queryClient: QueryClient,
+	refs: LiveSessionCacheRefs,
+	currencyId?: string | null
+) {
+	if (currencyId !== undefined) {
+		return currencyId;
+	}
+
+	const detail =
+		queryClient.getQueryData<LiveSessionDetailData>(refs.detailKey) ?? null;
+
+	return detail?.currencyId ?? null;
+}
+
+function getListFallbackItem(
+	queryClient: QueryClient,
+	refs: LiveSessionCacheRefs,
+	status: LiveSessionStatus
+): LiveSessionListItem {
+	const allList = queryClient.getQueryData<LiveSessionListData>(
+		refs.listKeys.all
+	);
+	const currentListItem = allList?.items.find(
+		(item) => item.id === refs.sessionId
+	);
+
+	if (currentListItem) {
+		return {
+			...currentListItem,
+			status,
+		};
+	}
+
+	const detail =
+		queryClient.getQueryData<LiveSessionDetailData>(refs.detailKey) ?? null;
+
+	return {
+		currencyId: detail?.currencyId ?? null,
+		id: refs.sessionId,
+		status,
+		updatedAt:
+			typeof detail?.updatedAt === "string" || detail?.updatedAt instanceof Date
+				? detail.updatedAt
+				: undefined,
+	};
+}
+
+function applyChipsAddRemoveSummary(
+	summary: Record<string, unknown>,
+	payload: Record<string, unknown>
+) {
+	if (payload.type !== "add" || typeof payload.amount !== "number") {
+		return;
+	}
+
+	summary.totalBuyIn =
+		(typeof summary.totalBuyIn === "number" ? summary.totalBuyIn : 0) +
+		payload.amount;
+	summary.addonCount =
+		(typeof summary.addonCount === "number" ? summary.addonCount : 0) + 1;
+}
+
+function applyPurchaseChipsSummary(
+	summary: Record<string, unknown>,
+	payload: Record<string, unknown>
+) {
+	if (typeof payload.cost !== "number") {
+		return;
+	}
+
+	summary.rebuyCount =
+		(typeof summary.rebuyCount === "number" ? summary.rebuyCount : 0) + 1;
+	summary.rebuyCost =
+		(typeof summary.rebuyCost === "number" ? summary.rebuyCost : 0) +
+		payload.cost;
+}
+
+function applySessionEndSummary(
+	summary: Record<string, unknown>,
+	payload: Record<string, unknown>
+) {
+	if (typeof payload.cashOutAmount === "number") {
+		summary.cashOut = payload.cashOutAmount;
+		const totalBuyIn =
+			typeof summary.totalBuyIn === "number" ? summary.totalBuyIn : 0;
+		summary.profitLoss = payload.cashOutAmount - totalBuyIn;
+	}
+
+	if (payload.beforeDeadline === false) {
+		if (typeof payload.placement === "number") {
+			summary.placement = payload.placement;
+		}
+
+		if (typeof payload.totalEntries === "number") {
+			summary.totalEntries = payload.totalEntries;
+		}
+	}
+
+	if (typeof payload.prizeMoney === "number") {
+		const bountyPrizes =
+			typeof payload.bountyPrizes === "number" ? payload.bountyPrizes : 0;
+		summary.prizeMoney = payload.prizeMoney;
+		summary.bountyPrizes = bountyPrizes;
+		summary.profitLoss = payload.prizeMoney + bountyPrizes;
+	}
+}
+
+function applySessionStartSummary(
+	summary: Record<string, unknown>,
+	payload: Record<string, unknown>
+) {
+	if (typeof payload.buyInAmount !== "number") {
+		return;
+	}
+
+	summary.totalBuyIn =
+		(typeof summary.totalBuyIn === "number" ? summary.totalBuyIn : 0) +
+		payload.buyInAmount;
+}
+
+function applyUpdateStackSummary(
+	summary: Record<string, unknown>,
+	payload: Record<string, unknown>
+) {
+	if (typeof payload.stackAmount === "number") {
+		summary.currentStack = payload.stackAmount;
+	}
+}
+
+function applyUpdateTournamentInfoSummary(
+	summary: Record<string, unknown>,
+	payload: Record<string, unknown>
+) {
+	if (typeof payload.remainingPlayers === "number") {
+		summary.remainingPlayers = payload.remainingPlayers;
+	}
+
+	if (typeof payload.totalEntries === "number") {
+		summary.totalEntries = payload.totalEntries;
+	}
+
+	if (typeof payload.averageStack === "number") {
+		summary.averageStack = payload.averageStack;
+	}
+}
+
+const SUMMARY_APPLIERS: Partial<
+	Record<
+		LiveSessionEventType,
+		(summary: Record<string, unknown>, payload: Record<string, unknown>) => void
+	>
+> = {
+	chips_add_remove: applyChipsAddRemoveSummary,
+	purchase_chips: applyPurchaseChipsSummary,
+	session_end: applySessionEndSummary,
+	session_start: applySessionStartSummary,
+	update_stack: applyUpdateStackSummary,
+	update_tournament_info: applyUpdateTournamentInfoSummary,
+};
+
+function buildOptimisticSessionSummary(
+	summary: Record<string, unknown>,
+	eventType: LiveSessionEventType,
+	payload: Record<string, unknown>,
+	occurredAt?: number
+) {
+	const nextSummary = { ...summary };
+	const applySummary = SUMMARY_APPLIERS[eventType];
+	applySummary?.(nextSummary, payload);
+
+	if (occurredAt) {
+		nextSummary.lastUpdatedAt = occurredAt;
+	}
+
+	return nextSummary;
+}
+
+function patchSummaryForEvent(
+	queryClient: QueryClient,
+	refs: LiveSessionCacheRefs,
+	eventType: LiveSessionEventType,
+	payload: unknown,
+	occurredAt?: number
+) {
+	if (!payload || typeof payload !== "object") {
+		return;
+	}
+
+	patchLiveSessionDetail(queryClient, refs, (old) => {
+		if (!old?.summary) {
+			return old;
+		}
+
+		return {
+			...old,
+			summary: buildOptimisticSessionSummary(
+				old.summary,
+				eventType,
+				payload as Record<string, unknown>,
+				occurredAt
+			),
+		};
+	});
+
+	queryClient.setQueryData<LiveSessionListData>(refs.listKeys.all, (old) => {
+		if (!old) {
+			return old;
+		}
+
+		const typedPayload = payload as Record<string, unknown>;
+
+		return {
+			...old,
+			items: old.items.map((item) => {
+				if (item.id !== refs.sessionId) {
+					return item;
+				}
+
+				const nextItem = { ...item };
+
+				if (
+					eventType === "update_stack" &&
+					typeof typedPayload.stackAmount === "number"
+				) {
+					nextItem.latestStackAmount = typedPayload.stackAmount;
+				}
+
+				if (eventType === "update_tournament_info") {
+					if (typeof typedPayload.remainingPlayers === "number") {
+						nextItem.remainingPlayers = typedPayload.remainingPlayers;
+					}
+					if (typeof typedPayload.averageStack === "number") {
+						nextItem.averageStack = typedPayload.averageStack;
+					}
+				}
+
+				return nextItem;
+			}),
+		};
+	});
+}
+
+export async function cancelLiveSessionCaches(
+	queryClient: QueryClient,
+	refs: LiveSessionCacheRefs,
+	options?: InvalidateLiveSessionCacheOptions
+) {
+	await cancelTargets(queryClient, getOptimisticTargets(refs, options));
+}
+
+export function snapshotLiveSessionCaches(
+	queryClient: QueryClient,
+	refs: LiveSessionCacheRefs
+): LiveSessionCacheSnapshot {
+	return {
+		detail: snapshotQuery(queryClient, refs.detailKey),
+		events: snapshotQuery(queryClient, refs.eventsKey),
+		listActive: snapshotQuery(queryClient, refs.listKeys.active),
+		listAll: snapshotQuery(queryClient, refs.listKeys.all),
+		listPaused: snapshotQuery(queryClient, refs.listKeys.paused),
+		players: snapshotQuery(queryClient, refs.playersKey),
+	};
+}
+
+export function restoreLiveSessionCaches(
+	queryClient: QueryClient,
+	snapshot: LiveSessionCacheSnapshot | null | undefined
+) {
+	if (!snapshot) {
+		return;
+	}
+
+	restoreSnapshots(queryClient, [
+		snapshot.detail,
+		snapshot.events,
+		snapshot.players,
+		snapshot.listAll,
+		snapshot.listActive,
+		snapshot.listPaused,
+	]);
+}
+
+export async function invalidateLiveSessionCaches(
+	queryClient: QueryClient,
+	refs: LiveSessionCacheRefs,
+	{
+		currencyId,
+		includeDetail = true,
+		includeEvents = true,
+		includeHistorical = false,
+		includeLists = true,
+		includePlayers = true,
+	}: InvalidateLiveSessionCacheOptions & {
+		currencyId?: string | null;
+	} = {}
+) {
+	const targets = getOptimisticTargets(refs, {
+		includeDetail,
+		includeEvents,
+		includeLists,
+		includePlayers,
+	});
+
+	if (includeHistorical) {
+		targets.push(
+			...buildHistoricalTargets(
+				refs,
+				resolveCurrencyId(queryClient, refs, currencyId)
+			)
+		);
+	}
+
+	await invalidateTargets(queryClient, targets);
+}
+
+export function patchLiveSessionDetail(
+	queryClient: QueryClient,
+	refs: LiveSessionCacheRefs,
+	updater: (
+		session: LiveSessionDetailData | undefined
+	) => LiveSessionDetailData | undefined
+) {
+	queryClient.setQueryData<LiveSessionDetailData>(refs.detailKey, (old) =>
+		updater(old)
+	);
+}
+
+export function patchLiveSessionLists(
+	queryClient: QueryClient,
+	refs: LiveSessionCacheRefs,
+	updater: (item: LiveSessionListItem) => LiveSessionListItem
+) {
+	queryClient.setQueryData<LiveSessionListData>(refs.listKeys.all, (old) => {
+		if (!old) {
+			return old;
+		}
+
+		return {
+			...old,
+			items: old.items.map((item) =>
+				item.id === refs.sessionId ? updater(item) : item
+			),
+		};
+	});
+}
+
+export function transitionLiveSessionStatus(
+	queryClient: QueryClient,
+	refs: LiveSessionCacheRefs,
+	status: Extract<LiveSessionStatus, "active" | "paused">
+) {
+	patchLiveSessionDetail(queryClient, refs, (old) =>
+		old ? { ...old, status } : old
+	);
+
+	patchLiveSessionLists(queryClient, refs, (item) => ({
+		...item,
+		status,
+	}));
+
+	const fallbackItem = getListFallbackItem(queryClient, refs, status);
+
+	queryClient.setQueryData<LiveSessionListData>(refs.listKeys.active, (old) =>
+		old
+			? {
+					...old,
+					items: status === "active" ? [fallbackItem] : [],
+				}
+			: old
+	);
+
+	queryClient.setQueryData<LiveSessionListData>(refs.listKeys.paused, (old) =>
+		old
+			? {
+					...old,
+					items: status === "paused" ? [fallbackItem] : [],
+				}
+			: old
+	);
+}
+
+export function patchLiveSessionEvents(
+	queryClient: QueryClient,
+	refs: LiveSessionCacheRefs,
+	updater: (events: LiveSessionEvent[]) => LiveSessionEvent[]
+) {
+	queryClient.setQueryData<LiveSessionEvent[]>(refs.eventsKey, (old) =>
+		updater(old ?? [])
+	);
+
+	patchLiveSessionDetail(queryClient, refs, (old) =>
+		old
+			? {
+					...old,
+					events: updater((old.events ?? []) as LiveSessionEvent[]),
+				}
+			: old
+	);
+}
+
+export function patchLiveSessionPlayers(
+	queryClient: QueryClient,
+	refs: LiveSessionCacheRefs,
+	updater: (
+		players: LiveSessionTablePlayerItem[]
+	) => LiveSessionTablePlayerItem[]
+) {
+	queryClient.setQueryData<LiveSessionPlayersData>(refs.playersKey, (old) =>
+		old
+			? {
+					...old,
+					items: updater(old.items),
+				}
+			: old
+	);
+
+	patchLiveSessionDetail(queryClient, refs, (old) =>
+		old
+			? {
+					...old,
+					tablePlayers: updater(
+						(old.tablePlayers ?? []) as LiveSessionTablePlayerItem[]
+					),
+				}
+			: old
+	);
+}
+
+export function applyOptimisticLiveSessionEvent(
+	queryClient: QueryClient,
+	refs: LiveSessionCacheRefs,
+	{
+		event,
+		eventType,
+		occurredAt,
+		payload,
+	}: {
+		event?: LiveSessionEvent;
+		eventType: LiveSessionEventType;
+		occurredAt?: number;
+		payload: unknown;
+	}
+) {
+	const optimisticEvent: LiveSessionEvent = event ?? {
+		eventType,
+		id: `optimistic-${Date.now()}`,
+		occurredAt: new Date(
+			occurredAt ? occurredAt * 1000 : Date.now()
+		).toISOString(),
+		payload,
+	};
+
+	if (event) {
+		patchLiveSessionEvents(queryClient, refs, (events) =>
+			updateArrayItem(events, event.id, (currentEvent) => ({
+				...currentEvent,
+				occurredAt:
+					occurredAt !== undefined
+						? new Date(occurredAt * 1000).toISOString()
+						: currentEvent.occurredAt,
+				payload,
+			}))
+		);
+	} else {
+		patchLiveSessionEvents(queryClient, refs, (events) => [
+			...events,
+			optimisticEvent,
+		]);
+	}
+
+	if (eventType === "session_pause") {
+		transitionLiveSessionStatus(queryClient, refs, "paused");
+	}
+
+	if (eventType === "session_resume") {
+		transitionLiveSessionStatus(queryClient, refs, "active");
+	}
+
+	patchSummaryForEvent(queryClient, refs, eventType, payload, occurredAt);
+}
+
+export function getHistoricalInvalidationTargets(
+	queryClient: QueryClient,
+	refs: LiveSessionCacheRefs,
+	currencyId?: string | null
+) {
+	return buildHistoricalTargets(
+		refs,
+		resolveCurrencyId(queryClient, refs, currencyId)
+	);
+}

--- a/apps/web/src/players/hooks/use-poker-table-interaction.ts
+++ b/apps/web/src/players/hooks/use-poker-table-interaction.ts
@@ -2,25 +2,38 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import type { TablePlayer } from "@/live-sessions/components/poker-table";
 import {
-	cancelTargets,
-	invalidateTargets,
-	restoreSnapshots,
-	snapshotQuery,
-} from "@/utils/optimistic-update";
-import { trpc, trpcClient } from "@/utils/trpc";
+	applyOptimisticLiveSessionEvent,
+	cancelLiveSessionCaches,
+	getLiveSessionCacheRefs,
+	invalidateLiveSessionCaches,
+	type LiveSessionEvent,
+	type LiveSessionEventType,
+	type LiveSessionType,
+	patchLiveSessionDetail,
+	restoreLiveSessionCaches,
+	snapshotLiveSessionCaches,
+} from "@/live-sessions/lib/live-session-cache";
+import { trpcClient } from "@/utils/trpc";
 
 export interface SelectedPlayer {
 	playerId: string;
 	seatPosition: number;
 }
 
-export interface SessionDetailWithHeroSeat {
-	heroSeatPosition?: number | null;
-	[key: string]: unknown;
+function buildOptimisticEvent(
+	eventType: LiveSessionEventType,
+	payload: unknown
+): LiveSessionEvent {
+	return {
+		eventType,
+		id: `optimistic-${Date.now()}`,
+		occurredAt: new Date().toISOString(),
+		payload,
+	};
 }
 
 export function usePokerTableInteraction(
-	sessionType: "cash_game" | "tournament",
+	sessionType: LiveSessionType,
 	sessionId: string,
 	heroSeatPosition: number | null
 ) {
@@ -29,19 +42,7 @@ export function usePokerTableInteraction(
 	const [selectedPlayer, setSelectedPlayer] = useState<SelectedPlayer | null>(
 		null
 	);
-
-	const sessionKey =
-		sessionType === "cash_game"
-			? trpc.liveCashGameSession.getById.queryOptions({ id: sessionId })
-					.queryKey
-			: trpc.liveTournamentSession.getById.queryOptions({ id: sessionId })
-					.queryKey;
-
-	const [localHeroSeat, setLocalHeroSeat] = useState<number | null | undefined>(
-		undefined
-	);
-	const effectiveHeroSeat =
-		localHeroSeat === undefined ? heroSeatPosition : localHeroSeat;
+	const refs = getLiveSessionCacheRefs({ sessionId, sessionType });
 
 	const heroMutation = useMutation({
 		mutationFn: (nextSeatPosition: number | null) =>
@@ -55,30 +56,61 @@ export function usePokerTableInteraction(
 						heroSeatPosition: nextSeatPosition,
 					}),
 		onMutate: async (nextSeatPosition) => {
-			await cancelTargets(queryClient, [{ queryKey: sessionKey }]);
-			const previousSession = snapshotQuery(queryClient, sessionKey);
-			queryClient.setQueryData<SessionDetailWithHeroSeat>(sessionKey, (old) =>
+			await cancelLiveSessionCaches(queryClient, refs, {
+				includeLists: false,
+				includePlayers: false,
+			});
+			const snapshot = snapshotLiveSessionCaches(queryClient, refs);
+			const currentHeroSeat =
+				queryClient.getQueryData<{ heroSeatPosition?: number | null }>(
+					refs.detailKey
+				)?.heroSeatPosition ?? heroSeatPosition;
+
+			patchLiveSessionDetail(queryClient, refs, (old) =>
 				old ? { ...old, heroSeatPosition: nextSeatPosition } : old
 			);
-			const previousSeat =
-				localHeroSeat === undefined ? heroSeatPosition : localHeroSeat;
-			setLocalHeroSeat(nextSeatPosition);
-			return { previousSeat, previousSession };
+
+			if (currentHeroSeat === null && nextSeatPosition !== null) {
+				applyOptimisticLiveSessionEvent(queryClient, refs, {
+					event: buildOptimisticEvent("player_join", {
+						isHero: true,
+					}),
+					eventType: "player_join",
+					payload: {
+						isHero: true,
+					},
+				});
+			}
+
+			if (currentHeroSeat !== null && nextSeatPosition === null) {
+				applyOptimisticLiveSessionEvent(queryClient, refs, {
+					event: buildOptimisticEvent("player_leave", {
+						isHero: true,
+					}),
+					eventType: "player_leave",
+					payload: {
+						isHero: true,
+					},
+				});
+			}
+
+			return { snapshot };
 		},
 		onError: (_error, _variables, context) => {
-			restoreSnapshots(queryClient, [context?.previousSession]);
-			setLocalHeroSeat(context?.previousSeat ?? undefined);
+			restoreLiveSessionCaches(queryClient, context?.snapshot);
 		},
 		onSettled: async () => {
-			await invalidateTargets(queryClient, [{ queryKey: sessionKey }]);
-			setLocalHeroSeat(undefined);
+			await invalidateLiveSessionCaches(queryClient, refs, {
+				includeLists: false,
+				includePlayers: false,
+			});
 		},
 	});
 
 	return {
 		addPlayerSeat,
 		handleEmptySeatTap: (seatPosition: number) => {
-			if (effectiveHeroSeat === null) {
+			if (heroSeatPosition === null) {
 				heroMutation.mutate(seatPosition);
 				return;
 			}
@@ -90,10 +122,10 @@ export function usePokerTableInteraction(
 		handlePlayerSeatTap: (player: TablePlayer, seatPosition: number) => {
 			setSelectedPlayer({ playerId: player.player.id, seatPosition });
 		},
-		heroSeatPosition: effectiveHeroSeat,
+		heroSeatPosition,
 		selectedPlayer,
 		setAddPlayerSeat,
 		setSelectedPlayer,
-		waitingForHero: effectiveHeroSeat === null,
+		waitingForHero: heroSeatPosition === null,
 	};
 }

--- a/apps/web/src/players/hooks/use-table-players.ts
+++ b/apps/web/src/players/hooks/use-table-players.ts
@@ -1,4 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	applyOptimisticLiveSessionEvent,
+	cancelLiveSessionCaches,
+	getLiveSessionCacheRefs,
+	invalidateLiveSessionCaches,
+	type LiveSessionEvent,
+	type LiveSessionEventType,
+	type LiveSessionPlayersData,
+	type LiveSessionTablePlayerItem,
+	type LiveSessionType,
+	patchLiveSessionPlayers,
+	restoreLiveSessionCaches,
+	snapshotLiveSessionCaches,
+} from "@/live-sessions/lib/live-session-cache";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 interface UseTablePlayersOptions {
@@ -6,17 +20,64 @@ interface UseTablePlayersOptions {
 	liveTournamentSessionId?: string;
 }
 
-interface TablePlayerItem {
-	id: string;
-	isActive: boolean;
-	joinedAt: string;
-	leftAt: string | null;
-	player: { id: string; memo: string | null; name: string };
-	seatPosition: number | null;
+function buildOptimisticEvent(
+	eventType: LiveSessionEventType,
+	payload: unknown
+): LiveSessionEvent {
+	return {
+		eventType,
+		id: `optimistic-${Date.now()}`,
+		occurredAt: new Date().toISOString(),
+		payload,
+	};
 }
 
-interface TablePlayerData {
-	items: TablePlayerItem[];
+function getSessionContext({
+	liveCashGameSessionId,
+	liveTournamentSessionId,
+}: UseTablePlayersOptions): {
+	sessionId: string;
+	sessionParam:
+		| { liveCashGameSessionId: string }
+		| { liveTournamentSessionId: string };
+	sessionType: LiveSessionType;
+} {
+	if (liveCashGameSessionId) {
+		return {
+			sessionId: liveCashGameSessionId,
+			sessionParam: { liveCashGameSessionId },
+			sessionType: "cash_game",
+		};
+	}
+
+	return {
+		sessionId: liveTournamentSessionId ?? "",
+		sessionParam: { liveTournamentSessionId: liveTournamentSessionId ?? "" },
+		sessionType: "tournament",
+	};
+}
+
+function buildOptimisticPlayer(
+	params: {
+		playerId: string;
+		playerMemo?: string;
+		playerName: string;
+		seatPosition: number;
+	},
+	id = `optimistic-${Date.now()}`
+): LiveSessionTablePlayerItem {
+	return {
+		id,
+		player: {
+			id: params.playerId,
+			memo: params.playerMemo ?? null,
+			name: params.playerName,
+		},
+		isActive: true,
+		joinedAt: new Date().toISOString(),
+		leftAt: null,
+		seatPosition: params.seatPosition,
+	};
 }
 
 export function useTablePlayers({
@@ -24,22 +85,17 @@ export function useTablePlayers({
 	liveTournamentSessionId,
 }: UseTablePlayersOptions) {
 	const queryClient = useQueryClient();
-
-	const sessionParam = liveCashGameSessionId
-		? { liveCashGameSessionId }
-		: { liveTournamentSessionId: liveTournamentSessionId ?? "" };
+	const { sessionId, sessionParam, sessionType } = getSessionContext({
+		liveCashGameSessionId,
+		liveTournamentSessionId,
+	});
+	const refs = getLiveSessionCacheRefs({ sessionId, sessionType });
 
 	const playersQuery = useQuery({
 		...trpc.sessionTablePlayer.list.queryOptions(sessionParam),
 		enabled: !!(liveCashGameSessionId || liveTournamentSessionId),
 		refetchInterval: 5000,
 	});
-
-	const playersKey =
-		trpc.sessionTablePlayer.list.queryOptions(sessionParam).queryKey;
-
-	const invalidatePlayers = () =>
-		queryClient.invalidateQueries({ queryKey: playersKey });
 
 	const addMutation = useMutation({
 		mutationFn: (params: {
@@ -53,35 +109,39 @@ export function useTablePlayers({
 				seatPosition: params.seatPosition,
 			}),
 		onMutate: async (params) => {
-			await queryClient.cancelQueries({ queryKey: playersKey });
-			const prev = queryClient.getQueryData<TablePlayerData>(playersKey);
-			if (prev) {
-				queryClient.setQueryData<TablePlayerData>(playersKey, {
-					items: [
-						...prev.items,
-						{
-							id: `optimistic-${Date.now()}`,
-							player: {
-								id: params.playerId,
-								name: params.playerName,
-								memo: null,
-							},
-							isActive: true,
-							joinedAt: new Date().toISOString(),
-							leftAt: null,
-							seatPosition: params.seatPosition,
-						},
-					],
-				});
-			}
-			return { prev };
+			await cancelLiveSessionCaches(queryClient, refs, {
+				includeLists: false,
+			});
+			const snapshot = snapshotLiveSessionCaches(queryClient, refs);
+
+			patchLiveSessionPlayers(queryClient, refs, (currentPlayers) => [
+				...currentPlayers,
+				buildOptimisticPlayer({
+					playerId: params.playerId,
+					playerName: params.playerName,
+					seatPosition: params.seatPosition,
+				}),
+			]);
+			applyOptimisticLiveSessionEvent(queryClient, refs, {
+				event: buildOptimisticEvent("player_join", {
+					playerId: params.playerId,
+				}),
+				eventType: "player_join",
+				payload: {
+					playerId: params.playerId,
+				},
+			});
+
+			return { snapshot };
 		},
 		onError: (_err, _vars, ctx) => {
-			if (ctx?.prev) {
-				queryClient.setQueryData(playersKey, ctx.prev);
-			}
+			restoreLiveSessionCaches(queryClient, ctx?.snapshot);
 		},
-		onSettled: invalidatePlayers,
+		onSettled: async () => {
+			await invalidateLiveSessionCaches(queryClient, refs, {
+				includeLists: false,
+			});
+		},
 	});
 
 	const addNewMutation = useMutation({
@@ -99,39 +159,45 @@ export function useTablePlayers({
 				seatPosition: params.seatPosition,
 			}),
 		onMutate: async (params) => {
-			await queryClient.cancelQueries({ queryKey: playersKey });
-			const prev = queryClient.getQueryData<TablePlayerData>(playersKey);
-			if (prev) {
-				queryClient.setQueryData<TablePlayerData>(playersKey, {
-					items: [
-						...prev.items,
-						{
-							id: `optimistic-${Date.now()}`,
-							player: {
-								id: `new-${Date.now()}`,
-								name: params.playerName,
-								memo: params.playerMemo ?? null,
-							},
-							isActive: true,
-							joinedAt: new Date().toISOString(),
-							leftAt: null,
-							seatPosition: params.seatPosition,
-						},
-					],
-				});
-			}
-			return { prev };
+			await cancelLiveSessionCaches(queryClient, refs, {
+				includeLists: false,
+			});
+			const snapshot = snapshotLiveSessionCaches(queryClient, refs);
+			const optimisticPlayerId = `new-${Date.now()}`;
+
+			patchLiveSessionPlayers(queryClient, refs, (currentPlayers) => [
+				...currentPlayers,
+				buildOptimisticPlayer({
+					playerId: optimisticPlayerId,
+					playerMemo: params.playerMemo,
+					playerName: params.playerName,
+					seatPosition: params.seatPosition,
+				}),
+			]);
+			applyOptimisticLiveSessionEvent(queryClient, refs, {
+				event: buildOptimisticEvent("player_join", {
+					playerId: optimisticPlayerId,
+				}),
+				eventType: "player_join",
+				payload: {
+					playerId: optimisticPlayerId,
+				},
+			});
+
+			return { snapshot };
 		},
 		onError: (_err, _vars, ctx) => {
-			if (ctx?.prev) {
-				queryClient.setQueryData(playersKey, ctx.prev);
-			}
+			restoreLiveSessionCaches(queryClient, ctx?.snapshot);
 		},
-		onSettled: () => {
-			invalidatePlayers();
-			queryClient.invalidateQueries({
-				queryKey: trpc.player.list.queryOptions().queryKey,
-			});
+		onSettled: async () => {
+			await Promise.all([
+				invalidateLiveSessionCaches(queryClient, refs, {
+					includeLists: false,
+				}),
+				queryClient.invalidateQueries({
+					queryKey: trpc.player.list.queryOptions().queryKey,
+				}),
+			]);
 		},
 	});
 
@@ -142,25 +208,42 @@ export function useTablePlayers({
 				playerId,
 			}),
 		onMutate: async (playerId) => {
-			await queryClient.cancelQueries({ queryKey: playersKey });
-			const prev = queryClient.getQueryData<TablePlayerData>(playersKey);
-			if (prev) {
-				queryClient.setQueryData<TablePlayerData>(playersKey, {
-					items: prev.items.map((item) =>
-						item.player.id === playerId
-							? { ...item, isActive: false, leftAt: new Date().toISOString() }
-							: item
-					),
-				});
-			}
-			return { prev };
+			await cancelLiveSessionCaches(queryClient, refs, {
+				includeLists: false,
+			});
+			const snapshot = snapshotLiveSessionCaches(queryClient, refs);
+
+			patchLiveSessionPlayers(queryClient, refs, (currentPlayers) =>
+				currentPlayers.map((item) =>
+					item.player.id === playerId
+						? {
+								...item,
+								isActive: false,
+								leftAt: new Date().toISOString(),
+							}
+						: item
+				)
+			);
+			applyOptimisticLiveSessionEvent(queryClient, refs, {
+				event: buildOptimisticEvent("player_leave", {
+					playerId,
+				}),
+				eventType: "player_leave",
+				payload: {
+					playerId,
+				},
+			});
+
+			return { snapshot };
 		},
 		onError: (_err, _vars, ctx) => {
-			if (ctx?.prev) {
-				queryClient.setQueryData(playersKey, ctx.prev);
-			}
+			restoreLiveSessionCaches(queryClient, ctx?.snapshot);
 		},
-		onSettled: invalidatePlayers,
+		onSettled: async () => {
+			await invalidateLiveSessionCaches(queryClient, refs, {
+				includeLists: false,
+			});
+		},
 	});
 
 	const updateSeatMutation = useMutation({
@@ -171,40 +254,49 @@ export function useTablePlayers({
 				seatPosition: params.seatPosition,
 			}),
 		onMutate: async (params) => {
-			await queryClient.cancelQueries({ queryKey: playersKey });
-			const prev = queryClient.getQueryData<TablePlayerData>(playersKey);
-			if (prev) {
-				queryClient.setQueryData<TablePlayerData>(playersKey, {
-					items: prev.items.map((item) =>
-						item.player.id === params.playerId
-							? { ...item, seatPosition: params.seatPosition }
-							: item
-					),
-				});
-			}
-			return { prev };
+			await cancelLiveSessionCaches(queryClient, refs, {
+				includeEvents: false,
+				includeLists: false,
+			});
+			const snapshot = snapshotLiveSessionCaches(queryClient, refs);
+
+			patchLiveSessionPlayers(queryClient, refs, (currentPlayers) =>
+				currentPlayers.map((item) =>
+					item.player.id === params.playerId
+						? { ...item, seatPosition: params.seatPosition }
+						: item
+				)
+			);
+
+			return { snapshot };
 		},
 		onError: (_err, _vars, ctx) => {
-			if (ctx?.prev) {
-				queryClient.setQueryData(playersKey, ctx.prev);
-			}
+			restoreLiveSessionCaches(queryClient, ctx?.snapshot);
 		},
-		onSettled: invalidatePlayers,
+		onSettled: async () => {
+			await invalidateLiveSessionCaches(queryClient, refs, {
+				includeEvents: false,
+				includeLists: false,
+			});
+		},
 	});
 
-	const players = (playersQuery.data?.items ?? []).map((item) => ({
+	const players = ((playersQuery.data as LiveSessionPlayersData | undefined)
+		?.items ?? []) as LiveSessionTablePlayerItem[];
+
+	const visiblePlayers = players.map((item) => ({
 		id: item.id,
 		isActive: item.isActive,
 		player: { id: item.player.id, name: item.player.name },
 		seatPosition: item.seatPosition ?? null,
 	}));
 
-	const excludePlayerIds = players
+	const excludePlayerIds = visiblePlayers
 		.filter((p) => p.isActive)
 		.map((p) => p.player.id);
 
 	return {
-		players,
+		players: visiblePlayers,
 		excludePlayerIds,
 		handleAddExisting: (
 			playerId: string,

--- a/apps/web/src/routes/active-session/index.tsx
+++ b/apps/web/src/routes/active-session/index.tsx
@@ -198,6 +198,7 @@ function CashGameSession({ sessionId }: { sessionId: string }) {
 	if (!session) {
 		return null;
 	}
+	const status = session.status === "paused" ? "paused" : "active";
 
 	const ringGame = session.ringGameId
 		? ringGames.find((candidate) => candidate.id === session.ringGameId)
@@ -223,6 +224,7 @@ function CashGameSession({ sessionId }: { sessionId: string }) {
 			memo={session.memo}
 			onDiscard={discard}
 			state={sceneState}
+			status={status}
 			summary={<CashGameCompactSummary summary={session.summary} />}
 			title="Cash Game"
 		/>
@@ -245,6 +247,7 @@ function TournamentSession({ sessionId }: { sessionId: string }) {
 	if (!session) {
 		return null;
 	}
+	const status = session.status === "paused" ? "paused" : "active";
 	const tournamentSummary = buildTournamentSummary(
 		session as { summary: Record<string, unknown> }
 	);
@@ -258,6 +261,7 @@ function TournamentSession({ sessionId }: { sessionId: string }) {
 			memo={session.memo}
 			onDiscard={discard}
 			state={sceneState}
+			status={status}
 			summary={<TournamentCompactSummary summary={tournamentSummary} />}
 			title="Tournament"
 		/>

--- a/apps/web/src/shared/components/mobile-nav.tsx
+++ b/apps/web/src/shared/components/mobile-nav.tsx
@@ -7,9 +7,20 @@ import { CreateSessionDialog } from "@/live-sessions/components/create-session-d
 import { useActiveSession } from "@/live-sessions/hooks/use-active-session";
 import { useStackSheet } from "@/live-sessions/hooks/use-stack-sheet";
 import {
+	applyOptimisticLiveSessionEvent,
+	cancelLiveSessionCaches,
+	getLiveSessionCacheRefs,
+	invalidateLiveSessionCaches,
+	type LiveSessionEvent,
+	type LiveSessionEventType,
+	restoreLiveSessionCaches,
+	snapshotLiveSessionCaches,
+} from "@/live-sessions/lib/live-session-cache";
+import {
 	getMobileNavigationItems,
 	isActiveItem,
 	MobileNavItem,
+	type NavigationCenterAction,
 	NavigationCenterButton,
 	type NavigationItem,
 	RESOURCE_ITEMS,
@@ -20,6 +31,18 @@ import {
 	PopoverTrigger,
 } from "@/shared/components/ui/popover";
 import { trpcClient } from "@/utils/trpc";
+
+function buildOptimisticEvent(
+	eventType: LiveSessionEventType,
+	payload: unknown
+): LiveSessionEvent {
+	return {
+		eventType,
+		id: `optimistic-${Date.now()}`,
+		occurredAt: new Date().toISOString(),
+		payload,
+	};
+}
 
 function MobileNavPopoverItem({
 	active,
@@ -95,7 +118,36 @@ export function MobileNav() {
 				payload: {},
 			});
 		},
-		onSuccess: () => queryClient.invalidateQueries(),
+		onMutate: async () => {
+			if (!activeSession) {
+				return { snapshot: null };
+			}
+
+			const refs = getLiveSessionCacheRefs({
+				sessionId: activeSession.id,
+				sessionType: activeSession.type,
+			});
+			await cancelLiveSessionCaches(queryClient, refs);
+			const snapshot = snapshotLiveSessionCaches(queryClient, refs);
+
+			applyOptimisticLiveSessionEvent(queryClient, refs, {
+				event: buildOptimisticEvent("session_resume", {}),
+				eventType: "session_resume",
+				payload: {},
+			});
+
+			return { refs, snapshot };
+		},
+		onError: (_error, _variables, context) => {
+			restoreLiveSessionCaches(queryClient, context?.snapshot);
+		},
+		onSettled: async (_data, _error, _variables, context) => {
+			if (!context?.refs) {
+				return;
+			}
+
+			await invalidateLiveSessionCaches(queryClient, context.refs);
+		},
 	});
 
 	let centerAction: NavigationCenterAction;


### PR DESCRIPTION
## Summary
- redesign live session event handling across web, API, and DB to support the new event model and related UI flows
- fix stale client state after event edits and deletes by invalidating session and currency caches from `useSessionEvents`
- update live session screens, forms, navigation, and tests to align with the redesigned event workflow

## Testing
- `vitest run`
- `bun x ultracite check apps/web/src/live-sessions/components/__tests__/session-events-scene.test.tsx apps/web/src/live-sessions/hooks/use-session-events.ts`