### PR TITLE
claude/update-event-experience-nq9Li

### DIFF
--- a/apps/web/src/live-sessions/components/__tests__/live-stack-form-sheet.test.tsx
+++ b/apps/web/src/live-sessions/components/__tests__/live-stack-form-sheet.test.tsx
@@ -4,11 +4,6 @@ import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { LiveStackFormSheet } from "../live-stack-form-sheet";
 
-const CASH_STACK_DESCRIPTION_PATTERN =
-	/latest stack and any related all-ins or addons/i;
-const TOURNAMENT_STACK_DESCRIPTION_PATTERN =
-	/latest stack and tournament status for this tournament/i;
-
 const mocks = vi.hoisted(() => ({
 	activeSession: null as null | {
 		id: string;
@@ -61,19 +56,16 @@ vi.mock("@/live-sessions/hooks/use-stack-sheet", () => ({
 vi.mock("@/shared/components/ui/responsive-dialog", () => ({
 	ResponsiveDialog: ({
 		children,
-		description,
 		open,
 		title,
 	}: {
 		children: ReactNode;
-		description?: ReactNode;
 		open: boolean;
 		title: string;
 	}) =>
 		open ? (
 			<div>
 				<h2>{title}</h2>
-				{description ? <p>{description}</p> : null}
 				{children}
 			</div>
 		) : null,
@@ -165,9 +157,6 @@ describe("LiveStackFormSheet", () => {
 		render(<LiveStackFormSheet />);
 
 		expect(screen.getByText("Record Stack")).toBeInTheDocument();
-		expect(
-			screen.getByText(CASH_STACK_DESCRIPTION_PATTERN)
-		).toBeInTheDocument();
 
 		await user.click(
 			screen.getByRole("button", { name: "Open Cash Complete" })
@@ -186,9 +175,6 @@ describe("LiveStackFormSheet", () => {
 		render(<LiveStackFormSheet />);
 
 		expect(screen.getByText("Record Stack")).toBeInTheDocument();
-		expect(
-			screen.getByText(TOURNAMENT_STACK_DESCRIPTION_PATTERN)
-		).toBeInTheDocument();
 
 		await user.click(
 			screen.getByRole("button", { name: "Open Tournament Complete" })

--- a/apps/web/src/live-sessions/components/__tests__/live-stack-form-sheet.test.tsx
+++ b/apps/web/src/live-sessions/components/__tests__/live-stack-form-sheet.test.tsx
@@ -7,7 +7,7 @@ import { LiveStackFormSheet } from "../live-stack-form-sheet";
 const CASH_STACK_DESCRIPTION_PATTERN =
 	/latest stack and any related all-ins or addons/i;
 const TOURNAMENT_STACK_DESCRIPTION_PATTERN =
-	/latest stack and chip purchases for this tournament/i;
+	/latest stack and tournament status for this tournament/i;
 
 const mocks = vi.hoisted(() => ({
 	activeSession: null as null | {
@@ -105,10 +105,6 @@ vi.mock("@/live-sessions/components/tournament-stack-form", () => ({
 
 vi.mock("@/live-sessions/components/tournament-complete-form", () => ({
 	TournamentCompleteForm: () => <div>Tournament Complete Form</div>,
-}));
-
-vi.mock("@/live-sessions/components/tournament-info-form", () => ({
-	TournamentInfoForm: () => <div>Tournament Info Form</div>,
 }));
 
 vi.mock("@/utils/trpc", () => ({

--- a/apps/web/src/live-sessions/components/cash-game-stack-form.tsx
+++ b/apps/web/src/live-sessions/components/cash-game-stack-form.tsx
@@ -4,7 +4,6 @@ import { AllInBottomSheet } from "@/live-sessions/components/all-in-bottom-sheet
 import {
 	StackNumberField,
 	StackPrimaryRow,
-	StackQuickActions,
 } from "@/live-sessions/components/stack-ui";
 import { useStackFormContext } from "@/live-sessions/hooks/use-session-form";
 import { Button } from "@/shared/components/ui/button";
@@ -88,69 +87,75 @@ export function CashGameStackForm({
 	};
 
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-			<StackPrimaryRow>
-				<StackNumberField
-					className="sm:min-w-[12rem]"
-					id="cash-stack-amount"
-					inputMode="numeric"
-					label="Current Stack"
-					min={0}
-					onChange={setStackAmount}
-					required
-					type="number"
-					value={stackAmount}
-				/>
-				<Button disabled={isLoading} size="sm" type="submit">
-					{isLoading ? "..." : "Update"}
-				</Button>
-				<Button
-					onClick={handleComplete}
-					size="sm"
-					type="button"
-					variant="outline"
-				>
-					End
-				</Button>
-			</StackPrimaryRow>
+		<div className="flex flex-col gap-4">
+			<form onSubmit={handleSubmit}>
+				<StackPrimaryRow>
+					<StackNumberField
+						className="sm:min-w-[12rem]"
+						id="cash-stack-amount"
+						inputMode="numeric"
+						label="Current Stack"
+						min={0}
+						onChange={setStackAmount}
+						required
+						type="number"
+						value={stackAmount}
+					/>
+					<Button disabled={isLoading} size="sm" type="submit">
+						{isLoading ? "..." : "Update"}
+					</Button>
+				</StackPrimaryRow>
+			</form>
 
-			<StackQuickActions>
-				<Button
-					onClick={() => setAllInBottomSheetOpen(true)}
-					size="xs"
-					type="button"
-					variant="ghost"
-				>
-					+ All-in
-				</Button>
-				<Button
-					onClick={() => setAddonBottomSheetOpen(true)}
-					size="xs"
-					type="button"
-					variant="ghost"
-				>
-					+ Addon
-				</Button>
-				<Button
-					onClick={() => setRemoveBottomSheetOpen(true)}
-					size="xs"
-					type="button"
-					variant="ghost"
-				>
-					+ Remove
-				</Button>
-				<Button
-					onClick={() => setMemoBottomSheetOpen(true)}
-					size="xs"
-					type="button"
-					variant="ghost"
-				>
-					+ Memo
-				</Button>
-				<Button onClick={onPause} size="xs" type="button" variant="ghost">
-					Pause
-				</Button>
-			</StackQuickActions>
+			<div className="-mx-4 border-t" />
+
+			<div className="flex flex-col gap-2">
+				<p className="font-medium text-muted-foreground text-xs">Events</p>
+				<div className="grid grid-cols-2 gap-2">
+					<Button
+						onClick={() => setAllInBottomSheetOpen(true)}
+						type="button"
+						variant="outline"
+					>
+						All-in
+					</Button>
+					<Button
+						onClick={() => setAddonBottomSheetOpen(true)}
+						type="button"
+						variant="outline"
+					>
+						Add Chips
+					</Button>
+					<Button
+						onClick={() => setRemoveBottomSheetOpen(true)}
+						type="button"
+						variant="outline"
+					>
+						Remove Chips
+					</Button>
+					<Button
+						onClick={() => setMemoBottomSheetOpen(true)}
+						type="button"
+						variant="outline"
+					>
+						Memo
+					</Button>
+				</div>
+			</div>
+
+			<div className="-mx-4 border-t" />
+
+			<div className="flex flex-col gap-2">
+				<p className="font-medium text-muted-foreground text-xs">Session</p>
+				<div className="grid grid-cols-2 gap-2">
+					<Button onClick={onPause} type="button" variant="outline">
+						Pause
+					</Button>
+					<Button onClick={handleComplete} type="button" variant="outline">
+						Complete
+					</Button>
+				</div>
+			</div>
 
 			<AllInBottomSheet
 				onOpenChange={setAllInBottomSheetOpen}
@@ -171,7 +176,6 @@ export function CashGameStackForm({
 			/>
 
 			<ResponsiveDialog
-				description="Add a note to this session."
 				onOpenChange={setMemoBottomSheetOpen}
 				open={memoBottomSheetOpen}
 				title="Add Memo"
@@ -197,6 +201,6 @@ export function CashGameStackForm({
 					</DialogActionRow>
 				</form>
 			</ResponsiveDialog>
-		</form>
+		</div>
 	);
 }

--- a/apps/web/src/live-sessions/components/chip-purchase-sheet.tsx
+++ b/apps/web/src/live-sessions/components/chip-purchase-sheet.tsx
@@ -15,6 +15,7 @@ interface ChipPurchaseSheetProps {
 	onSubmit: (purchase: { name: string; cost: number; chips: number }) => void;
 	open: boolean;
 	readOnly?: boolean;
+	shortcuts?: Array<{ chips: number; cost: number; name: string }>;
 }
 
 export function ChipPurchaseSheet({
@@ -27,6 +28,7 @@ export function ChipPurchaseSheet({
 	onSubmit,
 	onDelete,
 	readOnly = false,
+	shortcuts,
 }: ChipPurchaseSheetProps) {
 	const [name, setName] = useState(initialValues?.name ?? defaultName ?? "");
 	const [cost, setCost] = useState(initialValues?.cost ?? defaultCost ?? 0);
@@ -70,6 +72,25 @@ export function ChipPurchaseSheet({
 			title={title}
 		>
 			<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+				{shortcuts && shortcuts.length > 0 && !readOnly && (
+					<div className="flex flex-wrap gap-2">
+						{shortcuts.map((s) => (
+							<Button
+								key={s.name}
+								onClick={() => {
+									setName(s.name);
+									setCost(s.cost);
+									setChips(s.chips);
+								}}
+								size="xs"
+								type="button"
+								variant="outline"
+							>
+								{s.name}
+							</Button>
+						))}
+					</div>
+				)}
 				<Field htmlFor="chip-purchase-name" label="Name" required>
 					<Input
 						disabled={readOnly}

--- a/apps/web/src/live-sessions/components/live-stack-form-sheet.tsx
+++ b/apps/web/src/live-sessions/components/live-stack-form-sheet.tsx
@@ -31,7 +31,6 @@ function CashGameStackSheet({ sessionId }: { sessionId: string }) {
 	return (
 		<>
 			<ResponsiveDialog
-				description="Record the latest stack and any related all-ins or addons for this cash game."
 				onOpenChange={stackSheet.setIsOpen}
 				open={stackSheet.isOpen}
 				title="Record Stack"
@@ -58,7 +57,6 @@ function CashGameStackSheet({ sessionId }: { sessionId: string }) {
 			</ResponsiveDialog>
 
 			<ResponsiveDialog
-				description="Enter the final stack to complete this cash game session."
 				onOpenChange={setIsCompleteOpen}
 				open={isCompleteOpen}
 				title="Complete Session"
@@ -96,7 +94,6 @@ function TournamentStackSheet({ sessionId }: { sessionId: string }) {
 	return (
 		<>
 			<ResponsiveDialog
-				description="Record the latest stack and tournament status for this tournament."
 				onOpenChange={stackSheet.setIsOpen}
 				open={stackSheet.isOpen}
 				title="Record Stack"
@@ -128,7 +125,6 @@ function TournamentStackSheet({ sessionId }: { sessionId: string }) {
 			</ResponsiveDialog>
 
 			<ResponsiveDialog
-				description="Enter the tournament result to complete this live session."
 				onOpenChange={setIsCompleteOpen}
 				open={isCompleteOpen}
 				title="Complete Tournament"

--- a/apps/web/src/live-sessions/components/live-stack-form-sheet.tsx
+++ b/apps/web/src/live-sessions/components/live-stack-form-sheet.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { CashGameCompleteForm } from "@/live-sessions/components/cash-game-complete-form";
 import { CashGameStackForm } from "@/live-sessions/components/cash-game-stack-form";
 import { TournamentCompleteForm } from "@/live-sessions/components/tournament-complete-form";
-import { TournamentInfoForm } from "@/live-sessions/components/tournament-info-form";
 import { TournamentStackForm } from "@/live-sessions/components/tournament-stack-form";
 import { useActiveSession } from "@/live-sessions/hooks/use-active-session";
 import { useCashGameStack } from "@/live-sessions/hooks/use-cash-game-stack";
@@ -43,12 +42,14 @@ function CashGameStackSheet({ sessionId }: { sessionId: string }) {
 					onChipAdd={(amount) => addChip(amount)}
 					onChipRemove={(amount) => removeChip(amount)}
 					onComplete={(currentStack) => {
-						stackSheet.close();
 						setDefaultFinalStack(currentStack);
 						setIsCompleteOpen(true);
 					}}
 					onMemo={(text) => addMemo(text)}
-					onPause={() => pause()}
+					onPause={() => {
+						pause();
+						stackSheet.close();
+					}}
 					onSubmit={(values) => {
 						recordStack(values);
 						stackSheet.close();
@@ -65,7 +66,11 @@ function CashGameStackSheet({ sessionId }: { sessionId: string }) {
 				<CashGameCompleteForm
 					defaultFinalStack={defaultFinalStack}
 					isLoading={isCompletePending}
-					onSubmit={(values) => complete(values)}
+					onSubmit={(values) => {
+						complete(values);
+						setIsCompleteOpen(false);
+						stackSheet.close();
+					}}
 				/>
 			</ResponsiveDialog>
 		</>
@@ -75,7 +80,6 @@ function CashGameStackSheet({ sessionId }: { sessionId: string }) {
 function TournamentStackSheet({ sessionId }: { sessionId: string }) {
 	const stackSheet = useStackSheet();
 	const [isCompleteOpen, setIsCompleteOpen] = useState(false);
-	const [isTournamentInfoOpen, setIsTournamentInfoOpen] = useState(false);
 
 	const {
 		chipPurchaseTypes,
@@ -92,7 +96,7 @@ function TournamentStackSheet({ sessionId }: { sessionId: string }) {
 	return (
 		<>
 			<ResponsiveDialog
-				description="Record the latest stack and chip purchases for this tournament."
+				description="Record the latest stack and tournament status for this tournament."
 				onOpenChange={stackSheet.setIsOpen}
 				open={stackSheet.isOpen}
 				title="Record Stack"
@@ -101,31 +105,24 @@ function TournamentStackSheet({ sessionId }: { sessionId: string }) {
 					chipPurchaseTypes={chipPurchaseTypes}
 					isLoading={isStackPending}
 					onComplete={() => {
-						stackSheet.close();
 						setIsCompleteOpen(true);
 					}}
 					onMemo={(text) => addMemo(text)}
-					onPause={() => pause()}
-					onPurchaseChips={(values) => purchaseChips(values)}
-					onSubmit={(values) => {
-						recordStack(values);
+					onPause={() => {
+						pause();
 						stackSheet.close();
 					}}
-				/>
-			</ResponsiveDialog>
-
-			<ResponsiveDialog
-				description="Update remaining players, total entries, and chip purchase counts for this tournament."
-				onOpenChange={setIsTournamentInfoOpen}
-				open={isTournamentInfoOpen}
-				title="Tournament Info"
-			>
-				<TournamentInfoForm
-					chipPurchaseTypes={chipPurchaseTypes}
-					isLoading={false}
+					onPurchaseChips={(values) => purchaseChips(values)}
 					onSubmit={(values) => {
-						updateTournamentInfo(values);
-						setIsTournamentInfoOpen(false);
+						recordStack({ stackAmount: values.stackAmount });
+						if (values.recordTournamentInfo) {
+							updateTournamentInfo({
+								remainingPlayers: values.remainingPlayers,
+								totalEntries: values.totalEntries,
+								chipPurchaseCounts: values.chipPurchaseCounts,
+							});
+						}
+						stackSheet.close();
 					}}
 				/>
 			</ResponsiveDialog>
@@ -138,7 +135,11 @@ function TournamentStackSheet({ sessionId }: { sessionId: string }) {
 			>
 				<TournamentCompleteForm
 					isLoading={isCompletePending}
-					onSubmit={(values) => complete(values)}
+					onSubmit={(values) => {
+						complete(values);
+						setIsCompleteOpen(false);
+						stackSheet.close();
+					}}
 				/>
 			</ResponsiveDialog>
 		</>

--- a/apps/web/src/live-sessions/components/tournament-stack-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-stack-form.tsx
@@ -1,15 +1,28 @@
+import { useState } from "react";
+import { ChipPurchaseSheet } from "@/live-sessions/components/chip-purchase-sheet";
 import {
 	StackNumberField,
 	StackPrimaryRow,
 	StackQuickActions,
+	StackSecondaryGrid,
 } from "@/live-sessions/components/stack-ui";
 import { useTournamentFormContext } from "@/live-sessions/hooks/use-session-form";
 import { Button } from "@/shared/components/ui/button";
+import { Checkbox } from "@/shared/components/ui/checkbox";
+import { Label } from "@/shared/components/ui/label";
 
 interface ChipPurchaseType {
 	chips: number;
 	cost: number;
 	name: string;
+}
+
+interface TournamentStackFormSubmitValues {
+	chipPurchaseCounts: Array<{ chipsPerUnit: number; count: number; name: string }>;
+	recordTournamentInfo: boolean;
+	remainingPlayers: number | null;
+	stackAmount: number;
+	totalEntries: number | null;
 }
 
 interface TournamentStackFormProps {
@@ -19,31 +32,11 @@ interface TournamentStackFormProps {
 	onMemo: (text: string) => void;
 	onPause: () => void;
 	onPurchaseChips: (values: {
-		name: string;
-		cost: number;
 		chips: number;
+		cost: number;
+		name: string;
 	}) => void;
-	onSubmit: (values: { stackAmount: number }) => void;
-}
-
-function buildChipPurchaseButtons(
-	chipPurchaseTypes: ChipPurchaseType[],
-	onAdd: (type: ChipPurchaseType) => void
-) {
-	if (chipPurchaseTypes.length === 0) {
-		return null;
-	}
-	return chipPurchaseTypes.map((t) => (
-		<Button
-			key={t.name}
-			onClick={() => onAdd(t)}
-			size="xs"
-			type="button"
-			variant="ghost"
-		>
-			+ {t.name}
-		</Button>
-	));
+	onSubmit: (values: TournamentStackFormSubmitValues) => void;
 }
 
 export function TournamentStackForm({
@@ -55,24 +48,36 @@ export function TournamentStackForm({
 	onPurchaseChips,
 	onSubmit,
 }: TournamentStackFormProps) {
-	const { state, setStackAmount } = useTournamentFormContext();
-	const { stackAmount } = state;
+	const { state, setStackAmount, setRemainingPlayers, setTotalEntries, setChipPurchaseCounts } =
+		useTournamentFormContext();
+	const { stackAmount, remainingPlayers, totalEntries, chipPurchaseCounts } = state;
 
-	const handleInstantAdd = (type: ChipPurchaseType) => {
-		onPurchaseChips({ name: type.name, cost: type.cost, chips: type.chips });
-		// Auto-increment stack display by chips received
-		const currentStack = Number(stackAmount) || 0;
-		setStackAmount(String(currentStack + type.chips));
-	};
+	const [recordTournamentInfo, setRecordTournamentInfo] = useState(true);
+	const [chipPurchaseSheetOpen, setChipPurchaseSheetOpen] = useState(false);
 
 	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
-		onSubmit({ stackAmount: Number(stackAmount) });
+		onSubmit({
+			stackAmount: Number(stackAmount),
+			recordTournamentInfo,
+			remainingPlayers: remainingPlayers ? Number(remainingPlayers) : null,
+			totalEntries: totalEntries ? Number(totalEntries) : null,
+			chipPurchaseCounts,
+		});
+	};
+
+	const handleChipPurchaseSubmit = (values: {
+		chips: number;
+		cost: number;
+		name: string;
+	}) => {
+		onPurchaseChips(values);
+		setChipPurchaseSheetOpen(false);
 	};
 
 	return (
-		<div className="flex flex-col gap-2">
-			<form className="flex flex-col gap-2" onSubmit={handleSubmit}>
+		<div className="flex flex-col gap-4">
+			<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
 				<StackPrimaryRow>
 					<StackNumberField
 						className="sm:min-w-[12rem]"
@@ -97,10 +102,95 @@ export function TournamentStackForm({
 						End
 					</Button>
 				</StackPrimaryRow>
+
+				<div className="flex items-center gap-2">
+					<Checkbox
+						checked={recordTournamentInfo}
+						id="record-tournament-info"
+						onCheckedChange={(checked) =>
+							setRecordTournamentInfo(checked === true)
+						}
+					/>
+					<Label htmlFor="record-tournament-info">トーナメント状況も記録する</Label>
+				</div>
+
+				{recordTournamentInfo && (
+					<div className="flex flex-col gap-3">
+						<StackSecondaryGrid>
+							<StackNumberField
+								className="flex-1"
+								id="tournament-remaining-players"
+								inputMode="numeric"
+								label="Remaining Players"
+								min={1}
+								onChange={setRemainingPlayers}
+								type="number"
+								value={remainingPlayers}
+							/>
+							<StackNumberField
+								className="flex-1"
+								id="tournament-total-entries"
+								inputMode="numeric"
+								label="Total Entries"
+								min={1}
+								onChange={setTotalEntries}
+								type="number"
+								value={totalEntries}
+							/>
+						</StackSecondaryGrid>
+
+						{chipPurchaseTypes.length > 0 && (
+							<div className="flex flex-col gap-1.5">
+								{chipPurchaseTypes.map((t) => {
+									const countEntry = chipPurchaseCounts.find(
+										(c) => c.name === t.name
+									);
+									const countValue = countEntry?.count ?? 0;
+									return (
+										<StackNumberField
+											className="flex-1"
+											id={`chip-purchase-count-${t.name}`}
+											inputMode="numeric"
+											key={t.name}
+											label={`${t.name} count`}
+											min={0}
+											onChange={(value) => {
+												const newCount = Number(value);
+												setChipPurchaseCounts((prev) => {
+													const without = prev.filter((c) => c.name !== t.name);
+													if (newCount === 0) {
+														return without;
+													}
+													return [
+														...without,
+														{
+															name: t.name,
+															count: newCount,
+															chipsPerUnit: t.chips,
+														},
+													];
+												});
+											}}
+											type="number"
+											value={countValue === 0 ? "" : String(countValue)}
+										/>
+									);
+								})}
+							</div>
+						)}
+					</div>
+				)}
 			</form>
 
 			<StackQuickActions>
-				{buildChipPurchaseButtons(chipPurchaseTypes, handleInstantAdd)}
+				<Button
+					onClick={() => setChipPurchaseSheetOpen(true)}
+					size="xs"
+					type="button"
+					variant="ghost"
+				>
+					+ Chip Purchase
+				</Button>
 				<Button
 					onClick={() => onMemo("")}
 					size="xs"
@@ -113,6 +203,13 @@ export function TournamentStackForm({
 					Pause
 				</Button>
 			</StackQuickActions>
+
+			<ChipPurchaseSheet
+				onOpenChange={setChipPurchaseSheetOpen}
+				onSubmit={handleChipPurchaseSubmit}
+				open={chipPurchaseSheetOpen}
+				shortcuts={chipPurchaseTypes}
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/live-sessions/components/tournament-stack-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-stack-form.tsx
@@ -3,13 +3,16 @@ import { ChipPurchaseSheet } from "@/live-sessions/components/chip-purchase-shee
 import {
 	StackNumberField,
 	StackPrimaryRow,
-	StackQuickActions,
 	StackSecondaryGrid,
 } from "@/live-sessions/components/stack-ui";
 import { useTournamentFormContext } from "@/live-sessions/hooks/use-session-form";
 import { Button } from "@/shared/components/ui/button";
 import { Checkbox } from "@/shared/components/ui/checkbox";
+import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
+import { Field } from "@/shared/components/ui/field";
 import { Label } from "@/shared/components/ui/label";
+import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
+import { Textarea } from "@/shared/components/ui/textarea";
 
 interface ChipPurchaseType {
 	chips: number;
@@ -54,6 +57,8 @@ export function TournamentStackForm({
 
 	const [recordTournamentInfo, setRecordTournamentInfo] = useState(true);
 	const [chipPurchaseSheetOpen, setChipPurchaseSheetOpen] = useState(false);
+	const [memoSheetOpen, setMemoSheetOpen] = useState(false);
+	const [memoText, setMemoText] = useState("");
 
 	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
@@ -75,6 +80,14 @@ export function TournamentStackForm({
 		setChipPurchaseSheetOpen(false);
 	};
 
+	const handleMemoSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		e.stopPropagation();
+		onMemo(memoText);
+		setMemoText("");
+		setMemoSheetOpen(false);
+	};
+
 	return (
 		<div className="flex flex-col gap-4">
 			<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
@@ -92,14 +105,6 @@ export function TournamentStackForm({
 					/>
 					<Button disabled={isLoading} size="sm" type="submit">
 						{isLoading ? "..." : "Update"}
-					</Button>
-					<Button
-						onClick={onComplete}
-						size="sm"
-						type="button"
-						variant="outline"
-					>
-						End
 					</Button>
 				</StackPrimaryRow>
 
@@ -182,27 +187,41 @@ export function TournamentStackForm({
 				)}
 			</form>
 
-			<StackQuickActions>
-				<Button
-					onClick={() => setChipPurchaseSheetOpen(true)}
-					size="xs"
-					type="button"
-					variant="ghost"
-				>
-					+ Chip Purchase
-				</Button>
-				<Button
-					onClick={() => onMemo("")}
-					size="xs"
-					type="button"
-					variant="ghost"
-				>
-					+ Memo
-				</Button>
-				<Button onClick={onPause} size="xs" type="button" variant="ghost">
-					Pause
-				</Button>
-			</StackQuickActions>
+			<div className="-mx-4 border-t" />
+
+			<div className="flex flex-col gap-2">
+				<p className="font-medium text-muted-foreground text-xs">Events</p>
+				<div className="grid grid-cols-2 gap-2">
+					<Button
+						onClick={() => setChipPurchaseSheetOpen(true)}
+						type="button"
+						variant="outline"
+					>
+						Chip Purchase
+					</Button>
+					<Button
+						onClick={() => setMemoSheetOpen(true)}
+						type="button"
+						variant="outline"
+					>
+						Memo
+					</Button>
+				</div>
+			</div>
+
+			<div className="-mx-4 border-t" />
+
+			<div className="flex flex-col gap-2">
+				<p className="font-medium text-muted-foreground text-xs">Session</p>
+				<div className="grid grid-cols-2 gap-2">
+					<Button onClick={onPause} type="button" variant="outline">
+						Pause
+					</Button>
+					<Button onClick={onComplete} type="button" variant="outline">
+						Complete
+					</Button>
+				</div>
+			</div>
 
 			<ChipPurchaseSheet
 				onOpenChange={setChipPurchaseSheetOpen}
@@ -210,6 +229,33 @@ export function TournamentStackForm({
 				open={chipPurchaseSheetOpen}
 				shortcuts={chipPurchaseTypes}
 			/>
+
+			<ResponsiveDialog
+				onOpenChange={setMemoSheetOpen}
+				open={memoSheetOpen}
+				title="Add Memo"
+			>
+				<form className="flex flex-col gap-4" onSubmit={handleMemoSubmit}>
+					<Field htmlFor="tournament-memo-text" label="Note">
+						<Textarea
+							id="tournament-memo-text"
+							onChange={(e) => setMemoText(e.target.value)}
+							placeholder="Enter a note..."
+							value={memoText}
+						/>
+					</Field>
+					<DialogActionRow>
+						<Button
+							onClick={() => setMemoSheetOpen(false)}
+							type="button"
+							variant="outline"
+						>
+							Cancel
+						</Button>
+						<Button type="submit">Add Memo</Button>
+					</DialogActionRow>
+				</form>
+			</ResponsiveDialog>
 		</div>
 	);
 }

--- a/apps/web/src/live-sessions/components/tournament-stack-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-stack-form.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { ChipPurchaseSheet } from "@/live-sessions/components/chip-purchase-sheet";
 import {
 	StackNumberField,
-	StackPrimaryRow,
 	StackSecondaryGrid,
 } from "@/live-sessions/components/stack-ui";
 import { useTournamentFormContext } from "@/live-sessions/hooks/use-session-form";
@@ -90,23 +89,17 @@ export function TournamentStackForm({
 
 	return (
 		<div className="flex flex-col gap-4">
-			<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-				<StackPrimaryRow>
-					<StackNumberField
-						className="sm:min-w-[12rem]"
-						id="tournament-stack-amount"
-						inputMode="numeric"
-						label="Current Stack"
-						min={0}
-						onChange={setStackAmount}
-						required
-						type="number"
-						value={stackAmount}
-					/>
-					<Button disabled={isLoading} size="sm" type="submit">
-						{isLoading ? "..." : "Update"}
-					</Button>
-				</StackPrimaryRow>
+			<form className="flex flex-col gap-3" onSubmit={handleSubmit}>
+				<StackNumberField
+					id="tournament-stack-amount"
+					inputMode="numeric"
+					label="Current Stack"
+					min={0}
+					onChange={setStackAmount}
+					required
+					type="number"
+					value={stackAmount}
+				/>
 
 				<div className="flex items-center gap-2">
 					<Checkbox
@@ -116,27 +109,25 @@ export function TournamentStackForm({
 							setRecordTournamentInfo(checked === true)
 						}
 					/>
-					<Label htmlFor="record-tournament-info">トーナメント状況も記録する</Label>
+					<Label htmlFor="record-tournament-info">トナメ情報も記録</Label>
 				</div>
 
 				{recordTournamentInfo && (
-					<div className="flex flex-col gap-3">
+					<>
 						<StackSecondaryGrid>
 							<StackNumberField
-								className="flex-1"
 								id="tournament-remaining-players"
 								inputMode="numeric"
-								label="Remaining Players"
+								label="残り人数"
 								min={1}
 								onChange={setRemainingPlayers}
 								type="number"
 								value={remainingPlayers}
 							/>
 							<StackNumberField
-								className="flex-1"
 								id="tournament-total-entries"
 								inputMode="numeric"
-								label="Total Entries"
+								label="エントリー数"
 								min={1}
 								onChange={setTotalEntries}
 								type="number"
@@ -153,7 +144,6 @@ export function TournamentStackForm({
 									const countValue = countEntry?.count ?? 0;
 									return (
 										<StackNumberField
-											className="flex-1"
 											id={`chip-purchase-count-${t.name}`}
 											inputMode="numeric"
 											key={t.name}
@@ -183,8 +173,12 @@ export function TournamentStackForm({
 								})}
 							</div>
 						)}
-					</div>
+					</>
 				)}
+
+				<Button className="w-full" disabled={isLoading} type="submit">
+					{isLoading ? "..." : "Update"}
+				</Button>
 			</form>
 
 			<div className="-mx-4 border-t" />

--- a/apps/web/src/live-sessions/components/tournament-stack-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-stack-form.tsx
@@ -109,7 +109,7 @@ export function TournamentStackForm({
 							setRecordTournamentInfo(checked === true)
 						}
 					/>
-					<Label htmlFor="record-tournament-info">トナメ情報も記録</Label>
+					<Label htmlFor="record-tournament-info">Record tournament info</Label>
 				</div>
 
 				{recordTournamentInfo && (
@@ -118,7 +118,7 @@ export function TournamentStackForm({
 							<StackNumberField
 								id="tournament-remaining-players"
 								inputMode="numeric"
-								label="残り人数"
+								label="Remaining Players"
 								min={1}
 								onChange={setRemainingPlayers}
 								type="number"
@@ -127,7 +127,7 @@ export function TournamentStackForm({
 							<StackNumberField
 								id="tournament-total-entries"
 								inputMode="numeric"
-								label="エントリー数"
+								label="Total Entries"
 								min={1}
 								onChange={setTotalEntries}
 								type="number"

--- a/apps/web/src/live-sessions/components/tournament-stack-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-stack-form.tsx
@@ -1,9 +1,6 @@
 import { useState } from "react";
 import { ChipPurchaseSheet } from "@/live-sessions/components/chip-purchase-sheet";
-import {
-	StackNumberField,
-	StackSecondaryGrid,
-} from "@/live-sessions/components/stack-ui";
+import { StackNumberField } from "@/live-sessions/components/stack-ui";
 import { useTournamentFormContext } from "@/live-sessions/hooks/use-session-form";
 import { Button } from "@/shared/components/ui/button";
 import { Checkbox } from "@/shared/components/ui/checkbox";
@@ -114,7 +111,7 @@ export function TournamentStackForm({
 
 				{recordTournamentInfo && (
 					<>
-						<StackSecondaryGrid>
+						<div className="grid grid-cols-2 gap-2">
 							<StackNumberField
 								id="tournament-remaining-players"
 								inputMode="numeric"
@@ -133,7 +130,7 @@ export function TournamentStackForm({
 								type="number"
 								value={totalEntries}
 							/>
-						</StackSecondaryGrid>
+						</div>
 
 						{chipPurchaseTypes.length > 0 && (
 							<div className="flex flex-col gap-1.5">


### PR DESCRIPTION
キャッシュゲーム:
- Pause ボタンでイベント記録後にシートを閉じるよう変更
- Session End でメインシートを開いたまま完了フォームを重ねて開き、
  完了時に両シートをまとめて閉じるよう変更

トーナメント:
- チップ購入を個別タイプボタンから「Chip Purchase」ボタン1本に統一し、
  シート内でショートカット選択 or 手入力できるよう変更
- トーナメント情報更新（残り人数・エントリー数・チップ購入数）を
  メインフォームに統合し、別ダイアログを廃止
- デフォルトで update_stack + update_tournament_info を同時記録し、
  チェックボックスでオプトアウト可能に変更
- Pause / Session End は Cash game と同様の変更を適用

closes #131

https://claude.ai/code/session_01KjUkh9eX4QufLD8EtkStJM