### PR TITLE
refactor(TransactionForm): replace Select with combobox, remove cancel button and dialog descriptions

### DIFF
--- a/apps/web/src/__tests__/currencies-route.test.tsx
+++ b/apps/web/src/__tests__/currencies-route.test.tsx
@@ -91,7 +91,6 @@ vi.mock("@/currencies/components/currency-form", () => ({
 vi.mock("@/currencies/components/transaction-form", () => ({
 	TransactionForm: ({
 		defaultValues,
-		onCancel,
 	}: {
 		defaultValues?: {
 			amount: number;
@@ -99,14 +98,10 @@ vi.mock("@/currencies/components/transaction-form", () => ({
 			transactedAt: string;
 			transactionTypeId: string;
 		};
-		onCancel?: () => void;
 	}) => (
 		<div>
 			<div>Transaction Form</div>
 			{defaultValues ? <pre>{JSON.stringify(defaultValues)}</pre> : null}
-			<button onClick={onCancel} type="button">
-				Cancel Transaction
-			</button>
 		</div>
 	),
 }));
@@ -115,11 +110,13 @@ vi.mock("@/shared/components/ui/responsive-dialog", () => ({
 	ResponsiveDialog: ({
 		children,
 		description,
+		onOpenChange,
 		open,
 		title,
 	}: {
 		children: ReactNode;
 		description?: ReactNode;
+		onOpenChange?: (open: boolean) => void;
 		open: boolean;
 		title: string;
 	}) =>
@@ -127,6 +124,9 @@ vi.mock("@/shared/components/ui/responsive-dialog", () => ({
 			<div>
 				<h2>{title}</h2>
 				{description ? <p>{description}</p> : null}
+				<button onClick={() => onOpenChange?.(false)} type="button">
+					Close Dialog
+				</button>
 				{children}
 			</div>
 		) : null,
@@ -218,9 +218,7 @@ describe("CurrenciesPage", () => {
 			screen.getByRole("heading", { name: "Add Transaction" })
 		).toBeInTheDocument();
 
-		await user.click(
-			screen.getByRole("button", { name: "Cancel Transaction" })
-		);
+		await user.click(screen.getByRole("button", { name: "Close Dialog" }));
 		expect(
 			screen.queryByRole("heading", { name: "Add Transaction" })
 		).not.toBeInTheDocument();

--- a/apps/web/src/currencies/components/__tests__/transaction-form.test.tsx
+++ b/apps/web/src/currencies/components/__tests__/transaction-form.test.tsx
@@ -98,9 +98,10 @@ describe("TransactionForm", () => {
 			target: { value: "2026-04-05" },
 		});
 
-		await user.click(screen.getByRole("combobox"));
-		await user.click(screen.getByRole("option", { name: "+ New type..." }));
-		await user.type(screen.getByLabelText("New Type Name"), "Manual");
+		const typeInput = screen.getByRole("combobox");
+		await user.type(typeInput, "Manual");
+		await user.click(screen.getByRole("option", { name: 'Create "Manual"' }));
+
 		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		expect(mocks.createTypeMutate).toHaveBeenCalledWith({ name: "Manual" });
@@ -111,15 +112,4 @@ describe("TransactionForm", () => {
 			transactionTypeId: "created-manual",
 		});
 	}, 15_000);
-
-	it("calls onCancel when cancel is pressed", async () => {
-		const user = userEvent.setup();
-		const onCancel = vi.fn();
-
-		render(<TransactionForm onCancel={onCancel} onSubmit={vi.fn()} />);
-
-		await user.click(screen.getByRole("button", { name: "Cancel" }));
-
-		expect(onCancel).toHaveBeenCalledOnce();
-	});
 });

--- a/apps/web/src/currencies/components/transaction-form.tsx
+++ b/apps/web/src/currencies/components/transaction-form.tsx
@@ -1,19 +1,21 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTransactionTypes } from "@/currencies/hooks/use-transaction-types";
 import { Button } from "@/shared/components/ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandItem,
+	CommandList,
+} from "@/shared/components/ui/command";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/shared/components/ui/select";
+	Popover,
+	PopoverAnchor,
+	PopoverContent,
+} from "@/shared/components/ui/popover";
 import { Textarea } from "@/shared/components/ui/textarea";
-
-const NEW_TYPE_VALUE = "__new__";
 
 interface TransactionFormValues {
 	amount: number;
@@ -25,7 +27,6 @@ interface TransactionFormValues {
 interface TransactionFormProps {
 	defaultValues?: TransactionFormValues;
 	isLoading?: boolean;
-	onCancel?: () => void;
 	onSubmit: (values: TransactionFormValues) => void;
 }
 
@@ -45,36 +46,60 @@ function getButtonLabel(isCreatingType: boolean, isLoading: boolean) {
 
 export function TransactionForm({
 	onSubmit,
-	onCancel,
 	defaultValues,
 	isLoading = false,
 }: TransactionFormProps) {
 	const { types, createType, isCreatingType } = useTransactionTypes();
-	const [selectedType, setSelectedType] = useState(
+
+	const defaultType = defaultValues?.transactionTypeId
+		? (types.find((t) => t.id === defaultValues.transactionTypeId)?.name ?? "")
+		: "";
+
+	const [typeInput, setTypeInput] = useState(defaultType);
+	const [selectedTypeId, setSelectedTypeId] = useState(
 		defaultValues?.transactionTypeId ?? ""
 	);
-	const [newTypeName, setNewTypeName] = useState("");
+	const [isTypeOpen, setIsTypeOpen] = useState(false);
+	const typeAnchorRef = useRef<HTMLDivElement>(null);
 
-	const isNewType = selectedType === NEW_TYPE_VALUE;
+	const normalizedInput = typeInput.trim();
+	const filteredTypes = types.filter(
+		(t) =>
+			!normalizedInput ||
+			t.name.toLowerCase().includes(normalizedInput.toLowerCase())
+	);
+	const matchingType = types.find(
+		(t) => t.name.toLowerCase() === normalizedInput.toLowerCase()
+	);
+	const canCreate = Boolean(normalizedInput && !matchingType);
+	const shouldRenderPopover =
+		isTypeOpen && (types.length > 0 || Boolean(normalizedInput));
 
-	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+	const handleTypeSelect = (type: { id: string; name: string }) => {
+		setTypeInput(type.name);
+		setSelectedTypeId(type.id);
+		setIsTypeOpen(false);
+	};
+
+	const handleTypeCreate = async () => {
+		if (!normalizedInput) {
+			return;
+		}
+		const created = await createType(normalizedInput);
+		handleTypeSelect(created);
+	};
+
+	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
+		if (!selectedTypeId) {
+			return;
+		}
 		const formData = new FormData(e.currentTarget);
 		const amount = Number(formData.get("amount"));
 		const transactedAt = formData.get("transactedAt") as string;
 		const memo = (formData.get("memo") as string) || undefined;
 
-		let transactionTypeId = selectedType;
-
-		if (isNewType) {
-			if (!newTypeName.trim()) {
-				return;
-			}
-			const created = await createType(newTypeName.trim());
-			transactionTypeId = created.id;
-		}
-
-		onSubmit({ amount, transactionTypeId, transactedAt, memo });
+		onSubmit({ amount, transactionTypeId: selectedTypeId, transactedAt, memo });
 	};
 
 	return (
@@ -89,32 +114,85 @@ export function TransactionForm({
 					type="number"
 				/>
 			</Field>
-			<Field htmlFor="transactionTypeId" label="Type" required>
-				<Select onValueChange={setSelectedType} required value={selectedType}>
-					<SelectTrigger className="w-full" id="transactionTypeId">
-						<SelectValue placeholder="Select type..." />
-					</SelectTrigger>
-					<SelectContent>
-						{types.map((t) => (
-							<SelectItem key={t.id} value={t.id}>
-								{t.name}
-							</SelectItem>
-						))}
-						<SelectItem value={NEW_TYPE_VALUE}>+ New type...</SelectItem>
-					</SelectContent>
-				</Select>
+			<Field label="Type" required>
+				<Popover
+					modal={false}
+					onOpenChange={setIsTypeOpen}
+					open={shouldRenderPopover}
+				>
+					<PopoverAnchor asChild>
+						<div ref={typeAnchorRef}>
+							<Input
+								aria-label="Type"
+								autoComplete="off"
+								onChange={(e) => {
+									setTypeInput(e.target.value);
+									setSelectedTypeId("");
+									setIsTypeOpen(true);
+								}}
+								onFocus={() => setIsTypeOpen(true)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") {
+										e.preventDefault();
+										if (matchingType) {
+											handleTypeSelect(matchingType);
+										} else if (canCreate) {
+											handleTypeCreate().catch(() => undefined);
+										}
+									}
+									if (e.key === "Escape") {
+										setIsTypeOpen(false);
+									}
+								}}
+								placeholder="Select or create type..."
+								role="combobox"
+								value={typeInput}
+							/>
+						</div>
+					</PopoverAnchor>
+					{shouldRenderPopover ? (
+						<PopoverContent
+							align="start"
+							className="p-0"
+							onOpenAutoFocus={(e) => e.preventDefault()}
+							style={
+								typeAnchorRef.current
+									? { width: typeAnchorRef.current.offsetWidth }
+									: undefined
+							}
+						>
+							<Command shouldFilter={false}>
+								<CommandList>
+									{filteredTypes.length === 0 && !canCreate ? (
+										<CommandEmpty>No types found.</CommandEmpty>
+									) : null}
+									{filteredTypes.map((t) => (
+										<CommandItem
+											key={t.id}
+											onMouseDown={(e) => e.preventDefault()}
+											onSelect={() => handleTypeSelect(t)}
+											value={t.name}
+										>
+											{t.name}
+										</CommandItem>
+									))}
+									{canCreate ? (
+										<CommandItem
+											onMouseDown={(e) => e.preventDefault()}
+											onSelect={() => {
+												handleTypeCreate().catch(() => undefined);
+											}}
+											value={`create-${normalizedInput}`}
+										>
+											Create &quot;{normalizedInput}&quot;
+										</CommandItem>
+									) : null}
+								</CommandList>
+							</Command>
+						</PopoverContent>
+					) : null}
+				</Popover>
 			</Field>
-			{isNewType && (
-				<Field htmlFor="newTypeName" label="New Type Name">
-					<Input
-						id="newTypeName"
-						onChange={(e) => setNewTypeName(e.target.value)}
-						placeholder="Enter new type name"
-						required
-						value={newTypeName}
-					/>
-				</Field>
-			)}
 			<Field htmlFor="transactedAt" label="Date" required>
 				<Input
 					defaultValue={
@@ -137,11 +215,6 @@ export function TransactionForm({
 				/>
 			</Field>
 			<DialogActionRow>
-				{onCancel ? (
-					<Button onClick={onCancel} type="button" variant="outline">
-						Cancel
-					</Button>
-				) : null}
 				<Button disabled={isLoading || isCreatingType} type="submit">
 					{getButtonLabel(isCreatingType, isLoading)}
 				</Button>

--- a/apps/web/src/routes/currencies/index.tsx
+++ b/apps/web/src/routes/currencies/index.tsx
@@ -218,7 +218,6 @@ function CurrenciesPage() {
 			</ResponsiveDialog>
 
 			<ResponsiveDialog
-				description="Record a manual balance change for this currency."
 				onOpenChange={(open) => {
 					if (!open) {
 						setAddTransactionCurrencyId(null);
@@ -229,13 +228,11 @@ function CurrenciesPage() {
 			>
 				<TransactionForm
 					isLoading={isAddTransactionPending}
-					onCancel={() => setAddTransactionCurrencyId(null)}
 					onSubmit={handleAddTransaction}
 				/>
 			</ResponsiveDialog>
 
 			<ResponsiveDialog
-				description="Update the type, amount, date, or memo for this transaction."
 				onOpenChange={(open) => {
 					if (!open) {
 						setEditingTransaction(null);
@@ -256,7 +253,6 @@ function CurrenciesPage() {
 							memo: editingTransaction.memo ?? undefined,
 						}}
 						isLoading={isEditTransactionPending}
-						onCancel={() => setEditingTransaction(null)}
 						onSubmit={handleEditTransaction}
 					/>
 				)}


### PR DESCRIPTION
## Summary

Closes #162

- Remove description text below the title in Add/Edit Transaction dialogs
- Remove the cancel button (and `onCancel` prop) from `TransactionForm`; dialogs are dismissed via their own close controls
- Replace the Radix UI `Select` + conditional new-type input with a combobox (text input + Popover/Command dropdown), matching the `TagPickerBase` pattern used for player tags — supports filtering existing types and creating new ones inline

## Test plan

- [ ] All 467 tests pass (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Add Transaction dialog: no description text shown below title
- [ ] Edit Transaction dialog: no description text shown below title
- [ ] TransactionForm: no cancel button visible
- [ ] Type field: typing filters existing types in dropdown
- [ ] Type field: typing a name with no match shows "Create X" option
- [ ] Type field: selecting an existing type sets it correctly on submit
- [ ] Type field: creating a new type calls the mutation and submits the new ID

https://claude.ai/code/session_014i5XkP3CUSrE2o9wQmZebU