### PR TITLE
fix: トーナメント完了モーダルにbeforeDeadlineチェックボックスを追加

### DIFF
--- a/apps/web/src/__tests__/tournament-lifecycle.test.tsx
+++ b/apps/web/src/__tests__/tournament-lifecycle.test.tsx
@@ -688,19 +688,18 @@ describe("TournamentCompleteForm — complete dialog fields", () => {
 		expect(button).toBeDisabled();
 	});
 
-	it("placement input has min=1 and is required", () => {
+	it("placement input has numeric inputMode", () => {
 		render(<TournamentCompleteForm isLoading={false} onSubmit={vi.fn()} />);
 
 		const input = screen.getByLabelText(REGEX_PLACEMENT_LABEL);
-		expect(input).toHaveAttribute("min", "1");
-		expect(input).toBeRequired();
+		expect(input).toHaveAttribute("inputMode", "numeric");
 	});
 
 	it("prizeMoney input has defaultValue of 0", () => {
 		render(<TournamentCompleteForm isLoading={false} onSubmit={vi.fn()} />);
 
 		const input = screen.getByLabelText(REGEX_PRIZE_MONEY_LABEL);
-		expect(input).toHaveValue(0);
+		expect(input).toHaveValue("0");
 	});
 });
 

--- a/apps/web/src/live-sessions/components/tournament-complete-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-complete-form.tsx
@@ -1,7 +1,10 @@
+import { useState } from "react";
 import { Button } from "@/shared/components/ui/button";
+import { Checkbox } from "@/shared/components/ui/checkbox";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
+import { Label } from "@/shared/components/ui/label";
 
 interface TournamentCompleteFormProps {
 	isLoading: boolean;
@@ -26,49 +29,68 @@ export function TournamentCompleteForm({
 	isLoading,
 	onSubmit,
 }: TournamentCompleteFormProps) {
+	const [beforeDeadline, setBeforeDeadline] = useState(false);
+
 	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		const formData = new FormData(e.currentTarget);
-		const placement = Number(formData.get("placement"));
-		const totalEntries = Number(formData.get("totalEntries"));
 		const prizeMoney = Number(formData.get("prizeMoney"));
 		const bountyRaw = formData.get("bountyPrizes") as string;
 		const bountyPrizes = bountyRaw ? Number(bountyRaw) : 0;
 
-		onSubmit({
-			beforeDeadline: false,
-			placement,
-			totalEntries,
-			prizeMoney,
-			bountyPrizes,
-		});
+		if (beforeDeadline) {
+			onSubmit({ beforeDeadline: true, prizeMoney, bountyPrizes });
+		} else {
+			const placement = Number(formData.get("placement"));
+			const totalEntries = Number(formData.get("totalEntries"));
+			onSubmit({
+				beforeDeadline: false,
+				placement,
+				totalEntries,
+				prizeMoney,
+				bountyPrizes,
+			});
+		}
 	};
 
 	return (
 		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-			<Field htmlFor="placement" label="Placement" required>
-				<Input
-					id="placement"
-					inputMode="numeric"
-					min={1}
-					name="placement"
-					placeholder="1"
-					required
-					type="number"
+			<div className="flex items-center gap-2">
+				<Checkbox
+					checked={beforeDeadline}
+					id="beforeDeadline"
+					onCheckedChange={(checked) => setBeforeDeadline(checked === true)}
 				/>
-			</Field>
+				<Label htmlFor="beforeDeadline">レジストクローズ前に完了</Label>
+			</div>
 
-			<Field htmlFor="totalEntries" label="Total Entries" required>
-				<Input
-					id="totalEntries"
-					inputMode="numeric"
-					min={1}
-					name="totalEntries"
-					placeholder="100"
-					required
-					type="number"
-				/>
-			</Field>
+			{!beforeDeadline && (
+				<div className="grid grid-cols-2 gap-4">
+					<Field htmlFor="placement" label="Placement" required>
+						<Input
+							id="placement"
+							inputMode="numeric"
+							min={1}
+							name="placement"
+							placeholder="1"
+							required
+							type="number"
+						/>
+					</Field>
+
+					<Field htmlFor="totalEntries" label="Total Entries" required>
+						<Input
+							id="totalEntries"
+							inputMode="numeric"
+							min={1}
+							name="totalEntries"
+							placeholder="100"
+							required
+							type="number"
+						/>
+					</Field>
+				</div>
+			)}
 
 			<Field htmlFor="prizeMoney" label="Prize Money" required>
 				<Input

--- a/apps/web/src/live-sessions/components/tournament-complete-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-complete-form.tsx
@@ -1,10 +1,16 @@
+import { useForm } from "@tanstack/react-form";
 import { useState } from "react";
+import { z } from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { Checkbox } from "@/shared/components/ui/checkbox";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
 import { Label } from "@/shared/components/ui/label";
+import {
+	optionalNumericString,
+	requiredNumericString,
+} from "@/shared/lib/form-fields";
 
 interface TournamentCompleteFormProps {
 	isLoading: boolean;
@@ -25,36 +31,64 @@ interface TournamentCompleteFormProps {
 	) => void;
 }
 
+const afterDeadlineSchema = z.object({
+	placement: requiredNumericString({ integer: true, min: 1 }),
+	totalEntries: requiredNumericString({ integer: true, min: 1 }),
+	prizeMoney: requiredNumericString({ integer: true, min: 0 }),
+	bountyPrizes: optionalNumericString({ integer: true, min: 0 }),
+});
+
+const beforeDeadlineSchema = z.object({
+	placement: z.string(),
+	totalEntries: z.string(),
+	prizeMoney: requiredNumericString({ integer: true, min: 0 }),
+	bountyPrizes: optionalNumericString({ integer: true, min: 0 }),
+});
+
 export function TournamentCompleteForm({
 	isLoading,
 	onSubmit,
 }: TournamentCompleteFormProps) {
 	const [beforeDeadline, setBeforeDeadline] = useState(false);
 
-	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-		const formData = new FormData(e.currentTarget);
-		const prizeMoney = Number(formData.get("prizeMoney"));
-		const bountyRaw = formData.get("bountyPrizes") as string;
-		const bountyPrizes = bountyRaw ? Number(bountyRaw) : 0;
-
-		if (beforeDeadline) {
-			onSubmit({ beforeDeadline: true, prizeMoney, bountyPrizes });
-		} else {
-			const placement = Number(formData.get("placement"));
-			const totalEntries = Number(formData.get("totalEntries"));
-			onSubmit({
-				beforeDeadline: false,
-				placement,
-				totalEntries,
-				prizeMoney,
-				bountyPrizes,
-			});
-		}
-	};
+	const form = useForm({
+		defaultValues: {
+			placement: "",
+			totalEntries: "",
+			prizeMoney: "0",
+			bountyPrizes: "",
+		},
+		validators: {
+			onSubmit: beforeDeadline ? beforeDeadlineSchema : afterDeadlineSchema,
+		},
+		onSubmit: ({ value }) => {
+			if (beforeDeadline) {
+				onSubmit({
+					beforeDeadline: true,
+					prizeMoney: Number(value.prizeMoney),
+					bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
+				});
+			} else {
+				onSubmit({
+					beforeDeadline: false,
+					placement: Number(value.placement),
+					totalEntries: Number(value.totalEntries),
+					prizeMoney: Number(value.prizeMoney),
+					bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
+				});
+			}
+		},
+	});
 
 	return (
-		<form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
 			<div className="flex items-center gap-2">
 				<Checkbox
 					checked={beforeDeadline}
@@ -68,60 +102,104 @@ export function TournamentCompleteForm({
 
 			{!beforeDeadline && (
 				<div className="grid grid-cols-2 gap-4">
-					<Field htmlFor="placement" label="Placement" required>
-						<Input
-							id="placement"
-							inputMode="numeric"
-							min={1}
-							name="placement"
-							placeholder="1"
-							required
-							type="number"
-						/>
-					</Field>
+					<form.Field name="placement">
+						{(field) => (
+							<Field
+								error={field.state.meta.errors[0]?.message}
+								htmlFor={field.name}
+								label="Placement"
+								required
+							>
+								<Input
+									id={field.name}
+									inputMode="numeric"
+									name={field.name}
+									onBlur={field.handleBlur}
+									onChange={(e) => field.handleChange(e.target.value)}
+									placeholder="1"
+									value={field.state.value}
+								/>
+							</Field>
+						)}
+					</form.Field>
 
-					<Field htmlFor="totalEntries" label="Total Entries" required>
-						<Input
-							id="totalEntries"
-							inputMode="numeric"
-							min={1}
-							name="totalEntries"
-							placeholder="100"
-							required
-							type="number"
-						/>
-					</Field>
+					<form.Field name="totalEntries">
+						{(field) => (
+							<Field
+								error={field.state.meta.errors[0]?.message}
+								htmlFor={field.name}
+								label="Total Entries"
+								required
+							>
+								<Input
+									id={field.name}
+									inputMode="numeric"
+									name={field.name}
+									onBlur={field.handleBlur}
+									onChange={(e) => field.handleChange(e.target.value)}
+									placeholder="100"
+									value={field.state.value}
+								/>
+							</Field>
+						)}
+					</form.Field>
 				</div>
 			)}
 
-			<Field htmlFor="prizeMoney" label="Prize Money" required>
-				<Input
-					defaultValue={0}
-					id="prizeMoney"
-					inputMode="numeric"
-					min={0}
-					name="prizeMoney"
-					placeholder="0"
-					required
-					type="number"
-				/>
-			</Field>
+			<form.Field name="prizeMoney">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Prize Money"
+						required
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="0"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
 
-			<Field htmlFor="bountyPrizes" label="Bounty Prizes">
-				<Input
-					id="bountyPrizes"
-					inputMode="numeric"
-					min={0}
-					name="bountyPrizes"
-					placeholder="0"
-					type="number"
-				/>
-			</Field>
+			<form.Field name="bountyPrizes">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Bounty Prizes"
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="0"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
 
 			<DialogActionRow>
-				<Button disabled={isLoading} type="submit">
-					{isLoading ? "Completing..." : "Complete Tournament"}
-				</Button>
+				<form.Subscribe
+					selector={(state) => [state.canSubmit, state.isSubmitting]}
+				>
+					{([canSubmit, isSubmitting]) => (
+						<Button
+							disabled={isLoading || !canSubmit || isSubmitting}
+							type="submit"
+						>
+							{isLoading ? "Completing..." : "Complete Tournament"}
+						</Button>
+					)}
+				</form.Subscribe>
 			</DialogActionRow>
 		</form>
 	);

--- a/apps/web/src/live-sessions/components/tournament-complete-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-complete-form.tsx
@@ -61,7 +61,7 @@ export function TournamentCompleteForm({
 					id="beforeDeadline"
 					onCheckedChange={(checked) => setBeforeDeadline(checked === true)}
 				/>
-				<Label htmlFor="beforeDeadline">レジストクローズ前に完了</Label>
+				<Label htmlFor="beforeDeadline">Completed before registration closes</Label>
 			</div>
 
 			{!beforeDeadline && (

--- a/apps/web/src/live-sessions/components/tournament-complete-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-complete-form.tsx
@@ -61,7 +61,9 @@ export function TournamentCompleteForm({
 					id="beforeDeadline"
 					onCheckedChange={(checked) => setBeforeDeadline(checked === true)}
 				/>
-				<Label htmlFor="beforeDeadline">Completed before registration closes</Label>
+				<Label htmlFor="beforeDeadline">
+					Completed before registration closes
+				</Label>
 			</div>
 
 			{!beforeDeadline && (

--- a/apps/web/src/shared/lib/form-fields.ts
+++ b/apps/web/src/shared/lib/form-fields.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+
+interface NumericRules {
+	integer?: boolean;
+	max?: number;
+	min?: number;
+}
+
+function parseNumeric(value: string, integer: boolean) {
+	const trimmed = value.trim();
+	if (trimmed === "") {
+		return Number.NaN;
+	}
+	return integer ? Number.parseInt(trimmed, 10) : Number(trimmed);
+}
+
+function numericStringSchema({
+	required,
+	integer = false,
+	min,
+	max,
+}: NumericRules & { required: boolean }) {
+	return z.string().superRefine((rawValue, ctx) => {
+		const trimmed = rawValue.trim();
+		if (trimmed === "") {
+			if (required) {
+				ctx.addIssue({ code: "custom", message: "Required" });
+			}
+			return;
+		}
+		const parsed = parseNumeric(trimmed, integer);
+		if (!Number.isFinite(parsed)) {
+			ctx.addIssue({ code: "custom", message: "Must be a number" });
+			return;
+		}
+		if (min !== undefined && parsed < min) {
+			ctx.addIssue({ code: "custom", message: `Must be at least ${min}` });
+		}
+		if (max !== undefined && parsed > max) {
+			ctx.addIssue({ code: "custom", message: `Must be at most ${max}` });
+		}
+	});
+}
+
+export function requiredNumericString(rules: NumericRules = {}) {
+	return numericStringSchema({ required: true, ...rules });
+}
+
+export function optionalNumericString(rules: NumericRules = {}) {
+	return numericStringSchema({ required: false, ...rules });
+}
+
+export function parseOptionalInt(value: string): number | undefined {
+	const trimmed = value.trim();
+	if (trimmed === "") {
+		return undefined;
+	}
+	const parsed = Number.parseInt(trimmed, 10);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function parseOptionalNumber(value: string): number | undefined {
+	const trimmed = value.trim();
+	if (trimmed === "") {
+		return undefined;
+	}
+	const parsed = Number(trimmed);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function parseRequiredInt(value: string): number {
+	return parseOptionalInt(value) ?? 0;
+}
+
+export function parseRequiredNumber(value: string): number {
+	return parseOptionalNumber(value) ?? 0;
+}


### PR DESCRIPTION
## Summary

- `tournament-complete-form.tsx` に「レジストクローズ前に完了」チェックボックスを追加
- チェック時は `beforeDeadline: true` ペイロードを送信し、placement・totalEntries フィールドを非表示にする
- チェックなし時は placement と totalEntries を2カラムグリッドで横並び表示（モバイル対応）

Closes #158

## Test plan

- [ ] トーナメントセッションの Complete ボタンを押してモーダルを開く
- [ ] デフォルト状態: placement と totalEntries が横並びで表示される
- [ ] 「レジストクローズ前に完了」チェックボックスをオンにする → placement・totalEntries が非表示になる
- [ ] チェックありで送信 → `beforeDeadline: true` ペイロードが送られること
- [ ] チェックなしで送信 → `beforeDeadline: false` ペイロードが送られること

https://claude.ai/code/session_01S241VXyCnY6Dst5T8EFG3Q