### PR TITLE
refactor: linked accountコンポーネントの改修 (#166)

### DIFF
--- a/apps/web/src/shared/components/linked-accounts.tsx
+++ b/apps/web/src/shared/components/linked-accounts.tsx
@@ -1,5 +1,5 @@
 import { useForm } from "@tanstack/react-form";
-import { Link2, Unlink2 } from "lucide-react";
+import { IconLink, IconUnlink } from "@tabler/icons-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import z from "zod";
@@ -211,9 +211,7 @@ export function LinkedAccounts() {
 			<ManagementList>
 				<ManagementListItem
 					actions={
-						hasCredential ? (
-							<Badge variant="secondary">Linked</Badge>
-						) : (
+						hasCredential ? undefined : (
 							<Button
 								onClick={() => setSetPasswordOpen(true)}
 								size="sm"
@@ -223,7 +221,16 @@ export function LinkedAccounts() {
 							</Button>
 						)
 					}
-					title="Email / Password"
+					title={
+						<span className="flex items-center gap-2">
+							Email / Password
+							{hasCredential ? (
+								<Badge className="border-green-500 text-green-600" variant="outline">
+									Linked
+								</Badge>
+							) : null}
+						</span>
+					}
 				/>
 
 				{PROVIDERS.map((provider) => {
@@ -240,7 +247,7 @@ export function LinkedAccounts() {
 										size="sm"
 										variant="outline"
 									>
-										<Unlink2 />
+										<IconUnlink />
 										Unlink
 									</Button>
 								) : (
@@ -249,7 +256,7 @@ export function LinkedAccounts() {
 										size="sm"
 										variant="outline"
 									>
-										<Link2 />
+										<IconLink />
 										Link
 									</Button>
 								)
@@ -259,7 +266,10 @@ export function LinkedAccounts() {
 							title={
 								<span className="flex items-center gap-2">
 									{provider.label}
-									<Badge variant={isLinked ? "secondary" : "outline"}>
+									<Badge
+										className={isLinked ? "border-green-500 text-green-600" : ""}
+										variant="outline"
+									>
 										{isLinked ? "Linked" : "Not linked"}
 									</Badge>
 								</span>

--- a/apps/web/src/shared/components/linked-accounts.tsx
+++ b/apps/web/src/shared/components/linked-accounts.tsx
@@ -1,4 +1,5 @@
 import { useForm } from "@tanstack/react-form";
+import { Link2, Unlink2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import z from "zod";
@@ -9,6 +10,7 @@ import {
 } from "@/shared/components/management/management-list";
 import { DiscordIcon } from "./icons/discord";
 import { GoogleIcon } from "./icons/google";
+import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { DialogActionRow } from "./ui/dialog-action-row";
 import { Field } from "./ui/field";
@@ -210,7 +212,7 @@ export function LinkedAccounts() {
 				<ManagementListItem
 					actions={
 						hasCredential ? (
-							<span className="text-muted-foreground text-xs">Linked</span>
+							<Badge variant="secondary">Linked</Badge>
 						) : (
 							<Button
 								onClick={() => setSetPasswordOpen(true)}
@@ -220,11 +222,6 @@ export function LinkedAccounts() {
 								Set Password
 							</Button>
 						)
-					}
-					description={
-						hasCredential
-							? "Use your email and password to sign in directly."
-							: "Add a password login alongside your linked social accounts."
 					}
 					title="Email / Password"
 				/>
@@ -243,6 +240,7 @@ export function LinkedAccounts() {
 										size="sm"
 										variant="outline"
 									>
+										<Unlink2 />
 										Unlink
 									</Button>
 								) : (
@@ -251,14 +249,21 @@ export function LinkedAccounts() {
 										size="sm"
 										variant="outline"
 									>
+										<Link2 />
 										Link
 									</Button>
 								)
 							}
-							description={isLinked ? "Linked" : "Not linked"}
 							key={provider.id}
 							leading={provider.icon}
-							title={provider.label}
+							title={
+								<span className="flex items-center gap-2">
+									{provider.label}
+									<Badge variant={isLinked ? "secondary" : "outline"}>
+										{isLinked ? "Linked" : "Not linked"}
+									</Badge>
+								</span>
+							}
 						/>
 					);
 				})}

--- a/apps/web/src/shared/components/linked-accounts.tsx
+++ b/apps/web/src/shared/components/linked-accounts.tsx
@@ -210,6 +210,7 @@ export function LinkedAccounts() {
 		<div className="space-y-3">
 			<ManagementList>
 				<ManagementListItem
+					className="min-h-14"
 					actions={
 						hasCredential ? undefined : (
 							<Button
@@ -239,6 +240,7 @@ export function LinkedAccounts() {
 
 					return (
 						<ManagementListItem
+							className="min-h-14"
 							actions={
 								isLinked ? (
 									<Button

--- a/apps/web/src/shared/components/management/management-list.tsx
+++ b/apps/web/src/shared/components/management/management-list.tsx
@@ -24,14 +24,14 @@ function ManagementListItem({
 }: ManagementListItemProps) {
 	return (
 		<div
-			className={cn("rounded-md border p-3", className)}
+			className={cn("flex items-center rounded-md border p-3", className)}
 			data-slot="management-list-item"
 			{...props}
 		>
-			<div className="flex items-start justify-between gap-3">
+			<div className="flex w-full items-center justify-between gap-3">
 				<div className="min-w-0 flex-1">
-					<div className="flex items-start gap-2">
-						{leading ? <div className="shrink-0 pt-0.5">{leading}</div> : null}
+					<div className="flex items-center gap-2">
+						{leading ? <div className="shrink-0">{leading}</div> : null}
 						<div className="min-w-0 flex-1">
 							<div className="font-medium text-sm">{title}</div>
 							{description ? (


### PR DESCRIPTION
## Summary

- linked/not linked の表示を2段目の description テキストからバッジ (`Badge`) に変更
- Email/Password アイテムのサブテキスト (description) を削除
- Link/Unlink ボタンに `Link2` / `Unlink2` アイコン (lucide-react) を追加

Closes #166

https://claude.ai/code/session_01BWX4bAzZeDXKLNV7dR7DQ6