### PR TITLE
refactor: TransactionFormの改修 (#162)

### DIFF
--- a/apps/web/src/currencies/components/__tests__/transaction-form.test.tsx
+++ b/apps/web/src/currencies/components/__tests__/transaction-form.test.tsx
@@ -98,9 +98,9 @@ describe("TransactionForm", () => {
 			target: { value: "2026-04-05" },
 		});
 
-		await user.click(screen.getByRole("combobox"));
-		await user.click(screen.getByRole("option", { name: "+ New type..." }));
-		await user.type(screen.getByLabelText("New Type Name"), "Manual");
+		const typeCombobox = screen.getByRole("combobox");
+		await user.type(typeCombobox, "Manual");
+		await user.click(screen.getByRole("option", { name: 'Create "Manual"' }));
 		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		expect(mocks.createTypeMutate).toHaveBeenCalledWith({ name: "Manual" });
@@ -111,15 +111,4 @@ describe("TransactionForm", () => {
 			transactionTypeId: "created-manual",
 		});
 	}, 15_000);
-
-	it("calls onCancel when cancel is pressed", async () => {
-		const user = userEvent.setup();
-		const onCancel = vi.fn();
-
-		render(<TransactionForm onCancel={onCancel} onSubmit={vi.fn()} />);
-
-		await user.click(screen.getByRole("button", { name: "Cancel" }));
-
-		expect(onCancel).toHaveBeenCalledOnce();
-	});
 });

--- a/apps/web/src/currencies/components/transaction-form.tsx
+++ b/apps/web/src/currencies/components/transaction-form.tsx
@@ -1,19 +1,21 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTransactionTypes } from "@/currencies/hooks/use-transaction-types";
+import {
+	Command,
+	CommandEmpty,
+	CommandItem,
+	CommandList,
+} from "@/shared/components/ui/command";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/shared/components/ui/select";
+	Popover,
+	PopoverAnchor,
+	PopoverContent,
+} from "@/shared/components/ui/popover";
 import { Textarea } from "@/shared/components/ui/textarea";
-
-const NEW_TYPE_VALUE = "__new__";
 
 interface TransactionFormValues {
 	amount: number;
@@ -25,7 +27,6 @@ interface TransactionFormValues {
 interface TransactionFormProps {
 	defaultValues?: TransactionFormValues;
 	isLoading?: boolean;
-	onCancel?: () => void;
 	onSubmit: (values: TransactionFormValues) => void;
 }
 
@@ -45,17 +46,52 @@ function getButtonLabel(isCreatingType: boolean, isLoading: boolean) {
 
 export function TransactionForm({
 	onSubmit,
-	onCancel,
 	defaultValues,
 	isLoading = false,
 }: TransactionFormProps) {
 	const { types, createType, isCreatingType } = useTransactionTypes();
-	const [selectedType, setSelectedType] = useState(
+	const [typeInput, setTypeInput] = useState("");
+	const [selectedTypeId, setSelectedTypeId] = useState(
 		defaultValues?.transactionTypeId ?? ""
 	);
-	const [newTypeName, setNewTypeName] = useState("");
+	const [isTypeOpen, setIsTypeOpen] = useState(false);
+	const [typeDropdownWidth, setTypeDropdownWidth] = useState<number>();
+	const typeAnchorRef = useRef<HTMLDivElement>(null);
 
-	const isNewType = selectedType === NEW_TYPE_VALUE;
+	useEffect(() => {
+		if (selectedTypeId && !typeInput) {
+			const found = types.find((t) => t.id === selectedTypeId);
+			if (found) {
+				setTypeInput(found.name);
+			}
+		}
+	}, [types, selectedTypeId, typeInput]);
+
+	useEffect(() => {
+		if (!(isTypeOpen && typeAnchorRef.current)) {
+			return;
+		}
+		setTypeDropdownWidth(typeAnchorRef.current.offsetWidth);
+	}, [isTypeOpen]);
+
+	const normalizedTypeInput = typeInput.trim();
+	const filteredTypes = types.filter(
+		(t) =>
+			!normalizedTypeInput ||
+			t.name.toLowerCase().includes(normalizedTypeInput.toLowerCase())
+	);
+	const exactMatchType = types.find(
+		(t) => t.name.toLowerCase() === normalizedTypeInput.toLowerCase()
+	);
+	const canCreateType = Boolean(normalizedTypeInput && !exactMatchType);
+	const shouldShowTypePopover =
+		isTypeOpen && (types.length > 0 || Boolean(normalizedTypeInput));
+
+	const handleSelectType = (type: { id: string; name: string }) => {
+		setSelectedTypeId(type.id);
+		setTypeInput(type.name);
+		setIsTypeOpen(false);
+	};
 
 	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
@@ -64,14 +100,17 @@ export function TransactionForm({
 		const transactedAt = formData.get("transactedAt") as string;
 		const memo = (formData.get("memo") as string) || undefined;
 
-		let transactionTypeId = selectedType;
+		let transactionTypeId = selectedTypeId;
 
-		if (isNewType) {
-			if (!newTypeName.trim()) {
+		if (!transactionTypeId) {
+			if (exactMatchType) {
+				transactionTypeId = exactMatchType.id;
+			} else if (normalizedTypeInput) {
+				const created = await createType(normalizedTypeInput);
+				transactionTypeId = created.id;
+			} else {
 				return;
 			}
-			const created = await createType(newTypeName.trim());
-			transactionTypeId = created.id;
 		}
 
 		onSubmit({ amount, transactionTypeId, transactedAt, memo });
@@ -89,32 +128,77 @@ export function TransactionForm({
 					type="number"
 				/>
 			</Field>
-			<Field htmlFor="transactionTypeId" label="Type" required>
-				<Select onValueChange={setSelectedType} required value={selectedType}>
-					<SelectTrigger className="w-full" id="transactionTypeId">
-						<SelectValue placeholder="Select type..." />
-					</SelectTrigger>
-					<SelectContent>
-						{types.map((t) => (
-							<SelectItem key={t.id} value={t.id}>
-								{t.name}
-							</SelectItem>
-						))}
-						<SelectItem value={NEW_TYPE_VALUE}>+ New type...</SelectItem>
-					</SelectContent>
-				</Select>
+			<Field htmlFor="typeInput" label="Type" required>
+				<Popover
+					modal={false}
+					onOpenChange={setIsTypeOpen}
+					open={shouldShowTypePopover}
+				>
+					<PopoverAnchor asChild>
+						<div ref={typeAnchorRef}>
+							<Input
+								aria-expanded={shouldShowTypePopover}
+								aria-label="Search or create transaction type"
+								autoComplete="off"
+								id="typeInput"
+								onChange={(e) => {
+									setTypeInput(e.target.value);
+									setSelectedTypeId("");
+									setIsTypeOpen(true);
+								}}
+								onFocus={() => setIsTypeOpen(true)}
+								onKeyDown={(e) => {
+									if (e.key === "Escape") {
+										setIsTypeOpen(false);
+									}
+								}}
+								placeholder="Select or create type..."
+								required
+								role="combobox"
+								value={typeInput}
+							/>
+						</div>
+					</PopoverAnchor>
+					{shouldShowTypePopover ? (
+						<PopoverContent
+							align="start"
+							className="p-0"
+							onOpenAutoFocus={(e) => e.preventDefault()}
+							style={typeDropdownWidth ? { width: typeDropdownWidth } : undefined}
+						>
+							<Command shouldFilter={false}>
+								<CommandList>
+									{filteredTypes.length === 0 && !canCreateType ? (
+										<CommandEmpty>No matching types.</CommandEmpty>
+									) : null}
+									{filteredTypes.map((t) => (
+										<CommandItem
+											key={t.id}
+											onMouseDown={(e) => e.preventDefault()}
+											onSelect={() => handleSelectType(t)}
+											value={t.name}
+										>
+											{t.name}
+										</CommandItem>
+									))}
+									{canCreateType ? (
+										<CommandItem
+											onMouseDown={(e) => e.preventDefault()}
+											onSelect={async () => {
+												const created = await createType(normalizedTypeInput);
+												handleSelectType(created);
+											}}
+											value={`create-${normalizedTypeInput}`}
+										>
+											Create &quot;{normalizedTypeInput}&quot;
+										</CommandItem>
+									) : null}
+								</CommandList>
+							</Command>
+						</PopoverContent>
+					) : null}
+				</Popover>
 			</Field>
-			{isNewType && (
-				<Field htmlFor="newTypeName" label="New Type Name">
-					<Input
-						id="newTypeName"
-						onChange={(e) => setNewTypeName(e.target.value)}
-						placeholder="Enter new type name"
-						required
-						value={newTypeName}
-					/>
-				</Field>
-			)}
 			<Field htmlFor="transactedAt" label="Date" required>
 				<Input
 					defaultValue={
@@ -137,11 +221,6 @@ export function TransactionForm({
 				/>
 			</Field>
 			<DialogActionRow>
-				{onCancel ? (
-					<Button onClick={onCancel} type="button" variant="outline">
-						Cancel
-					</Button>
-				) : null}
 				<Button disabled={isLoading || isCreatingType} type="submit">
 					{getButtonLabel(isCreatingType, isLoading)}
 				</Button>

--- a/apps/web/src/routes/currencies/index.tsx
+++ b/apps/web/src/routes/currencies/index.tsx
@@ -218,7 +218,6 @@ function CurrenciesPage() {
 			</ResponsiveDialog>
 
 			<ResponsiveDialog
-				description="Record a manual balance change for this currency."
 				onOpenChange={(open) => {
 					if (!open) {
 						setAddTransactionCurrencyId(null);
@@ -229,13 +228,11 @@ function CurrenciesPage() {
 			>
 				<TransactionForm
 					isLoading={isAddTransactionPending}
-					onCancel={() => setAddTransactionCurrencyId(null)}
 					onSubmit={handleAddTransaction}
 				/>
 			</ResponsiveDialog>
 
 			<ResponsiveDialog
-				description="Update the type, amount, date, or memo for this transaction."
 				onOpenChange={(open) => {
 					if (!open) {
 						setEditingTransaction(null);
@@ -256,7 +253,6 @@ function CurrenciesPage() {
 							memo: editingTransaction.memo ?? undefined,
 						}}
 						isLoading={isEditTransactionPending}
-						onCancel={() => setEditingTransaction(null)}
 						onSubmit={handleEditTransaction}
 					/>
 				)}


### PR DESCRIPTION
## Summary

- ダイアログのタイトル下テキスト(description)を削除
- TransactionFormのキャンセルボタンと`onCancel`プロパティを削除
- 種別(Type)入力フィールドをSelect → テキスト入力+ドロップダウン(コンボボックス)に変更
  - 既存タイプをテキストで検索して選択、または新規タイプ名を入力して作成できる形式に変更
  - TagPickerBaseと同じパターンを採用

## Test plan

- [ ] テキスト入力後にドロップダウンが表示され、既存タイプを選択できる
- [ ] 既存タイプに一致しない文字列入力時に「Create "XXX"」オプションが表示され、選択すると新規タイプが作成される
- [ ] キャンセルボタンが非表示になっており、ダイアログのXボタンで閉じられる
- [ ] 編集時(defaultValues)に既存タイプ名がコンボボックスに正しく表示される
- [ ] ダイアログのタイトル下テキストが表示されない

Closes #162

https://claude.ai/code/session_01QgHgzV9rm9qJW8iBw5F86G