### PR TITLE
refactor: TransactionFormの改修 (#162)

### DIFF
--- a/apps/web/src/__tests__/currencies-route.test.tsx
+++ b/apps/web/src/__tests__/currencies-route.test.tsx
@@ -91,7 +91,6 @@ vi.mock("@/currencies/components/currency-form", () => ({
 vi.mock("@/currencies/components/transaction-form", () => ({
 	TransactionForm: ({
 		defaultValues,
-		onCancel,
 	}: {
 		defaultValues?: {
 			amount: number;
@@ -99,14 +98,10 @@ vi.mock("@/currencies/components/transaction-form", () => ({
 			transactedAt: string;
 			transactionTypeId: string;
 		};
-		onCancel?: () => void;
 	}) => (
 		<div>
 			<div>Transaction Form</div>
 			{defaultValues ? <pre>{JSON.stringify(defaultValues)}</pre> : null}
-			<button onClick={onCancel} type="button">
-				Cancel Transaction
-			</button>
 		</div>
 	),
 }));
@@ -115,11 +110,13 @@ vi.mock("@/shared/components/ui/responsive-dialog", () => ({
 	ResponsiveDialog: ({
 		children,
 		description,
+		onOpenChange,
 		open,
 		title,
 	}: {
 		children: ReactNode;
 		description?: ReactNode;
+		onOpenChange: (open: boolean) => void;
 		open: boolean;
 		title: string;
 	}) =>
@@ -127,6 +124,9 @@ vi.mock("@/shared/components/ui/responsive-dialog", () => ({
 			<div>
 				<h2>{title}</h2>
 				{description ? <p>{description}</p> : null}
+				<button onClick={() => onOpenChange(false)} type="button">
+					Close {title}
+				</button>
 				{children}
 			</div>
 		) : null,
@@ -219,7 +219,7 @@ describe("CurrenciesPage", () => {
 		).toBeInTheDocument();
 
 		await user.click(
-			screen.getByRole("button", { name: "Cancel Transaction" })
+			screen.getByRole("button", { name: "Close Add Transaction" })
 		);
 		expect(
 			screen.queryByRole("heading", { name: "Add Transaction" })

--- a/apps/web/src/currencies/components/__tests__/transaction-form.test.tsx
+++ b/apps/web/src/currencies/components/__tests__/transaction-form.test.tsx
@@ -98,9 +98,8 @@ describe("TransactionForm", () => {
 			target: { value: "2026-04-05" },
 		});
 
-		await user.click(screen.getByRole("combobox"));
-		await user.click(screen.getByRole("option", { name: "+ New type..." }));
-		await user.type(screen.getByLabelText("New Type Name"), "Manual");
+		await user.type(screen.getByRole("combobox"), "Manual");
+		await user.click(screen.getByRole("option", { name: 'Create "Manual"' }));
 		await user.click(screen.getByRole("button", { name: "Save" }));
 
 		expect(mocks.createTypeMutate).toHaveBeenCalledWith({ name: "Manual" });
@@ -111,15 +110,4 @@ describe("TransactionForm", () => {
 			transactionTypeId: "created-manual",
 		});
 	}, 15_000);
-
-	it("calls onCancel when cancel is pressed", async () => {
-		const user = userEvent.setup();
-		const onCancel = vi.fn();
-
-		render(<TransactionForm onCancel={onCancel} onSubmit={vi.fn()} />);
-
-		await user.click(screen.getByRole("button", { name: "Cancel" }));
-
-		expect(onCancel).toHaveBeenCalledOnce();
-	});
 });

--- a/apps/web/src/currencies/components/transaction-form.tsx
+++ b/apps/web/src/currencies/components/transaction-form.tsx
@@ -1,17 +1,22 @@
 import { useForm } from "@tanstack/react-form";
+import { useEffect, useRef, useState } from "react";
 import { z } from "zod";
 import { useTransactionTypes } from "@/currencies/hooks/use-transaction-types";
 import { Button } from "@/shared/components/ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandItem,
+	CommandList,
+} from "@/shared/components/ui/command";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/shared/components/ui/select";
+	Popover,
+	PopoverAnchor,
+	PopoverContent,
+} from "@/shared/components/ui/popover";
 import { Textarea } from "@/shared/components/ui/textarea";
 import { requiredNumericString } from "@/shared/lib/form-fields";
 
@@ -27,8 +32,150 @@ interface TransactionFormValues {
 interface TransactionFormProps {
 	defaultValues?: TransactionFormValues;
 	isLoading?: boolean;
-	onCancel?: () => void;
 	onSubmit: (values: TransactionFormValues) => void;
+}
+
+interface TypeComboboxProps {
+	id?: string;
+	newTypeName: string;
+	onNewTypeNameChange: (name: string) => void;
+	onTypeChange: (id: string) => void;
+	typeId: string;
+	types: { id: string; name: string }[];
+}
+
+function TypeCombobox({
+	id,
+	newTypeName,
+	onNewTypeNameChange,
+	onTypeChange,
+	typeId,
+	types,
+}: TypeComboboxProps) {
+	const initialDisplay =
+		typeId === NEW_TYPE_VALUE
+			? newTypeName
+			: (types.find((t) => t.id === typeId)?.name ?? "");
+
+	const [inputValue, setInputValue] = useState(initialDisplay);
+	const [isOpen, setIsOpen] = useState(false);
+	const [contentWidth, setContentWidth] = useState<number>();
+	const anchorRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!typeId || typeId === NEW_TYPE_VALUE) {
+			return;
+		}
+		const typeName = types.find((t) => t.id === typeId)?.name;
+		if (typeName) {
+			setInputValue(typeName);
+		}
+	}, [typeId, types]);
+
+	const normalizedInput = inputValue.trim();
+	const filteredTypes = types.filter(
+		(t) =>
+			!normalizedInput ||
+			t.name.toLowerCase().includes(normalizedInput.toLowerCase())
+	);
+	const exactMatch = types.find(
+		(t) => t.name.toLowerCase() === normalizedInput.toLowerCase()
+	);
+	const canCreate = Boolean(normalizedInput && !exactMatch);
+	const shouldShowPopover =
+		isOpen && (types.length > 0 || Boolean(normalizedInput));
+
+	useEffect(() => {
+		if (!(shouldShowPopover && anchorRef.current)) {
+			return;
+		}
+		setContentWidth(anchorRef.current.offsetWidth);
+	}, [shouldShowPopover]);
+
+	const handleSelect = (type: { id: string; name: string }) => {
+		setInputValue(type.name);
+		onTypeChange(type.id);
+		onNewTypeNameChange("");
+		setIsOpen(false);
+	};
+
+	const handleCreate = () => {
+		onTypeChange(NEW_TYPE_VALUE);
+		onNewTypeNameChange(normalizedInput);
+		setIsOpen(false);
+	};
+
+	return (
+		<Popover modal={false} onOpenChange={setIsOpen} open={shouldShowPopover}>
+			<PopoverAnchor asChild>
+				<div ref={anchorRef}>
+					<Input
+						aria-expanded={shouldShowPopover}
+						autoComplete="off"
+						id={id}
+						onChange={(e) => {
+							setInputValue(e.target.value);
+							setIsOpen(true);
+							onTypeChange("");
+							onNewTypeNameChange("");
+						}}
+						onFocus={() => setIsOpen(true)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") {
+								e.preventDefault();
+								if (exactMatch) {
+									handleSelect(exactMatch);
+								} else if (canCreate) {
+									handleCreate();
+								}
+							}
+							if (e.key === "Escape") {
+								setIsOpen(false);
+							}
+						}}
+						placeholder="Select or create type..."
+						role="combobox"
+						value={inputValue}
+					/>
+				</div>
+			</PopoverAnchor>
+			{shouldShowPopover ? (
+				<PopoverContent
+					align="start"
+					className="p-0"
+					onOpenAutoFocus={(e) => e.preventDefault()}
+					style={contentWidth ? { width: contentWidth } : undefined}
+				>
+					<Command shouldFilter={false}>
+						<CommandList>
+							{filteredTypes.length === 0 && !canCreate ? (
+								<CommandEmpty>No matching types.</CommandEmpty>
+							) : null}
+							{filteredTypes.map((t) => (
+								<CommandItem
+									key={t.id}
+									onMouseDown={(e) => e.preventDefault()}
+									onSelect={() => handleSelect(t)}
+									value={t.name}
+								>
+									{t.name}
+								</CommandItem>
+							))}
+							{canCreate ? (
+								<CommandItem
+									onMouseDown={(e) => e.preventDefault()}
+									onSelect={handleCreate}
+									value={`create-${normalizedInput}`}
+								>
+									Create &quot;{normalizedInput}&quot;
+								</CommandItem>
+							) : null}
+						</CommandList>
+					</Command>
+				</PopoverContent>
+			) : null}
+		</Popover>
+	);
 }
 
 function todayISODate() {
@@ -70,7 +217,6 @@ function buildSchema() {
 
 export function TransactionForm({
 	onSubmit,
-	onCancel,
 	defaultValues,
 	isLoading = false,
 }: TransactionFormProps) {
@@ -135,57 +281,28 @@ export function TransactionForm({
 				)}
 			</form.Field>
 			<form.Field name="transactionTypeId">
-				{(field) => (
-					<Field
-						error={field.state.meta.errors[0]?.message}
-						htmlFor={field.name}
-						label="Type"
-						required
-					>
-						<Select
-							onValueChange={(v) => field.handleChange(v)}
-							value={field.state.value}
-						>
-							<SelectTrigger className="w-full" id={field.name}>
-								<SelectValue placeholder="Select type..." />
-							</SelectTrigger>
-							<SelectContent>
-								{types.map((t) => (
-									<SelectItem key={t.id} value={t.id}>
-										{t.name}
-									</SelectItem>
-								))}
-								<SelectItem value={NEW_TYPE_VALUE}>+ New type...</SelectItem>
-							</SelectContent>
-						</Select>
-					</Field>
+				{(typeField) => (
+					<form.Field name="newTypeName">
+						{(newTypeField) => (
+							<Field
+								error={typeField.state.meta.errors[0]?.message}
+								htmlFor={typeField.name}
+								label="Type"
+								required
+							>
+								<TypeCombobox
+									id={typeField.name}
+									newTypeName={newTypeField.state.value}
+									onNewTypeNameChange={newTypeField.handleChange}
+									onTypeChange={typeField.handleChange}
+									typeId={typeField.state.value}
+									types={types}
+								/>
+							</Field>
+						)}
+					</form.Field>
 				)}
 			</form.Field>
-			<form.Subscribe
-				selector={(state) => state.values.transactionTypeId === NEW_TYPE_VALUE}
-			>
-				{(isNewType) =>
-					isNewType ? (
-						<form.Field name="newTypeName">
-							{(field) => (
-								<Field
-									error={field.state.meta.errors[0]?.message}
-									htmlFor={field.name}
-									label="New Type Name"
-								>
-									<Input
-										id={field.name}
-										onBlur={field.handleBlur}
-										onChange={(e) => field.handleChange(e.target.value)}
-										placeholder="Enter new type name"
-										value={field.state.value}
-									/>
-								</Field>
-							)}
-						</form.Field>
-					) : null
-				}
-			</form.Subscribe>
 			<form.Field name="transactedAt">
 				{(field) => (
 					<Field
@@ -220,11 +337,6 @@ export function TransactionForm({
 				)}
 			</form.Field>
 			<DialogActionRow>
-				{onCancel ? (
-					<Button onClick={onCancel} type="button" variant="outline">
-						Cancel
-					</Button>
-				) : null}
 				<form.Subscribe
 					selector={(state) => [state.canSubmit, state.isSubmitting]}
 				>

--- a/apps/web/src/currencies/components/transaction-form.tsx
+++ b/apps/web/src/currencies/components/transaction-form.tsx
@@ -117,6 +117,12 @@ function TypeCombobox({
 						aria-expanded={shouldShowPopover}
 						autoComplete="off"
 						id={id}
+						onBlur={(e) => {
+							const relatedTarget = e.relatedTarget as HTMLElement | null;
+							if (!relatedTarget?.closest('[data-slot="popover-content"]')) {
+								setIsOpen(false);
+							}
+						}}
 						onChange={(e) => {
 							setInputValue(e.target.value);
 							setIsFiltering(true);
@@ -148,6 +154,7 @@ function TypeCombobox({
 				<PopoverContent
 					align="start"
 					className="p-0"
+					onFocusOutside={(e) => e.preventDefault()}
 					onOpenAutoFocus={(e) => e.preventDefault()}
 					style={contentWidth ? { width: contentWidth } : undefined}
 				>

--- a/apps/web/src/currencies/components/transaction-form.tsx
+++ b/apps/web/src/currencies/components/transaction-form.tsx
@@ -58,6 +58,7 @@ function TypeCombobox({
 			: (types.find((t) => t.id === typeId)?.name ?? "");
 
 	const [inputValue, setInputValue] = useState(initialDisplay);
+	const [isFiltering, setIsFiltering] = useState(false);
 	const [isOpen, setIsOpen] = useState(false);
 	const [contentWidth, setContentWidth] = useState<number>();
 	const anchorRef = useRef<HTMLDivElement>(null);
@@ -69,13 +70,14 @@ function TypeCombobox({
 		const typeName = types.find((t) => t.id === typeId)?.name;
 		if (typeName) {
 			setInputValue(typeName);
+			setIsFiltering(false);
 		}
 	}, [typeId, types]);
 
 	const normalizedInput = inputValue.trim();
 	const filteredTypes = types.filter(
 		(t) =>
-			!normalizedInput ||
+			!(isFiltering && normalizedInput) ||
 			t.name.toLowerCase().includes(normalizedInput.toLowerCase())
 	);
 	const exactMatch = types.find(
@@ -94,12 +96,14 @@ function TypeCombobox({
 
 	const handleSelect = (type: { id: string; name: string }) => {
 		setInputValue(type.name);
+		setIsFiltering(false);
 		onTypeChange(type.id);
 		onNewTypeNameChange("");
 		setIsOpen(false);
 	};
 
 	const handleCreate = () => {
+		setIsFiltering(false);
 		onTypeChange(NEW_TYPE_VALUE);
 		onNewTypeNameChange(normalizedInput);
 		setIsOpen(false);
@@ -115,6 +119,7 @@ function TypeCombobox({
 						id={id}
 						onChange={(e) => {
 							setInputValue(e.target.value);
+							setIsFiltering(true);
 							setIsOpen(true);
 							onTypeChange("");
 							onNewTypeNameChange("");
@@ -260,26 +265,6 @@ export function TransactionForm({
 				form.handleSubmit();
 			}}
 		>
-			<form.Field name="amount">
-				{(field) => (
-					<Field
-						error={field.state.meta.errors[0]?.message}
-						htmlFor={field.name}
-						label="Amount"
-						required
-					>
-						<Input
-							id={field.name}
-							inputMode="numeric"
-							name={field.name}
-							onBlur={field.handleBlur}
-							onChange={(e) => field.handleChange(e.target.value)}
-							placeholder="Enter amount (negative for withdrawal)"
-							value={field.state.value}
-						/>
-					</Field>
-				)}
-			</form.Field>
 			<form.Field name="transactionTypeId">
 				{(typeField) => (
 					<form.Field name="newTypeName">
@@ -301,6 +286,26 @@ export function TransactionForm({
 							</Field>
 						)}
 					</form.Field>
+				)}
+			</form.Field>
+			<form.Field name="amount">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Amount"
+						required
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="Enter amount (negative for withdrawal)"
+							value={field.state.value}
+						/>
+					</Field>
 				)}
 			</form.Field>
 			<form.Field name="transactedAt">

--- a/apps/web/src/routes/currencies/index.tsx
+++ b/apps/web/src/routes/currencies/index.tsx
@@ -217,7 +217,6 @@ function CurrenciesPage() {
 			</ResponsiveDialog>
 
 			<ResponsiveDialog
-				description="Record a manual balance change for this currency."
 				onOpenChange={(open) => {
 					if (!open) {
 						setAddTransactionCurrencyId(null);
@@ -228,13 +227,11 @@ function CurrenciesPage() {
 			>
 				<TransactionForm
 					isLoading={isAddTransactionPending}
-					onCancel={() => setAddTransactionCurrencyId(null)}
 					onSubmit={handleAddTransaction}
 				/>
 			</ResponsiveDialog>
 
 			<ResponsiveDialog
-				description="Update the type, amount, date, or memo for this transaction."
 				onOpenChange={(open) => {
 					if (!open) {
 						setEditingTransaction(null);
@@ -255,7 +252,6 @@ function CurrenciesPage() {
 							memo: editingTransaction.memo ?? undefined,
 						}}
 						isLoading={isEditTransactionPending}
-						onCancel={() => setEditingTransaction(null)}
 						onSubmit={handleEditTransaction}
 					/>
 				)}

--- a/apps/web/src/shared/components/linked-accounts.tsx
+++ b/apps/web/src/shared/components/linked-accounts.tsx
@@ -1,5 +1,5 @@
-import { useForm } from "@tanstack/react-form";
 import { IconLink, IconUnlink } from "@tabler/icons-react";
+import { useForm } from "@tanstack/react-form";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import z from "zod";
@@ -210,7 +210,6 @@ export function LinkedAccounts() {
 		<div className="space-y-3">
 			<ManagementList>
 				<ManagementListItem
-					className="min-h-14"
 					actions={
 						hasCredential ? undefined : (
 							<Button
@@ -222,11 +221,15 @@ export function LinkedAccounts() {
 							</Button>
 						)
 					}
+					className="min-h-14"
 					title={
 						<span className="flex items-center gap-2">
 							Email / Password
 							{hasCredential ? (
-								<Badge className="border-green-500 text-green-600" variant="outline">
+								<Badge
+									className="border-green-500 text-green-600"
+									variant="outline"
+								>
 									Linked
 								</Badge>
 							) : null}
@@ -240,7 +243,6 @@ export function LinkedAccounts() {
 
 					return (
 						<ManagementListItem
-							className="min-h-14"
 							actions={
 								isLinked ? (
 									<Button
@@ -263,13 +265,16 @@ export function LinkedAccounts() {
 									</Button>
 								)
 							}
+							className="min-h-14"
 							key={provider.id}
 							leading={provider.icon}
 							title={
 								<span className="flex items-center gap-2">
 									{provider.label}
 									<Badge
-										className={isLinked ? "border-green-500 text-green-600" : ""}
+										className={
+											isLinked ? "border-green-500 text-green-600" : ""
+										}
 										variant="outline"
 									>
 										{isLinked ? "Linked" : "Not linked"}


### PR DESCRIPTION
## Summary

- タイトル下の説明文をダイアログから削除（Add/Edit Transactionダイアログ）
- キャンセルボタンをフォームから削除（`onCancel` プロップも削除）
- 種別入力を `Select` からテキスト入力 + ドロップダウン（`TypeCombobox`）に変更
  - 入力しながら既存種別を絞り込み選択できる
  - 入力テキストが既存種別と一致しない場合、`Create "X"` オプションで新規作成可能
  - `TagPickerBase` と同じ Popover + Command パターンを採用

## Test plan

- [ ] `transaction-form.test.tsx`: 既存テスト2件がパス（編集値の送信、新規種別作成）
- [ ] `currencies-route.test.tsx`: ダイアログ開閉テストがパス（キャンセルボタン削除に対応）
- [ ] 全82テストファイル / 482テストがパス
- [ ] Biome lint チェック通過

https://claude.ai/code/session_01EwSRQbfFYHgF49uVw6Mz16