### PR TITLE
Migrate all forms to TanStack Form (#71)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,6 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist-mono": "^5.2.7",
-    "@hookform/resolvers": "^5.2.2",
     "@sapphire2/api": "workspace:*",
     "@sapphire2/auth": "workspace:*",
     "@sapphire2/env": "workspace:*",

--- a/apps/web/src/currencies/components/__tests__/currency-form.test.tsx
+++ b/apps/web/src/currencies/components/__tests__/currency-form.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { CurrencyForm } from "../currency-form";
@@ -20,7 +20,8 @@ describe("CurrencyForm", () => {
 		});
 	});
 
-	it("submits edited values without changing the payload shape", () => {
+	it("submits edited values without changing the payload shape", async () => {
+		const user = userEvent.setup();
 		const onSubmit = vi.fn();
 
 		render(
@@ -30,13 +31,11 @@ describe("CurrencyForm", () => {
 			/>
 		);
 
-		fireEvent.change(screen.getByLabelText("Currency Name *"), {
-			target: { value: "USD" },
-		});
-		fireEvent.change(screen.getByLabelText("Unit"), {
-			target: { value: "US$" },
-		});
-		fireEvent.click(screen.getByRole("button", { name: "Save" }));
+		await user.clear(screen.getByLabelText("Currency Name *"));
+		await user.type(screen.getByLabelText("Currency Name *"), "USD");
+		await user.clear(screen.getByLabelText("Unit"));
+		await user.type(screen.getByLabelText("Unit"), "US$");
+		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		expect(onSubmit).toHaveBeenCalledWith({
 			name: "USD",

--- a/apps/web/src/currencies/components/currency-form.tsx
+++ b/apps/web/src/currencies/components/currency-form.tsx
@@ -1,3 +1,5 @@
+import { useForm } from "@tanstack/react-form";
+import z from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
@@ -15,49 +17,96 @@ interface CurrencyFormProps {
 	onSubmit: (values: CurrencyFormValues) => void;
 }
 
+const currencyFormSchema = z.object({
+	name: z
+		.string()
+		.min(1, "Currency name is required")
+		.max(100, "Currency name must be 100 characters or less"),
+	unit: z.string().max(10, "Unit must be 10 characters or less").optional(),
+});
+
 export function CurrencyForm({
 	onSubmit,
 	onCancel,
 	defaultValues,
 	isLoading = false,
 }: CurrencyFormProps) {
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		const formData = new FormData(e.currentTarget);
-		const name = formData.get("name") as string;
-		const unit = (formData.get("unit") as string) || undefined;
-		onSubmit({ name, unit });
-	};
+	const form = useForm({
+		defaultValues: {
+			name: defaultValues?.name ?? "",
+			unit: defaultValues?.unit ?? "",
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				name: value.name,
+				unit: value.unit || undefined,
+			});
+		},
+		validators: {
+			onSubmit: currencyFormSchema,
+		},
+	});
 
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-			<Field htmlFor="name" label="Currency Name" required>
-				<Input
-					defaultValue={defaultValues?.name}
-					id="name"
-					name="name"
-					placeholder="e.g. Gold, Points"
-					required
-				/>
-			</Field>
-			<Field htmlFor="unit" label="Unit">
-				<Input
-					defaultValue={defaultValues?.unit}
-					id="unit"
-					name="unit"
-					placeholder="e.g. G, pts"
-				/>
-			</Field>
-			<DialogActionRow>
-				{onCancel ? (
-					<Button onClick={onCancel} type="button" variant="outline">
-						Cancel
-					</Button>
-				) : null}
-				<Button disabled={isLoading} type="submit">
-					{isLoading ? "Saving..." : "Save"}
-				</Button>
-			</DialogActionRow>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="name">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Currency Name"
+						required
+					>
+						<Input
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="e.g. Gold, Points"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
+			<form.Field name="unit">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Unit"
+					>
+						<Input
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="e.g. G, pts"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
+			<form.Subscribe>
+				{(state) => (
+					<DialogActionRow>
+						{onCancel ? (
+							<Button onClick={onCancel} type="button" variant="outline">
+								Cancel
+							</Button>
+						) : null}
+						<Button disabled={isLoading || !state.canSubmit || state.isSubmitting} type="submit">
+							{isLoading || state.isSubmitting ? "Saving..." : "Save"}
+						</Button>
+					</DialogActionRow>
+				)}
+			</form.Subscribe>
 		</form>
 	);
 }

--- a/apps/web/src/currencies/components/currency-form.tsx
+++ b/apps/web/src/currencies/components/currency-form.tsx
@@ -101,7 +101,10 @@ export function CurrencyForm({
 								Cancel
 							</Button>
 						) : null}
-						<Button disabled={isLoading || !state.canSubmit || state.isSubmitting} type="submit">
+						<Button
+							disabled={isLoading || !state.canSubmit || state.isSubmitting}
+							type="submit"
+						>
 							{isLoading || state.isSubmitting ? "Saving..." : "Save"}
 						</Button>
 					</DialogActionRow>

--- a/apps/web/src/currencies/components/transaction-form.tsx
+++ b/apps/web/src/currencies/components/transaction-form.tsx
@@ -34,7 +34,11 @@ function todayISODate() {
 	return new Date().toISOString().slice(0, 10);
 }
 
-function getButtonLabel(isCreatingType: boolean, isLoading: boolean, isSubmitting: boolean) {
+function getButtonLabel(
+	isCreatingType: boolean,
+	isLoading: boolean,
+	isSubmitting: boolean
+) {
 	if (isCreatingType || isSubmitting) {
 		return "Saving...";
 	}
@@ -46,9 +50,7 @@ function getButtonLabel(isCreatingType: boolean, isLoading: boolean, isSubmittin
 
 const transactionFormSchema = z.object({
 	amount: z.coerce.number({ invalid_type_error: "Amount is required" }),
-	transactionTypeId: z
-		.string()
-		.min(1, "Type is required"),
+	transactionTypeId: z.string().min(1, "Type is required"),
 	newTypeName: z.string().optional(),
 	transactedAt: z.string().min(1, "Date is required"),
 	memo: z.string().optional(),

--- a/apps/web/src/currencies/components/transaction-form.tsx
+++ b/apps/web/src/currencies/components/transaction-form.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useForm } from "@tanstack/react-form";
+import z from "zod";
 import { useTransactionTypes } from "@/currencies/hooks/use-transaction-types";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
@@ -33,15 +34,25 @@ function todayISODate() {
 	return new Date().toISOString().slice(0, 10);
 }
 
-function getButtonLabel(isCreatingType: boolean, isLoading: boolean) {
-	if (isCreatingType) {
-		return "Creating type...";
+function getButtonLabel(isCreatingType: boolean, isLoading: boolean, isSubmitting: boolean) {
+	if (isCreatingType || isSubmitting) {
+		return "Saving...";
 	}
 	if (isLoading) {
 		return "Saving...";
 	}
 	return "Save";
 }
+
+const transactionFormSchema = z.object({
+	amount: z.coerce.number({ invalid_type_error: "Amount is required" }),
+	transactionTypeId: z
+		.string()
+		.min(1, "Type is required"),
+	newTypeName: z.string().optional(),
+	transactedAt: z.string().min(1, "Date is required"),
+	memo: z.string().optional(),
+});
 
 export function TransactionForm({
 	onSubmit,
@@ -50,102 +61,189 @@ export function TransactionForm({
 	isLoading = false,
 }: TransactionFormProps) {
 	const { types, createType, isCreatingType } = useTransactionTypes();
-	const [selectedType, setSelectedType] = useState(
-		defaultValues?.transactionTypeId ?? ""
-	);
-	const [newTypeName, setNewTypeName] = useState("");
 
-	const isNewType = selectedType === NEW_TYPE_VALUE;
+	const form = useForm({
+		defaultValues: {
+			amount: defaultValues?.amount ?? (undefined as number | undefined),
+			transactionTypeId: defaultValues?.transactionTypeId ?? "",
+			newTypeName: "",
+			transactedAt: defaultValues?.transactedAt
+				? new Date(defaultValues.transactedAt).toISOString().slice(0, 10)
+				: todayISODate(),
+			memo: defaultValues?.memo ?? "",
+		},
+		onSubmit: async ({ value }) => {
+			let transactionTypeId = value.transactionTypeId;
 
-	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		const formData = new FormData(e.currentTarget);
-		const amount = Number(formData.get("amount"));
-		const transactedAt = formData.get("transactedAt") as string;
-		const memo = (formData.get("memo") as string) || undefined;
-
-		let transactionTypeId = selectedType;
-
-		if (isNewType) {
-			if (!newTypeName.trim()) {
-				return;
+			if (transactionTypeId === NEW_TYPE_VALUE) {
+				if (!value.newTypeName?.trim()) {
+					return;
+				}
+				const created = await createType(value.newTypeName.trim());
+				transactionTypeId = created.id;
 			}
-			const created = await createType(newTypeName.trim());
-			transactionTypeId = created.id;
-		}
 
-		onSubmit({ amount, transactionTypeId, transactedAt, memo });
-	};
+			onSubmit({
+				amount: value.amount as number,
+				transactionTypeId,
+				transactedAt: value.transactedAt,
+				memo: value.memo || undefined,
+			});
+		},
+		validators: {
+			onSubmit: transactionFormSchema,
+		},
+	});
 
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-			<Field htmlFor="amount" label="Amount" required>
-				<Input
-					defaultValue={defaultValues?.amount}
-					id="amount"
-					name="amount"
-					placeholder="Enter amount (negative for withdrawal)"
-					required
-					type="number"
-				/>
-			</Field>
-			<Field htmlFor="transactionTypeId" label="Type" required>
-				<Select onValueChange={setSelectedType} required value={selectedType}>
-					<SelectTrigger className="w-full" id="transactionTypeId">
-						<SelectValue placeholder="Select type..." />
-					</SelectTrigger>
-					<SelectContent>
-						{types.map((t) => (
-							<SelectItem key={t.id} value={t.id}>
-								{t.name}
-							</SelectItem>
-						))}
-						<SelectItem value={NEW_TYPE_VALUE}>+ New type...</SelectItem>
-					</SelectContent>
-				</Select>
-			</Field>
-			{isNewType && (
-				<Field htmlFor="newTypeName" label="New Type Name">
-					<Input
-						id="newTypeName"
-						onChange={(e) => setNewTypeName(e.target.value)}
-						placeholder="Enter new type name"
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="amount">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Amount"
 						required
-						value={newTypeName}
-					/>
-				</Field>
-			)}
-			<Field htmlFor="transactedAt" label="Date" required>
-				<Input
-					defaultValue={
-						defaultValues?.transactedAt
-							? new Date(defaultValues.transactedAt).toISOString().slice(0, 10)
-							: todayISODate()
-					}
-					id="transactedAt"
-					name="transactedAt"
-					required
-					type="date"
-				/>
-			</Field>
-			<Field htmlFor="memo" label="Memo">
-				<Textarea
-					defaultValue={defaultValues?.memo}
-					id="memo"
-					name="memo"
-					placeholder="Optional note"
-				/>
-			</Field>
-			<DialogActionRow>
-				{onCancel ? (
-					<Button onClick={onCancel} type="button" variant="outline">
-						Cancel
-					</Button>
-				) : null}
-				<Button disabled={isLoading || isCreatingType} type="submit">
-					{getButtonLabel(isCreatingType, isLoading)}
-				</Button>
-			</DialogActionRow>
+					>
+						<Input
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) =>
+								field.handleChange(
+									e.target.value === "" ? undefined : Number(e.target.value)
+								)
+							}
+							placeholder="Enter amount (negative for withdrawal)"
+							type="number"
+							value={field.state.value ?? ""}
+						/>
+					</Field>
+				)}
+			</form.Field>
+
+			<form.Field name="transactionTypeId">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Type"
+						required
+					>
+						<Select
+							name={field.name}
+							onValueChange={(value) => field.handleChange(value)}
+							value={field.state.value}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue placeholder="Select type..." />
+							</SelectTrigger>
+							<SelectContent>
+								{types.map((t) => (
+									<SelectItem key={t.id} value={t.id}>
+										{t.name}
+									</SelectItem>
+								))}
+								<SelectItem value={NEW_TYPE_VALUE}>+ New type...</SelectItem>
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
+
+			<form.Subscribe selector={(state) => state.values.transactionTypeId}>
+				{(transactionTypeId) =>
+					transactionTypeId === NEW_TYPE_VALUE ? (
+						<form.Field name="newTypeName">
+							{(field) => (
+								<Field
+									error={field.state.meta.errors[0]?.message}
+									htmlFor={field.name}
+									label="New Type Name"
+								>
+									<Input
+										id={field.name}
+										name={field.name}
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										placeholder="Enter new type name"
+										value={field.state.value}
+									/>
+								</Field>
+							)}
+						</form.Field>
+					) : null
+				}
+			</form.Subscribe>
+
+			<form.Field name="transactedAt">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Date"
+						required
+					>
+						<Input
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							type="date"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
+
+			<form.Field name="memo">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Memo"
+					>
+						<Textarea
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="Optional note"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
+
+			<form.Subscribe>
+				{(state) => (
+					<DialogActionRow>
+						{onCancel ? (
+							<Button onClick={onCancel} type="button" variant="outline">
+								Cancel
+							</Button>
+						) : null}
+						<Button
+							disabled={
+								isLoading ||
+								isCreatingType ||
+								!state.canSubmit ||
+								state.isSubmitting
+							}
+							type="submit"
+						>
+							{getButtonLabel(isCreatingType, isLoading, state.isSubmitting)}
+						</Button>
+					</DialogActionRow>
+				)}
+			</form.Subscribe>
 		</form>
 	);
 }

--- a/apps/web/src/live-sessions/components/cash-game-complete-form.tsx
+++ b/apps/web/src/live-sessions/components/cash-game-complete-form.tsx
@@ -1,3 +1,5 @@
+import { useForm } from "@tanstack/react-form";
+import z from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
@@ -9,39 +11,77 @@ interface CashGameCompleteFormProps {
 	onSubmit: (values: { finalStack: number }) => void;
 }
 
+const cashGameCompleteFormSchema = z.object({
+	finalStack: z.coerce
+		.number({ invalid_type_error: "Final stack is required" })
+		.min(0, "Final stack must be 0 or greater"),
+});
+
 export function CashGameCompleteForm({
 	defaultFinalStack,
 	isLoading,
 	onSubmit,
 }: CashGameCompleteFormProps) {
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		const formData = new FormData(e.currentTarget);
-		const finalStack = Number(formData.get("finalStack"));
-
-		onSubmit({ finalStack });
-	};
+	const form = useForm({
+		defaultValues: {
+			finalStack: defaultFinalStack ?? (undefined as number | undefined),
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({ finalStack: value.finalStack as number });
+		},
+		validators: {
+			onSubmit: cashGameCompleteFormSchema,
+		},
+	});
 
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-			<Field htmlFor="finalStack" label="Final Stack" required>
-				<Input
-					defaultValue={defaultFinalStack ?? ""}
-					id="finalStack"
-					inputMode="numeric"
-					min={0}
-					name="finalStack"
-					placeholder="0"
-					required
-					type="number"
-				/>
-			</Field>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="finalStack">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Final Stack"
+						required
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							min={0}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) =>
+								field.handleChange(
+									e.target.value === "" ? undefined : Number(e.target.value)
+								)
+							}
+							placeholder="0"
+							type="number"
+							value={field.state.value !== undefined ? String(field.state.value) : ""}
+						/>
+					</Field>
+				)}
+			</form.Field>
 
-			<DialogActionRow>
-				<Button disabled={isLoading} type="submit">
-					{isLoading ? "Completing..." : "Complete Session"}
-				</Button>
-			</DialogActionRow>
+			<form.Subscribe>
+				{(state) => (
+					<DialogActionRow>
+						<Button
+							disabled={isLoading || !state.canSubmit || state.isSubmitting}
+							type="submit"
+						>
+							{isLoading || state.isSubmitting ? "Completing..." : "Complete Session"}
+						</Button>
+					</DialogActionRow>
+				)}
+			</form.Subscribe>
 		</form>
 	);
 }

--- a/apps/web/src/live-sessions/components/cash-game-complete-form.tsx
+++ b/apps/web/src/live-sessions/components/cash-game-complete-form.tsx
@@ -64,7 +64,9 @@ export function CashGameCompleteForm({
 							}
 							placeholder="0"
 							type="number"
-							value={field.state.value !== undefined ? String(field.state.value) : ""}
+							value={
+								field.state.value === undefined ? "" : String(field.state.value)
+							}
 						/>
 					</Field>
 				)}
@@ -77,7 +79,9 @@ export function CashGameCompleteForm({
 							disabled={isLoading || !state.canSubmit || state.isSubmitting}
 							type="submit"
 						>
-							{isLoading || state.isSubmitting ? "Completing..." : "Complete Session"}
+							{isLoading || state.isSubmitting
+								? "Completing..."
+								: "Complete Session"}
 						</Button>
 					</DialogActionRow>
 				)}

--- a/apps/web/src/live-sessions/components/cash-game-stack-form.tsx
+++ b/apps/web/src/live-sessions/components/cash-game-stack-form.tsx
@@ -4,9 +4,8 @@ import z from "zod";
 import { AddonBottomSheet } from "@/live-sessions/components/addon-bottom-sheet";
 import { AllInBottomSheet } from "@/live-sessions/components/all-in-bottom-sheet";
 import { MemoFields } from "@/live-sessions/components/event-fields/memo-fields";
-import {
-	StackPrimaryRow,
-} from "@/live-sessions/components/stack-ui";
+import { StackPrimaryRow } from "@/live-sessions/components/stack-ui";
+import { useStackFormContext } from "@/live-sessions/hooks/use-session-form";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
@@ -45,6 +44,8 @@ export function CashGameStackForm({
 	onPause,
 	onSubmit,
 }: CashGameStackFormProps) {
+	const { state: stackFormState, setStackAmount: setContextStackAmount } =
+		useStackFormContext();
 	const [allInBottomSheetOpen, setAllInBottomSheetOpen] = useState(false);
 	const [addonBottomSheetOpen, setAddonBottomSheetOpen] = useState(false);
 	const [removeBottomSheetOpen, setRemoveBottomSheetOpen] = useState(false);
@@ -53,7 +54,9 @@ export function CashGameStackForm({
 
 	const form = useForm({
 		defaultValues: {
-			stackAmount: undefined as number | undefined,
+			stackAmount: stackFormState.stackAmount
+				? Number(stackFormState.stackAmount)
+				: (undefined as number | undefined),
 		},
 		onSubmit: ({ value }) => {
 			onSubmit({ stackAmount: value.stackAmount as number });
@@ -76,7 +79,9 @@ export function CashGameStackForm({
 	const handleAddonSubmit = (values: { amount: number }) => {
 		onChipAdd(values.amount);
 		const currentStack = form.getFieldValue("stackAmount") ?? 0;
-		form.setFieldValue("stackAmount", (currentStack as number) + values.amount);
+		const newStackValue = (currentStack as number) + values.amount;
+		form.setFieldValue("stackAmount", newStackValue);
+		setContextStackAmount(String(newStackValue));
 		setAddonBottomSheetOpen(false);
 	};
 
@@ -123,13 +128,18 @@ export function CashGameStackForm({
 									min={0}
 									name={field.name}
 									onBlur={field.handleBlur}
-									onChange={(e) =>
+									onChange={(e) => {
 										field.handleChange(
 											e.target.value === "" ? undefined : Number(e.target.value)
-										)
-									}
+										);
+										setContextStackAmount(e.target.value);
+									}}
 									type="number"
-									value={field.state.value !== undefined ? String(field.state.value) : ""}
+									value={
+										field.state.value === undefined
+											? ""
+											: String(field.state.value)
+									}
 								/>
 							</Field>
 						)}

--- a/apps/web/src/live-sessions/components/cash-game-stack-form.tsx
+++ b/apps/web/src/live-sessions/components/cash-game-stack-form.tsx
@@ -1,14 +1,16 @@
+import { useForm } from "@tanstack/react-form";
 import { useState } from "react";
+import z from "zod";
 import { AddonBottomSheet } from "@/live-sessions/components/addon-bottom-sheet";
 import { AllInBottomSheet } from "@/live-sessions/components/all-in-bottom-sheet";
 import { MemoFields } from "@/live-sessions/components/event-fields/memo-fields";
 import {
-	StackNumberField,
 	StackPrimaryRow,
 } from "@/live-sessions/components/stack-ui";
-import { useStackFormContext } from "@/live-sessions/hooks/use-session-form";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
+import { Field } from "@/shared/components/ui/field";
+import { Input } from "@/shared/components/ui/input";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 
 interface CashGameStackFormProps {
@@ -27,6 +29,12 @@ interface CashGameStackFormProps {
 	onSubmit: (values: { stackAmount: number }) => void;
 }
 
+const cashGameStackFormSchema = z.object({
+	stackAmount: z.coerce
+		.number({ invalid_type_error: "Stack amount is required" })
+		.min(0, "Stack amount must be 0 or greater"),
+});
+
 export function CashGameStackForm({
 	isLoading,
 	onAllIn,
@@ -37,14 +45,23 @@ export function CashGameStackForm({
 	onPause,
 	onSubmit,
 }: CashGameStackFormProps) {
-	const { state, setStackAmount } = useStackFormContext();
-	const { stackAmount } = state;
-
 	const [allInBottomSheetOpen, setAllInBottomSheetOpen] = useState(false);
 	const [addonBottomSheetOpen, setAddonBottomSheetOpen] = useState(false);
 	const [removeBottomSheetOpen, setRemoveBottomSheetOpen] = useState(false);
 	const [memoBottomSheetOpen, setMemoBottomSheetOpen] = useState(false);
 	const [memoText, setMemoText] = useState("");
+
+	const form = useForm({
+		defaultValues: {
+			stackAmount: undefined as number | undefined,
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({ stackAmount: value.stackAmount as number });
+		},
+		validators: {
+			onSubmit: cashGameStackFormSchema,
+		},
+	});
 
 	const handleAllInSubmit = (values: {
 		potSize: number;
@@ -58,8 +75,8 @@ export function CashGameStackForm({
 
 	const handleAddonSubmit = (values: { amount: number }) => {
 		onChipAdd(values.amount);
-		const currentStack = Number(stackAmount) || 0;
-		setStackAmount(String(currentStack + values.amount));
+		const currentStack = form.getFieldValue("stackAmount") ?? 0;
+		form.setFieldValue("stackAmount", (currentStack as number) + values.amount);
 		setAddonBottomSheetOpen(false);
 	};
 
@@ -76,33 +93,58 @@ export function CashGameStackForm({
 		setMemoBottomSheetOpen(false);
 	};
 
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		onSubmit({ stackAmount: Number(stackAmount) });
-	};
-
 	const handleComplete = () => {
-		onComplete(Number(stackAmount) || 0);
+		const currentStack = form.getFieldValue("stackAmount") ?? 0;
+		onComplete((currentStack as number) || 0);
 	};
 
 	return (
 		<div className="flex flex-col gap-4">
-			<form onSubmit={handleSubmit}>
+			<form
+				onSubmit={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					form.handleSubmit();
+				}}
+			>
 				<StackPrimaryRow>
-					<StackNumberField
-						className="sm:min-w-[12rem]"
-						id="cash-stack-amount"
-						inputMode="numeric"
-						label="Current Stack"
-						min={0}
-						onChange={setStackAmount}
-						required
-						type="number"
-						value={stackAmount}
-					/>
-					<Button disabled={isLoading} size="sm" type="submit">
-						{isLoading ? "..." : "Update"}
-					</Button>
+					<form.Field name="stackAmount">
+						{(field) => (
+							<Field
+								className="sm:min-w-[12rem]"
+								error={field.state.meta.errors[0]?.message}
+								htmlFor={field.name}
+								label="Current Stack"
+								required
+							>
+								<Input
+									id={field.name}
+									inputMode="numeric"
+									min={0}
+									name={field.name}
+									onBlur={field.handleBlur}
+									onChange={(e) =>
+										field.handleChange(
+											e.target.value === "" ? undefined : Number(e.target.value)
+										)
+									}
+									type="number"
+									value={field.state.value !== undefined ? String(field.state.value) : ""}
+								/>
+							</Field>
+						)}
+					</form.Field>
+					<form.Subscribe>
+						{(state) => (
+							<Button
+								disabled={isLoading || !state.canSubmit || state.isSubmitting}
+								size="sm"
+								type="submit"
+							>
+								{isLoading || state.isSubmitting ? "..." : "Update"}
+							</Button>
+						)}
+					</form.Subscribe>
 				</StackPrimaryRow>
 			</form>
 

--- a/apps/web/src/live-sessions/components/create-cash-game-session-form.tsx
+++ b/apps/web/src/live-sessions/components/create-cash-game-session-form.tsx
@@ -1,5 +1,6 @@
 import { useForm } from "@tanstack/react-form";
 import { useState } from "react";
+import z from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { Field } from "@/shared/components/ui/field";
@@ -34,6 +35,13 @@ interface CreateCashGameSessionFormProps {
 	stores: Array<{ id: string; name: string }>;
 }
 
+const createCashGameSessionFormSchema = z.object({
+	initialBuyIn: z.coerce
+		.number({ invalid_type_error: "Buy-in is required" })
+		.min(0, "Must be 0 or greater"),
+	memo: z.string().optional(),
+});
+
 export function CreateCashGameSessionForm({
 	currencies,
 	isLoading,
@@ -62,7 +70,7 @@ export function CreateCashGameSessionForm({
 
 	const form = useForm({
 		defaultValues: {
-			initialBuyIn: "",
+			initialBuyIn: undefined as number | undefined,
 			memo: "",
 		},
 		onSubmit: ({ value }) => {
@@ -73,16 +81,19 @@ export function CreateCashGameSessionForm({
 				storeId: selectedStoreId,
 				ringGameId: selectedRingGameId,
 				currencyId: selectedCurrencyId,
-				initialBuyIn: Number(value.initialBuyIn),
+				initialBuyIn: value.initialBuyIn as number,
 				memo: value.memo || undefined,
 			});
+		},
+		validators: {
+			onSubmit: createCashGameSessionFormSchema,
 		},
 	});
 
 	const handleStoreChange = (value: string) => {
 		setSelectedStoreId(value);
 		setSelectedRingGameId(undefined);
-		form.setFieldValue("initialBuyIn", "");
+		form.setFieldValue("initialBuyIn", undefined);
 		onStoreChange?.(value);
 	};
 
@@ -90,7 +101,10 @@ export function CreateCashGameSessionForm({
 		setSelectedRingGameId(value);
 		const ringGame = ringGames.find((g) => g.id === value);
 		if (ringGame) {
-			form.setFieldValue("initialBuyIn", ringGame.maxBuyIn?.toString() ?? "");
+			form.setFieldValue(
+				"initialBuyIn",
+				ringGame.maxBuyIn ?? undefined
+			);
 			setSelectedCurrencyId(ringGame.currencyId ?? undefined);
 		}
 	};
@@ -189,25 +203,21 @@ export function CreateCashGameSessionForm({
 						name="initialBuyIn"
 						validators={{
 							onChange: ({ value }) => {
-								if (value === "") {
+								if (value === undefined || value === null) {
 									return "Buy-in is required";
 								}
-								const numValue = Number(value);
-								if (Number.isNaN(numValue)) {
-									return "Must be a number";
-								}
-								if (numValue < 0) {
+								if (value < 0) {
 									return "Must be 0 or greater";
 								}
 								if (
 									selectedRingGame?.minBuyIn != null &&
-									numValue < selectedRingGame.minBuyIn
+									value < selectedRingGame.minBuyIn
 								) {
 									return `Must be at least ${selectedRingGame.minBuyIn}`;
 								}
 								if (
 									selectedRingGame?.maxBuyIn != null &&
-									numValue > selectedRingGame.maxBuyIn
+									value > selectedRingGame.maxBuyIn
 								) {
 									return `Must be at most ${selectedRingGame.maxBuyIn}`;
 								}
@@ -217,7 +227,7 @@ export function CreateCashGameSessionForm({
 					>
 						{(field) => (
 							<Field
-								error={field.state.meta.errors[0]}
+								error={field.state.meta.errors[0]?.message}
 								htmlFor={field.name}
 								label="Initial Buy-in"
 							>
@@ -225,10 +235,15 @@ export function CreateCashGameSessionForm({
 									id={field.name}
 									max={selectedRingGame?.maxBuyIn ?? undefined}
 									min={selectedRingGame?.minBuyIn ?? 0}
+									name={field.name}
 									onBlur={field.handleBlur}
-									onChange={(e) => field.handleChange(e.target.value)}
+									onChange={(e) =>
+										field.handleChange(
+											e.target.value === "" ? undefined : Number(e.target.value)
+										)
+									}
 									type="number"
-									value={field.state.value}
+									value={field.state.value !== undefined ? String(field.state.value) : ""}
 								/>
 							</Field>
 						)}
@@ -239,6 +254,7 @@ export function CreateCashGameSessionForm({
 							<Field htmlFor={field.name} label="Memo">
 								<Textarea
 									id={field.name}
+									name={field.name}
 									onBlur={field.handleBlur}
 									onChange={(e) => field.handleChange(e.target.value)}
 									placeholder="Notes about this session"
@@ -259,7 +275,7 @@ export function CreateCashGameSessionForm({
 						}
 						type="submit"
 					>
-						{isLoading ? "Starting..." : "Start Session"}
+						{isLoading || state.isSubmitting ? "Starting..." : "Start Session"}
 					</Button>
 				)}
 			</form.Subscribe>

--- a/apps/web/src/live-sessions/components/create-cash-game-session-form.tsx
+++ b/apps/web/src/live-sessions/components/create-cash-game-session-form.tsx
@@ -227,7 +227,11 @@ export function CreateCashGameSessionForm({
 					>
 						{(field) => (
 							<Field
-								error={field.state.meta.errors[0]?.message}
+								error={
+									field.state.meta.errors[0]
+										? String(field.state.meta.errors[0])
+										: undefined
+								}
 								htmlFor={field.name}
 								label="Initial Buy-in"
 							>

--- a/apps/web/src/live-sessions/components/create-cash-game-session-form.tsx
+++ b/apps/web/src/live-sessions/components/create-cash-game-session-form.tsx
@@ -101,10 +101,7 @@ export function CreateCashGameSessionForm({
 		setSelectedRingGameId(value);
 		const ringGame = ringGames.find((g) => g.id === value);
 		if (ringGame) {
-			form.setFieldValue(
-				"initialBuyIn",
-				ringGame.maxBuyIn ?? undefined
-			);
+			form.setFieldValue("initialBuyIn", ringGame.maxBuyIn ?? undefined);
 			setSelectedCurrencyId(ringGame.currencyId ?? undefined);
 		}
 	};
@@ -247,7 +244,11 @@ export function CreateCashGameSessionForm({
 										)
 									}
 									type="number"
-									value={field.state.value !== undefined ? String(field.state.value) : ""}
+									value={
+										field.state.value === undefined
+											? ""
+											: String(field.state.value)
+									}
 								/>
 							</Field>
 						)}

--- a/apps/web/src/live-sessions/components/create-tournament-session-form.tsx
+++ b/apps/web/src/live-sessions/components/create-tournament-session-form.tsx
@@ -242,11 +242,17 @@ export function CreateTournamentSessionForm({
 										onBlur={field.handleBlur}
 										onChange={(e) =>
 											field.handleChange(
-												e.target.value === "" ? undefined : Number(e.target.value)
+												e.target.value === ""
+													? undefined
+													: Number(e.target.value)
 											)
 										}
 										type="number"
-										value={field.state.value !== undefined ? String(field.state.value) : ""}
+										value={
+											field.state.value === undefined
+												? ""
+												: String(field.state.value)
+										}
 									/>
 								</Field>
 							)}
@@ -268,11 +274,17 @@ export function CreateTournamentSessionForm({
 										onBlur={field.handleBlur}
 										onChange={(e) =>
 											field.handleChange(
-												e.target.value === "" ? undefined : Number(e.target.value)
+												e.target.value === ""
+													? undefined
+													: Number(e.target.value)
 											)
 										}
 										type="number"
-										value={field.state.value !== undefined ? String(field.state.value) : ""}
+										value={
+											field.state.value === undefined
+												? ""
+												: String(field.state.value)
+										}
 									/>
 								</Field>
 							)}
@@ -300,7 +312,11 @@ export function CreateTournamentSessionForm({
 										)
 									}
 									type="number"
-									value={field.state.value !== undefined ? String(field.state.value) : ""}
+									value={
+										field.state.value === undefined
+											? ""
+											: String(field.state.value)
+									}
 								/>
 							</Field>
 						)}
@@ -332,7 +348,9 @@ export function CreateTournamentSessionForm({
 						}
 						type="submit"
 					>
-						{isLoading || state.isSubmitting ? "Starting..." : "Start Tournament"}
+						{isLoading || state.isSubmitting
+							? "Starting..."
+							: "Start Tournament"}
 					</Button>
 				)}
 			</form.Subscribe>

--- a/apps/web/src/live-sessions/components/create-tournament-session-form.tsx
+++ b/apps/web/src/live-sessions/components/create-tournament-session-form.tsx
@@ -1,4 +1,6 @@
+import { useForm } from "@tanstack/react-form";
 import { useState } from "react";
+import z from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { Field } from "@/shared/components/ui/field";
@@ -36,6 +38,17 @@ interface CreateTournamentSessionFormProps {
 	}>;
 }
 
+const createTournamentSessionFormSchema = z.object({
+	buyIn: z.coerce
+		.number({ invalid_type_error: "Buy-in is required" })
+		.min(0, "Must be 0 or greater"),
+	entryFee: z.coerce.number().min(0, "Must be 0 or greater").optional(),
+	startingStack: z.coerce
+		.number({ invalid_type_error: "Starting stack is required" })
+		.min(0, "Must be 0 or greater"),
+	memo: z.string().optional(),
+});
+
 export function CreateTournamentSessionForm({
 	currencies,
 	isLoading,
@@ -53,9 +66,49 @@ export function CreateTournamentSessionForm({
 	const [selectedCurrencyId, setSelectedCurrencyId] = useState<
 		string | undefined
 	>(undefined);
-	const [buyIn, setBuyIn] = useState<string>("");
-	const [entryFee, setEntryFee] = useState<string>("");
-	const [startingStack, setStartingStack] = useState<string>("");
+
+	const selectedTournament = selectedTournamentId
+		? tournaments.find((t) => t.id === selectedTournamentId)
+		: null;
+
+	const isBuyInLocked =
+		selectedTournament?.buyIn !== null &&
+		selectedTournament?.buyIn !== undefined;
+	const isEntryFeeLocked =
+		selectedTournament?.entryFee !== null &&
+		selectedTournament?.entryFee !== undefined;
+	const isStartingStackLocked =
+		selectedTournament?.startingStack !== null &&
+		selectedTournament?.startingStack !== undefined;
+	const isCurrencyLocked =
+		selectedTournament?.currencyId !== null &&
+		selectedTournament?.currencyId !== undefined;
+
+	const form = useForm({
+		defaultValues: {
+			buyIn: undefined as number | undefined,
+			entryFee: undefined as number | undefined,
+			startingStack: undefined as number | undefined,
+			memo: "",
+		},
+		onSubmit: ({ value }) => {
+			if (!(selectedStoreId && selectedTournamentId)) {
+				return;
+			}
+			onSubmit({
+				storeId: selectedStoreId,
+				tournamentId: selectedTournamentId,
+				currencyId: selectedCurrencyId,
+				buyIn: value.buyIn as number,
+				entryFee: value.entryFee,
+				startingStack: value.startingStack as number,
+				memo: value.memo || undefined,
+			});
+		},
+		validators: {
+			onSubmit: createTournamentSessionFormSchema,
+		},
+	});
 
 	const handleStoreChange = (value: string) => {
 		setSelectedStoreId(value);
@@ -67,15 +120,9 @@ export function CreateTournamentSessionForm({
 		if (t.currencyId) {
 			setSelectedCurrencyId(t.currencyId);
 		}
-		if (t.buyIn !== null) {
-			setBuyIn(String(t.buyIn));
-		}
-		if (t.entryFee !== null) {
-			setEntryFee(String(t.entryFee));
-		}
-		if (t.startingStack !== null) {
-			setStartingStack(String(t.startingStack));
-		}
+		form.setFieldValue("buyIn", t.buyIn ?? undefined);
+		form.setFieldValue("entryFee", t.entryFee ?? undefined);
+		form.setFieldValue("startingStack", t.startingStack ?? undefined);
 	};
 
 	const handleTournamentChange = (value: string) => {
@@ -90,49 +137,18 @@ export function CreateTournamentSessionForm({
 		setSelectedCurrencyId(value);
 	};
 
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		if (!(selectedStoreId && selectedTournamentId)) {
-			return;
-		}
-		const formData = new FormData(e.currentTarget);
-		const memo = (formData.get("memo") as string) || undefined;
-		const entryFeeNum = entryFee ? Number(entryFee) : undefined;
-
-		onSubmit({
-			storeId: selectedStoreId,
-			tournamentId: selectedTournamentId,
-			currencyId: selectedCurrencyId,
-			buyIn: Number(buyIn),
-			entryFee: entryFeeNum,
-			startingStack: Number(startingStack),
-			memo,
-		});
-	};
-
 	const hasTournaments = tournaments.length > 0;
-
-	// Determine which fields are locked by the selected tournament
-	const selectedTournament = selectedTournamentId
-		? tournaments.find((t) => t.id === selectedTournamentId)
-		: null;
-	const isBuyInLocked =
-		selectedTournament?.buyIn !== null &&
-		selectedTournament?.buyIn !== undefined;
-	const isEntryFeeLocked =
-		selectedTournament?.entryFee !== null &&
-		selectedTournament?.entryFee !== undefined;
-	const isStartingStackLocked =
-		selectedTournament?.startingStack !== null &&
-		selectedTournament?.startingStack !== undefined;
-	const isCurrencyLocked =
-		selectedTournament?.currencyId !== null &&
-		selectedTournament?.currencyId !== undefined;
-
 	const canSubmit = !!selectedStoreId && !!selectedTournamentId;
 
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
 			<Field label="Store" required>
 				{stores.length > 0 ? (
 					<Select onValueChange={handleStoreChange} value={selectedStoreId}>
@@ -208,57 +224,118 @@ export function CreateTournamentSessionForm({
 					)}
 
 					<div className="flex gap-3">
-						<Field className="flex-1" htmlFor="buyIn" label="Buy-in" required>
-							<Input
-								disabled={isBuyInLocked}
-								id="buyIn"
-								inputMode="numeric"
-								min={0}
-								onChange={(e) => setBuyIn(e.target.value)}
-								required
-								type="number"
-								value={buyIn}
-							/>
-						</Field>
-						<Field className="flex-1" htmlFor="entryFee" label="Entry Fee">
-							<Input
-								disabled={isEntryFeeLocked}
-								id="entryFee"
-								inputMode="numeric"
-								min={0}
-								onChange={(e) => setEntryFee(e.target.value)}
-								type="number"
-								value={entryFee}
-							/>
-						</Field>
+						<form.Field name="buyIn">
+							{(field) => (
+								<Field
+									className="flex-1"
+									error={field.state.meta.errors[0]?.message}
+									htmlFor={field.name}
+									label="Buy-in"
+									required
+								>
+									<Input
+										disabled={isBuyInLocked}
+										id={field.name}
+										inputMode="numeric"
+										min={0}
+										name={field.name}
+										onBlur={field.handleBlur}
+										onChange={(e) =>
+											field.handleChange(
+												e.target.value === "" ? undefined : Number(e.target.value)
+											)
+										}
+										type="number"
+										value={field.state.value !== undefined ? String(field.state.value) : ""}
+									/>
+								</Field>
+							)}
+						</form.Field>
+						<form.Field name="entryFee">
+							{(field) => (
+								<Field
+									className="flex-1"
+									error={field.state.meta.errors[0]?.message}
+									htmlFor={field.name}
+									label="Entry Fee"
+								>
+									<Input
+										disabled={isEntryFeeLocked}
+										id={field.name}
+										inputMode="numeric"
+										min={0}
+										name={field.name}
+										onBlur={field.handleBlur}
+										onChange={(e) =>
+											field.handleChange(
+												e.target.value === "" ? undefined : Number(e.target.value)
+											)
+										}
+										type="number"
+										value={field.state.value !== undefined ? String(field.state.value) : ""}
+									/>
+								</Field>
+							)}
+						</form.Field>
 					</div>
 
-					<Field htmlFor="startingStack" label="Starting Stack" required>
-						<Input
-							disabled={isStartingStackLocked}
-							id="startingStack"
-							inputMode="numeric"
-							min={0}
-							onChange={(e) => setStartingStack(e.target.value)}
-							required
-							type="number"
-							value={startingStack}
-						/>
-					</Field>
+					<form.Field name="startingStack">
+						{(field) => (
+							<Field
+								error={field.state.meta.errors[0]?.message}
+								htmlFor={field.name}
+								label="Starting Stack"
+								required
+							>
+								<Input
+									disabled={isStartingStackLocked}
+									id={field.name}
+									inputMode="numeric"
+									min={0}
+									name={field.name}
+									onBlur={field.handleBlur}
+									onChange={(e) =>
+										field.handleChange(
+											e.target.value === "" ? undefined : Number(e.target.value)
+										)
+									}
+									type="number"
+									value={field.state.value !== undefined ? String(field.state.value) : ""}
+								/>
+							</Field>
+						)}
+					</form.Field>
 
-					<Field htmlFor="memo" label="Memo">
-						<Textarea
-							id="memo"
-							name="memo"
-							placeholder="Notes about this tournament"
-						/>
-					</Field>
+					<form.Field name="memo">
+						{(field) => (
+							<Field htmlFor={field.name} label="Memo">
+								<Textarea
+									id={field.name}
+									name={field.name}
+									onBlur={field.handleBlur}
+									onChange={(e) => field.handleChange(e.target.value)}
+									placeholder="Notes about this tournament"
+									value={field.state.value}
+								/>
+							</Field>
+						)}
+					</form.Field>
 				</>
 			)}
 
-			<Button className="mt-2" disabled={isLoading || !canSubmit} type="submit">
-				{isLoading ? "Starting..." : "Start Tournament"}
-			</Button>
+			<form.Subscribe>
+				{(state) => (
+					<Button
+						className="mt-2"
+						disabled={
+							isLoading || !canSubmit || !state.canSubmit || state.isSubmitting
+						}
+						type="submit"
+					>
+						{isLoading || state.isSubmitting ? "Starting..." : "Start Tournament"}
+					</Button>
+				)}
+			</form.Subscribe>
 		</form>
 	);
 }

--- a/apps/web/src/live-sessions/components/tournament-complete-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-complete-form.tsx
@@ -93,8 +93,11 @@ export function TournamentCompleteForm({
 								)
 							}
 							placeholder="1"
+							required
 							type="number"
-							value={field.state.value !== undefined ? String(field.state.value) : ""}
+							value={
+								field.state.value === undefined ? "" : String(field.state.value)
+							}
 						/>
 					</Field>
 				)}
@@ -121,7 +124,9 @@ export function TournamentCompleteForm({
 							}
 							placeholder="100"
 							type="number"
-							value={field.state.value !== undefined ? String(field.state.value) : ""}
+							value={
+								field.state.value === undefined ? "" : String(field.state.value)
+							}
 						/>
 					</Field>
 				)}
@@ -174,7 +179,9 @@ export function TournamentCompleteForm({
 							}
 							placeholder="0"
 							type="number"
-							value={field.state.value !== undefined ? String(field.state.value) : ""}
+							value={
+								field.state.value === undefined ? "" : String(field.state.value)
+							}
 						/>
 					</Field>
 				)}
@@ -187,7 +194,9 @@ export function TournamentCompleteForm({
 							disabled={isLoading || !state.canSubmit || state.isSubmitting}
 							type="submit"
 						>
-							{isLoading || state.isSubmitting ? "Completing..." : "Complete Tournament"}
+							{isLoading || state.isSubmitting
+								? "Completing..."
+								: "Complete Tournament"}
 						</Button>
 					</DialogActionRow>
 				)}

--- a/apps/web/src/live-sessions/components/tournament-complete-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-complete-form.tsx
@@ -1,3 +1,5 @@
+import { useForm } from "@tanstack/react-form";
+import z from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
@@ -22,83 +24,174 @@ interface TournamentCompleteFormProps {
 	) => void;
 }
 
+const tournamentCompleteFormSchema = z.object({
+	placement: z.coerce
+		.number({ invalid_type_error: "Placement is required" })
+		.int("Must be a whole number")
+		.min(1, "Must be at least 1"),
+	totalEntries: z.coerce
+		.number({ invalid_type_error: "Total entries is required" })
+		.int("Must be a whole number")
+		.min(1, "Must be at least 1"),
+	prizeMoney: z.coerce
+		.number({ invalid_type_error: "Prize money is required" })
+		.min(0, "Must be 0 or greater"),
+	bountyPrizes: z.coerce.number().min(0, "Must be 0 or greater").optional(),
+});
+
 export function TournamentCompleteForm({
 	isLoading,
 	onSubmit,
 }: TournamentCompleteFormProps) {
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		const formData = new FormData(e.currentTarget);
-		const placement = Number(formData.get("placement"));
-		const totalEntries = Number(formData.get("totalEntries"));
-		const prizeMoney = Number(formData.get("prizeMoney"));
-		const bountyRaw = formData.get("bountyPrizes") as string;
-		const bountyPrizes = bountyRaw ? Number(bountyRaw) : 0;
-
-		onSubmit({
-			beforeDeadline: false,
-			placement,
-			totalEntries,
-			prizeMoney,
-			bountyPrizes,
-		});
-	};
+	const form = useForm({
+		defaultValues: {
+			placement: undefined as number | undefined,
+			totalEntries: undefined as number | undefined,
+			prizeMoney: 0 as number,
+			bountyPrizes: undefined as number | undefined,
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				beforeDeadline: false,
+				placement: value.placement as number,
+				totalEntries: value.totalEntries as number,
+				prizeMoney: value.prizeMoney,
+				bountyPrizes: value.bountyPrizes ?? 0,
+			});
+		},
+		validators: {
+			onSubmit: tournamentCompleteFormSchema,
+		},
+	});
 
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-			<Field htmlFor="placement" label="Placement" required>
-				<Input
-					id="placement"
-					inputMode="numeric"
-					min={1}
-					name="placement"
-					placeholder="1"
-					required
-					type="number"
-				/>
-			</Field>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="placement">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Placement"
+						required
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							min={1}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) =>
+								field.handleChange(
+									e.target.value === "" ? undefined : Number(e.target.value)
+								)
+							}
+							placeholder="1"
+							type="number"
+							value={field.state.value !== undefined ? String(field.state.value) : ""}
+						/>
+					</Field>
+				)}
+			</form.Field>
 
-			<Field htmlFor="totalEntries" label="Total Entries" required>
-				<Input
-					id="totalEntries"
-					inputMode="numeric"
-					min={1}
-					name="totalEntries"
-					placeholder="100"
-					required
-					type="number"
-				/>
-			</Field>
+			<form.Field name="totalEntries">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Total Entries"
+						required
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							min={1}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) =>
+								field.handleChange(
+									e.target.value === "" ? undefined : Number(e.target.value)
+								)
+							}
+							placeholder="100"
+							type="number"
+							value={field.state.value !== undefined ? String(field.state.value) : ""}
+						/>
+					</Field>
+				)}
+			</form.Field>
 
-			<Field htmlFor="prizeMoney" label="Prize Money" required>
-				<Input
-					defaultValue={0}
-					id="prizeMoney"
-					inputMode="numeric"
-					min={0}
-					name="prizeMoney"
-					placeholder="0"
-					required
-					type="number"
-				/>
-			</Field>
+			<form.Field name="prizeMoney">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Prize Money"
+						required
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							min={0}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) =>
+								field.handleChange(
+									e.target.value === "" ? 0 : Number(e.target.value)
+								)
+							}
+							placeholder="0"
+							type="number"
+							value={String(field.state.value)}
+						/>
+					</Field>
+				)}
+			</form.Field>
 
-			<Field htmlFor="bountyPrizes" label="Bounty Prizes">
-				<Input
-					id="bountyPrizes"
-					inputMode="numeric"
-					min={0}
-					name="bountyPrizes"
-					placeholder="0"
-					type="number"
-				/>
-			</Field>
+			<form.Field name="bountyPrizes">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Bounty Prizes"
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							min={0}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) =>
+								field.handleChange(
+									e.target.value === "" ? undefined : Number(e.target.value)
+								)
+							}
+							placeholder="0"
+							type="number"
+							value={field.state.value !== undefined ? String(field.state.value) : ""}
+						/>
+					</Field>
+				)}
+			</form.Field>
 
-			<DialogActionRow>
-				<Button disabled={isLoading} type="submit">
-					{isLoading ? "Completing..." : "Complete Tournament"}
-				</Button>
-			</DialogActionRow>
+			<form.Subscribe>
+				{(state) => (
+					<DialogActionRow>
+						<Button
+							disabled={isLoading || !state.canSubmit || state.isSubmitting}
+							type="submit"
+						>
+							{isLoading || state.isSubmitting ? "Completing..." : "Complete Tournament"}
+						</Button>
+					</DialogActionRow>
+				)}
+			</form.Subscribe>
 		</form>
 	);
 }

--- a/apps/web/src/live-sessions/components/tournament-info-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-info-form.tsx
@@ -1,10 +1,13 @@
+import { useForm } from "@tanstack/react-form";
+import z from "zod";
 import {
 	StackNumberField,
 	StackSecondaryGrid,
 } from "@/live-sessions/components/stack-ui";
-import { useTournamentFormContext } from "@/live-sessions/hooks/use-session-form";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
+import { Field } from "@/shared/components/ui/field";
+import { Input } from "@/shared/components/ui/input";
 
 interface TournamentInfoFormProps {
 	chipPurchaseTypes?: Array<{ name: string; cost: number; chips: number }>;
@@ -20,94 +23,168 @@ interface TournamentInfoFormProps {
 	}) => void;
 }
 
+const tournamentInfoFormSchema = z.object({
+	remainingPlayers: z.coerce
+		.number()
+		.int("Must be a whole number")
+		.min(1, "Must be at least 1")
+		.optional(),
+	totalEntries: z.coerce
+		.number()
+		.int("Must be a whole number")
+		.min(1, "Must be at least 1")
+		.optional(),
+	chipPurchaseCounts: z.array(
+		z.object({
+			name: z.string(),
+			count: z.coerce.number().int().min(0),
+			chipsPerUnit: z.number(),
+		})
+	),
+});
+
 export function TournamentInfoForm({
 	chipPurchaseTypes = [],
 	isLoading,
 	onSubmit,
 }: TournamentInfoFormProps) {
-	const { state, setRemainingPlayers, setTotalEntries, setChipPurchaseCounts } =
-		useTournamentFormContext();
-	const { remainingPlayers, totalEntries, chipPurchaseCounts } = state;
-
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		onSubmit({
-			remainingPlayers: remainingPlayers ? Number(remainingPlayers) : null,
-			totalEntries: totalEntries ? Number(totalEntries) : null,
-			chipPurchaseCounts,
-		});
-	};
+	const form = useForm({
+		defaultValues: {
+			remainingPlayers: undefined as number | undefined,
+			totalEntries: undefined as number | undefined,
+			chipPurchaseCounts: [] as Array<{
+				name: string;
+				count: number;
+				chipsPerUnit: number;
+			}>,
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				remainingPlayers: value.remainingPlayers ?? null,
+				totalEntries: value.totalEntries ?? null,
+				chipPurchaseCounts: value.chipPurchaseCounts,
+			});
+		},
+		validators: {
+			onSubmit: tournamentInfoFormSchema,
+		},
+	});
 
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
 			<StackSecondaryGrid>
-				<StackNumberField
-					className="flex-1"
-					id="tournament-remaining-players"
-					inputMode="numeric"
-					label="Remaining Players"
-					min={1}
-					onChange={setRemainingPlayers}
-					type="number"
-					value={remainingPlayers}
-				/>
-				<StackNumberField
-					className="flex-1"
-					id="tournament-total-entries"
-					inputMode="numeric"
-					label="Total Entries"
-					min={1}
-					onChange={setTotalEntries}
-					type="number"
-					value={totalEntries}
-				/>
+				<form.Field name="remainingPlayers">
+					{(field) => (
+						<Field
+							className="flex-1"
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label="Remaining Players"
+						>
+							<Input
+								id={field.name}
+								inputMode="numeric"
+								min={1}
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) =>
+									field.handleChange(
+										e.target.value === "" ? undefined : Number(e.target.value)
+									)
+								}
+								type="number"
+								value={field.state.value ?? ""}
+							/>
+						</Field>
+					)}
+				</form.Field>
+				<form.Field name="totalEntries">
+					{(field) => (
+						<Field
+							className="flex-1"
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label="Total Entries"
+						>
+							<Input
+								id={field.name}
+								inputMode="numeric"
+								min={1}
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) =>
+									field.handleChange(
+										e.target.value === "" ? undefined : Number(e.target.value)
+									)
+								}
+								type="number"
+								value={field.state.value ?? ""}
+							/>
+						</Field>
+					)}
+				</form.Field>
 			</StackSecondaryGrid>
 
 			{chipPurchaseTypes.length > 0 && (
 				<div className="flex flex-col gap-1.5">
-					{chipPurchaseTypes.map((t) => {
-						const countEntry = chipPurchaseCounts.find(
-							(c) => c.name === t.name
-						);
-						const countValue = countEntry?.count ?? 0;
-						return (
-							<StackNumberField
-								className="flex-1"
-								id={`chip-purchase-count-${t.name}`}
-								inputMode="numeric"
-								key={t.name}
-								label={`${t.name} count`}
-								min={0}
-								onChange={(value) => {
-									const newCount = Number(value);
-									setChipPurchaseCounts((prev) => {
-										const without = prev.filter((c) => c.name !== t.name);
-										if (newCount === 0) {
-											return without;
-										}
-										return [
-											...without,
-											{
-												name: t.name,
-												count: newCount,
-												chipsPerUnit: t.chips,
-											},
-										];
-									});
-								}}
-								type="number"
-								value={countValue === 0 ? "" : String(countValue)}
-							/>
-						);
-					})}
+					{chipPurchaseTypes.map((t) => (
+						<form.Field key={t.name} name="chipPurchaseCounts">
+							{(field) => {
+								const counts = field.state.value;
+								const countEntry = counts.find((c) => c.name === t.name);
+								const countValue = countEntry?.count ?? 0;
+								return (
+									<StackNumberField
+										className="flex-1"
+										id={`chip-purchase-count-${t.name}`}
+										inputMode="numeric"
+										label={`${t.name} count`}
+										min={0}
+										onChange={(value) => {
+											const newCount = Number(value);
+											const without = counts.filter((c) => c.name !== t.name);
+											if (newCount === 0) {
+												field.handleChange(without);
+											} else {
+												field.handleChange([
+													...without,
+													{
+														name: t.name,
+														count: newCount,
+														chipsPerUnit: t.chips,
+													},
+												]);
+											}
+										}}
+										type="number"
+										value={countValue === 0 ? "" : String(countValue)}
+									/>
+								);
+							}}
+						</form.Field>
+					))}
 				</div>
 			)}
 
-			<DialogActionRow>
-				<Button disabled={isLoading} type="submit">
-					{isLoading ? "Saving..." : "Update"}
-				</Button>
-			</DialogActionRow>
+			<form.Subscribe>
+				{(state) => (
+					<DialogActionRow>
+						<Button
+							disabled={isLoading || !state.canSubmit || state.isSubmitting}
+							type="submit"
+						>
+							{isLoading || state.isSubmitting ? "Saving..." : "Update"}
+						</Button>
+					</DialogActionRow>
+				)}
+			</form.Subscribe>
 		</form>
 	);
 }

--- a/apps/web/src/live-sessions/components/tournament-stack-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-stack-form.tsx
@@ -1,11 +1,16 @@
+import { useForm } from "@tanstack/react-form";
 import { useState } from "react";
+import z from "zod";
 import { ChipPurchaseSheet } from "@/live-sessions/components/chip-purchase-sheet";
 import { MemoFields } from "@/live-sessions/components/event-fields/memo-fields";
-import { StackNumberField } from "@/live-sessions/components/stack-ui";
-import { useTournamentFormContext } from "@/live-sessions/hooks/use-session-form";
+import {
+	StackNumberField,
+} from "@/live-sessions/components/stack-ui";
 import { Button } from "@/shared/components/ui/button";
 import { Checkbox } from "@/shared/components/ui/checkbox";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
+import { Field } from "@/shared/components/ui/field";
+import { Input } from "@/shared/components/ui/input";
 import { Label } from "@/shared/components/ui/label";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 
@@ -41,6 +46,30 @@ interface TournamentStackFormProps {
 	onSubmit: (values: TournamentStackFormSubmitValues) => void;
 }
 
+const tournamentStackFormSchema = z.object({
+	stackAmount: z.coerce
+		.number({ invalid_type_error: "Stack amount is required" })
+		.min(0, "Stack amount must be 0 or greater"),
+	recordTournamentInfo: z.boolean(),
+	remainingPlayers: z.coerce
+		.number()
+		.int()
+		.min(1, "Must be at least 1")
+		.optional(),
+	totalEntries: z.coerce
+		.number()
+		.int()
+		.min(1, "Must be at least 1")
+		.optional(),
+	chipPurchaseCounts: z.array(
+		z.object({
+			name: z.string(),
+			count: z.number().int().min(0),
+			chipsPerUnit: z.number(),
+		})
+	),
+});
+
 export function TournamentStackForm({
 	chipPurchaseTypes = [],
 	isLoading,
@@ -50,31 +79,35 @@ export function TournamentStackForm({
 	onPurchaseChips,
 	onSubmit,
 }: TournamentStackFormProps) {
-	const {
-		state,
-		setStackAmount,
-		setRemainingPlayers,
-		setTotalEntries,
-		setChipPurchaseCounts,
-	} = useTournamentFormContext();
-	const { stackAmount, remainingPlayers, totalEntries, chipPurchaseCounts } =
-		state;
-
-	const [recordTournamentInfo, setRecordTournamentInfo] = useState(true);
 	const [chipPurchaseSheetOpen, setChipPurchaseSheetOpen] = useState(false);
 	const [memoSheetOpen, setMemoSheetOpen] = useState(false);
 	const [memoText, setMemoText] = useState("");
 
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		onSubmit({
-			stackAmount: Number(stackAmount),
-			recordTournamentInfo,
-			remainingPlayers: remainingPlayers ? Number(remainingPlayers) : null,
-			totalEntries: totalEntries ? Number(totalEntries) : null,
-			chipPurchaseCounts,
-		});
-	};
+	const form = useForm({
+		defaultValues: {
+			stackAmount: undefined as number | undefined,
+			recordTournamentInfo: true,
+			remainingPlayers: undefined as number | undefined,
+			totalEntries: undefined as number | undefined,
+			chipPurchaseCounts: [] as Array<{
+				name: string;
+				count: number;
+				chipsPerUnit: number;
+			}>,
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				stackAmount: value.stackAmount as number,
+				recordTournamentInfo: value.recordTournamentInfo,
+				remainingPlayers: value.remainingPlayers ?? null,
+				totalEntries: value.totalEntries ?? null,
+				chipPurchaseCounts: value.chipPurchaseCounts,
+			});
+		},
+		validators: {
+			onSubmit: tournamentStackFormSchema,
+		},
+	});
 
 	const handleChipPurchaseSubmit = (values: {
 		chips: number;
@@ -95,96 +128,168 @@ export function TournamentStackForm({
 
 	return (
 		<div className="flex flex-col gap-4">
-			<form className="flex flex-col gap-3" onSubmit={handleSubmit}>
-				<StackNumberField
-					id="tournament-stack-amount"
-					inputMode="numeric"
-					label="Current Stack"
-					min={0}
-					onChange={setStackAmount}
-					required
-					type="number"
-					value={stackAmount}
-				/>
+			<form
+				className="flex flex-col gap-3"
+				onSubmit={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					form.handleSubmit();
+				}}
+			>
+				<form.Field name="stackAmount">
+					{(field) => (
+						<StackNumberField
+							id="tournament-stack-amount"
+							inputMode="numeric"
+							label="Current Stack"
+							min={0}
+							onChange={(value) =>
+								field.handleChange(value === "" ? undefined : Number(value))
+							}
+							required
+							type="number"
+							value={field.state.value !== undefined ? String(field.state.value) : ""}
+						/>
+					)}
+				</form.Field>
 
-				<div className="flex items-center gap-2">
-					<Checkbox
-						checked={recordTournamentInfo}
-						id="record-tournament-info"
-						onCheckedChange={(checked) =>
-							setRecordTournamentInfo(checked === true)
-						}
-					/>
-					<Label htmlFor="record-tournament-info">Record tournament info</Label>
-				</div>
-
-				{recordTournamentInfo && (
-					<>
-						<div className="grid grid-cols-2 gap-2">
-							<StackNumberField
-								id="tournament-remaining-players"
-								inputMode="numeric"
-								label="Remaining Players"
-								min={1}
-								onChange={setRemainingPlayers}
-								type="number"
-								value={remainingPlayers}
+				<form.Field name="recordTournamentInfo">
+					{(field) => (
+						<div className="flex items-center gap-2">
+							<Checkbox
+								checked={field.state.value}
+								id="record-tournament-info"
+								onCheckedChange={(checked) =>
+									field.handleChange(checked === true)
+								}
 							/>
-							<StackNumberField
-								id="tournament-total-entries"
-								inputMode="numeric"
-								label="Total Entries"
-								min={1}
-								onChange={setTotalEntries}
-								type="number"
-								value={totalEntries}
-							/>
+							<Label htmlFor="record-tournament-info">
+								Record tournament info
+							</Label>
 						</div>
+					)}
+				</form.Field>
 
-						{chipPurchaseTypes.length > 0 && (
-							<div className="flex flex-col gap-1.5">
-								{chipPurchaseTypes.map((t) => {
-									const countEntry = chipPurchaseCounts.find(
-										(c) => c.name === t.name
-									);
-									const countValue = countEntry?.count ?? 0;
-									return (
-										<StackNumberField
-											id={`chip-purchase-count-${t.name}`}
-											inputMode="numeric"
-											key={t.name}
-											label={`${t.name} count`}
-											min={0}
-											onChange={(value) => {
-												const newCount = Number(value);
-												setChipPurchaseCounts((prev) => {
-													const without = prev.filter((c) => c.name !== t.name);
-													if (newCount === 0) {
-														return without;
+				<form.Subscribe selector={(state) => state.values.recordTournamentInfo}>
+					{(recordTournamentInfo) =>
+						recordTournamentInfo ? (
+							<>
+								<div className="grid grid-cols-2 gap-2">
+									<form.Field name="remainingPlayers">
+										{(field) => (
+											<Field
+												error={field.state.meta.errors[0]?.message}
+												htmlFor={field.name}
+												label="Remaining Players"
+											>
+												<Input
+													id={field.name}
+													inputMode="numeric"
+													min={1}
+													name={field.name}
+													onBlur={field.handleBlur}
+													onChange={(e) =>
+														field.handleChange(
+															e.target.value === ""
+																? undefined
+																: Number(e.target.value)
+														)
 													}
-													return [
-														...without,
-														{
-															name: t.name,
-															count: newCount,
-															chipsPerUnit: t.chips,
-														},
-													];
-												});
-											}}
-											type="number"
-											value={countValue === 0 ? "" : String(countValue)}
-										/>
-									);
-								})}
-							</div>
-						)}
-					</>
-				)}
+													type="number"
+													value={field.state.value ?? ""}
+												/>
+											</Field>
+										)}
+									</form.Field>
+									<form.Field name="totalEntries">
+										{(field) => (
+											<Field
+												error={field.state.meta.errors[0]?.message}
+												htmlFor={field.name}
+												label="Total Entries"
+											>
+												<Input
+													id={field.name}
+													inputMode="numeric"
+													min={1}
+													name={field.name}
+													onBlur={field.handleBlur}
+													onChange={(e) =>
+														field.handleChange(
+															e.target.value === ""
+																? undefined
+																: Number(e.target.value)
+														)
+													}
+													type="number"
+													value={field.state.value ?? ""}
+												/>
+											</Field>
+										)}
+									</form.Field>
+								</div>
 
-				<Button className="w-full" disabled={isLoading} type="submit">
-					{isLoading ? "..." : "Update"}
-				</Button>
+								{chipPurchaseTypes.length > 0 && (
+									<div className="flex flex-col gap-1.5">
+										{chipPurchaseTypes.map((t) => (
+											<form.Field key={t.name} name="chipPurchaseCounts">
+												{(field) => {
+													const counts = field.state.value;
+													const countEntry = counts.find(
+														(c) => c.name === t.name
+													);
+													const countValue = countEntry?.count ?? 0;
+													return (
+														<StackNumberField
+															id={`chip-purchase-count-${t.name}`}
+															inputMode="numeric"
+															label={`${t.name} count`}
+															min={0}
+															onChange={(value) => {
+																const newCount = Number(value);
+																const without = counts.filter(
+																	(c) => c.name !== t.name
+																);
+																if (newCount === 0) {
+																	field.handleChange(without);
+																} else {
+																	field.handleChange([
+																		...without,
+																		{
+																			name: t.name,
+																			count: newCount,
+																			chipsPerUnit: t.chips,
+																		},
+																	]);
+																}
+															}}
+															type="number"
+															value={
+																countValue === 0 ? "" : String(countValue)
+															}
+														/>
+													);
+												}}
+											</form.Field>
+										))}
+									</div>
+								)}
+							</>
+						) : null
+					}
+				</form.Subscribe>
+
+				<form.Subscribe>
+					{(state) => (
+						<Button
+							className="w-full"
+							disabled={isLoading || !state.canSubmit || state.isSubmitting}
+							type="submit"
+						>
+							{isLoading || state.isSubmitting ? "..." : "Update"}
+						</Button>
+					)}
+				</form.Subscribe>
 			</form>
 
 			<div className="-mx-4 border-t" />

--- a/apps/web/src/live-sessions/components/tournament-stack-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-stack-form.tsx
@@ -3,9 +3,8 @@ import { useState } from "react";
 import z from "zod";
 import { ChipPurchaseSheet } from "@/live-sessions/components/chip-purchase-sheet";
 import { MemoFields } from "@/live-sessions/components/event-fields/memo-fields";
-import {
-	StackNumberField,
-} from "@/live-sessions/components/stack-ui";
+import { StackNumberField } from "@/live-sessions/components/stack-ui";
+import { useTournamentFormContext } from "@/live-sessions/hooks/use-session-form";
 import { Button } from "@/shared/components/ui/button";
 import { Checkbox } from "@/shared/components/ui/checkbox";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
@@ -56,11 +55,7 @@ const tournamentStackFormSchema = z.object({
 		.int()
 		.min(1, "Must be at least 1")
 		.optional(),
-	totalEntries: z.coerce
-		.number()
-		.int()
-		.min(1, "Must be at least 1")
-		.optional(),
+	totalEntries: z.coerce.number().int().min(1, "Must be at least 1").optional(),
 	chipPurchaseCounts: z.array(
 		z.object({
 			name: z.string(),
@@ -79,13 +74,17 @@ export function TournamentStackForm({
 	onPurchaseChips,
 	onSubmit,
 }: TournamentStackFormProps) {
+	const { state: stackFormState, setStackAmount: setContextStackAmount } =
+		useTournamentFormContext();
 	const [chipPurchaseSheetOpen, setChipPurchaseSheetOpen] = useState(false);
 	const [memoSheetOpen, setMemoSheetOpen] = useState(false);
 	const [memoText, setMemoText] = useState("");
 
 	const form = useForm({
 		defaultValues: {
-			stackAmount: undefined as number | undefined,
+			stackAmount: stackFormState.stackAmount
+				? Number(stackFormState.stackAmount)
+				: (undefined as number | undefined),
 			recordTournamentInfo: true,
 			remainingPlayers: undefined as number | undefined,
 			totalEntries: undefined as number | undefined,
@@ -143,12 +142,15 @@ export function TournamentStackForm({
 							inputMode="numeric"
 							label="Current Stack"
 							min={0}
-							onChange={(value) =>
-								field.handleChange(value === "" ? undefined : Number(value))
-							}
+							onChange={(value) => {
+								field.handleChange(value === "" ? undefined : Number(value));
+								setContextStackAmount(value);
+							}}
 							required
 							type="number"
-							value={field.state.value !== undefined ? String(field.state.value) : ""}
+							value={
+								field.state.value === undefined ? "" : String(field.state.value)
+							}
 						/>
 					)}
 				</form.Field>
@@ -264,9 +266,7 @@ export function TournamentStackForm({
 																}
 															}}
 															type="number"
-															value={
-																countValue === 0 ? "" : String(countValue)
-															}
+															value={countValue === 0 ? "" : String(countValue)}
 														/>
 													);
 												}}

--- a/apps/web/src/sessions/components/__tests__/session-form.test.tsx
+++ b/apps/web/src/sessions/components/__tests__/session-form.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { SessionForm } from "../session-form";
@@ -7,14 +7,6 @@ const EV_HELPER_RE = /Expected value cash-out based on all-in equity/;
 const BUY_IN_RE = /Buy-in/;
 const SESSION_DATE_RE = /Session Date/;
 const SESSION_TAG = { id: "series", name: "Series" };
-
-function getForm() {
-	const form = screen.getByRole("button", { name: "Save" }).closest("form");
-	if (!form) {
-		throw new Error("Session form not found");
-	}
-	return form;
-}
 
 describe("SessionForm", () => {
 	it("renders cash game mode by default", () => {
@@ -121,7 +113,7 @@ describe("SessionForm", () => {
 		await user.click(screen.getByLabelText("Search tags"));
 		await user.click(screen.getByText("Series"));
 
-		fireEvent.submit(getForm());
+		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		expect(onSubmit).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/apps/web/src/sessions/components/cash-game-fields.tsx
+++ b/apps/web/src/sessions/components/cash-game-fields.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Input } from "@/shared/components/ui/input";
 import { Label } from "@/shared/components/ui/label";
 import {
@@ -9,19 +8,24 @@ import {
 	SelectValue,
 } from "@/shared/components/ui/select";
 
-interface CashGameFieldsProps {
+export interface CashGameFieldsProps {
+	ante?: number;
+	anteType?: string;
+	blind1?: number;
+	blind2?: number;
+	blind3?: number;
 	currencies?: Array<{ id: string; name: string }>;
-	defaultValues?: {
-		ante?: number;
-		anteType?: string;
-		blind1?: number;
-		blind2?: number;
-		blind3?: number;
-		tableSize?: number;
-		variant?: string;
-	};
+	onAnteChange?: (value: number | undefined) => void;
+	onAnteTypeChange?: (value: string) => void;
+	onBlind1Change?: (value: number | undefined) => void;
+	onBlind2Change?: (value: number | undefined) => void;
+	onBlind3Change?: (value: number | undefined) => void;
 	onCurrencyChange?: (id: string | undefined) => void;
+	onTableSizeChange?: (value: number | undefined) => void;
+	onVariantChange?: (value: string) => void;
 	selectedCurrencyId?: string;
+	tableSize?: number;
+	variant?: string;
 }
 
 const NONE_VALUE = "__none__";
@@ -34,16 +38,31 @@ const ANTE_TYPES = [
 
 const TABLE_SIZES = [2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
 
-export function CashGameFields({
-	currencies,
-	defaultValues,
-	onCurrencyChange,
-	selectedCurrencyId,
-}: CashGameFieldsProps) {
-	const [anteType, setAnteType] = useState<string>(
-		defaultValues?.anteType ?? "none"
-	);
+function parseNumericInput(value: string): number | undefined {
+	if (!value) return undefined;
+	const parsed = Number.parseFloat(value);
+	return Number.isNaN(parsed) ? undefined : parsed;
+}
 
+export function CashGameFields({
+	ante,
+	anteType = "none",
+	blind1,
+	blind2,
+	blind3,
+	currencies,
+	onAnteChange,
+	onAnteTypeChange,
+	onBlind1Change,
+	onBlind2Change,
+	onBlind3Change,
+	onCurrencyChange,
+	onTableSizeChange,
+	onVariantChange,
+	selectedCurrencyId,
+	tableSize,
+	variant = "nlh",
+}: CashGameFieldsProps) {
 	const isAnteDisabled = anteType === "none";
 
 	return (
@@ -79,7 +98,10 @@ export function CashGameFields({
 			{/* Variant */}
 			<div className="flex flex-col gap-2">
 				<Label htmlFor="variant">Variant</Label>
-				<Select defaultValue={defaultValues?.variant ?? "nlh"} name="variant">
+				<Select
+					onValueChange={(v) => onVariantChange?.(v)}
+					value={variant}
+				>
 					<SelectTrigger className="w-full" id="variant">
 						<SelectValue placeholder="Select variant" />
 					</SelectTrigger>
@@ -94,37 +116,37 @@ export function CashGameFields({
 				<div className="flex flex-col gap-2">
 					<Label htmlFor="blind1">SB</Label>
 					<Input
-						defaultValue={defaultValues?.blind1}
 						id="blind1"
 						inputMode="numeric"
 						min={0}
-						name="blind1"
+						onChange={(e) => onBlind1Change?.(parseNumericInput(e.target.value))}
 						placeholder="0"
 						type="number"
+						value={blind1 ?? ""}
 					/>
 				</div>
 				<div className="flex flex-col gap-2">
 					<Label htmlFor="blind2">BB</Label>
 					<Input
-						defaultValue={defaultValues?.blind2}
 						id="blind2"
 						inputMode="numeric"
 						min={0}
-						name="blind2"
+						onChange={(e) => onBlind2Change?.(parseNumericInput(e.target.value))}
 						placeholder="0"
 						type="number"
+						value={blind2 ?? ""}
 					/>
 				</div>
 				<div className="flex flex-col gap-2">
 					<Label htmlFor="blind3">Straddle</Label>
 					<Input
-						defaultValue={defaultValues?.blind3}
 						id="blind3"
 						inputMode="numeric"
 						min={0}
-						name="blind3"
+						onChange={(e) => onBlind3Change?.(parseNumericInput(e.target.value))}
 						placeholder="0"
 						type="number"
+						value={blind3 ?? ""}
 					/>
 				</div>
 			</div>
@@ -134,9 +156,8 @@ export function CashGameFields({
 				<div className="flex flex-1 flex-col gap-2">
 					<Label htmlFor="anteType">Ante Type</Label>
 					<Select
-						defaultValue={defaultValues?.anteType ?? "none"}
-						name="anteType"
-						onValueChange={setAnteType}
+						onValueChange={(v) => onAnteTypeChange?.(v)}
+						value={anteType}
 					>
 						<SelectTrigger className="w-full" id="anteType">
 							<SelectValue placeholder="Select ante type" />
@@ -153,14 +174,14 @@ export function CashGameFields({
 				<div className="flex flex-1 flex-col gap-2">
 					<Label htmlFor="ante">Ante</Label>
 					<Input
-						defaultValue={defaultValues?.ante}
 						disabled={isAnteDisabled}
 						id="ante"
 						inputMode="numeric"
 						min={0}
-						name="ante"
+						onChange={(e) => onAnteChange?.(parseNumericInput(e.target.value))}
 						placeholder="0"
 						type="number"
+						value={isAnteDisabled ? "" : (ante ?? "")}
 					/>
 				</div>
 			</div>
@@ -169,13 +190,16 @@ export function CashGameFields({
 			<div className="flex flex-col gap-2">
 				<Label htmlFor="tableSize">Table Size</Label>
 				<Select
-					defaultValue={defaultValues?.tableSize?.toString()}
-					name="tableSize"
+					onValueChange={(v) =>
+						onTableSizeChange?.(v === NONE_VALUE ? undefined : Number(v))
+					}
+					value={tableSize?.toString() ?? NONE_VALUE}
 				>
 					<SelectTrigger className="w-full" id="tableSize">
 						<SelectValue placeholder="Select table size" />
 					</SelectTrigger>
 					<SelectContent>
+						<SelectItem value={NONE_VALUE}>None</SelectItem>
 						{TABLE_SIZES.map((size) => (
 							<SelectItem key={size} value={size.toString()}>
 								{size}-max

--- a/apps/web/src/sessions/components/cash-game-fields.tsx
+++ b/apps/web/src/sessions/components/cash-game-fields.tsx
@@ -39,7 +39,9 @@ const ANTE_TYPES = [
 const TABLE_SIZES = [2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
 
 function parseNumericInput(value: string): number | undefined {
-	if (!value) return undefined;
+	if (!value) {
+		return undefined;
+	}
 	const parsed = Number.parseFloat(value);
 	return Number.isNaN(parsed) ? undefined : parsed;
 }
@@ -98,10 +100,7 @@ export function CashGameFields({
 			{/* Variant */}
 			<div className="flex flex-col gap-2">
 				<Label htmlFor="variant">Variant</Label>
-				<Select
-					onValueChange={(v) => onVariantChange?.(v)}
-					value={variant}
-				>
+				<Select onValueChange={(v) => onVariantChange?.(v)} value={variant}>
 					<SelectTrigger className="w-full" id="variant">
 						<SelectValue placeholder="Select variant" />
 					</SelectTrigger>
@@ -119,7 +118,9 @@ export function CashGameFields({
 						id="blind1"
 						inputMode="numeric"
 						min={0}
-						onChange={(e) => onBlind1Change?.(parseNumericInput(e.target.value))}
+						onChange={(e) =>
+							onBlind1Change?.(parseNumericInput(e.target.value))
+						}
 						placeholder="0"
 						type="number"
 						value={blind1 ?? ""}
@@ -131,7 +132,9 @@ export function CashGameFields({
 						id="blind2"
 						inputMode="numeric"
 						min={0}
-						onChange={(e) => onBlind2Change?.(parseNumericInput(e.target.value))}
+						onChange={(e) =>
+							onBlind2Change?.(parseNumericInput(e.target.value))
+						}
 						placeholder="0"
 						type="number"
 						value={blind2 ?? ""}
@@ -143,7 +146,9 @@ export function CashGameFields({
 						id="blind3"
 						inputMode="numeric"
 						min={0}
-						onChange={(e) => onBlind3Change?.(parseNumericInput(e.target.value))}
+						onChange={(e) =>
+							onBlind3Change?.(parseNumericInput(e.target.value))
+						}
 						placeholder="0"
 						type="number"
 						value={blind3 ?? ""}
@@ -155,10 +160,7 @@ export function CashGameFields({
 			<div className="flex gap-3">
 				<div className="flex flex-1 flex-col gap-2">
 					<Label htmlFor="anteType">Ante Type</Label>
-					<Select
-						onValueChange={(v) => onAnteTypeChange?.(v)}
-						value={anteType}
-					>
+					<Select onValueChange={(v) => onAnteTypeChange?.(v)} value={anteType}>
 						<SelectTrigger className="w-full" id="anteType">
 							<SelectValue placeholder="Select ante type" />
 						</SelectTrigger>

--- a/apps/web/src/sessions/components/session-form.tsx
+++ b/apps/web/src/sessions/components/session-form.tsx
@@ -1,9 +1,10 @@
-import { useForm } from "@tanstack/react-form";
+// biome-ignore assist/source/organizeImports: useStore is re-exported from react-form; react-store is not a direct dependency
+import { useForm, useStore } from "@tanstack/react-form";
+import { useState } from "react";
 import z from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
-import { Label } from "@/shared/components/ui/label";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/components/ui/tabs";
 import { TagInput } from "@/shared/components/ui/tag-input";
 import { Textarea } from "@/shared/components/ui/textarea";
@@ -159,10 +160,7 @@ const cashGameSchema = z.object({
 	ringGameId: z.string().optional(),
 	buyIn: z.number().min(0, "Buy-in cannot be negative"),
 	cashOut: z.number().min(0, "Cash-out cannot be negative"),
-	evCashOut: z
-		.number()
-		.min(0, "EV cash-out cannot be negative")
-		.optional(),
+	evCashOut: z.number().min(0, "EV cash-out cannot be negative").optional(),
 	variant: z.string().min(1, "Variant is required"),
 	blind1: z.number().min(0, "SB cannot be negative").optional(),
 	blind2: z.number().min(0, "BB cannot be negative").optional(),
@@ -207,10 +205,7 @@ const tournamentSchema = z.object({
 		.int("Total entries must be a whole number")
 		.min(1, "Total entries must be at least 1")
 		.optional(),
-	prizeMoney: z
-		.number()
-		.min(0, "Prize money cannot be negative")
-		.optional(),
+	prizeMoney: z.number().min(0, "Prize money cannot be negative").optional(),
 	rebuyCount: z
 		.number()
 		.int("Rebuy count must be a whole number")
@@ -261,16 +256,22 @@ function SessionFormFields({
 	stores,
 	tags,
 }: SessionFormFieldsProps) {
-	const selectedStoreId = form.useStore((s) => {
+	const selectedStoreId = useStore(form.store, (s) => {
 		const v = s.values;
-		if (v.sessionType === "cash_game") return v.storeId;
+		if (v.sessionType === "cash_game") {
+			return v.storeId;
+		}
 		return v.storeId;
 	});
 
-	const selectedGameId = form.useStore((s) => {
+	const selectedGameId = useStore(form.store, (s) => {
 		const v = s.values;
-		if (v.sessionType === "cash_game") return v.ringGameId;
-		if (v.sessionType === "tournament") return v.tournamentId;
+		if (v.sessionType === "cash_game") {
+			return v.ringGameId;
+		}
+		if (v.sessionType === "tournament") {
+			return v.tournamentId;
+		}
 		return undefined;
 	});
 
@@ -517,13 +518,13 @@ function SessionFormFields({
 								onBlur={field.handleBlur}
 								onChange={(e) => {
 									const val = e.target.value;
-									if (!val) {
-										field.handleChange(undefined);
-									} else {
+									if (val) {
 										const parsed = Number.parseInt(val, 10);
 										field.handleChange(
 											Number.isNaN(parsed) ? undefined : parsed
 										);
+									} else {
+										field.handleChange(undefined);
 									}
 								}}
 								placeholder="0"
@@ -616,13 +617,13 @@ function SessionFormFields({
 										onBlur={field.handleBlur}
 										onChange={(e) => {
 											const val = e.target.value;
-											if (!val) {
-												field.handleChange(undefined);
-											} else {
+											if (val) {
 												const parsed = Number.parseFloat(val);
 												field.handleChange(
 													Number.isNaN(parsed) ? undefined : parsed
 												);
+											} else {
+												field.handleChange(undefined);
 											}
 										}}
 										placeholder="0"
@@ -785,8 +786,8 @@ export function SessionForm({
 					blind1: value.blind1,
 					blind2: value.blind2,
 					blind3: value.blind3,
-					anteType: anteType !== "none" ? anteType : undefined,
-					ante: anteType !== "none" ? value.ante : undefined,
+					anteType: anteType === "none" ? undefined : anteType,
+					ante: anteType === "none" ? undefined : value.ante,
 					tableSize: value.tableSize,
 					ringGameId: value.ringGameId,
 				});
@@ -812,16 +813,18 @@ export function SessionForm({
 		},
 	});
 
-	const sessionType = form.useStore((s) => {
-		const v = s.values;
-		return v.sessionType;
-	});
+	const [sessionType, setSessionType] = useState<"cash_game" | "tournament">(
+		initialSessionType
+	);
 	const isCashGame = sessionType === "cash_game";
 	const gameOptions = isCashGame ? ringGames : tournaments;
 
 	const handleSessionTypeChange = (value: string) => {
 		const newType = value as "cash_game" | "tournament";
-		if (newType === sessionType) return;
+		if (newType === sessionType) {
+			return;
+		}
+		setSessionType(newType);
 
 		const current = form.getFieldValue("sessionDate" as never) as string;
 		const currentStartTime = form.getFieldValue("startTime" as never) as
@@ -904,71 +907,71 @@ export function SessionForm({
 		onStoreChange?.(storeId);
 	};
 
+	const applyRingGameDefaults = (gameId: string) => {
+		if (!ringGames) {
+			return;
+		}
+		const game = ringGames.find((g) => g.id === gameId);
+		if (!game) {
+			return;
+		}
+		if (game.variant != null) {
+			form.setFieldValue("variant" as never, game.variant as never);
+		}
+		form.setFieldValue(
+			"blind1" as never,
+			nullToUndefined(game.blind1) as never
+		);
+		form.setFieldValue(
+			"blind2" as never,
+			nullToUndefined(game.blind2) as never
+		);
+		form.setFieldValue(
+			"blind3" as never,
+			nullToUndefined(game.blind3) as never
+		);
+		form.setFieldValue("ante" as never, nullToUndefined(game.ante) as never);
+		form.setFieldValue(
+			"anteType" as never,
+			(nullToUndefined(game.anteType) ?? "none") as never
+		);
+		form.setFieldValue(
+			"tableSize" as never,
+			nullToUndefined(game.tableSize) as never
+		);
+		if (game.currencyId) {
+			form.setFieldValue("currencyId" as never, game.currencyId as never);
+		}
+	};
+
+	const applyTournamentDefaults = (gameId: string) => {
+		if (!tournaments) {
+			return;
+		}
+		const game = tournaments.find((t) => t.id === gameId);
+		if (!game) {
+			return;
+		}
+		if (game.buyIn != null) {
+			form.setFieldValue("tournamentBuyIn" as never, game.buyIn as never);
+		}
+		if (game.entryFee != null) {
+			form.setFieldValue("entryFee" as never, game.entryFee as never);
+		}
+	};
+
 	const handleGameChange = (value: string) => {
 		const gameId = value === NONE_VALUE ? undefined : value;
 
 		if (isCashGame) {
 			form.setFieldValue("ringGameId" as never, gameId as never);
-
-			// Auto-fill fields from ring game
-			if (ringGames && gameId) {
-				const game = ringGames.find((g) => g.id === gameId);
-				if (game) {
-					if (game.variant != null) {
-						form.setFieldValue("variant" as never, game.variant as never);
-					}
-					form.setFieldValue(
-						"blind1" as never,
-						nullToUndefined(game.blind1) as never
-					);
-					form.setFieldValue(
-						"blind2" as never,
-						nullToUndefined(game.blind2) as never
-					);
-					form.setFieldValue(
-						"blind3" as never,
-						nullToUndefined(game.blind3) as never
-					);
-					form.setFieldValue(
-						"ante" as never,
-						nullToUndefined(game.ante) as never
-					);
-					form.setFieldValue(
-						"anteType" as never,
-						(nullToUndefined(game.anteType) ?? "none") as never
-					);
-					form.setFieldValue(
-						"tableSize" as never,
-						nullToUndefined(game.tableSize) as never
-					);
-					if (game.currencyId) {
-						form.setFieldValue(
-							"currencyId" as never,
-							game.currencyId as never
-						);
-					}
-				}
+			if (gameId) {
+				applyRingGameDefaults(gameId);
 			}
 		} else {
 			form.setFieldValue("tournamentId" as never, gameId as never);
-
-			// Auto-fill fields from tournament
-			if (tournaments && gameId) {
-				const game = tournaments.find((t) => t.id === gameId);
-				if (game) {
-					if (game.buyIn != null) {
-						form.setFieldValue(
-							"tournamentBuyIn" as never,
-							game.buyIn as never
-						);
-					}
-					if (game.entryFee != null) {
-						form.setFieldValue(
-							"entryFee" as never,
-							game.entryFee as never
-						);
-					}
-				}
+			if (gameId) {
+				applyTournamentDefaults(gameId);
 			}
 		}
 	};

--- a/apps/web/src/sessions/components/session-form.tsx
+++ b/apps/web/src/sessions/components/session-form.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useForm } from "@tanstack/react-form";
+import z from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
@@ -135,166 +136,307 @@ function getTodayDateString(): string {
 	return `${year}-${month}-${day}`;
 }
 
-function parseOptionalInt(value: string): number | undefined {
-	if (!value) {
-		return undefined;
-	}
-	const parsed = Number.parseInt(value, 10);
-	return Number.isNaN(parsed) ? undefined : parsed;
-}
-
-function parseCashGameFields(
-	formData: FormData
-): Omit<
-	CashGameFormValues,
-	"endTime" | "memo" | "sessionDate" | "startTime" | "tagIds"
-> {
-	const anteType = (formData.get("anteType") as string) || "none";
-	return {
-		type: "cash_game",
-		buyIn: Number(formData.get("buyIn")),
-		cashOut: Number(formData.get("cashOut")),
-		evCashOut: parseOptionalInt(formData.get("evCashOut") as string),
-		variant: (formData.get("variant") as string) || "nlh",
-		blind1: parseOptionalInt(formData.get("blind1") as string),
-		blind2: parseOptionalInt(formData.get("blind2") as string),
-		blind3: parseOptionalInt(formData.get("blind3") as string),
-		ante:
-			anteType === "none"
-				? undefined
-				: parseOptionalInt(formData.get("ante") as string),
-		anteType: anteType || undefined,
-		tableSize: parseOptionalInt(formData.get("tableSize") as string),
-	};
-}
-
-function parseTournamentFields(
-	formData: FormData
-): Omit<
-	TournamentFormValues,
-	"endTime" | "memo" | "sessionDate" | "startTime" | "tagIds"
-> {
-	return {
-		type: "tournament",
-		tournamentBuyIn: Number(formData.get("tournamentBuyIn")),
-		entryFee: parseOptionalInt(formData.get("entryFee") as string),
-		placement: parseOptionalInt(formData.get("placement") as string),
-		totalEntries: parseOptionalInt(formData.get("totalEntries") as string),
-		prizeMoney: parseOptionalInt(formData.get("prizeMoney") as string),
-		rebuyCount: parseOptionalInt(formData.get("rebuyCount") as string),
-		rebuyCost: parseOptionalInt(formData.get("rebuyCost") as string),
-		addonCost: parseOptionalInt(formData.get("addonCost") as string),
-		bountyPrizes: parseOptionalInt(formData.get("bountyPrizes") as string),
-	};
-}
-
-function nullToUndefined(value: unknown): unknown {
+function nullToUndefined<T>(value: T | null | undefined): T | undefined {
 	return value === null ? undefined : value;
 }
 
-function buildCashGameOverrides(
-	game: RingGameOption
-): Partial<SessionFormDefaults> {
-	return {
-		variant: (nullToUndefined(game.variant) as string) ?? undefined,
-		blind1: (nullToUndefined(game.blind1) as number) ?? undefined,
-		blind2: (nullToUndefined(game.blind2) as number) ?? undefined,
-		blind3: (nullToUndefined(game.blind3) as number) ?? undefined,
-		ante: (nullToUndefined(game.ante) as number) ?? undefined,
-		anteType: (nullToUndefined(game.anteType) as string) ?? undefined,
-		tableSize: (nullToUndefined(game.tableSize) as number) ?? undefined,
-	};
-}
+// Zod schemas
 
-function buildTournamentOverrides(
-	game: TournamentOption
-): Partial<SessionFormDefaults> {
-	return {
-		tournamentBuyIn: (nullToUndefined(game.buyIn) as number) ?? undefined,
-		entryFee: (nullToUndefined(game.entryFee) as number) ?? undefined,
-	};
-}
+const cashGameSchema = z.object({
+	sessionType: z.literal("cash_game"),
+	sessionDate: z
+		.string()
+		.min(1, "Session date is required")
+		.regex(/^\d{4}-\d{2}-\d{2}$/, "Session date must be in YYYY-MM-DD format"),
+	startTime: z.string().optional(),
+	endTime: z.string().optional(),
+	breakMinutes: z
+		.number()
+		.int("Break time must be a whole number")
+		.min(0, "Break time cannot be negative")
+		.optional(),
+	storeId: z.string().optional(),
+	ringGameId: z.string().optional(),
+	buyIn: z.number().min(0, "Buy-in cannot be negative"),
+	cashOut: z.number().min(0, "Cash-out cannot be negative"),
+	evCashOut: z
+		.number()
+		.min(0, "EV cash-out cannot be negative")
+		.optional(),
+	variant: z.string().min(1, "Variant is required"),
+	blind1: z.number().min(0, "SB cannot be negative").optional(),
+	blind2: z.number().min(0, "BB cannot be negative").optional(),
+	blind3: z.number().min(0, "Straddle cannot be negative").optional(),
+	anteType: z.string().optional(),
+	ante: z.number().min(0, "Ante cannot be negative").optional(),
+	tableSize: z
+		.number()
+		.int("Table size must be a whole number")
+		.min(2, "Table size must be at least 2")
+		.max(10, "Table size must be at most 10")
+		.optional(),
+	currencyId: z.string().optional(),
+	tagIds: z.array(z.string()).optional(),
+	memo: z.string().max(50_000, "Memo is too long").optional(),
+});
+
+const tournamentSchema = z.object({
+	sessionType: z.literal("tournament"),
+	sessionDate: z
+		.string()
+		.min(1, "Session date is required")
+		.regex(/^\d{4}-\d{2}-\d{2}$/, "Session date must be in YYYY-MM-DD format"),
+	startTime: z.string().optional(),
+	endTime: z.string().optional(),
+	breakMinutes: z
+		.number()
+		.int("Break time must be a whole number")
+		.min(0, "Break time cannot be negative")
+		.optional(),
+	storeId: z.string().optional(),
+	tournamentId: z.string().optional(),
+	tournamentBuyIn: z.number().min(0, "Buy-in cannot be negative"),
+	entryFee: z.number().min(0, "Entry fee cannot be negative").optional(),
+	placement: z
+		.number()
+		.int("Placement must be a whole number")
+		.min(1, "Placement must be at least 1")
+		.optional(),
+	totalEntries: z
+		.number()
+		.int("Total entries must be a whole number")
+		.min(1, "Total entries must be at least 1")
+		.optional(),
+	prizeMoney: z
+		.number()
+		.min(0, "Prize money cannot be negative")
+		.optional(),
+	rebuyCount: z
+		.number()
+		.int("Rebuy count must be a whole number")
+		.min(0, "Rebuy count cannot be negative")
+		.optional(),
+	rebuyCost: z.number().min(0, "Rebuy cost cannot be negative").optional(),
+	addonCost: z.number().min(0, "Addon cost cannot be negative").optional(),
+	bountyPrizes: z
+		.number()
+		.min(0, "Bounty prizes cannot be negative")
+		.optional(),
+	currencyId: z.string().optional(),
+	tagIds: z.array(z.string()).optional(),
+	memo: z.string().max(50_000, "Memo is too long").optional(),
+});
+
+const sessionFormSchema = z.discriminatedUnion("sessionType", [
+	cashGameSchema,
+	tournamentSchema,
+]);
+
+type SessionFormInternalValues = z.infer<typeof sessionFormSchema>;
 
 const NONE_VALUE = "__none__";
 
-function SessionFormFields({
-	currencies,
-	defaultValues,
-	effectiveDefaults,
-	gameLabel,
-	gameOptions,
-	handleGameChange,
-	handleStoreChange,
-	isCashGame,
-	onCreateTag,
-	selectedCurrencyId,
-	selectedGameId,
-	selectedStoreId,
-	selectedTagIds,
-	setSelectedCurrencyId,
-	setSelectedTagIds,
-	stores,
-	tags,
-}: {
+interface SessionFormFieldsProps {
 	currencies?: Array<{ id: string; name: string }>;
-	defaultValues?: SessionFormDefaults;
-	effectiveDefaults?: SessionFormDefaults;
+	form: ReturnType<typeof useForm<SessionFormInternalValues>>;
 	gameLabel: string;
 	gameOptions?: Array<{ id: string; name: string }>;
 	handleGameChange: (value: string) => void;
 	handleStoreChange: (value: string) => void;
 	isCashGame: boolean;
 	onCreateTag?: (name: string) => Promise<{ id: string; name: string }>;
-	selectedCurrencyId: string | undefined;
-	selectedGameId: string | undefined;
-	selectedStoreId: string | undefined;
-	selectedTagIds: string[];
-	setSelectedCurrencyId: (id: string | undefined) => void;
-	setSelectedTagIds: React.Dispatch<React.SetStateAction<string[]>>;
 	stores?: Array<{ id: string; name: string }>;
 	tags?: Array<{ id: string; name: string }>;
-}) {
+}
+
+function SessionFormFields({
+	currencies,
+	form,
+	gameLabel,
+	gameOptions,
+	handleGameChange,
+	handleStoreChange,
+	isCashGame,
+	onCreateTag,
+	stores,
+	tags,
+}: SessionFormFieldsProps) {
+	const selectedStoreId = form.useStore((s) => {
+		const v = s.values;
+		if (v.sessionType === "cash_game") return v.storeId;
+		return v.storeId;
+	});
+
+	const selectedGameId = form.useStore((s) => {
+		const v = s.values;
+		if (v.sessionType === "cash_game") return v.ringGameId;
+		if (v.sessionType === "tournament") return v.tournamentId;
+		return undefined;
+	});
+
 	const detailContent = isCashGame ? (
-		<CashGameFields
-			currencies={currencies}
-			defaultValues={effectiveDefaults}
-			key={`cash-${selectedGameId ?? "none"}`}
-			onCurrencyChange={setSelectedCurrencyId}
-			selectedCurrencyId={selectedCurrencyId}
-		/>
+		<form.Field name="variant">
+			{(variantField) => (
+				<form.Field name="blind1">
+					{(blind1Field) => (
+						<form.Field name="blind2">
+							{(blind2Field) => (
+								<form.Field name="blind3">
+									{(blind3Field) => (
+										<form.Field name="anteType">
+											{(anteTypeField) => (
+												<form.Field name="ante">
+													{(anteField) => (
+														<form.Field name="tableSize">
+															{(tableSizeField) => (
+																<form.Field name="currencyId">
+																	{(currencyField) => (
+																		<CashGameFields
+																			ante={anteField.state.value}
+																			anteType={anteTypeField.state.value}
+																			blind1={blind1Field.state.value}
+																			blind2={blind2Field.state.value}
+																			blind3={blind3Field.state.value}
+																			currencies={currencies}
+																			onAnteChange={(v) =>
+																				anteField.handleChange(v)
+																			}
+																			onAnteTypeChange={(v) => {
+																				anteTypeField.handleChange(v);
+																				if (v === "none") {
+																					anteField.handleChange(undefined);
+																				}
+																			}}
+																			onBlind1Change={(v) =>
+																				blind1Field.handleChange(v)
+																			}
+																			onBlind2Change={(v) =>
+																				blind2Field.handleChange(v)
+																			}
+																			onBlind3Change={(v) =>
+																				blind3Field.handleChange(v)
+																			}
+																			onCurrencyChange={(v) =>
+																				currencyField.handleChange(v)
+																			}
+																			onTableSizeChange={(v) =>
+																				tableSizeField.handleChange(v)
+																			}
+																			onVariantChange={(v) =>
+																				variantField.handleChange(v)
+																			}
+																			selectedCurrencyId={
+																				currencyField.state.value
+																			}
+																			tableSize={tableSizeField.state.value}
+																			variant={variantField.state.value}
+																		/>
+																	)}
+																</form.Field>
+															)}
+														</form.Field>
+													)}
+												</form.Field>
+											)}
+										</form.Field>
+									)}
+								</form.Field>
+							)}
+						</form.Field>
+					)}
+				</form.Field>
+			)}
+		</form.Field>
 	) : (
-		<TournamentDetailFields
-			currencies={currencies}
-			defaultValues={effectiveDefaults}
-			key={`tourney-detail-${selectedGameId ?? "none"}`}
-			onCurrencyChange={setSelectedCurrencyId}
-			selectedCurrencyId={selectedCurrencyId}
-		/>
+		<form.Field name="rebuyCount">
+			{(rebuyCountField) => (
+				<form.Field name="rebuyCost">
+					{(rebuyCostField) => (
+						<form.Field name="addonCost">
+							{(addonCostField) => (
+								<form.Field name="bountyPrizes">
+									{(bountyPrizesField) => (
+										<form.Field name="currencyId">
+											{(currencyField) => (
+												<TournamentDetailFields
+													addonCost={addonCostField.state.value}
+													bountyPrizes={bountyPrizesField.state.value}
+													currencies={currencies}
+													onAddonCostChange={(v) =>
+														addonCostField.handleChange(v)
+													}
+													onBountyPrizesChange={(v) =>
+														bountyPrizesField.handleChange(v)
+													}
+													onCurrencyChange={(v) =>
+														currencyField.handleChange(v)
+													}
+													onRebuyCostChange={(v) =>
+														rebuyCostField.handleChange(v)
+													}
+													onRebuyCountChange={(v) =>
+														rebuyCountField.handleChange(v)
+													}
+													rebuyCost={rebuyCostField.state.value}
+													rebuyCount={rebuyCountField.state.value}
+													selectedCurrencyId={currencyField.state.value}
+												/>
+											)}
+										</form.Field>
+									)}
+								</form.Field>
+							)}
+						</form.Field>
+					)}
+				</form.Field>
+			)}
+		</form.Field>
 	);
 
 	const tagsContent = (
 		<>
-			<Field label="Session Tags">
-				<TagInput
-					availableTags={tags}
-					onAdd={(tag) => setSelectedTagIds((prev) => [...prev, tag.id])}
-					onCreateTag={onCreateTag}
-					onRemove={(tag) =>
-						setSelectedTagIds((prev) => prev.filter((id) => id !== tag.id))
-					}
-					selectedTags={selectedTagIds
-						.map((id) => tags?.find((t) => t.id === id))
-						.filter((t): t is { id: string; name: string } => t !== undefined)}
-				/>
-			</Field>
-			<Field htmlFor="memo" label="Memo">
-				<Textarea
-					defaultValue={defaultValues?.memo}
-					id="memo"
-					name="memo"
-					placeholder="Notes about this session"
-				/>
-			</Field>
+			<form.Field name="tagIds">
+				{(tagIdsField) => (
+					<Field label="Session Tags">
+						<TagInput
+							availableTags={tags}
+							onAdd={(tag) =>
+								tagIdsField.handleChange([
+									...(tagIdsField.state.value ?? []),
+									tag.id,
+								])
+							}
+							onCreateTag={onCreateTag}
+							onRemove={(tag) =>
+								tagIdsField.handleChange(
+									(tagIdsField.state.value ?? []).filter((id) => id !== tag.id)
+								)
+							}
+							selectedTags={(tagIdsField.state.value ?? [])
+								.map((id) => tags?.find((t) => t.id === id))
+								.filter(
+									(t): t is { id: string; name: string } => t !== undefined
+								)}
+						/>
+					</Field>
+				)}
+			</form.Field>
+			<form.Field name="memo">
+				{(memoField) => (
+					<Field htmlFor="memo" label="Memo">
+						<Textarea
+							id="memo"
+							name="memo"
+							onBlur={memoField.handleBlur}
+							onChange={(e) =>
+								memoField.handleChange(e.target.value || undefined)
+							}
+							placeholder="Notes about this session"
+							value={memoField.state.value ?? ""}
+						/>
+					</Field>
+				)}
+			</form.Field>
 		</>
 	);
 
@@ -303,54 +445,94 @@ function SessionFormFields({
 			{/* === Top section (always visible) === */}
 			<div className="flex flex-col gap-4">
 				{/* Session Date */}
-				<div className="flex flex-col gap-2">
-					<Label htmlFor="sessionDate">
-						Session Date <span className="text-destructive">*</span>
-					</Label>
-					<Input
-						defaultValue={defaultValues?.sessionDate ?? getTodayDateString()}
-						id="sessionDate"
-						name="sessionDate"
-						required
-						type="date"
-					/>
-				</div>
+				<form.Field name="sessionDate">
+					{(field) => (
+						<Field
+							error={field.state.meta.errors[0]?.message}
+							htmlFor="sessionDate"
+							label="Session Date"
+							required
+						>
+							<Input
+								id="sessionDate"
+								name="sessionDate"
+								onBlur={field.handleBlur}
+								onChange={(e) => field.handleChange(e.target.value)}
+								type="date"
+								value={field.state.value}
+							/>
+						</Field>
+					)}
+				</form.Field>
 
 				{/* Start Time / End Time */}
 				<div className="grid grid-cols-2 gap-3">
-					<div className="flex flex-col gap-2">
-						<Label htmlFor="startTime">Start Time</Label>
-						<Input
-							defaultValue={defaultValues?.startTime}
-							id="startTime"
-							name="startTime"
-							type="time"
-						/>
-					</div>
-					<div className="flex flex-col gap-2">
-						<Label htmlFor="endTime">End Time</Label>
-						<Input
-							defaultValue={defaultValues?.endTime}
-							id="endTime"
-							name="endTime"
-							type="time"
-						/>
-					</div>
+					<form.Field name="startTime">
+						{(field) => (
+							<Field htmlFor="startTime" label="Start Time">
+								<Input
+									id="startTime"
+									name="startTime"
+									onBlur={field.handleBlur}
+									onChange={(e) =>
+										field.handleChange(e.target.value || undefined)
+									}
+									type="time"
+									value={field.state.value ?? ""}
+								/>
+							</Field>
+						)}
+					</form.Field>
+					<form.Field name="endTime">
+						{(field) => (
+							<Field htmlFor="endTime" label="End Time">
+								<Input
+									id="endTime"
+									name="endTime"
+									onBlur={field.handleBlur}
+									onChange={(e) =>
+										field.handleChange(e.target.value || undefined)
+									}
+									type="time"
+									value={field.state.value ?? ""}
+								/>
+							</Field>
+						)}
+					</form.Field>
 				</div>
 
 				{/* Break Time */}
-				<div className="flex flex-col gap-2">
-					<Label htmlFor="breakMinutes">Break Time (min)</Label>
-					<Input
-						defaultValue={defaultValues?.breakMinutes}
-						id="breakMinutes"
-						inputMode="numeric"
-						min={0}
-						name="breakMinutes"
-						placeholder="0"
-						type="number"
-					/>
-				</div>
+				<form.Field name="breakMinutes">
+					{(field) => (
+						<Field
+							error={field.state.meta.errors[0]?.message}
+							htmlFor="breakMinutes"
+							label="Break Time (min)"
+						>
+							<Input
+								id="breakMinutes"
+								inputMode="numeric"
+								min={0}
+								name="breakMinutes"
+								onBlur={field.handleBlur}
+								onChange={(e) => {
+									const val = e.target.value;
+									if (!val) {
+										field.handleChange(undefined);
+									} else {
+										const parsed = Number.parseInt(val, 10);
+										field.handleChange(
+											Number.isNaN(parsed) ? undefined : parsed
+										);
+									}
+								}}
+								placeholder="0"
+								type="number"
+								value={field.state.value ?? ""}
+							/>
+						</Field>
+					)}
+				</form.Field>
 
 				{/* Store / Game Selectors */}
 				<StoreGameSelectors
@@ -367,62 +549,136 @@ function SessionFormFields({
 				{isCashGame && (
 					<>
 						<div className="grid grid-cols-2 gap-3">
-							<div className="flex flex-col gap-2">
-								<Label htmlFor="buyIn">
-									Buy-in <span className="text-destructive">*</span>
-								</Label>
-								<Input
-									defaultValue={defaultValues?.buyIn}
-									id="buyIn"
-									inputMode="numeric"
-									min={0}
-									name="buyIn"
-									placeholder="0"
-									required
-									type="number"
-								/>
-							</div>
-							<div className="flex flex-col gap-2">
-								<Label htmlFor="cashOut">
-									Cash-out <span className="text-destructive">*</span>
-								</Label>
-								<Input
-									defaultValue={defaultValues?.cashOut}
-									id="cashOut"
-									inputMode="numeric"
-									min={0}
-									name="cashOut"
-									placeholder="0"
-									required
-									type="number"
-								/>
-							</div>
+							<form.Field name="buyIn">
+								{(field) => (
+									<Field
+										error={field.state.meta.errors[0]?.message}
+										htmlFor="buyIn"
+										label="Buy-in"
+										required
+									>
+										<Input
+											id="buyIn"
+											inputMode="numeric"
+											min={0}
+											name="buyIn"
+											onBlur={field.handleBlur}
+											onChange={(e) => {
+												const parsed = Number.parseFloat(e.target.value);
+												field.handleChange(Number.isNaN(parsed) ? 0 : parsed);
+											}}
+											placeholder="0"
+											type="number"
+											value={field.state.value ?? ""}
+										/>
+									</Field>
+								)}
+							</form.Field>
+							<form.Field name="cashOut">
+								{(field) => (
+									<Field
+										error={field.state.meta.errors[0]?.message}
+										htmlFor="cashOut"
+										label="Cash-out"
+										required
+									>
+										<Input
+											id="cashOut"
+											inputMode="numeric"
+											min={0}
+											name="cashOut"
+											onBlur={field.handleBlur}
+											onChange={(e) => {
+												const parsed = Number.parseFloat(e.target.value);
+												field.handleChange(Number.isNaN(parsed) ? 0 : parsed);
+											}}
+											placeholder="0"
+											type="number"
+											value={field.state.value ?? ""}
+										/>
+									</Field>
+								)}
+							</form.Field>
 						</div>
-						<div className="flex flex-col gap-2">
-							<Label htmlFor="evCashOut">EV Cash-out</Label>
-							<Input
-								defaultValue={defaultValues?.evCashOut}
-								id="evCashOut"
-								inputMode="numeric"
-								min={0}
-								name="evCashOut"
-								placeholder="0"
-								type="number"
-							/>
-							<p className="text-muted-foreground text-xs">
-								Expected value cash-out based on all-in equity. Leave empty if
-								not tracking EV.
-							</p>
-						</div>
+						<form.Field name="evCashOut">
+							{(field) => (
+								<Field
+									description="Expected value cash-out based on all-in equity. Leave empty if not tracking EV."
+									error={field.state.meta.errors[0]?.message}
+									htmlFor="evCashOut"
+									label="EV Cash-out"
+								>
+									<Input
+										id="evCashOut"
+										inputMode="numeric"
+										min={0}
+										name="evCashOut"
+										onBlur={field.handleBlur}
+										onChange={(e) => {
+											const val = e.target.value;
+											if (!val) {
+												field.handleChange(undefined);
+											} else {
+												const parsed = Number.parseFloat(val);
+												field.handleChange(
+													Number.isNaN(parsed) ? undefined : parsed
+												);
+											}
+										}}
+										placeholder="0"
+										type="number"
+										value={field.state.value ?? ""}
+									/>
+								</Field>
+							)}
+						</form.Field>
 					</>
 				)}
 
 				{/* Tournament primary fields (outside accordion) */}
 				{!isCashGame && (
-					<TournamentPrimaryFields
-						defaultValues={effectiveDefaults}
-						key={`tourney-primary-${selectedGameId ?? "none"}`}
-					/>
+					<form.Field name="tournamentBuyIn">
+						{(buyInField) => (
+							<form.Field name="entryFee">
+								{(entryFeeField) => (
+									<form.Field name="prizeMoney">
+										{(prizeMoneyField) => (
+											<form.Field name="placement">
+												{(placementField) => (
+													<form.Field name="totalEntries">
+														{(totalEntriesField) => (
+															<TournamentPrimaryFields
+																entryFee={entryFeeField.state.value}
+																onEntryFeeChange={(v) =>
+																	entryFeeField.handleChange(v)
+																}
+																onPlacementChange={(v) =>
+																	placementField.handleChange(v)
+																}
+																onPrizeMoneyChange={(v) =>
+																	prizeMoneyField.handleChange(v)
+																}
+																onTotalEntriesChange={(v) =>
+																	totalEntriesField.handleChange(v)
+																}
+																onTournamentBuyInChange={(v) =>
+																	buyInField.handleChange(v)
+																}
+																placement={placementField.state.value}
+																prizeMoney={prizeMoneyField.state.value}
+																totalEntries={totalEntriesField.state.value}
+																tournamentBuyIn={buyInField.state.value}
+															/>
+														)}
+													</form.Field>
+												)}
+											</form.Field>
+										)}
+									</form.Field>
+								)}
+							</form.Field>
+						)}
+					</form.Field>
 				)}
 			</div>
 
@@ -457,106 +713,280 @@ export function SessionForm({
 	tags,
 	tournaments,
 }: SessionFormProps) {
-	const [sessionType, setSessionType] = useState<"cash_game" | "tournament">(
-		defaultValues?.type ?? "cash_game"
-	);
-	const [selectedTagIds, setSelectedTagIds] = useState<string[]>(
-		defaultValues?.tagIds ?? []
-	);
-	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(
-		defaultValues?.storeId
-	);
-	const [selectedGameId, setSelectedGameId] = useState<string | undefined>(
-		defaultValues?.ringGameId ?? defaultValues?.tournamentId
-	);
-	const [selectedCurrencyId, setSelectedCurrencyId] = useState<
-		string | undefined
-	>(defaultValues?.currencyId);
+	const initialSessionType = defaultValues?.type ?? "cash_game";
+	const isCashGameInitial = initialSessionType === "cash_game";
 
+	const form = useForm<SessionFormInternalValues>({
+		defaultValues: isCashGameInitial
+			? ({
+					sessionType: "cash_game" as const,
+					sessionDate: defaultValues?.sessionDate ?? getTodayDateString(),
+					startTime: defaultValues?.startTime,
+					endTime: defaultValues?.endTime,
+					breakMinutes: defaultValues?.breakMinutes,
+					storeId: defaultValues?.storeId,
+					ringGameId: defaultValues?.ringGameId,
+					buyIn: defaultValues?.buyIn ?? 0,
+					cashOut: defaultValues?.cashOut ?? 0,
+					evCashOut: defaultValues?.evCashOut,
+					variant: defaultValues?.variant ?? "nlh",
+					blind1: defaultValues?.blind1,
+					blind2: defaultValues?.blind2,
+					blind3: defaultValues?.blind3,
+					anteType: defaultValues?.anteType ?? "none",
+					ante: defaultValues?.ante,
+					tableSize: defaultValues?.tableSize,
+					currencyId: defaultValues?.currencyId,
+					tagIds: defaultValues?.tagIds ?? [],
+					memo: defaultValues?.memo,
+				} satisfies SessionFormInternalValues)
+			: ({
+					sessionType: "tournament" as const,
+					sessionDate: defaultValues?.sessionDate ?? getTodayDateString(),
+					startTime: defaultValues?.startTime,
+					endTime: defaultValues?.endTime,
+					breakMinutes: defaultValues?.breakMinutes,
+					storeId: defaultValues?.storeId,
+					tournamentId: defaultValues?.tournamentId,
+					tournamentBuyIn: defaultValues?.tournamentBuyIn ?? 0,
+					entryFee: defaultValues?.entryFee,
+					placement: defaultValues?.placement,
+					totalEntries: defaultValues?.totalEntries,
+					prizeMoney: defaultValues?.prizeMoney,
+					rebuyCount: defaultValues?.rebuyCount,
+					rebuyCost: defaultValues?.rebuyCost,
+					addonCost: defaultValues?.addonCost,
+					bountyPrizes: defaultValues?.bountyPrizes,
+					currencyId: defaultValues?.currencyId,
+					tagIds: defaultValues?.tagIds ?? [],
+					memo: defaultValues?.memo,
+				} satisfies SessionFormInternalValues),
+		onSubmit: ({ value }) => {
+			const common = {
+				sessionDate: value.sessionDate,
+				startTime: value.startTime,
+				endTime: value.endTime,
+				breakMinutes: value.breakMinutes,
+				tagIds: value.tagIds,
+				memo: value.memo,
+				storeId: value.storeId,
+				currencyId: value.currencyId,
+			};
+
+			if (value.sessionType === "cash_game") {
+				const anteType = value.anteType ?? "none";
+				onSubmit({
+					...common,
+					type: "cash_game",
+					buyIn: value.buyIn,
+					cashOut: value.cashOut,
+					evCashOut: value.evCashOut,
+					variant: value.variant,
+					blind1: value.blind1,
+					blind2: value.blind2,
+					blind3: value.blind3,
+					anteType: anteType !== "none" ? anteType : undefined,
+					ante: anteType !== "none" ? value.ante : undefined,
+					tableSize: value.tableSize,
+					ringGameId: value.ringGameId,
+				});
+			} else {
+				onSubmit({
+					...common,
+					type: "tournament",
+					tournamentBuyIn: value.tournamentBuyIn,
+					entryFee: value.entryFee,
+					placement: value.placement,
+					totalEntries: value.totalEntries,
+					prizeMoney: value.prizeMoney,
+					rebuyCount: value.rebuyCount,
+					rebuyCost: value.rebuyCost,
+					addonCost: value.addonCost,
+					bountyPrizes: value.bountyPrizes,
+					tournamentId: value.tournamentId,
+				});
+			}
+		},
+		validators: {
+			onSubmit: sessionFormSchema,
+		},
+	});
+
+	const sessionType = form.useStore((s) => {
+		const v = s.values;
+		return v.sessionType;
+	});
 	const isCashGame = sessionType === "cash_game";
 	const gameOptions = isCashGame ? ringGames : tournaments;
 
-	const effectiveDefaults = (() => {
-		if (!selectedGameId) {
-			return defaultValues;
+	const handleSessionTypeChange = (value: string) => {
+		const newType = value as "cash_game" | "tournament";
+		if (newType === sessionType) return;
+
+		const current = form.getFieldValue("sessionDate" as never) as string;
+		const currentStartTime = form.getFieldValue("startTime" as never) as
+			| string
+			| undefined;
+		const currentEndTime = form.getFieldValue("endTime" as never) as
+			| string
+			| undefined;
+		const currentBreakMinutes = form.getFieldValue("breakMinutes" as never) as
+			| number
+			| undefined;
+		const currentStoreId = form.getFieldValue("storeId" as never) as
+			| string
+			| undefined;
+		const currentTagIds = form.getFieldValue("tagIds" as never) as string[];
+		const currentMemo = form.getFieldValue("memo" as never) as
+			| string
+			| undefined;
+		const currentCurrencyId = form.getFieldValue("currencyId" as never) as
+			| string
+			| undefined;
+
+		if (newType === "cash_game") {
+			form.reset({
+				sessionType: "cash_game",
+				sessionDate: current ?? getTodayDateString(),
+				startTime: currentStartTime,
+				endTime: currentEndTime,
+				breakMinutes: currentBreakMinutes,
+				storeId: currentStoreId,
+				ringGameId: undefined,
+				buyIn: 0,
+				cashOut: 0,
+				evCashOut: undefined,
+				variant: "nlh",
+				blind1: undefined,
+				blind2: undefined,
+				blind3: undefined,
+				anteType: "none",
+				ante: undefined,
+				tableSize: undefined,
+				currencyId: currentCurrencyId,
+				tagIds: currentTagIds ?? [],
+				memo: currentMemo,
+			});
+		} else {
+			form.reset({
+				sessionType: "tournament",
+				sessionDate: current ?? getTodayDateString(),
+				startTime: currentStartTime,
+				endTime: currentEndTime,
+				breakMinutes: currentBreakMinutes,
+				storeId: currentStoreId,
+				tournamentId: undefined,
+				tournamentBuyIn: 0,
+				entryFee: undefined,
+				placement: undefined,
+				totalEntries: undefined,
+				prizeMoney: undefined,
+				rebuyCount: undefined,
+				rebuyCost: undefined,
+				addonCost: undefined,
+				bountyPrizes: undefined,
+				currencyId: currentCurrencyId,
+				tagIds: currentTagIds ?? [],
+				memo: currentMemo,
+			});
 		}
-		if (isCashGame && ringGames) {
-			const game = ringGames.find((g) => g.id === selectedGameId);
-			if (game) {
-				return { ...defaultValues, ...buildCashGameOverrides(game) };
-			}
-		}
-		if (!isCashGame && tournaments) {
-			const game = tournaments.find((t) => t.id === selectedGameId);
-			if (game) {
-				return { ...defaultValues, ...buildTournamentOverrides(game) };
-			}
-		}
-		return defaultValues;
-	})();
+	};
 
 	const handleStoreChange = (value: string) => {
 		const storeId = value === NONE_VALUE ? undefined : value;
-		setSelectedStoreId(storeId);
-		setSelectedGameId(undefined);
+		form.setFieldValue("storeId" as never, storeId as never);
+		// Clear game selection when store changes
+		if (isCashGame) {
+			form.setFieldValue("ringGameId" as never, undefined as never);
+		} else {
+			form.setFieldValue("tournamentId" as never, undefined as never);
+		}
 		onStoreChange?.(storeId);
 	};
 
 	const handleGameChange = (value: string) => {
 		const gameId = value === NONE_VALUE ? undefined : value;
-		setSelectedGameId(gameId);
-
-		// Auto-fill currency from ring game
-		if (isCashGame && ringGames && gameId) {
-			const game = ringGames.find((g) => g.id === gameId);
-			if (game?.currencyId) {
-				setSelectedCurrencyId(game.currencyId);
-			}
-		}
-	};
-
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		const formData = new FormData(e.currentTarget);
-
-		const common = {
-			sessionDate: formData.get("sessionDate") as string,
-			startTime: (formData.get("startTime") as string) || undefined,
-			endTime: (formData.get("endTime") as string) || undefined,
-			breakMinutes: parseOptionalInt(formData.get("breakMinutes") as string),
-			tagIds: selectedTagIds,
-			memo: (formData.get("memo") as string) || undefined,
-			storeId: selectedStoreId,
-			currencyId: selectedCurrencyId,
-		};
 
 		if (isCashGame) {
-			onSubmit({
-				...common,
-				...parseCashGameFields(formData),
-				ringGameId: selectedGameId,
-			});
+			form.setFieldValue("ringGameId" as never, gameId as never);
+
+			// Auto-fill fields from ring game
+			if (ringGames && gameId) {
+				const game = ringGames.find((g) => g.id === gameId);
+				if (game) {
+					if (game.variant != null) {
+						form.setFieldValue("variant" as never, game.variant as never);
+					}
+					form.setFieldValue(
+						"blind1" as never,
+						nullToUndefined(game.blind1) as never
+					);
+					form.setFieldValue(
+						"blind2" as never,
+						nullToUndefined(game.blind2) as never
+					);
+					form.setFieldValue(
+						"blind3" as never,
+						nullToUndefined(game.blind3) as never
+					);
+					form.setFieldValue(
+						"ante" as never,
+						nullToUndefined(game.ante) as never
+					);
+					form.setFieldValue(
+						"anteType" as never,
+						(nullToUndefined(game.anteType) ?? "none") as never
+					);
+					form.setFieldValue(
+						"tableSize" as never,
+						nullToUndefined(game.tableSize) as never
+					);
+					if (game.currencyId) {
+						form.setFieldValue(
+							"currencyId" as never,
+							game.currencyId as never
+						);
+					}
+				}
+			}
 		} else {
-			onSubmit({
-				...common,
-				...parseTournamentFields(formData),
-				tournamentId: selectedGameId,
-			});
+			form.setFieldValue("tournamentId" as never, gameId as never);
+
+			// Auto-fill fields from tournament
+			if (tournaments && gameId) {
+				const game = tournaments.find((t) => t.id === gameId);
+				if (game) {
+					if (game.buyIn != null) {
+						form.setFieldValue(
+							"tournamentBuyIn" as never,
+							game.buyIn as never
+						);
+					}
+					if (game.entryFee != null) {
+						form.setFieldValue(
+							"entryFee" as never,
+							game.entryFee as never
+						);
+					}
+				}
+			}
 		}
 	};
 
 	const gameLabel = isCashGame ? "Cash Game" : "Tournament";
 
 	return (
-		<form className="flex flex-col gap-2" onSubmit={handleSubmit}>
+		<form
+			className="flex flex-col gap-2"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
 			{/* Session Type */}
 			<Field label="Session Type">
-				<Tabs
-					onValueChange={(value) =>
-						setSessionType(value as "cash_game" | "tournament")
-					}
-					value={sessionType}
-				>
+				<Tabs onValueChange={handleSessionTypeChange} value={sessionType}>
 					<TabsList className="grid w-full grid-cols-2">
 						<TabsTrigger value="cash_game">Cash Game</TabsTrigger>
 						<TabsTrigger value="tournament">Tournament</TabsTrigger>
@@ -566,27 +996,28 @@ export function SessionForm({
 
 			<SessionFormFields
 				currencies={currencies}
-				defaultValues={defaultValues}
-				effectiveDefaults={effectiveDefaults}
+				form={form}
 				gameLabel={gameLabel}
 				gameOptions={gameOptions}
 				handleGameChange={handleGameChange}
 				handleStoreChange={handleStoreChange}
 				isCashGame={isCashGame}
 				onCreateTag={onCreateTag}
-				selectedCurrencyId={selectedCurrencyId}
-				selectedGameId={selectedGameId}
-				selectedStoreId={selectedStoreId}
-				selectedTagIds={selectedTagIds}
-				setSelectedCurrencyId={setSelectedCurrencyId}
-				setSelectedTagIds={setSelectedTagIds}
 				stores={stores}
 				tags={tags}
 			/>
 
-			<Button className="mt-2" disabled={isLoading} type="submit">
-				{isLoading ? "Saving..." : "Save"}
-			</Button>
+			<form.Subscribe>
+				{(state) => (
+					<Button
+						className="mt-2"
+						disabled={isLoading || !state.canSubmit || state.isSubmitting}
+						type="submit"
+					>
+						{isLoading || state.isSubmitting ? "Saving..." : "Save"}
+					</Button>
+				)}
+			</form.Subscribe>
 		</form>
 	);
 }

--- a/apps/web/src/sessions/components/tournament-fields.tsx
+++ b/apps/web/src/sessions/components/tournament-fields.tsx
@@ -8,33 +8,53 @@ import {
 	SelectValue,
 } from "@/shared/components/ui/select";
 
-interface TournamentFieldsDefaultValues {
-	addonCost?: number;
-	bountyPrizes?: number;
+export interface TournamentPrimaryFieldsProps {
 	entryFee?: number;
+	onEntryFeeChange?: (value: number | undefined) => void;
+	onPlacementChange?: (value: number | undefined) => void;
+	onPrizeMoneyChange?: (value: number | undefined) => void;
+	onTotalEntriesChange?: (value: number | undefined) => void;
+	onTournamentBuyInChange?: (value: number) => void;
 	placement?: number;
 	prizeMoney?: number;
-	rebuyCost?: number;
-	rebuyCount?: number;
 	totalEntries?: number;
 	tournamentBuyIn?: number;
 }
 
-interface TournamentFieldsProps {
-	defaultValues?: TournamentFieldsDefaultValues;
-}
-
-interface TournamentDetailFieldsProps extends TournamentFieldsProps {
+export interface TournamentDetailFieldsProps {
+	addonCost?: number;
+	bountyPrizes?: number;
 	currencies?: Array<{ id: string; name: string }>;
+	onAddonCostChange?: (value: number | undefined) => void;
+	onBountyPrizesChange?: (value: number | undefined) => void;
 	onCurrencyChange?: (id: string | undefined) => void;
+	onRebuyCostChange?: (value: number | undefined) => void;
+	onRebuyCountChange?: (value: number | undefined) => void;
+	rebuyCost?: number;
+	rebuyCount?: number;
 	selectedCurrencyId?: string;
 }
 
 const NONE_VALUE = "__none__";
 
+function parseNumericInput(value: string): number | undefined {
+	if (!value) return undefined;
+	const parsed = Number.parseFloat(value);
+	return Number.isNaN(parsed) ? undefined : parsed;
+}
+
 export function TournamentPrimaryFields({
-	defaultValues,
-}: TournamentFieldsProps) {
+	entryFee,
+	onEntryFeeChange,
+	onPlacementChange,
+	onPrizeMoneyChange,
+	onTotalEntriesChange,
+	onTournamentBuyInChange,
+	placement,
+	prizeMoney,
+	totalEntries,
+	tournamentBuyIn,
+}: TournamentPrimaryFieldsProps) {
 	return (
 		<>
 			{/* Tournament Buy-in / Entry Fee */}
@@ -44,26 +64,29 @@ export function TournamentPrimaryFields({
 						Buy-in <span className="text-destructive">*</span>
 					</Label>
 					<Input
-						defaultValue={defaultValues?.tournamentBuyIn}
 						id="tournamentBuyIn"
 						inputMode="numeric"
 						min={0}
-						name="tournamentBuyIn"
+						onChange={(e) => {
+							const val = parseNumericInput(e.target.value);
+							onTournamentBuyInChange?.(val ?? 0);
+						}}
 						placeholder="0"
 						required
 						type="number"
+						value={tournamentBuyIn ?? ""}
 					/>
 				</div>
 				<div className="flex flex-col gap-2">
 					<Label htmlFor="entryFee">Entry Fee</Label>
 					<Input
-						defaultValue={defaultValues?.entryFee}
 						id="entryFee"
 						inputMode="numeric"
 						min={0}
-						name="entryFee"
+						onChange={(e) => onEntryFeeChange?.(parseNumericInput(e.target.value))}
 						placeholder="0"
 						type="number"
+						value={entryFee ?? ""}
 					/>
 				</div>
 			</div>
@@ -72,13 +95,13 @@ export function TournamentPrimaryFields({
 			<div className="flex flex-col gap-2">
 				<Label htmlFor="prizeMoney">Prize Money</Label>
 				<Input
-					defaultValue={defaultValues?.prizeMoney}
 					id="prizeMoney"
 					inputMode="numeric"
 					min={0}
-					name="prizeMoney"
+					onChange={(e) => onPrizeMoneyChange?.(parseNumericInput(e.target.value))}
 					placeholder="0"
 					type="number"
+					value={prizeMoney ?? ""}
 				/>
 			</div>
 
@@ -87,25 +110,29 @@ export function TournamentPrimaryFields({
 				<div className="flex flex-col gap-2">
 					<Label htmlFor="placement">Placement</Label>
 					<Input
-						defaultValue={defaultValues?.placement}
 						id="placement"
 						inputMode="numeric"
 						min={1}
-						name="placement"
+						onChange={(e) =>
+							onPlacementChange?.(parseNumericInput(e.target.value))
+						}
 						placeholder="e.g. 3"
 						type="number"
+						value={placement ?? ""}
 					/>
 				</div>
 				<div className="flex flex-col gap-2">
 					<Label htmlFor="totalEntries">Total Entries</Label>
 					<Input
-						defaultValue={defaultValues?.totalEntries}
 						id="totalEntries"
 						inputMode="numeric"
 						min={1}
-						name="totalEntries"
+						onChange={(e) =>
+							onTotalEntriesChange?.(parseNumericInput(e.target.value))
+						}
 						placeholder="e.g. 50"
 						type="number"
+						value={totalEntries ?? ""}
 					/>
 				</div>
 			</div>
@@ -114,9 +141,16 @@ export function TournamentPrimaryFields({
 }
 
 export function TournamentDetailFields({
+	addonCost,
+	bountyPrizes,
 	currencies,
-	defaultValues,
+	onAddonCostChange,
+	onBountyPrizesChange,
 	onCurrencyChange,
+	onRebuyCostChange,
+	onRebuyCountChange,
+	rebuyCost,
+	rebuyCount,
 	selectedCurrencyId,
 }: TournamentDetailFieldsProps) {
 	return (
@@ -154,25 +188,29 @@ export function TournamentDetailFields({
 				<div className="flex flex-col gap-2">
 					<Label htmlFor="rebuyCount">Rebuy Count</Label>
 					<Input
-						defaultValue={defaultValues?.rebuyCount}
 						id="rebuyCount"
 						inputMode="numeric"
 						min={0}
-						name="rebuyCount"
+						onChange={(e) =>
+							onRebuyCountChange?.(parseNumericInput(e.target.value))
+						}
 						placeholder="0"
 						type="number"
+						value={rebuyCount ?? ""}
 					/>
 				</div>
 				<div className="flex flex-col gap-2">
 					<Label htmlFor="rebuyCost">Rebuy Cost</Label>
 					<Input
-						defaultValue={defaultValues?.rebuyCost}
 						id="rebuyCost"
 						inputMode="numeric"
 						min={0}
-						name="rebuyCost"
+						onChange={(e) =>
+							onRebuyCostChange?.(parseNumericInput(e.target.value))
+						}
 						placeholder="0"
 						type="number"
+						value={rebuyCost ?? ""}
 					/>
 				</div>
 			</div>
@@ -182,25 +220,29 @@ export function TournamentDetailFields({
 				<div className="flex flex-col gap-2">
 					<Label htmlFor="addonCost">Addon Cost</Label>
 					<Input
-						defaultValue={defaultValues?.addonCost}
 						id="addonCost"
 						inputMode="numeric"
 						min={0}
-						name="addonCost"
+						onChange={(e) =>
+							onAddonCostChange?.(parseNumericInput(e.target.value))
+						}
 						placeholder="0"
 						type="number"
+						value={addonCost ?? ""}
 					/>
 				</div>
 				<div className="flex flex-col gap-2">
 					<Label htmlFor="bountyPrizes">Bounty Prizes</Label>
 					<Input
-						defaultValue={defaultValues?.bountyPrizes}
 						id="bountyPrizes"
 						inputMode="numeric"
 						min={0}
-						name="bountyPrizes"
+						onChange={(e) =>
+							onBountyPrizesChange?.(parseNumericInput(e.target.value))
+						}
 						placeholder="0"
 						type="number"
+						value={bountyPrizes ?? ""}
 					/>
 				</div>
 			</div>
@@ -208,11 +250,80 @@ export function TournamentDetailFields({
 	);
 }
 
-export function TournamentFields({ defaultValues }: TournamentFieldsProps) {
+interface TournamentFieldsProps {
+	addonCost?: number;
+	bountyPrizes?: number;
+	currencies?: Array<{ id: string; name: string }>;
+	entryFee?: number;
+	onAddonCostChange?: (value: number | undefined) => void;
+	onBountyPrizesChange?: (value: number | undefined) => void;
+	onCurrencyChange?: (id: string | undefined) => void;
+	onEntryFeeChange?: (value: number | undefined) => void;
+	onPlacementChange?: (value: number | undefined) => void;
+	onPrizeMoneyChange?: (value: number | undefined) => void;
+	onRebuyCostChange?: (value: number | undefined) => void;
+	onRebuyCountChange?: (value: number | undefined) => void;
+	onTotalEntriesChange?: (value: number | undefined) => void;
+	onTournamentBuyInChange?: (value: number) => void;
+	placement?: number;
+	prizeMoney?: number;
+	rebuyCost?: number;
+	rebuyCount?: number;
+	selectedCurrencyId?: string;
+	totalEntries?: number;
+	tournamentBuyIn?: number;
+}
+
+export function TournamentFields({
+	addonCost,
+	bountyPrizes,
+	currencies,
+	entryFee,
+	onAddonCostChange,
+	onBountyPrizesChange,
+	onCurrencyChange,
+	onEntryFeeChange,
+	onPlacementChange,
+	onPrizeMoneyChange,
+	onRebuyCostChange,
+	onRebuyCountChange,
+	onTotalEntriesChange,
+	onTournamentBuyInChange,
+	placement,
+	prizeMoney,
+	rebuyCost,
+	rebuyCount,
+	selectedCurrencyId,
+	totalEntries,
+	tournamentBuyIn,
+}: TournamentFieldsProps) {
 	return (
 		<>
-			<TournamentPrimaryFields defaultValues={defaultValues} />
-			<TournamentDetailFields defaultValues={defaultValues} />
+			<TournamentPrimaryFields
+				entryFee={entryFee}
+				onEntryFeeChange={onEntryFeeChange}
+				onPlacementChange={onPlacementChange}
+				onPrizeMoneyChange={onPrizeMoneyChange}
+				onTotalEntriesChange={onTotalEntriesChange}
+				onTournamentBuyInChange={onTournamentBuyInChange}
+				placement={placement}
+				prizeMoney={prizeMoney}
+				totalEntries={totalEntries}
+				tournamentBuyIn={tournamentBuyIn}
+			/>
+			<TournamentDetailFields
+				addonCost={addonCost}
+				bountyPrizes={bountyPrizes}
+				currencies={currencies}
+				onAddonCostChange={onAddonCostChange}
+				onBountyPrizesChange={onBountyPrizesChange}
+				onCurrencyChange={onCurrencyChange}
+				onRebuyCostChange={onRebuyCostChange}
+				onRebuyCountChange={onRebuyCountChange}
+				rebuyCost={rebuyCost}
+				rebuyCount={rebuyCount}
+				selectedCurrencyId={selectedCurrencyId}
+			/>
 		</>
 	);
 }

--- a/apps/web/src/sessions/components/tournament-fields.tsx
+++ b/apps/web/src/sessions/components/tournament-fields.tsx
@@ -38,7 +38,9 @@ export interface TournamentDetailFieldsProps {
 const NONE_VALUE = "__none__";
 
 function parseNumericInput(value: string): number | undefined {
-	if (!value) return undefined;
+	if (!value) {
+		return undefined;
+	}
 	const parsed = Number.parseFloat(value);
 	return Number.isNaN(parsed) ? undefined : parsed;
 }
@@ -83,7 +85,9 @@ export function TournamentPrimaryFields({
 						id="entryFee"
 						inputMode="numeric"
 						min={0}
-						onChange={(e) => onEntryFeeChange?.(parseNumericInput(e.target.value))}
+						onChange={(e) =>
+							onEntryFeeChange?.(parseNumericInput(e.target.value))
+						}
 						placeholder="0"
 						type="number"
 						value={entryFee ?? ""}
@@ -98,7 +102,9 @@ export function TournamentPrimaryFields({
 					id="prizeMoney"
 					inputMode="numeric"
 					min={0}
-					onChange={(e) => onPrizeMoneyChange?.(parseNumericInput(e.target.value))}
+					onChange={(e) =>
+						onPrizeMoneyChange?.(parseNumericInput(e.target.value))
+					}
 					placeholder="0"
 					type="number"
 					value={prizeMoney ?? ""}

--- a/apps/web/src/shared/components/management/tag-name-form.tsx
+++ b/apps/web/src/shared/components/management/tag-name-form.tsx
@@ -1,7 +1,16 @@
+import { useForm } from "@tanstack/react-form";
 import type * as React from "react";
+import z from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
+
+const tagNameFormSchema = z.object({
+	name: z
+		.string()
+		.min(1, "Tag name is required")
+		.max(50, "Tag name must be 50 characters or less"),
+});
 
 export function TagNameForm({
 	children,
@@ -14,30 +23,56 @@ export function TagNameForm({
 	isLoading?: boolean;
 	onSubmit: (name: string) => void;
 }) {
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		const formData = new FormData(e.currentTarget);
-		const name = formData.get("name") as string;
-		onSubmit(name);
-	};
+	const form = useForm({
+		defaultValues: {
+			name: defaultName ?? "",
+		},
+		onSubmit: ({ value }) => {
+			onSubmit(value.name);
+		},
+		validators: {
+			onSubmit: tagNameFormSchema,
+		},
+	});
 
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-			<Field htmlFor="tag-name" label="Tag Name" required>
-				<Input
-					defaultValue={defaultName}
-					id="tag-name"
-					maxLength={50}
-					minLength={1}
-					name="name"
-					placeholder="Enter tag name"
-					required
-				/>
-			</Field>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="name">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Tag Name"
+						required
+					>
+						<Input
+							id={field.name}
+							maxLength={50}
+							minLength={1}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="Enter tag name"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
 			{children}
-			<Button disabled={isLoading} type="submit">
-				{isLoading ? "Saving..." : "Save"}
-			</Button>
+			<form.Subscribe>
+				{(state) => (
+					<Button disabled={isLoading || !state.canSubmit || state.isSubmitting} type="submit">
+						{isLoading || state.isSubmitting ? "Saving..." : "Save"}
+					</Button>
+				)}
+			</form.Subscribe>
 		</form>
 	);
 }

--- a/apps/web/src/shared/components/management/tag-name-form.tsx
+++ b/apps/web/src/shared/components/management/tag-name-form.tsx
@@ -68,7 +68,10 @@ export function TagNameForm({
 			{children}
 			<form.Subscribe>
 				{(state) => (
-					<Button disabled={isLoading || !state.canSubmit || state.isSubmitting} type="submit">
+					<Button
+						disabled={isLoading || !state.canSubmit || state.isSubmitting}
+						type="submit"
+					>
 						{isLoading || state.isSubmitting ? "Saving..." : "Save"}
 					</Button>
 				)}

--- a/apps/web/src/stores/components/__tests__/ring-game-form.test.tsx
+++ b/apps/web/src/stores/components/__tests__/ring-game-form.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { RingGameForm } from "../ring-game-form";
 
@@ -22,15 +23,8 @@ vi.mock("@/utils/trpc", () => ({
 }));
 
 describe("RingGameForm", () => {
-	function getForm() {
-		const form = screen.getByRole("button", { name: "Save" }).closest("form");
-		if (!form) {
-			throw new Error("Save form not found");
-		}
-		return form;
-	}
-
-	it("renders memo as textarea and preserves default values on submit", () => {
+	it("renders memo as textarea and preserves default values on submit", async () => {
+		const user = userEvent.setup();
 		const onSubmit = vi.fn();
 
 		render(
@@ -50,7 +44,7 @@ describe("RingGameForm", () => {
 		expect(memo.tagName).toBe("TEXTAREA");
 		expect(memo).toHaveValue("deep stack\nweekday game");
 
-		fireEvent.submit(getForm());
+		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		expect(onSubmit).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -62,19 +56,21 @@ describe("RingGameForm", () => {
 		);
 	});
 
-	it("submits multiline memo in create mode", () => {
+	it("submits multiline memo in create mode", async () => {
+		const user = userEvent.setup();
 		const onSubmit = vi.fn();
 
 		render(<RingGameForm onSubmit={onSubmit} />);
 
-		fireEvent.change(screen.getByLabelText("Game Name *"), {
-			target: { value: "5/10 NLH" },
-		});
-		fireEvent.change(screen.getByLabelText("Memo"), {
-			target: { value: "straddles allowed\nweekend only" },
-		});
+		await user.clear(screen.getByLabelText("Game Name *"));
+		await user.type(screen.getByLabelText("Game Name *"), "5/10 NLH");
+		await user.clear(screen.getByLabelText("Memo"));
+		await user.type(
+			screen.getByLabelText("Memo"),
+			"straddles allowed\nweekend only"
+		);
 
-		fireEvent.submit(getForm());
+		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		expect(onSubmit).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/apps/web/src/stores/components/__tests__/tournament-form.test.tsx
+++ b/apps/web/src/stores/components/__tests__/tournament-form.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { TournamentForm } from "../tournament-form";
@@ -23,15 +23,8 @@ vi.mock("@/utils/trpc", () => ({
 }));
 
 describe("TournamentForm", () => {
-	function getForm() {
-		const form = screen.getByRole("button", { name: "Save" }).closest("form");
-		if (!form) {
-			throw new Error("Save form not found");
-		}
-		return form;
-	}
-
-	it("renders memo as textarea and preserves edit payload", () => {
+	it("renders memo as textarea and preserves edit payload", async () => {
+		const user = userEvent.setup();
 		const onSubmit = vi.fn();
 
 		render(
@@ -53,7 +46,7 @@ describe("TournamentForm", () => {
 		expect(memo.tagName).toBe("TEXTAREA");
 		expect(memo).toHaveValue("two flights\nfinal table on Sunday");
 
-		fireEvent.submit(getForm());
+		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		expect(onSubmit).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -67,19 +60,24 @@ describe("TournamentForm", () => {
 		);
 	});
 
-	it("submits multiline memo in create mode", () => {
+	it("submits multiline memo in create mode", async () => {
+		const user = userEvent.setup();
 		const onSubmit = vi.fn();
 
 		render(<TournamentForm onSubmit={onSubmit} />);
 
-		fireEvent.change(screen.getByLabelText("Tournament Name *"), {
-			target: { value: "Nightly Deepstack" },
-		});
-		fireEvent.change(screen.getByLabelText("Memo"), {
-			target: { value: "late reg open\n15 minute levels" },
-		});
+		await user.clear(screen.getByLabelText("Tournament Name *"));
+		await user.type(
+			screen.getByLabelText("Tournament Name *"),
+			"Nightly Deepstack"
+		);
+		await user.clear(screen.getByLabelText("Memo"));
+		await user.type(
+			screen.getByLabelText("Memo"),
+			"late reg open\n15 minute levels"
+		);
 
-		fireEvent.submit(getForm());
+		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		expect(onSubmit).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -97,13 +95,15 @@ describe("TournamentForm", () => {
 
 		render(<TournamentForm onSubmit={onSubmit} />);
 
-		fireEvent.change(screen.getByLabelText("Tournament Name *"), {
-			target: { value: "Nightly Deepstack" },
-		});
+		await user.clear(screen.getByLabelText("Tournament Name *"));
+		await user.type(
+			screen.getByLabelText("Tournament Name *"),
+			"Nightly Deepstack"
+		);
 		await user.type(screen.getByLabelText("Search tags"), "Series");
 		await user.keyboard("{Enter}");
 
-		fireEvent.submit(getForm());
+		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		expect(onSubmit).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/apps/web/src/stores/components/ring-game-form.tsx
+++ b/apps/web/src/stores/components/ring-game-form.tsx
@@ -1,5 +1,6 @@
+import { useForm } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import z from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
@@ -49,233 +50,397 @@ const ANTE_TYPES = [
 	{ value: "all", label: "All Ante" },
 ] as const;
 
-function parseOptionalInt(value: string): number | undefined {
-	if (!value) {
-		return undefined;
-	}
-	const parsed = Number.parseInt(value, 10);
-	return Number.isNaN(parsed) ? undefined : parsed;
-}
+const ringGameFormSchema = z.object({
+	name: z
+		.string()
+		.min(1, "Game name is required")
+		.max(100, "Game name must be 100 characters or less"),
+	variant: z.string().min(1, "Variant is required"),
+	blind1: z.coerce.number().nonnegative("Blind 1 must be non-negative").optional(),
+	blind2: z.coerce.number().nonnegative("Blind 2 must be non-negative").optional(),
+	blind3: z.coerce.number().nonnegative("Blind 3 must be non-negative").optional(),
+	ante: z.coerce.number().nonnegative("Ante must be non-negative").optional(),
+	anteType: z.enum(["none", "bb", "all"]).optional(),
+	minBuyIn: z.coerce.number().nonnegative("Min Buy-In must be non-negative").optional(),
+	maxBuyIn: z.coerce.number().nonnegative("Max Buy-In must be non-negative").optional(),
+	tableSize: z.coerce.number().nonnegative("Table size must be non-negative").optional(),
+	currencyId: z.string().optional(),
+	memo: z.string().max(10_000, "Memo must be 10,000 characters or less").optional(),
+});
 
 export function RingGameForm({
 	onSubmit,
 	defaultValues,
 	isLoading = false,
 }: RingGameFormProps) {
-	const [anteType, setAnteType] = useState<string>(
-		defaultValues?.anteType ?? "none"
-	);
-
 	const currenciesQuery = useQuery(trpc.currency.list.queryOptions());
 	const currencies = currenciesQuery.data ?? [];
 
-	const variant = (defaultValues?.variant ??
-		"nlh") as keyof typeof GAME_VARIANTS;
-	const blindLabels = GAME_VARIANTS[variant]?.blindLabels ?? {
+	const form = useForm({
+		defaultValues: {
+			name: defaultValues?.name ?? "",
+			variant: defaultValues?.variant ?? "nlh",
+			blind1: defaultValues?.blind1 ?? undefined,
+			blind2: defaultValues?.blind2 ?? undefined,
+			blind3: defaultValues?.blind3 ?? undefined,
+			ante: defaultValues?.ante ?? undefined,
+			anteType: defaultValues?.anteType ?? "none",
+			minBuyIn: defaultValues?.minBuyIn ?? undefined,
+			maxBuyIn: defaultValues?.maxBuyIn ?? undefined,
+			tableSize: defaultValues?.tableSize ?? undefined,
+			currencyId: defaultValues?.currencyId ?? "",
+			memo: defaultValues?.memo ?? "",
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				name: value.name,
+				variant: value.variant || "nlh",
+				blind1: value.blind1,
+				blind2: value.blind2,
+				blind3: value.blind3,
+				ante: value.anteType === "none" ? undefined : value.ante,
+				anteType: (value.anteType as "all" | "bb" | "none" | undefined) || undefined,
+				minBuyIn: value.minBuyIn,
+				maxBuyIn: value.maxBuyIn,
+				tableSize: value.tableSize,
+				currencyId: value.currencyId || undefined,
+				memo: value.memo || undefined,
+			});
+		},
+		validators: {
+			onSubmit: ringGameFormSchema,
+		},
+	});
+
+	const blindLabels = GAME_VARIANTS[
+		form.getFieldValue("variant") as keyof typeof GAME_VARIANTS
+	]?.blindLabels ?? {
 		blind1: "SB",
 		blind2: "BB",
 		blind3: "Straddle",
 	};
 
+	const anteType = form.getFieldValue("anteType");
 	const isAnteDisabled = anteType === "none";
 
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		const formData = new FormData(e.currentTarget);
-
-		const values: RingGameFormValues = {
-			name: formData.get("name") as string,
-			variant: (formData.get("variant") as string) || "nlh",
-			blind1: parseOptionalInt(formData.get("blind1") as string),
-			blind2: parseOptionalInt(formData.get("blind2") as string),
-			blind3: parseOptionalInt(formData.get("blind3") as string),
-			ante: isAnteDisabled
-				? undefined
-				: parseOptionalInt(formData.get("ante") as string),
-			anteType: ((formData.get("anteType") as string) || undefined) as
-				| "all"
-				| "bb"
-				| "none"
-				| undefined,
-			minBuyIn: parseOptionalInt(formData.get("minBuyIn") as string),
-			maxBuyIn: parseOptionalInt(formData.get("maxBuyIn") as string),
-			tableSize: parseOptionalInt(formData.get("tableSize") as string),
-			currencyId: (formData.get("currencyId") as string) || undefined,
-			memo: (formData.get("memo") as string) || undefined,
-		};
-
-		onSubmit(values);
-	};
-
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-			<Field htmlFor="name" label="Game Name" required>
-				<Input
-					defaultValue={defaultValues?.name}
-					id="name"
-					name="name"
-					placeholder="e.g. 1/2 NLH"
-					required
-				/>
-			</Field>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="name">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Game Name"
+						required
+					>
+						<Input
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="e.g. 1/2 NLH"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
 
-			<Field htmlFor="variant" label="Variant" required>
-				<Select defaultValue={defaultValues?.variant ?? "nlh"} name="variant">
-					<SelectTrigger className="w-full" id="variant">
-						<SelectValue placeholder="Select variant" />
-					</SelectTrigger>
-					<SelectContent>
-						{Object.entries(GAME_VARIANTS).map(([key, val]) => (
-							<SelectItem key={key} value={key}>
-								{val.label}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-			</Field>
+			<form.Field name="variant">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Variant"
+						required
+					>
+						<Select
+							name={field.name}
+							onValueChange={(value) => field.handleChange(value)}
+							value={field.state.value}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue placeholder="Select variant" />
+							</SelectTrigger>
+							<SelectContent>
+								{Object.entries(GAME_VARIANTS).map(([key, val]) => (
+									<SelectItem key={key} value={key}>
+										{val.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
 
 			<div className="grid grid-cols-3 gap-3">
-				<Field htmlFor="blind1" label={blindLabels.blind1}>
-					<Input
-						defaultValue={defaultValues?.blind1}
-						id="blind1"
-						inputMode="numeric"
-						min={0}
-						name="blind1"
-						placeholder="0"
-						type="number"
-					/>
-				</Field>
-				<Field htmlFor="blind2" label={blindLabels.blind2}>
-					<Input
-						defaultValue={defaultValues?.blind2}
-						id="blind2"
-						inputMode="numeric"
-						min={0}
-						name="blind2"
-						placeholder="0"
-						type="number"
-					/>
-				</Field>
-				<Field htmlFor="blind3" label={blindLabels.blind3}>
-					<Input
-						defaultValue={defaultValues?.blind3}
-						id="blind3"
-						inputMode="numeric"
-						min={0}
-						name="blind3"
-						placeholder="0"
-						type="number"
-					/>
-				</Field>
+				<form.Field name="blind1">
+					{(field) => (
+						<Field
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label={blindLabels.blind1}
+						>
+							<Input
+								id={field.name}
+								inputMode="numeric"
+								min={0}
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) =>
+									field.handleChange(e.target.value === "" ? undefined : Number(e.target.value))
+								}
+								placeholder="0"
+								type="number"
+								value={field.state.value ?? ""}
+							/>
+						</Field>
+					)}
+				</form.Field>
+				<form.Field name="blind2">
+					{(field) => (
+						<Field
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label={blindLabels.blind2}
+						>
+							<Input
+								id={field.name}
+								inputMode="numeric"
+								min={0}
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) =>
+									field.handleChange(e.target.value === "" ? undefined : Number(e.target.value))
+								}
+								placeholder="0"
+								type="number"
+								value={field.state.value ?? ""}
+							/>
+						</Field>
+					)}
+				</form.Field>
+				<form.Field name="blind3">
+					{(field) => (
+						<Field
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label={blindLabels.blind3}
+						>
+							<Input
+								id={field.name}
+								inputMode="numeric"
+								min={0}
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) =>
+									field.handleChange(e.target.value === "" ? undefined : Number(e.target.value))
+								}
+								placeholder="0"
+								type="number"
+								value={field.state.value ?? ""}
+							/>
+						</Field>
+					)}
+				</form.Field>
 			</div>
 
 			<div className="flex gap-3">
-				<Field className="flex-1" htmlFor="anteType" label="Ante Type">
-					<Select
-						defaultValue={defaultValues?.anteType ?? "none"}
-						name="anteType"
-						onValueChange={setAnteType}
-					>
-						<SelectTrigger className="w-full" id="anteType">
-							<SelectValue placeholder="Select ante type" />
-						</SelectTrigger>
-						<SelectContent>
-							{ANTE_TYPES.map((at) => (
-								<SelectItem key={at.value} value={at.value}>
-									{at.label}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				</Field>
+				<form.Field name="anteType">
+					{(field) => (
+						<Field
+							className="flex-1"
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label="Ante Type"
+						>
+							<Select
+								name={field.name}
+								onValueChange={(value) => field.handleChange(value)}
+								value={field.state.value ?? "none"}
+							>
+								<SelectTrigger className="w-full" id={field.name}>
+									<SelectValue placeholder="Select ante type" />
+								</SelectTrigger>
+								<SelectContent>
+									{ANTE_TYPES.map((at) => (
+										<SelectItem key={at.value} value={at.value}>
+											{at.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</Field>
+					)}
+				</form.Field>
 
-				<Field className="flex-1" htmlFor="ante" label="Ante">
-					<Input
-						defaultValue={defaultValues?.ante}
-						disabled={isAnteDisabled}
-						id="ante"
-						inputMode="numeric"
-						min={0}
-						name="ante"
-						placeholder="0"
-						type="number"
-					/>
-				</Field>
+				<form.Field name="ante">
+					{(field) => (
+						<Field
+							className="flex-1"
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label="Ante"
+						>
+							<Input
+								disabled={isAnteDisabled}
+								id={field.name}
+								inputMode="numeric"
+								min={0}
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) =>
+									field.handleChange(e.target.value === "" ? undefined : Number(e.target.value))
+								}
+								placeholder="0"
+								type="number"
+								value={field.state.value ?? ""}
+							/>
+						</Field>
+					)}
+				</form.Field>
 			</div>
 
 			<div className="grid grid-cols-2 gap-3">
-				<Field htmlFor="minBuyIn" label="Min Buy-In">
-					<Input
-						defaultValue={defaultValues?.minBuyIn}
-						id="minBuyIn"
-						inputMode="numeric"
-						min={0}
-						name="minBuyIn"
-						placeholder="0"
-						type="number"
-					/>
-				</Field>
-				<Field htmlFor="maxBuyIn" label="Max Buy-In">
-					<Input
-						defaultValue={defaultValues?.maxBuyIn}
-						id="maxBuyIn"
-						inputMode="numeric"
-						min={0}
-						name="maxBuyIn"
-						placeholder="0"
-						type="number"
-					/>
-				</Field>
+				<form.Field name="minBuyIn">
+					{(field) => (
+						<Field
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label="Min Buy-In"
+						>
+							<Input
+								id={field.name}
+								inputMode="numeric"
+								min={0}
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) =>
+									field.handleChange(e.target.value === "" ? undefined : Number(e.target.value))
+								}
+								placeholder="0"
+								type="number"
+								value={field.state.value ?? ""}
+							/>
+						</Field>
+					)}
+				</form.Field>
+				<form.Field name="maxBuyIn">
+					{(field) => (
+						<Field
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label="Max Buy-In"
+						>
+							<Input
+								id={field.name}
+								inputMode="numeric"
+								min={0}
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) =>
+									field.handleChange(e.target.value === "" ? undefined : Number(e.target.value))
+								}
+								placeholder="0"
+								type="number"
+								value={field.state.value ?? ""}
+							/>
+						</Field>
+					)}
+				</form.Field>
 			</div>
 
-			<Field htmlFor="tableSize" label="Table Size">
-				<Select
-					defaultValue={defaultValues?.tableSize?.toString()}
-					name="tableSize"
-				>
-					<SelectTrigger className="w-full" id="tableSize">
-						<SelectValue placeholder="Select table size" />
-					</SelectTrigger>
-					<SelectContent>
-						{TABLE_SIZES.map((size) => (
-							<SelectItem key={size} value={size.toString()}>
-								{size}-max
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-			</Field>
+			<form.Field name="tableSize">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Table Size"
+					>
+						<Select
+							name={field.name}
+							onValueChange={(value) =>
+								field.handleChange(value === "" ? undefined : Number(value))
+							}
+							value={(field.state.value ?? "").toString()}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue placeholder="Select table size" />
+							</SelectTrigger>
+							<SelectContent>
+								{TABLE_SIZES.map((size) => (
+									<SelectItem key={size} value={size.toString()}>
+										{size}-max
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
 
-			<Field htmlFor="currencyId" label="Currency">
-				<Select defaultValue={defaultValues?.currencyId} name="currencyId">
-					<SelectTrigger className="w-full" id="currencyId">
-						<SelectValue placeholder="Select currency" />
-					</SelectTrigger>
-					<SelectContent>
-						{currencies.map((c) => (
-							<SelectItem key={c.id} value={c.id}>
-								{c.name}
-								{c.unit ? ` (${c.unit})` : ""}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-			</Field>
+			<form.Field name="currencyId">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Currency"
+					>
+						<Select
+							name={field.name}
+							onValueChange={(value) => field.handleChange(value)}
+							value={field.state.value ?? ""}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue placeholder="Select currency" />
+							</SelectTrigger>
+							<SelectContent>
+								{currencies.map((c) => (
+									<SelectItem key={c.id} value={c.id}>
+										{c.name}
+										{c.unit ? ` (${c.unit})` : ""}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
 
-			<Field htmlFor="memo" label="Memo">
-				<Textarea
-					defaultValue={defaultValues?.memo}
-					id="memo"
-					name="memo"
-					placeholder="Notes about this game"
-					rows={4}
-				/>
-			</Field>
+			<form.Field name="memo">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Memo"
+					>
+						<Textarea
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="Notes about this game"
+							rows={4}
+							value={field.state.value ?? ""}
+						/>
+					</Field>
+				)}
+			</form.Field>
 
-			<Button disabled={isLoading} type="submit">
-				{isLoading ? "Saving..." : "Save"}
-			</Button>
+			<form.Subscribe>
+				{(state) => (
+					<Button disabled={isLoading || !state.canSubmit || state.isSubmitting} type="submit">
+						{isLoading || state.isSubmitting ? "Saving..." : "Save"}
+					</Button>
+				)}
+			</form.Subscribe>
 		</form>
 	);
 }

--- a/apps/web/src/stores/components/ring-game-form.tsx
+++ b/apps/web/src/stores/components/ring-game-form.tsx
@@ -56,16 +56,37 @@ const ringGameFormSchema = z.object({
 		.min(1, "Game name is required")
 		.max(100, "Game name must be 100 characters or less"),
 	variant: z.string().min(1, "Variant is required"),
-	blind1: z.coerce.number().nonnegative("Blind 1 must be non-negative").optional(),
-	blind2: z.coerce.number().nonnegative("Blind 2 must be non-negative").optional(),
-	blind3: z.coerce.number().nonnegative("Blind 3 must be non-negative").optional(),
+	blind1: z.coerce
+		.number()
+		.nonnegative("Blind 1 must be non-negative")
+		.optional(),
+	blind2: z.coerce
+		.number()
+		.nonnegative("Blind 2 must be non-negative")
+		.optional(),
+	blind3: z.coerce
+		.number()
+		.nonnegative("Blind 3 must be non-negative")
+		.optional(),
 	ante: z.coerce.number().nonnegative("Ante must be non-negative").optional(),
 	anteType: z.enum(["none", "bb", "all"]).optional(),
-	minBuyIn: z.coerce.number().nonnegative("Min Buy-In must be non-negative").optional(),
-	maxBuyIn: z.coerce.number().nonnegative("Max Buy-In must be non-negative").optional(),
-	tableSize: z.coerce.number().nonnegative("Table size must be non-negative").optional(),
+	minBuyIn: z.coerce
+		.number()
+		.nonnegative("Min Buy-In must be non-negative")
+		.optional(),
+	maxBuyIn: z.coerce
+		.number()
+		.nonnegative("Max Buy-In must be non-negative")
+		.optional(),
+	tableSize: z.coerce
+		.number()
+		.nonnegative("Table size must be non-negative")
+		.optional(),
 	currencyId: z.string().optional(),
-	memo: z.string().max(10_000, "Memo must be 10,000 characters or less").optional(),
+	memo: z
+		.string()
+		.max(10_000, "Memo must be 10,000 characters or less")
+		.optional(),
 });
 
 export function RingGameForm({
@@ -99,7 +120,8 @@ export function RingGameForm({
 				blind2: value.blind2,
 				blind3: value.blind3,
 				ante: value.anteType === "none" ? undefined : value.ante,
-				anteType: (value.anteType as "all" | "bb" | "none" | undefined) || undefined,
+				anteType:
+					(value.anteType as "all" | "bb" | "none" | undefined) || undefined,
 				minBuyIn: value.minBuyIn,
 				maxBuyIn: value.maxBuyIn,
 				tableSize: value.tableSize,
@@ -195,7 +217,9 @@ export function RingGameForm({
 								name={field.name}
 								onBlur={field.handleBlur}
 								onChange={(e) =>
-									field.handleChange(e.target.value === "" ? undefined : Number(e.target.value))
+									field.handleChange(
+										e.target.value === "" ? undefined : Number(e.target.value)
+									)
 								}
 								placeholder="0"
 								type="number"
@@ -218,7 +242,9 @@ export function RingGameForm({
 								name={field.name}
 								onBlur={field.handleBlur}
 								onChange={(e) =>
-									field.handleChange(e.target.value === "" ? undefined : Number(e.target.value))
+									field.handleChange(
+										e.target.value === "" ? undefined : Number(e.target.value)
+									)
 								}
 								placeholder="0"
 								type="number"
@@ -241,7 +267,9 @@ export function RingGameForm({
 								name={field.name}
 								onBlur={field.handleBlur}
 								onChange={(e) =>
-									field.handleChange(e.target.value === "" ? undefined : Number(e.target.value))
+									field.handleChange(
+										e.target.value === "" ? undefined : Number(e.target.value)
+									)
 								}
 								placeholder="0"
 								type="number"
@@ -297,7 +325,9 @@ export function RingGameForm({
 								name={field.name}
 								onBlur={field.handleBlur}
 								onChange={(e) =>
-									field.handleChange(e.target.value === "" ? undefined : Number(e.target.value))
+									field.handleChange(
+										e.target.value === "" ? undefined : Number(e.target.value)
+									)
 								}
 								placeholder="0"
 								type="number"
@@ -323,7 +353,9 @@ export function RingGameForm({
 								name={field.name}
 								onBlur={field.handleBlur}
 								onChange={(e) =>
-									field.handleChange(e.target.value === "" ? undefined : Number(e.target.value))
+									field.handleChange(
+										e.target.value === "" ? undefined : Number(e.target.value)
+									)
 								}
 								placeholder="0"
 								type="number"
@@ -346,7 +378,9 @@ export function RingGameForm({
 								name={field.name}
 								onBlur={field.handleBlur}
 								onChange={(e) =>
-									field.handleChange(e.target.value === "" ? undefined : Number(e.target.value))
+									field.handleChange(
+										e.target.value === "" ? undefined : Number(e.target.value)
+									)
 								}
 								placeholder="0"
 								type="number"
@@ -436,7 +470,10 @@ export function RingGameForm({
 
 			<form.Subscribe>
 				{(state) => (
-					<Button disabled={isLoading || !state.canSubmit || state.isSubmitting} type="submit">
+					<Button
+						disabled={isLoading || !state.canSubmit || state.isSubmitting}
+						type="submit"
+					>
 						{isLoading || state.isSubmitting ? "Saving..." : "Save"}
 					</Button>
 				)}

--- a/apps/web/src/stores/components/store-form.tsx
+++ b/apps/web/src/stores/components/store-form.tsx
@@ -1,3 +1,5 @@
+import { useForm } from "@tanstack/react-form";
+import z from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
@@ -14,41 +16,88 @@ interface StoreFormProps {
 	onSubmit: (values: StoreFormValues) => void;
 }
 
+const storeFormSchema = z.object({
+	name: z
+		.string()
+		.min(1, "Store name is required")
+		.max(100, "Store name must be 100 characters or less"),
+	memo: z.string().max(10_000, "Memo must be 10,000 characters or less").optional(),
+});
+
 export function StoreForm({
 	onSubmit,
 	defaultValues,
 	isLoading = false,
 }: StoreFormProps) {
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		const formData = new FormData(e.currentTarget);
-		const name = formData.get("name") as string;
-		const memo = (formData.get("memo") as string) || undefined;
-		onSubmit({ name, memo });
-	};
+	const form = useForm({
+		defaultValues: {
+			name: defaultValues?.name ?? "",
+			memo: defaultValues?.memo ?? "",
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				name: value.name,
+				memo: value.memo || undefined,
+			});
+		},
+		validators: {
+			onSubmit: storeFormSchema,
+		},
+	});
 
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-			<Field htmlFor="name" label="Store Name" required>
-				<Input
-					defaultValue={defaultValues?.name}
-					id="name"
-					name="name"
-					placeholder="Enter store name"
-					required
-				/>
-			</Field>
-			<Field htmlFor="memo" label="Memo">
-				<Textarea
-					defaultValue={defaultValues?.memo}
-					id="memo"
-					name="memo"
-					placeholder="Optional notes about this store"
-				/>
-			</Field>
-			<Button disabled={isLoading} type="submit">
-				{isLoading ? "Saving..." : "Save"}
-			</Button>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="name">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Store Name"
+						required
+					>
+						<Input
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="Enter store name"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
+			<form.Field name="memo">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Memo"
+					>
+						<Textarea
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="Optional notes about this store"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
+			<form.Subscribe>
+				{(state) => (
+					<Button disabled={isLoading || !state.canSubmit || state.isSubmitting} type="submit">
+						{isLoading || state.isSubmitting ? "Saving..." : "Save"}
+					</Button>
+				)}
+			</form.Subscribe>
 		</form>
 	);
 }

--- a/apps/web/src/stores/components/store-form.tsx
+++ b/apps/web/src/stores/components/store-form.tsx
@@ -21,7 +21,10 @@ const storeFormSchema = z.object({
 		.string()
 		.min(1, "Store name is required")
 		.max(100, "Store name must be 100 characters or less"),
-	memo: z.string().max(10_000, "Memo must be 10,000 characters or less").optional(),
+	memo: z
+		.string()
+		.max(10_000, "Memo must be 10,000 characters or less")
+		.optional(),
 });
 
 export function StoreForm({
@@ -93,7 +96,10 @@ export function StoreForm({
 			</form.Field>
 			<form.Subscribe>
 				{(state) => (
-					<Button disabled={isLoading || !state.canSubmit || state.isSubmitting} type="submit">
+					<Button
+						disabled={isLoading || !state.canSubmit || state.isSubmitting}
+						type="submit"
+					>
 						{isLoading || state.isSubmitting ? "Saving..." : "Save"}
 					</Button>
 				)}

--- a/apps/web/src/stores/components/tournament-form.tsx
+++ b/apps/web/src/stores/components/tournament-form.tsx
@@ -65,7 +65,10 @@ const tournamentFormSchema = z.object({
 	bountyAmount: z.coerce.number().min(0, "Must be 0 or greater").optional(),
 	tableSize: z.coerce.number().min(0, "Must be 0 or greater").optional(),
 	currencyId: z.string().optional(),
-	memo: z.string().max(10_000, "Memo must be 10,000 characters or less").optional(),
+	memo: z
+		.string()
+		.max(10_000, "Memo must be 10,000 characters or less")
+		.optional(),
 	tags: z.array(z.string()).optional(),
 });
 
@@ -83,12 +86,14 @@ export function TournamentForm({
 			variant: defaultValues?.variant ?? "nlh",
 			buyIn: defaultValues?.buyIn ?? (undefined as number | undefined),
 			entryFee: defaultValues?.entryFee ?? (undefined as number | undefined),
-			startingStack: defaultValues?.startingStack ?? (undefined as number | undefined),
+			startingStack:
+				defaultValues?.startingStack ?? (undefined as number | undefined),
 			chipPurchases: (defaultValues?.chipPurchases ?? []).map((cp) => ({
 				...cp,
 				uid: crypto.randomUUID(),
 			})) as Array<{ name: string; cost: number; chips: number; uid: string }>,
-			bountyAmount: defaultValues?.bountyAmount ?? (undefined as number | undefined),
+			bountyAmount:
+				defaultValues?.bountyAmount ?? (undefined as number | undefined),
 			tableSize: defaultValues?.tableSize ?? (undefined as number | undefined),
 			currencyId: defaultValues?.currencyId ?? "",
 			memo: defaultValues?.memo ?? "",
@@ -196,7 +201,11 @@ export function TournamentForm({
 								}
 								placeholder="0"
 								type="number"
-								value={field.state.value !== undefined ? String(field.state.value) : ""}
+								value={
+									field.state.value === undefined
+										? ""
+										: String(field.state.value)
+								}
 							/>
 						</Field>
 					)}
@@ -221,7 +230,11 @@ export function TournamentForm({
 								}
 								placeholder="0"
 								type="number"
-								value={field.state.value !== undefined ? String(field.state.value) : ""}
+								value={
+									field.state.value === undefined
+										? ""
+										: String(field.state.value)
+								}
 							/>
 						</Field>
 					)}
@@ -248,7 +261,9 @@ export function TournamentForm({
 							}
 							placeholder="0"
 							type="number"
-							value={field.state.value !== undefined ? String(field.state.value) : ""}
+							value={
+								field.state.value === undefined ? "" : String(field.state.value)
+							}
 						/>
 					</Field>
 				)}
@@ -290,7 +305,9 @@ export function TournamentForm({
 												id={`cp-name-${cp.uid}`}
 												onChange={(e) => {
 													const updated = field.state.value.map((item, i) =>
-														i === index ? { ...item, name: e.target.value } : item
+														i === index
+															? { ...item, name: e.target.value }
+															: item
 													);
 													field.handleChange(updated);
 												}}
@@ -311,7 +328,10 @@ export function TournamentForm({
 													const parsed = Number.parseInt(e.target.value, 10);
 													const updated = field.state.value.map((item, i) =>
 														i === index
-															? { ...item, cost: Number.isNaN(parsed) ? 0 : parsed }
+															? {
+																	...item,
+																	cost: Number.isNaN(parsed) ? 0 : parsed,
+																}
 															: item
 													);
 													field.handleChange(updated);
@@ -334,7 +354,10 @@ export function TournamentForm({
 													const parsed = Number.parseInt(e.target.value, 10);
 													const updated = field.state.value.map((item, i) =>
 														i === index
-															? { ...item, chips: Number.isNaN(parsed) ? 0 : parsed }
+															? {
+																	...item,
+																	chips: Number.isNaN(parsed) ? 0 : parsed,
+																}
 															: item
 													);
 													field.handleChange(updated);
@@ -385,7 +408,9 @@ export function TournamentForm({
 							}
 							placeholder="0"
 							type="number"
-							value={field.state.value !== undefined ? String(field.state.value) : ""}
+							value={
+								field.state.value === undefined ? "" : String(field.state.value)
+							}
 						/>
 					</Field>
 				)}
@@ -486,7 +511,10 @@ export function TournamentForm({
 								)
 							}
 							placeholder="Add a tag"
-							selectedTags={field.state.value.map((name) => ({ id: name, name }))}
+							selectedTags={field.state.value.map((name) => ({
+								id: name,
+								name,
+							}))}
 						/>
 					</Field>
 				)}

--- a/apps/web/src/stores/components/tournament-form.tsx
+++ b/apps/web/src/stores/components/tournament-form.tsx
@@ -1,6 +1,7 @@
 import { IconPlus, IconTrash } from "@tabler/icons-react";
+import { useForm } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import z from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
@@ -20,13 +21,6 @@ const GAME_VARIANTS = {
 } as const;
 
 const TABLE_SIZES = [2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
-
-interface ChipPurchaseFormItem {
-	chips: number;
-	cost: number;
-	name: string;
-	uid: string;
-}
 
 export interface TournamentFormValues {
 	bountyAmount?: number;
@@ -51,309 +45,463 @@ interface TournamentFormProps {
 	onSubmit: (values: TournamentFormValues) => void;
 }
 
-function parseOptionalInt(value: string): number | undefined {
-	if (!value) {
-		return undefined;
-	}
-	const parsed = Number.parseInt(value, 10);
-	return Number.isNaN(parsed) ? undefined : parsed;
-}
+const chipPurchaseSchema = z.object({
+	name: z.string(),
+	cost: z.coerce.number().min(0, "Cost must be 0 or greater"),
+	chips: z.coerce.number().min(0, "Chips must be 0 or greater"),
+	uid: z.string(),
+});
 
-function emptyChipPurchase(): ChipPurchaseFormItem {
-	return { name: "", cost: 0, chips: 0, uid: crypto.randomUUID() };
-}
+const tournamentFormSchema = z.object({
+	name: z
+		.string()
+		.min(1, "Tournament name is required")
+		.max(100, "Tournament name must be 100 characters or less"),
+	variant: z.string().min(1, "Variant is required"),
+	buyIn: z.coerce.number().min(0, "Must be 0 or greater").optional(),
+	entryFee: z.coerce.number().min(0, "Must be 0 or greater").optional(),
+	startingStack: z.coerce.number().min(0, "Must be 0 or greater").optional(),
+	chipPurchases: z.array(chipPurchaseSchema),
+	bountyAmount: z.coerce.number().min(0, "Must be 0 or greater").optional(),
+	tableSize: z.coerce.number().min(0, "Must be 0 or greater").optional(),
+	currencyId: z.string().optional(),
+	memo: z.string().max(10_000, "Memo must be 10,000 characters or less").optional(),
+	tags: z.array(z.string()).optional(),
+});
 
 export function TournamentForm({
 	onSubmit,
 	defaultValues,
 	isLoading = false,
 }: TournamentFormProps) {
-	const [tags, setTags] = useState<string[]>(defaultValues?.tags ?? []);
-	const [chipPurchases, setChipPurchases] = useState<ChipPurchaseFormItem[]>(
-		() =>
-			(defaultValues?.chipPurchases ?? []).map((cp) => ({
-				...cp,
-				uid: crypto.randomUUID(),
-			}))
-	);
-
 	const currenciesQuery = useQuery(trpc.currency.list.queryOptions());
 	const currencies = currenciesQuery.data ?? [];
 
-	const addChipPurchase = () => {
-		setChipPurchases((prev) => [...prev, emptyChipPurchase()]);
-	};
-
-	const removeChipPurchase = (index: number) => {
-		setChipPurchases((prev) => prev.filter((_, i) => i !== index));
-	};
-
-	const updateChipPurchase = (
-		index: number,
-		field: keyof ChipPurchaseFormItem,
-		value: string
-	) => {
-		setChipPurchases((prev) =>
-			prev.map((cp, i) => {
-				if (i !== index) {
-					return cp;
-				}
-				if (field === "name") {
-					return { ...cp, name: value };
-				}
-				const parsed = Number.parseInt(value, 10);
-				return { ...cp, [field]: Number.isNaN(parsed) ? 0 : parsed };
-			})
-		);
-	};
-
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		const formData = new FormData(e.currentTarget);
-
-		const values: TournamentFormValues = {
-			name: formData.get("name") as string,
-			variant: (formData.get("variant") as string) || "nlh",
-			buyIn: parseOptionalInt(formData.get("buyIn") as string),
-			entryFee: parseOptionalInt(formData.get("entryFee") as string),
-			startingStack: parseOptionalInt(formData.get("startingStack") as string),
-			chipPurchases: chipPurchases.map((cp) => ({
-				name: cp.name,
-				cost: cp.cost,
-				chips: cp.chips,
-			})),
-			bountyAmount: parseOptionalInt(formData.get("bountyAmount") as string),
-			tableSize: parseOptionalInt(formData.get("tableSize") as string),
-			currencyId: (formData.get("currencyId") as string) || undefined,
-			memo: (formData.get("memo") as string) || undefined,
-			tags,
-		};
-
-		onSubmit(values);
-	};
+	const form = useForm({
+		defaultValues: {
+			name: defaultValues?.name ?? "",
+			variant: defaultValues?.variant ?? "nlh",
+			buyIn: defaultValues?.buyIn ?? (undefined as number | undefined),
+			entryFee: defaultValues?.entryFee ?? (undefined as number | undefined),
+			startingStack: defaultValues?.startingStack ?? (undefined as number | undefined),
+			chipPurchases: (defaultValues?.chipPurchases ?? []).map((cp) => ({
+				...cp,
+				uid: crypto.randomUUID(),
+			})) as Array<{ name: string; cost: number; chips: number; uid: string }>,
+			bountyAmount: defaultValues?.bountyAmount ?? (undefined as number | undefined),
+			tableSize: defaultValues?.tableSize ?? (undefined as number | undefined),
+			currencyId: defaultValues?.currencyId ?? "",
+			memo: defaultValues?.memo ?? "",
+			tags: defaultValues?.tags ?? ([] as string[]),
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				name: value.name,
+				variant: value.variant || "nlh",
+				buyIn: value.buyIn,
+				entryFee: value.entryFee,
+				startingStack: value.startingStack,
+				chipPurchases: value.chipPurchases.map(({ name, cost, chips }) => ({
+					name,
+					cost,
+					chips,
+				})),
+				bountyAmount: value.bountyAmount,
+				tableSize: value.tableSize,
+				currencyId: value.currencyId || undefined,
+				memo: value.memo || undefined,
+				tags: value.tags,
+			});
+		},
+		validators: {
+			onSubmit: tournamentFormSchema,
+		},
+	});
 
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-			<Field htmlFor="name" label="Tournament Name" required>
-				<Input
-					defaultValue={defaultValues?.name}
-					id="name"
-					name="name"
-					placeholder="e.g. Sunday Main Event"
-					required
-				/>
-			</Field>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="name">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Tournament Name"
+						required
+					>
+						<Input
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="e.g. Sunday Main Event"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
 
-			<Field htmlFor="variant" label="Variant" required>
-				<Select defaultValue={defaultValues?.variant ?? "nlh"} name="variant">
-					<SelectTrigger className="w-full" id="variant">
-						<SelectValue placeholder="Select variant" />
-					</SelectTrigger>
-					<SelectContent>
-						{Object.entries(GAME_VARIANTS).map(([key, val]) => (
-							<SelectItem key={key} value={key}>
-								{val.label}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-			</Field>
+			<form.Field name="variant">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Variant"
+						required
+					>
+						<Select
+							name={field.name}
+							onValueChange={(value) => field.handleChange(value)}
+							value={field.state.value}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue placeholder="Select variant" />
+							</SelectTrigger>
+							<SelectContent>
+								{Object.entries(GAME_VARIANTS).map(([key, val]) => (
+									<SelectItem key={key} value={key}>
+										{val.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
 
 			<div className="grid grid-cols-2 gap-3">
-				<Field htmlFor="buyIn" label="Buy-In">
-					<Input
-						defaultValue={defaultValues?.buyIn}
-						id="buyIn"
-						inputMode="numeric"
-						min={0}
-						name="buyIn"
-						placeholder="0"
-						type="number"
-					/>
-				</Field>
-				<Field htmlFor="entryFee" label="Entry Fee">
-					<Input
-						defaultValue={defaultValues?.entryFee}
-						id="entryFee"
-						inputMode="numeric"
-						min={0}
-						name="entryFee"
-						placeholder="0"
-						type="number"
-					/>
-				</Field>
+				<form.Field name="buyIn">
+					{(field) => (
+						<Field
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label="Buy-In"
+						>
+							<Input
+								id={field.name}
+								inputMode="numeric"
+								min={0}
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) =>
+									field.handleChange(
+										e.target.value === "" ? undefined : Number(e.target.value)
+									)
+								}
+								placeholder="0"
+								type="number"
+								value={field.state.value !== undefined ? String(field.state.value) : ""}
+							/>
+						</Field>
+					)}
+				</form.Field>
+				<form.Field name="entryFee">
+					{(field) => (
+						<Field
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label="Entry Fee"
+						>
+							<Input
+								id={field.name}
+								inputMode="numeric"
+								min={0}
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) =>
+									field.handleChange(
+										e.target.value === "" ? undefined : Number(e.target.value)
+									)
+								}
+								placeholder="0"
+								type="number"
+								value={field.state.value !== undefined ? String(field.state.value) : ""}
+							/>
+						</Field>
+					)}
+				</form.Field>
 			</div>
 
-			<Field htmlFor="startingStack" label="Starting Stack">
-				<Input
-					defaultValue={defaultValues?.startingStack}
-					id="startingStack"
-					inputMode="numeric"
-					min={0}
-					name="startingStack"
-					placeholder="0"
-					type="number"
-				/>
-			</Field>
-
-			<Field
-				className="rounded-md border p-3"
-				description="Define optional rebuy or addon structures used during play."
-				label="Chip Purchases"
-			>
-				<div className="flex items-center justify-between">
-					<Button
-						onClick={addChipPurchase}
-						size="xs"
-						type="button"
-						variant="outline"
+			<form.Field name="startingStack">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Starting Stack"
 					>
-						<IconPlus size={12} />
-						Add
-					</Button>
-				</div>
-				{chipPurchases.length > 0 && (
-					<div className="flex flex-col gap-2">
-						{chipPurchases.map((cp, index) => (
-							<div className="flex items-end gap-2" key={cp.uid}>
-								<Field
-									className="flex flex-1 flex-col gap-1"
-									htmlFor={`cp-name-${index}`}
-									label="Name"
-								>
-									<Input
-										id={`cp-name-${index}`}
-										onChange={(e) =>
-											updateChipPurchase(index, "name", e.target.value)
-										}
-										placeholder="e.g. Rebuy"
-										value={cp.name}
-									/>
-								</Field>
-								<Field
-									className="flex w-20 flex-col gap-1"
-									htmlFor={`cp-cost-${index}`}
-									label="Cost"
-								>
-									<Input
-										id={`cp-cost-${index}`}
-										inputMode="numeric"
-										min={0}
-										onChange={(e) =>
-											updateChipPurchase(index, "cost", e.target.value)
-										}
-										placeholder="0"
-										type="number"
-										value={cp.cost}
-									/>
-								</Field>
-								<Field
-									className="flex w-20 flex-col gap-1"
-									htmlFor={`cp-chips-${index}`}
-									label="Chips"
-								>
-									<Input
-										id={`cp-chips-${index}`}
-										inputMode="numeric"
-										min={0}
-										onChange={(e) =>
-											updateChipPurchase(index, "chips", e.target.value)
-										}
-										placeholder="0"
-										type="number"
-										value={cp.chips}
-									/>
-								</Field>
-								<Button
-									aria-label="Remove chip purchase"
-									onClick={() => removeChipPurchase(index)}
-									size="icon-xs"
-									type="button"
-									variant="ghost"
-								>
-									<IconTrash size={12} />
-								</Button>
-							</div>
-						))}
-					</div>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							min={0}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) =>
+								field.handleChange(
+									e.target.value === "" ? undefined : Number(e.target.value)
+								)
+							}
+							placeholder="0"
+							type="number"
+							value={field.state.value !== undefined ? String(field.state.value) : ""}
+						/>
+					</Field>
 				)}
-			</Field>
+			</form.Field>
 
-			<Field htmlFor="bountyAmount" label="Bounty Amount">
-				<Input
-					defaultValue={defaultValues?.bountyAmount}
-					id="bountyAmount"
-					inputMode="numeric"
-					min={0}
-					name="bountyAmount"
-					placeholder="0"
-					type="number"
-				/>
-			</Field>
+			<form.Field name="chipPurchases">
+				{(field) => (
+					<Field
+						className="rounded-md border p-3"
+						description="Define optional rebuy or addon structures used during play."
+						label="Chip Purchases"
+					>
+						<div className="flex items-center justify-between">
+							<Button
+								onClick={() =>
+									field.handleChange([
+										...field.state.value,
+										{ name: "", cost: 0, chips: 0, uid: crypto.randomUUID() },
+									])
+								}
+								size="xs"
+								type="button"
+								variant="outline"
+							>
+								<IconPlus size={12} />
+								Add
+							</Button>
+						</div>
+						{field.state.value.length > 0 && (
+							<div className="flex flex-col gap-2">
+								{field.state.value.map((cp, index) => (
+									<div className="flex items-end gap-2" key={cp.uid}>
+										<Field
+											className="flex flex-1 flex-col gap-1"
+											htmlFor={`cp-name-${cp.uid}`}
+											label="Name"
+										>
+											<Input
+												id={`cp-name-${cp.uid}`}
+												onChange={(e) => {
+													const updated = field.state.value.map((item, i) =>
+														i === index ? { ...item, name: e.target.value } : item
+													);
+													field.handleChange(updated);
+												}}
+												placeholder="e.g. Rebuy"
+												value={cp.name}
+											/>
+										</Field>
+										<Field
+											className="flex w-20 flex-col gap-1"
+											htmlFor={`cp-cost-${cp.uid}`}
+											label="Cost"
+										>
+											<Input
+												id={`cp-cost-${cp.uid}`}
+												inputMode="numeric"
+												min={0}
+												onChange={(e) => {
+													const parsed = Number.parseInt(e.target.value, 10);
+													const updated = field.state.value.map((item, i) =>
+														i === index
+															? { ...item, cost: Number.isNaN(parsed) ? 0 : parsed }
+															: item
+													);
+													field.handleChange(updated);
+												}}
+												placeholder="0"
+												type="number"
+												value={cp.cost}
+											/>
+										</Field>
+										<Field
+											className="flex w-20 flex-col gap-1"
+											htmlFor={`cp-chips-${cp.uid}`}
+											label="Chips"
+										>
+											<Input
+												id={`cp-chips-${cp.uid}`}
+												inputMode="numeric"
+												min={0}
+												onChange={(e) => {
+													const parsed = Number.parseInt(e.target.value, 10);
+													const updated = field.state.value.map((item, i) =>
+														i === index
+															? { ...item, chips: Number.isNaN(parsed) ? 0 : parsed }
+															: item
+													);
+													field.handleChange(updated);
+												}}
+												placeholder="0"
+												type="number"
+												value={cp.chips}
+											/>
+										</Field>
+										<Button
+											aria-label="Remove chip purchase"
+											onClick={() => {
+												field.handleChange(
+													field.state.value.filter((_, i) => i !== index)
+												);
+											}}
+											size="icon-xs"
+											type="button"
+											variant="ghost"
+										>
+											<IconTrash size={12} />
+										</Button>
+									</div>
+								))}
+							</div>
+						)}
+					</Field>
+				)}
+			</form.Field>
 
-			<Field htmlFor="tableSize" label="Table Size">
-				<Select
-					defaultValue={defaultValues?.tableSize?.toString()}
-					name="tableSize"
-				>
-					<SelectTrigger className="w-full" id="tableSize">
-						<SelectValue placeholder="Select table size" />
-					</SelectTrigger>
-					<SelectContent>
-						{TABLE_SIZES.map((size) => (
-							<SelectItem key={size} value={size.toString()}>
-								{size}-max
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-			</Field>
+			<form.Field name="bountyAmount">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Bounty Amount"
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							min={0}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) =>
+								field.handleChange(
+									e.target.value === "" ? undefined : Number(e.target.value)
+								)
+							}
+							placeholder="0"
+							type="number"
+							value={field.state.value !== undefined ? String(field.state.value) : ""}
+						/>
+					</Field>
+				)}
+			</form.Field>
 
-			<Field htmlFor="currencyId" label="Currency">
-				<Select defaultValue={defaultValues?.currencyId} name="currencyId">
-					<SelectTrigger className="w-full" id="currencyId">
-						<SelectValue placeholder="Select currency" />
-					</SelectTrigger>
-					<SelectContent>
-						{currencies.map((c) => (
-							<SelectItem key={c.id} value={c.id}>
-								{c.name}
-								{c.unit ? ` (${c.unit})` : ""}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-			</Field>
+			<form.Field name="tableSize">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Table Size"
+					>
+						<Select
+							name={field.name}
+							onValueChange={(value) =>
+								field.handleChange(value === "" ? undefined : Number(value))
+							}
+							value={(field.state.value ?? "").toString()}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue placeholder="Select table size" />
+							</SelectTrigger>
+							<SelectContent>
+								{TABLE_SIZES.map((size) => (
+									<SelectItem key={size} value={size.toString()}>
+										{size}-max
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
 
-			<Field htmlFor="memo" label="Memo">
-				<Textarea
-					defaultValue={defaultValues?.memo}
-					id="memo"
-					name="memo"
-					placeholder="Notes about this tournament"
-					rows={4}
-				/>
-			</Field>
+			<form.Field name="currencyId">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Currency"
+					>
+						<Select
+							name={field.name}
+							onValueChange={(value) => field.handleChange(value)}
+							value={field.state.value ?? ""}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue placeholder="Select currency" />
+							</SelectTrigger>
+							<SelectContent>
+								{currencies.map((c) => (
+									<SelectItem key={c.id} value={c.id}>
+										{c.name}
+										{c.unit ? ` (${c.unit})` : ""}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
 
-			<Field label="Tags">
-				<TagInput
-					onAdd={(tag) =>
-						setTags((prev) =>
-							prev.includes(tag.name) ? prev : [...prev, tag.name]
-						)
-					}
-					onCreateTag={async (name) => ({ id: name, name })}
-					onRemove={(tag) =>
-						setTags((prev) => prev.filter((t) => t !== tag.name))
-					}
-					placeholder="Add a tag"
-					selectedTags={tags.map((name) => ({ id: name, name }))}
-				/>
-			</Field>
+			<form.Field name="memo">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Memo"
+					>
+						<Textarea
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="Notes about this tournament"
+							rows={4}
+							value={field.state.value ?? ""}
+						/>
+					</Field>
+				)}
+			</form.Field>
 
-			<Button disabled={isLoading} type="submit">
-				{isLoading ? "Saving..." : "Save"}
-			</Button>
+			<form.Field name="tags">
+				{(field) => (
+					<Field label="Tags">
+						<TagInput
+							onAdd={(tag) =>
+								field.handleChange(
+									field.state.value.includes(tag.name)
+										? field.state.value
+										: [...field.state.value, tag.name]
+								)
+							}
+							onCreateTag={async (name) => ({ id: name, name })}
+							onRemove={(tag) =>
+								field.handleChange(
+									field.state.value.filter((t) => t !== tag.name)
+								)
+							}
+							placeholder="Add a tag"
+							selectedTags={field.state.value.map((name) => ({ id: name, name }))}
+						/>
+					</Field>
+				)}
+			</form.Field>
+
+			<form.Subscribe>
+				{(state) => (
+					<Button
+						disabled={isLoading || !state.canSubmit || state.isSubmitting}
+						type="submit"
+					>
+						{isLoading || state.isSubmitting ? "Saving..." : "Save"}
+					</Button>
+				)}
+			</form.Subscribe>
 		</form>
 	);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -52,7 +52,6 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@fontsource-variable/geist-mono": "^5.2.7",
-        "@hookform/resolvers": "^5.2.2",
         "@sapphire2/api": "workspace:*",
         "@sapphire2/auth": "workspace:*",
         "@sapphire2/env": "workspace:*",
@@ -564,8 +563,6 @@
 
     "@hono/trpc-server": ["@hono/trpc-server@0.4.2", "", { "peerDependencies": { "@trpc/server": "^10.10.0 || >11.0.0-rc", "hono": ">=4.0.0" } }, "sha512-3TDrc42CZLgcTFkXQba+y7JlRWRiyw1AqhLqztWyNS2IFT+3bHld0lxKdGBttCtGKHYx0505dM67RMazjhdZqw=="],
 
-    "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
-
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
@@ -913,8 +910,6 @@
     "@speed-highlight/core": ["@speed-highlight/core@1.2.14", "", {}, "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@surma/rollup-plugin-off-main-thread": ["@surma/rollup-plugin-off-main-thread@2.2.3", "", { "dependencies": { "ejs": "^3.1.6", "json5": "^2.2.0", "magic-string": "^0.25.0", "string.prototype.matchall": "^4.0.6" } }, "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ=="],
 
@@ -1933,8 +1928,6 @@
     "react-draggable": ["react-draggable@4.5.0", "", { "dependencies": { "clsx": "^2.1.1", "prop-types": "^15.8.1" }, "peerDependencies": { "react": ">= 16.3.0", "react-dom": ">= 16.3.0" } }, "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw=="],
 
     "react-grid-layout": ["react-grid-layout@1.5.3", "", { "dependencies": { "clsx": "^2.1.1", "fast-equals": "^4.0.3", "prop-types": "^15.8.1", "react-draggable": "^4.4.6", "react-resizable": "^3.0.5", "resize-observer-polyfill": "^1.5.1" }, "peerDependencies": { "react": ">= 16.3.0", "react-dom": ">= 16.3.0" } }, "sha512-KaG6IbjD6fYhagUtIvOzhftXG+ViKZjCjADe86X1KHl7C/dsBN2z0mi14nbvZKTkp0RKiil9RPcJBgq3LnoA8g=="],
-
-    "react-hook-form": ["react-hook-form@7.71.2", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 


### PR DESCRIPTION
## Summary

Closes #71 — migrates **all 14 form components** to TanStack Form (@tanstack/react-form) with comprehensive Zod validation.

## Changes

**All Forms Migrated (14 total):**

Core CRUD:
- CurrencyForm, StoreForm, RingGameForm, TournamentForm

Session management:
- CreateCashGameSessionForm, CreateTournamentSessionForm
- TournamentCompleteForm, CashGameCompleteForm
- TournamentStackForm, CashGameStackForm
- TournamentInfoForm, TransactionForm

Utility forms:
- TagNameForm

Most complex form:
- **SessionForm** — full rewrite using discriminated union Zod schema (`cashGameSchema | tournamentSchema`), all state moved into TanStack Form store, form.reset() preserves shared fields on session type switch, external API unchanged

**Child component updates:**
- `CashGameFields` — now accepts controlled value/onChange props
- `TournamentPrimaryFields` / `TournamentDetailFields` — now accept controlled props

**Dependency cleanup:**
- Removed unused `@hookform/resolvers` dependency

## Consistent patterns across all forms

- `useForm` from `@tanstack/react-form`
- Zod schemas with descriptive validation messages
- `form.Field` render-prop pattern
- `form.Subscribe` for button disabled states
- Error display via `field.state.meta.errors[0]?.message`

## Test plan

- [ ] Submit each form with valid data — verify submission succeeds
- [ ] Submit each form with invalid/empty required fields — verify error messages appear
- [ ] Verify session type toggle in SessionForm preserves shared fields (date, times, store, tags, memo)
- [ ] Verify ring game auto-fill populates variant/blind/ante/currency fields
- [ ] Verify tournament auto-fill populates buyIn/entryFee/startingStack fields
- [ ] TypeScript: `tsc --noEmit --skipLibCheck` passes with no source errors

https://claude.ai/code/session_01AqWE2yqwEqgx6ir8Ns7Kqs