### PR TITLE
claude/player-type-icons-B2P7L

### DIFF
--- a/apps/web/src/live-sessions/components/__tests__/add-player-sheet.test.tsx
+++ b/apps/web/src/live-sessions/components/__tests__/add-player-sheet.test.tsx
@@ -58,9 +58,7 @@ vi.mock("@/players/components/player-tag-input", () => ({
 }));
 
 vi.mock("@/players/components/player-avatar", () => ({
-	PlayerAvatar: ({ name }: { name: string }) => (
-		<div data-testid="player-avatar">{name.slice(0, 2).toUpperCase()}</div>
-	),
+	PlayerAvatar: () => <div data-testid="player-avatar" />,
 }));
 
 vi.mock("@/players/components/color-badge", () => ({

--- a/apps/web/src/live-sessions/components/add-player-sheet.tsx
+++ b/apps/web/src/live-sessions/components/add-player-sheet.tsx
@@ -160,7 +160,7 @@ export function AddPlayerSheet({
 							type="button"
 							variant="ghost"
 						>
-							<PlayerAvatar className="shrink-0" name={p.name} />
+							<PlayerAvatar className="shrink-0" />
 							<div className="min-w-0 flex-1">
 								<p className="truncate font-medium text-sm">{p.name}</p>
 								{p.tags.length > 0 && (

--- a/apps/web/src/live-sessions/components/poker-table.tsx
+++ b/apps/web/src/live-sessions/components/poker-table.tsx
@@ -106,8 +106,8 @@ function SeatSlot({
 
 			{/* Hero seat (no player) */}
 			{isHero && !isOccupied && (
-				<div className="flex size-9 items-center justify-center rounded-full border-2 border-amber-400 bg-amber-500/80 text-white shadow-md">
-					<IconUser size={14} />
+				<div className="flex size-10 items-center justify-center rounded-full border-2 border-amber-400 bg-amber-500/80 text-white shadow-md">
+					<IconUser size={16} />
 				</div>
 			)}
 
@@ -117,7 +117,7 @@ function SeatSlot({
 					<PlayerAvatar
 						className={cn(isLoading && "opacity-40")}
 						isHero={isHero}
-						name={player.player.name}
+						isTemporary={player.player.isTemporary}
 					/>
 					{isLoading && (
 						<IconLoader2

--- a/apps/web/src/players/components/player-avatar.tsx
+++ b/apps/web/src/players/components/player-avatar.tsx
@@ -19,7 +19,7 @@ export function PlayerAvatar({
 				isHero
 					? "border-amber-400 bg-amber-500/80 text-white"
 					: isTemporary
-						? "border-white/20 bg-white/10 text-white/60"
+						? "border-zinc-500/60 bg-zinc-700 text-white/80"
 						: "border-white/30 bg-slate-500 text-white",
 				className
 			)}

--- a/apps/web/src/players/components/player-avatar.tsx
+++ b/apps/web/src/players/components/player-avatar.tsx
@@ -1,27 +1,30 @@
+import { IconUser, IconUserQuestion } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 
 interface PlayerAvatarProps {
 	className?: string;
 	isHero?: boolean;
-	name: string;
+	isTemporary?: boolean;
 }
 
 export function PlayerAvatar({
 	className,
 	isHero = false,
-	name,
+	isTemporary = false,
 }: PlayerAvatarProps) {
 	return (
 		<div
 			className={cn(
-				"flex size-9 items-center justify-center rounded-full border-2 font-bold text-[11px] text-white shadow-md",
+				"flex size-10 items-center justify-center rounded-full border-2 shadow-md",
 				isHero
-					? "border-amber-400 bg-amber-500/80"
-					: "border-white/30 bg-slate-500",
+					? "border-amber-400 bg-amber-500/80 text-white"
+					: isTemporary
+						? "border-white/20 bg-white/10 text-white/60"
+						: "border-white/30 bg-slate-500 text-white",
 				className
 			)}
 		>
-			{name.slice(0, 2).toUpperCase()}
+			{isTemporary ? <IconUserQuestion size={16} /> : <IconUser size={16} />}
 		</div>
 	);
 }


### PR DESCRIPTION
- Add `isTemporary` boolean field to player schema (default false) to
  distinguish permanent (永続) vs temporary (一時) player types
- Add migration 0014 to add `is_temporary` column to player table
- Update session-table-player API list endpoint to include isTemporary
- Update TablePlayer interface and use-table-players hook to pass isTemporary
- Replace PlayerAvatar initials with icons: IconUser for permanent players,
  IconUserQuestion for temporary players
- Increase avatar size from size-9 to size-10 for all player types
- Increase hero empty-seat icon from size-9 to size-10 to match
- Update test mock to drop now-removed name prop from PlayerAvatar

https://claude.ai/code/session_012vgMqtJNUhVkav51gHgH1A