### PR TITLE
fix: トーナメント完了モーダルの修正 (#158)

### DIFF
--- a/apps/web/src/live-sessions/components/tournament-complete-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-complete-form.tsx
@@ -1,9 +1,11 @@
 import { useForm } from "@tanstack/react-form";
 import { z } from "zod";
 import { Button } from "@/shared/components/ui/button";
+import { Checkbox } from "@/shared/components/ui/checkbox";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
+import { Label } from "@/shared/components/ui/label";
 import {
 	optionalNumericString,
 	requiredNumericString,
@@ -28,12 +30,36 @@ interface TournamentCompleteFormProps {
 	) => void;
 }
 
-const tournamentCompleteSchema = z.object({
-	placement: requiredNumericString({ integer: true, min: 1 }),
-	totalEntries: requiredNumericString({ integer: true, min: 1 }),
-	prizeMoney: requiredNumericString({ integer: true, min: 0 }),
-	bountyPrizes: optionalNumericString({ integer: true, min: 0 }),
-});
+const tournamentCompleteSchema = z
+	.object({
+		beforeDeadline: z.boolean(),
+		placement: z.string(),
+		totalEntries: z.string(),
+		prizeMoney: requiredNumericString({ integer: true, min: 0 }),
+		bountyPrizes: optionalNumericString({ integer: true, min: 0 }),
+	})
+	.superRefine((data, ctx) => {
+		if (!data.beforeDeadline) {
+			const placementResult = requiredNumericString({
+				integer: true,
+				min: 1,
+			}).safeParse(data.placement);
+			if (!placementResult.success) {
+				for (const issue of placementResult.error.issues) {
+					ctx.addIssue({ ...issue, path: ["placement"] });
+				}
+			}
+			const totalEntriesResult = requiredNumericString({
+				integer: true,
+				min: 1,
+			}).safeParse(data.totalEntries);
+			if (!totalEntriesResult.success) {
+				for (const issue of totalEntriesResult.error.issues) {
+					ctx.addIssue({ ...issue, path: ["totalEntries"] });
+				}
+			}
+		}
+	});
 
 export function TournamentCompleteForm({
 	isLoading,
@@ -41,19 +67,28 @@ export function TournamentCompleteForm({
 }: TournamentCompleteFormProps) {
 	const form = useForm({
 		defaultValues: {
+			beforeDeadline: false,
 			placement: "",
 			totalEntries: "",
 			prizeMoney: "0",
 			bountyPrizes: "",
 		},
 		onSubmit: ({ value }) => {
-			onSubmit({
-				beforeDeadline: false,
-				placement: Number(value.placement),
-				totalEntries: Number(value.totalEntries),
-				prizeMoney: Number(value.prizeMoney),
-				bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
-			});
+			if (value.beforeDeadline) {
+				onSubmit({
+					beforeDeadline: true,
+					prizeMoney: Number(value.prizeMoney),
+					bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
+				});
+			} else {
+				onSubmit({
+					beforeDeadline: false,
+					placement: Number(value.placement),
+					totalEntries: Number(value.totalEntries),
+					prizeMoney: Number(value.prizeMoney),
+					bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
+				});
+			}
 		},
 		validators: {
 			onSubmit: tournamentCompleteSchema,
@@ -69,47 +104,74 @@ export function TournamentCompleteForm({
 				form.handleSubmit();
 			}}
 		>
-			<form.Field name="placement">
-				{(field) => (
-					<Field
-						error={field.state.meta.errors[0]?.message}
-						htmlFor={field.name}
-						label="Placement"
-						required
-					>
-						<Input
-							id={field.name}
-							inputMode="numeric"
-							name={field.name}
-							onBlur={field.handleBlur}
-							onChange={(e) => field.handleChange(e.target.value)}
-							placeholder="1"
-							value={field.state.value}
-						/>
-					</Field>
-				)}
-			</form.Field>
+			<div className="flex items-center gap-2">
+				<form.Field name="beforeDeadline">
+					{(field) => (
+						<>
+							<Checkbox
+								checked={field.state.value}
+								id={field.name}
+								onCheckedChange={(checked) =>
+									field.handleChange(checked === true)
+								}
+							/>
+							<Label htmlFor={field.name}>
+								Completed before registration deadline
+							</Label>
+						</>
+					)}
+				</form.Field>
+			</div>
 
-			<form.Field name="totalEntries">
-				{(field) => (
-					<Field
-						error={field.state.meta.errors[0]?.message}
-						htmlFor={field.name}
-						label="Total Entries"
-						required
-					>
-						<Input
-							id={field.name}
-							inputMode="numeric"
-							name={field.name}
-							onBlur={field.handleBlur}
-							onChange={(e) => field.handleChange(e.target.value)}
-							placeholder="100"
-							value={field.state.value}
-						/>
-					</Field>
-				)}
-			</form.Field>
+			<form.Subscribe selector={(state) => state.values.beforeDeadline}>
+				{(beforeDeadline) =>
+					!beforeDeadline && (
+						<div className="grid grid-cols-2 gap-2">
+							<form.Field name="placement">
+								{(field) => (
+									<Field
+										error={field.state.meta.errors[0]?.message}
+										htmlFor={field.name}
+										label="Placement"
+										required
+									>
+										<Input
+											id={field.name}
+											inputMode="numeric"
+											name={field.name}
+											onBlur={field.handleBlur}
+											onChange={(e) => field.handleChange(e.target.value)}
+											placeholder="1"
+											value={field.state.value}
+										/>
+									</Field>
+								)}
+							</form.Field>
+
+							<form.Field name="totalEntries">
+								{(field) => (
+									<Field
+										error={field.state.meta.errors[0]?.message}
+										htmlFor={field.name}
+										label="Total Entries"
+										required
+									>
+										<Input
+											id={field.name}
+											inputMode="numeric"
+											name={field.name}
+											onBlur={field.handleBlur}
+											onChange={(e) => field.handleChange(e.target.value)}
+											placeholder="100"
+											value={field.state.value}
+										/>
+									</Field>
+								)}
+							</form.Field>
+						</div>
+					)
+				}
+			</form.Subscribe>
 
 			<form.Field name="prizeMoney">
 				{(field) => (

--- a/apps/web/src/shared/components/linked-accounts.tsx
+++ b/apps/web/src/shared/components/linked-accounts.tsx
@@ -1,5 +1,5 @@
-import { useForm } from "@tanstack/react-form";
 import { IconLink, IconUnlink } from "@tabler/icons-react";
+import { useForm } from "@tanstack/react-form";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import z from "zod";
@@ -210,7 +210,6 @@ export function LinkedAccounts() {
 		<div className="space-y-3">
 			<ManagementList>
 				<ManagementListItem
-					className="min-h-14"
 					actions={
 						hasCredential ? undefined : (
 							<Button
@@ -222,11 +221,15 @@ export function LinkedAccounts() {
 							</Button>
 						)
 					}
+					className="min-h-14"
 					title={
 						<span className="flex items-center gap-2">
 							Email / Password
 							{hasCredential ? (
-								<Badge className="border-green-500 text-green-600" variant="outline">
+								<Badge
+									className="border-green-500 text-green-600"
+									variant="outline"
+								>
 									Linked
 								</Badge>
 							) : null}
@@ -240,7 +243,6 @@ export function LinkedAccounts() {
 
 					return (
 						<ManagementListItem
-							className="min-h-14"
 							actions={
 								isLinked ? (
 									<Button
@@ -263,13 +265,16 @@ export function LinkedAccounts() {
 									</Button>
 								)
 							}
+							className="min-h-14"
 							key={provider.id}
 							leading={provider.icon}
 							title={
 								<span className="flex items-center gap-2">
 									{provider.label}
 									<Badge
-										className={isLinked ? "border-green-500 text-green-600" : ""}
+										className={
+											isLinked ? "border-green-500 text-green-600" : ""
+										}
 										variant="outline"
 									>
 										{isLinked ? "Linked" : "Not linked"}


### PR DESCRIPTION
## Summary

- "Completed before registration deadline" チェックボックスを追加。チェック時は `beforeDeadline: true` ペイロードを送信し、`placement` / `totalEntries` を省略する
- Placement と Total Entries フィールドを `grid-cols-2` で横並び表示にし、モバイルでも縦積みにならないよう調整
- `superRefine` による条件付きバリデーション: `beforeDeadline` が `false` の場合のみ placement / totalEntries を必須チェック

## Test plan

- [ ] チェックボックスなし（デフォルト）: placement・totalEntries・prizeMoney を入力して完了できる
- [ ] チェックボックスあり: prizeMoney のみで完了でき、`beforeDeadline: true` ペイロードが送られる
- [ ] チェックボックスなしで placement/totalEntries を空のまま送信するとバリデーションエラーが表示される
- [ ] モバイル幅で placement と totalEntries が横並びになっている

Closes #158

https://claude.ai/code/session_016diAHF2N2bZ8rFn52A6cj8