### PR TITLE
Remove subtitle from CurrencyPage title

### DIFF
--- a/apps/web/src/routes/currencies/index.tsx
+++ b/apps/web/src/routes/currencies/index.tsx
@@ -138,7 +138,6 @@ function CurrenciesPage() {
 						</Button>
 					</>
 				}
-				description="Track balances and manual transactions for each currency."
 				heading="Currencies"
 			/>
 


### PR DESCRIPTION
Removes the subtitle/description text below the "Currencies" heading on the CurrencyPage.

Closes #164