### PR TITLE
Remove CurrencyForm cancel button and description text

### DIFF
--- a/apps/web/src/currencies/components/currency-form.tsx
+++ b/apps/web/src/currencies/components/currency-form.tsx
@@ -91,11 +91,6 @@ export function CurrencyForm({
 				)}
 			</form.Field>
 			<DialogActionRow>
-				{onCancel ? (
-					<Button onClick={onCancel} type="button" variant="outline">
-						Cancel
-					</Button>
-				) : null}
 				<form.Subscribe
 					selector={(state) => [state.canSubmit, state.isSubmitting]}
 				>

--- a/apps/web/src/routes/currencies/index.tsx
+++ b/apps/web/src/routes/currencies/index.tsx
@@ -181,7 +181,6 @@ function CurrenciesPage() {
 			)}
 
 			<ResponsiveDialog
-				description="Create a currency to track balances and manual transactions."
 				onOpenChange={setIsCreateOpen}
 				open={isCreateOpen}
 				title="New Currency"
@@ -194,7 +193,6 @@ function CurrenciesPage() {
 			</ResponsiveDialog>
 
 			<ResponsiveDialog
-				description="Update the currency name or unit shown across balances."
 				onOpenChange={(open) => {
 					if (!open) {
 						setEditingCurrency(null);


### PR DESCRIPTION
## Summary
- Removed the cancel button from the CurrencyForm component
- Removed the subtitle/description text from the "New Currency" dialog
- Removed the subtitle/description text from the "Edit Currency" dialog

Closes #161