### PR TITLE
refactor: TransactionFormの改修 (#162)

### DIFF
--- a/apps/web/src/__tests__/currencies-route.test.tsx
+++ b/apps/web/src/__tests__/currencies-route.test.tsx
@@ -91,7 +91,6 @@ vi.mock("@/currencies/components/currency-form", () => ({
 vi.mock("@/currencies/components/transaction-form", () => ({
 	TransactionForm: ({
 		defaultValues,
-		onCancel,
 	}: {
 		defaultValues?: {
 			amount: number;
@@ -99,14 +98,10 @@ vi.mock("@/currencies/components/transaction-form", () => ({
 			transactedAt: string;
 			transactionTypeId: string;
 		};
-		onCancel?: () => void;
 	}) => (
 		<div>
 			<div>Transaction Form</div>
 			{defaultValues ? <pre>{JSON.stringify(defaultValues)}</pre> : null}
-			<button onClick={onCancel} type="button">
-				Cancel Transaction
-			</button>
 		</div>
 	),
 }));
@@ -217,13 +212,6 @@ describe("CurrenciesPage", () => {
 		expect(
 			screen.getByRole("heading", { name: "Add Transaction" })
 		).toBeInTheDocument();
-
-		await user.click(
-			screen.getByRole("button", { name: "Cancel Transaction" })
-		);
-		expect(
-			screen.queryByRole("heading", { name: "Add Transaction" })
-		).not.toBeInTheDocument();
 
 		await user.click(screen.getAllByText("USD")[0]);
 		expect(screen.queryByText("Transaction History")).not.toBeInTheDocument();

--- a/apps/web/src/currencies/components/__tests__/transaction-form.test.tsx
+++ b/apps/web/src/currencies/components/__tests__/transaction-form.test.tsx
@@ -98,9 +98,9 @@ describe("TransactionForm", () => {
 			target: { value: "2026-04-05" },
 		});
 
-		await user.click(screen.getByRole("combobox"));
-		await user.click(screen.getByRole("option", { name: "+ New type..." }));
-		await user.type(screen.getByLabelText("New Type Name"), "Manual");
+		await user.type(screen.getByRole("combobox"), "Manual");
+		await user.keyboard("{Enter}");
+
 		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		expect(mocks.createTypeMutate).toHaveBeenCalledWith({ name: "Manual" });
@@ -111,15 +111,4 @@ describe("TransactionForm", () => {
 			transactionTypeId: "created-manual",
 		});
 	}, 15_000);
-
-	it("calls onCancel when cancel is pressed", async () => {
-		const user = userEvent.setup();
-		const onCancel = vi.fn();
-
-		render(<TransactionForm onCancel={onCancel} onSubmit={vi.fn()} />);
-
-		await user.click(screen.getByRole("button", { name: "Cancel" }));
-
-		expect(onCancel).toHaveBeenCalledOnce();
-	});
 });

--- a/apps/web/src/currencies/components/transaction-form.tsx
+++ b/apps/web/src/currencies/components/transaction-form.tsx
@@ -1,21 +1,13 @@
 import { useForm } from "@tanstack/react-form";
 import { z } from "zod";
+import { TransactionTypeInput } from "@/currencies/components/transaction-type-input";
 import { useTransactionTypes } from "@/currencies/hooks/use-transaction-types";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/shared/components/ui/select";
 import { Textarea } from "@/shared/components/ui/textarea";
 import { requiredNumericString } from "@/shared/lib/form-fields";
-
-const NEW_TYPE_VALUE = "__new__";
 
 interface TransactionFormValues {
 	amount: number;
@@ -27,7 +19,6 @@ interface TransactionFormValues {
 interface TransactionFormProps {
 	defaultValues?: TransactionFormValues;
 	isLoading?: boolean;
-	onCancel?: () => void;
 	onSubmit: (values: TransactionFormValues) => void;
 }
 
@@ -35,42 +26,15 @@ function todayISODate() {
 	return new Date().toISOString().slice(0, 10);
 }
 
-function getButtonLabel(isCreatingType: boolean, isLoading: boolean) {
-	if (isCreatingType) {
-		return "Creating type...";
-	}
-	if (isLoading) {
-		return "Saving...";
-	}
-	return "Save";
-}
-
-function buildSchema() {
-	return z
-		.object({
-			amount: requiredNumericString(),
-			transactionTypeId: z.string().min(1, "Type is required"),
-			newTypeName: z.string(),
-			transactedAt: z.string().min(1, "Date is required"),
-			memo: z.string(),
-		})
-		.superRefine((value, ctx) => {
-			if (
-				value.transactionTypeId === NEW_TYPE_VALUE &&
-				value.newTypeName.trim() === ""
-			) {
-				ctx.addIssue({
-					code: "custom",
-					path: ["newTypeName"],
-					message: "New type name is required",
-				});
-			}
-		});
-}
+const transactionFormSchema = z.object({
+	amount: requiredNumericString(),
+	transactionTypeId: z.string().min(1, "Type is required"),
+	transactedAt: z.string().min(1, "Date is required"),
+	memo: z.string(),
+});
 
 export function TransactionForm({
 	onSubmit,
-	onCancel,
 	defaultValues,
 	isLoading = false,
 }: TransactionFormProps) {
@@ -81,27 +45,21 @@ export function TransactionForm({
 			amount:
 				defaultValues?.amount === undefined ? "" : String(defaultValues.amount),
 			transactionTypeId: defaultValues?.transactionTypeId ?? "",
-			newTypeName: "",
 			transactedAt: defaultValues?.transactedAt
 				? new Date(defaultValues.transactedAt).toISOString().slice(0, 10)
 				: todayISODate(),
 			memo: defaultValues?.memo ?? "",
 		},
-		onSubmit: async ({ value }) => {
-			let transactionTypeId = value.transactionTypeId;
-			if (transactionTypeId === NEW_TYPE_VALUE) {
-				const created = await createType(value.newTypeName.trim());
-				transactionTypeId = created.id;
-			}
+		onSubmit: ({ value }) => {
 			onSubmit({
 				amount: Number(value.amount),
-				transactionTypeId,
+				transactionTypeId: value.transactionTypeId,
 				transactedAt: value.transactedAt,
 				memo: value.memo ? value.memo : undefined,
 			});
 		},
 		validators: {
-			onSubmit: buildSchema(),
+			onSubmit: transactionFormSchema,
 		},
 	});
 
@@ -142,50 +100,16 @@ export function TransactionForm({
 						label="Type"
 						required
 					>
-						<Select
-							onValueChange={(v) => field.handleChange(v)}
+						<TransactionTypeInput
+							availableTypes={types}
+							id={field.name}
+							onChange={(id) => field.handleChange(id)}
+							onCreateType={createType}
 							value={field.state.value}
-						>
-							<SelectTrigger className="w-full" id={field.name}>
-								<SelectValue placeholder="Select type..." />
-							</SelectTrigger>
-							<SelectContent>
-								{types.map((t) => (
-									<SelectItem key={t.id} value={t.id}>
-										{t.name}
-									</SelectItem>
-								))}
-								<SelectItem value={NEW_TYPE_VALUE}>+ New type...</SelectItem>
-							</SelectContent>
-						</Select>
+						/>
 					</Field>
 				)}
 			</form.Field>
-			<form.Subscribe
-				selector={(state) => state.values.transactionTypeId === NEW_TYPE_VALUE}
-			>
-				{(isNewType) =>
-					isNewType ? (
-						<form.Field name="newTypeName">
-							{(field) => (
-								<Field
-									error={field.state.meta.errors[0]?.message}
-									htmlFor={field.name}
-									label="New Type Name"
-								>
-									<Input
-										id={field.name}
-										onBlur={field.handleBlur}
-										onChange={(e) => field.handleChange(e.target.value)}
-										placeholder="Enter new type name"
-										value={field.state.value}
-									/>
-								</Field>
-							)}
-						</form.Field>
-					) : null
-				}
-			</form.Subscribe>
 			<form.Field name="transactedAt">
 				{(field) => (
 					<Field
@@ -220,11 +144,6 @@ export function TransactionForm({
 				)}
 			</form.Field>
 			<DialogActionRow>
-				{onCancel ? (
-					<Button onClick={onCancel} type="button" variant="outline">
-						Cancel
-					</Button>
-				) : null}
 				<form.Subscribe
 					selector={(state) => [state.canSubmit, state.isSubmitting]}
 				>
@@ -235,7 +154,9 @@ export function TransactionForm({
 							}
 							type="submit"
 						>
-							{getButtonLabel(isCreatingType, isLoading)}
+							{isCreatingType || isLoading || isSubmitting
+								? "Saving..."
+								: "Save"}
 						</Button>
 					)}
 				</form.Subscribe>

--- a/apps/web/src/currencies/components/transaction-type-input.tsx
+++ b/apps/web/src/currencies/components/transaction-type-input.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useRef, useState } from "react";
+import {
+	Command,
+	CommandEmpty,
+	CommandItem,
+	CommandList,
+} from "@/shared/components/ui/command";
+import { Input } from "@/shared/components/ui/input";
+import {
+	Popover,
+	PopoverAnchor,
+	PopoverContent,
+} from "@/shared/components/ui/popover";
+
+interface TransactionType {
+	id: string;
+	name: string;
+}
+
+interface TransactionTypeInputProps {
+	availableTypes: TransactionType[];
+	id?: string;
+	onChange: (id: string) => void;
+	onCreateType?: (name: string) => Promise<TransactionType>;
+	placeholder?: string;
+	value: string;
+}
+
+export function TransactionTypeInput({
+	availableTypes,
+	id,
+	onChange,
+	onCreateType,
+	placeholder = "Select or create type...",
+	value,
+}: TransactionTypeInputProps) {
+	const [inputValue, setInputValue] = useState(
+		() => availableTypes.find((t) => t.id === value)?.name ?? ""
+	);
+	const [isOpen, setIsOpen] = useState(false);
+	const [contentWidth, setContentWidth] = useState<number>();
+	const anchorRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!value) {
+			return;
+		}
+		const typeName = availableTypes.find((t) => t.id === value)?.name;
+		if (typeName) {
+			setInputValue(typeName);
+		}
+	}, [value, availableTypes]);
+
+	useEffect(() => {
+		if (!(isOpen && anchorRef.current)) {
+			return;
+		}
+		setContentWidth(anchorRef.current.offsetWidth);
+	}, [isOpen]);
+
+	const normalizedInput = inputValue.trim();
+	const filteredTypes = availableTypes.filter(
+		(t) =>
+			!normalizedInput ||
+			t.name.toLowerCase().includes(normalizedInput.toLowerCase())
+	);
+	const matchingType = availableTypes.find(
+		(t) => t.name.toLowerCase() === normalizedInput.toLowerCase()
+	);
+	const canCreate = Boolean(onCreateType && normalizedInput && !matchingType);
+	const shouldRenderPopover =
+		isOpen && (availableTypes.length > 0 || Boolean(normalizedInput));
+
+	const handleSelect = (type: TransactionType) => {
+		setInputValue(type.name);
+		onChange(type.id);
+		setIsOpen(false);
+	};
+
+	const handleCreate = async () => {
+		if (!(normalizedInput && onCreateType)) {
+			return;
+		}
+		const created = await onCreateType(normalizedInput);
+		handleSelect(created);
+	};
+
+	return (
+		<Popover modal={false} onOpenChange={setIsOpen} open={shouldRenderPopover}>
+			<PopoverAnchor asChild>
+				<div ref={anchorRef}>
+					<Input
+						aria-expanded={shouldRenderPopover}
+						autoComplete="off"
+						id={id}
+						onChange={(e) => {
+							setInputValue(e.target.value);
+							onChange("");
+							setIsOpen(true);
+						}}
+						onFocus={() => setIsOpen(true)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") {
+								e.preventDefault();
+								if (matchingType) {
+									handleSelect(matchingType);
+								} else {
+									handleCreate().catch(() => undefined);
+								}
+							}
+							if (e.key === "Escape") {
+								setIsOpen(false);
+							}
+						}}
+						placeholder={placeholder}
+						role="combobox"
+						value={inputValue}
+					/>
+				</div>
+			</PopoverAnchor>
+			{shouldRenderPopover ? (
+				<PopoverContent
+					align="start"
+					className="p-0"
+					onOpenAutoFocus={(e) => e.preventDefault()}
+					style={contentWidth ? { width: contentWidth } : undefined}
+				>
+					<Command shouldFilter={false}>
+						<CommandList>
+							{filteredTypes.length === 0 && !canCreate ? (
+								<CommandEmpty>No matching types.</CommandEmpty>
+							) : null}
+							{filteredTypes.map((t) => (
+								<CommandItem
+									key={t.id}
+									onMouseDown={(e) => e.preventDefault()}
+									onSelect={() => handleSelect(t)}
+									value={t.name}
+								>
+									{t.name}
+								</CommandItem>
+							))}
+							{canCreate ? (
+								<CommandItem
+									onMouseDown={(e) => e.preventDefault()}
+									onSelect={() => handleCreate().catch(() => undefined)}
+									value={`create-${normalizedInput}`}
+								>
+									Create &quot;{normalizedInput}&quot;
+								</CommandItem>
+							) : null}
+						</CommandList>
+					</Command>
+				</PopoverContent>
+			) : null}
+		</Popover>
+	);
+}

--- a/apps/web/src/routes/currencies/index.tsx
+++ b/apps/web/src/routes/currencies/index.tsx
@@ -217,7 +217,6 @@ function CurrenciesPage() {
 			</ResponsiveDialog>
 
 			<ResponsiveDialog
-				description="Record a manual balance change for this currency."
 				onOpenChange={(open) => {
 					if (!open) {
 						setAddTransactionCurrencyId(null);
@@ -228,13 +227,11 @@ function CurrenciesPage() {
 			>
 				<TransactionForm
 					isLoading={isAddTransactionPending}
-					onCancel={() => setAddTransactionCurrencyId(null)}
 					onSubmit={handleAddTransaction}
 				/>
 			</ResponsiveDialog>
 
 			<ResponsiveDialog
-				description="Update the type, amount, date, or memo for this transaction."
 				onOpenChange={(open) => {
 					if (!open) {
 						setEditingTransaction(null);
@@ -255,7 +252,6 @@ function CurrenciesPage() {
 							memo: editingTransaction.memo ?? undefined,
 						}}
 						isLoading={isEditTransactionPending}
-						onCancel={() => setEditingTransaction(null)}
 						onSubmit={handleEditTransaction}
 					/>
 				)}

--- a/apps/web/src/shared/components/linked-accounts.tsx
+++ b/apps/web/src/shared/components/linked-accounts.tsx
@@ -1,5 +1,5 @@
-import { useForm } from "@tanstack/react-form";
 import { IconLink, IconUnlink } from "@tabler/icons-react";
+import { useForm } from "@tanstack/react-form";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import z from "zod";
@@ -210,7 +210,6 @@ export function LinkedAccounts() {
 		<div className="space-y-3">
 			<ManagementList>
 				<ManagementListItem
-					className="min-h-14"
 					actions={
 						hasCredential ? undefined : (
 							<Button
@@ -222,11 +221,15 @@ export function LinkedAccounts() {
 							</Button>
 						)
 					}
+					className="min-h-14"
 					title={
 						<span className="flex items-center gap-2">
 							Email / Password
 							{hasCredential ? (
-								<Badge className="border-green-500 text-green-600" variant="outline">
+								<Badge
+									className="border-green-500 text-green-600"
+									variant="outline"
+								>
 									Linked
 								</Badge>
 							) : null}
@@ -240,7 +243,6 @@ export function LinkedAccounts() {
 
 					return (
 						<ManagementListItem
-							className="min-h-14"
 							actions={
 								isLinked ? (
 									<Button
@@ -263,13 +265,16 @@ export function LinkedAccounts() {
 									</Button>
 								)
 							}
+							className="min-h-14"
 							key={provider.id}
 							leading={provider.icon}
 							title={
 								<span className="flex items-center gap-2">
 									{provider.label}
 									<Badge
-										className={isLinked ? "border-green-500 text-green-600" : ""}
+										className={
+											isLinked ? "border-green-500 text-green-600" : ""
+										}
 										variant="outline"
 									>
 										{isLinked ? "Linked" : "Not linked"}


### PR DESCRIPTION
## Summary

- TransactionFormのタイトル下テキスト（`description` prop）を削除
- TransactionFormのキャンセルボタンと `onCancel` propを削除
- 種別入力をSelectドロップダウンから、テキスト入力＋ポップオーバーによるコンボボックス（`TransactionTypeInput`）に変更。既存タイプのフィルタ選択と新規作成をインラインで対応

## Test plan

- [ ] `npm test` — 全482テスト通過
- [ ] `npm run lint` — 383ファイルにエラーなし
- [ ] Add Transactionダイアログでタイトル下テキストが表示されないこと
- [ ] Edit Transactionダイアログでタイトル下テキストが表示されないこと
- [ ] キャンセルボタンが表示されないこと
- [ ] 種別フィールドにテキスト入力でフィルタリングできること
- [ ] 既存の種別を選択して保存できること
- [ ] 新しい種別名を入力してEnterまたはCreate選択で作成・保存できること

Closes #162

https://claude.ai/code/session_01PxuNqPMFDFeh8dXfjb5UYs