### PR TITLE
claude/pwa-login-dashboard-G6Osd

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
 				short_name: "sapphire2",
 				description: "sapphire2 - PWA Application",
 				theme_color: "#0c0c0c",
+				start_url: "/dashboard",
 			},
 			pwaAssets: { disabled: false, config: true },
 			devOptions: { enabled: true },


### PR DESCRIPTION
PWAをインストール済みのユーザーが起動時にダッシュボードへ直接遷移するよう、
manifest の start_url を "/dashboard" に設定する。

https://claude.ai/code/session_016kSdmG89FE3aJoHt6tKweH