### PR TITLE
feat: add waiting-list screenshot OCR to auto-seat players

### DIFF
--- a/apps/web/src/__tests__/tournament-lifecycle.test.tsx
+++ b/apps/web/src/__tests__/tournament-lifecycle.test.tsx
@@ -61,6 +61,10 @@ vi.mock("@/live-sessions/components/player-detail-sheet", () => ({
 	PlayerDetailSheet: () => null,
 }));
 
+vi.mock("@/live-sessions/components/seat-from-screenshot-sheet", () => ({
+	SeatFromScreenshotSheet: () => null,
+}));
+
 // ---------------------------------------------------------------------------
 // Mock: tRPC client and proxy
 //

--- a/apps/web/src/live-sessions/components/__tests__/active-session-scene.test.tsx
+++ b/apps/web/src/live-sessions/components/__tests__/active-session-scene.test.tsx
@@ -57,6 +57,11 @@ vi.mock("@/live-sessions/components/player-detail-sheet", () => ({
 		open ? <div>Player detail sheet</div> : null,
 }));
 
+vi.mock("@/live-sessions/components/seat-from-screenshot-sheet", () => ({
+	SeatFromScreenshotSheet: ({ open }: { open: boolean }) =>
+		open ? <div>Seat from screenshot sheet</div> : null,
+}));
+
 vi.mock("@/shared/components/ui/responsive-dialog", () => ({
 	ResponsiveDialog: ({
 		children,
@@ -150,6 +155,7 @@ function createState(
 		players: [],
 		playerSheetOpen: false,
 		selectedPlayer: null,
+		sessionParam: { liveCashGameSessionId: "cash-1" },
 		setAddPlayerSheetOpen: vi.fn(),
 		setPlayerSheetOpen: vi.fn(),
 		waitingForHero: true,

--- a/apps/web/src/live-sessions/components/active-session-scene.tsx
+++ b/apps/web/src/live-sessions/components/active-session-scene.tsx
@@ -1,6 +1,6 @@
 import { IconAlertTriangle } from "@tabler/icons-react";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { AddPlayerSheet } from "@/live-sessions/components/add-player-sheet";
 import { PlayerDetailSheet } from "@/live-sessions/components/player-detail-sheet";
 import {
@@ -8,6 +8,7 @@ import {
 	type TableGameInfo,
 	type TablePlayer,
 } from "@/live-sessions/components/poker-table";
+import { SeatFromScreenshotSheet } from "@/live-sessions/components/seat-from-screenshot-sheet";
 import type { PlayerFormValues } from "@/players/components/player-form";
 import type {
 	PlayerDetailData,
@@ -20,6 +21,10 @@ import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
+
+type SessionParam =
+	| { liveCashGameSessionId: string; liveTournamentSessionId?: never }
+	| { liveCashGameSessionId?: never; liveTournamentSessionId: string };
 
 interface ActiveSessionSceneProps {
 	discardDescription?: ReactNode;
@@ -60,6 +65,7 @@ export interface ActiveSessionSceneState {
 	playerSheetOpen: boolean;
 	players: TablePlayer[];
 	selectedPlayer: (PlayerDetailData & { isTemporary: boolean }) | null;
+	sessionParam: SessionParam;
 	setAddPlayerSheetOpen: (open: boolean) => void;
 	setPlayerSheetOpen: (open: boolean) => void;
 	waitingForHero: boolean;
@@ -70,6 +76,10 @@ export function useActiveSessionSceneState({
 	sessionId,
 	sessionType,
 }: UseActiveSessionSceneStateOptions): ActiveSessionSceneState {
+	const sessionParam: SessionParam =
+		sessionType === "cash_game"
+			? { liveCashGameSessionId: sessionId }
+			: { liveTournamentSessionId: sessionId };
 	const tablePlayers = useTablePlayers(
 		sessionType === "cash_game"
 			? { liveCashGameSessionId: sessionId }
@@ -152,6 +162,7 @@ export function useActiveSessionSceneState({
 					tags: playerDetail.player.tags ?? [],
 				}
 			: null,
+		sessionParam,
 		setAddPlayerSheetOpen: (open) => {
 			if (!open) {
 				tableInteraction.setAddPlayerSeat(null);
@@ -224,6 +235,17 @@ export function ActiveSessionScene({
 	title,
 }: ActiveSessionSceneProps) {
 	const [isDiscardOpen, setIsDiscardOpen] = useState(false);
+	const [isScanSheetOpen, setIsScanSheetOpen] = useState(false);
+
+	const occupiedSeatPositions = useMemo(() => {
+		const set = new Set<number>();
+		for (const p of state.players) {
+			if (p.isActive && typeof p.seatPosition === "number") {
+				set.add(p.seatPosition);
+			}
+		}
+		return set;
+	}, [state.players]);
 
 	return (
 		<>
@@ -263,6 +285,7 @@ export function ActiveSessionScene({
 					onEmptySeatTap={state.onEmptySeatTap}
 					onHeroSeatTap={state.onHeroSeatTap}
 					onPlayerSeatTap={state.onPlayerSeatTap}
+					onScanPlayers={() => setIsScanSheetOpen(true)}
 					players={state.players}
 					waitingForHero={state.waitingForHero}
 				/>
@@ -289,6 +312,13 @@ export function ActiveSessionScene({
 				onSave={state.onPlayerSave}
 				open={state.playerSheetOpen}
 				player={state.selectedPlayer}
+			/>
+
+			<SeatFromScreenshotSheet
+				occupiedSeatPositions={occupiedSeatPositions}
+				onOpenChange={setIsScanSheetOpen}
+				open={isScanSheetOpen}
+				sessionParam={state.sessionParam}
 			/>
 
 			<DiscardDialog

--- a/apps/web/src/live-sessions/components/active-session-scene.tsx
+++ b/apps/web/src/live-sessions/components/active-session-scene.tsx
@@ -315,6 +315,7 @@ export function ActiveSessionScene({
 			/>
 
 			<SeatFromScreenshotSheet
+				heroSeatPosition={state.heroSeatPosition}
 				occupiedSeatPositions={occupiedSeatPositions}
 				onOpenChange={setIsScanSheetOpen}
 				open={isScanSheetOpen}

--- a/apps/web/src/live-sessions/components/poker-table.tsx
+++ b/apps/web/src/live-sessions/components/poker-table.tsx
@@ -1,6 +1,12 @@
-import { IconLoader2, IconPlus, IconUser } from "@tabler/icons-react";
+import {
+	IconLoader2,
+	IconPlus,
+	IconSparkles,
+	IconUser,
+} from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { PlayerAvatar } from "@/players/components/player-avatar";
+import { Button } from "@/shared/components/ui/button";
 
 const MAX_SEATS = 9;
 
@@ -53,6 +59,7 @@ interface PokerTableProps {
 	onEmptySeatTap: (seatPosition: number) => void;
 	onHeroSeatTap: () => void;
 	onPlayerSeatTap: (player: TablePlayer, seatPosition: number) => void;
+	onScanPlayers?: () => void;
 	players: TablePlayer[];
 	/** True when no hero is seated yet — empty seats show "Sit" hint */
 	waitingForHero: boolean;
@@ -153,6 +160,7 @@ export function PokerTable({
 	onEmptySeatTap,
 	onHeroSeatTap,
 	onPlayerSeatTap,
+	onScanPlayers,
 	players,
 	waitingForHero,
 }: PokerTableProps) {
@@ -186,6 +194,21 @@ export function PokerTable({
 						<span className="select-none text-white/20 text-xs">TABLE</span>
 					)}
 				</div>
+
+				{/* Scan players button (overlay, top-right of felt) */}
+				{onScanPlayers && (
+					<Button
+						aria-label="スクリーンショットから着席"
+						className="absolute top-[12%] right-[6%] z-10 h-7 gap-1 px-2 text-[10px]"
+						onClick={onScanPlayers}
+						size="xs"
+						type="button"
+						variant="outline"
+					>
+						<IconSparkles size={12} />
+						AI 着席
+					</Button>
+				)}
 
 				{/* Seats */}
 				{Array.from({ length: MAX_SEATS }, (_, i) => {

--- a/apps/web/src/live-sessions/components/poker-table.tsx
+++ b/apps/web/src/live-sessions/components/poker-table.tsx
@@ -195,18 +195,18 @@ export function PokerTable({
 					)}
 				</div>
 
-				{/* Scan players button (overlay, top-right of felt) */}
+				{/* Scan players button (top-center overlay) */}
 				{onScanPlayers && (
 					<Button
-						aria-label="スクリーンショットから着席"
-						className="absolute top-[12%] right-[6%] z-10 h-7 gap-1 px-2 text-[10px]"
+						aria-label="Seat from screenshot"
+						className="absolute top-0 left-1/2 z-10 h-7 -translate-x-1/2 gap-1 px-2 text-[10px]"
 						onClick={onScanPlayers}
 						size="xs"
 						type="button"
 						variant="outline"
 					>
 						<IconSparkles size={12} />
-						AI 着席
+						AI Seat
 					</Button>
 				)}
 

--- a/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
+++ b/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
@@ -4,25 +4,37 @@ import {
 } from "@sapphire2/api/routers/ai-extract-sources";
 import {
 	IconAlertTriangle,
+	IconChevronDown,
 	IconLoader2,
 	IconPhotoUp,
 	IconSparkles,
 } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+	type KeyboardEvent as ReactKeyboardEvent,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandItem,
+	CommandList,
+} from "@/shared/components/ui/command";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Input } from "@/shared/components/ui/input";
-import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/shared/components/ui/select";
+	Popover,
+	PopoverAnchor,
+	PopoverContent,
+} from "@/shared/components/ui/popover";
+import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 type SessionParam =
@@ -40,6 +52,11 @@ interface SeatFromScreenshotSheetProps {
 type Step = "select-app" | "upload" | "review";
 
 type RowAction = "existing" | "new" | "hero" | "skip";
+
+interface PlayerOption {
+	id: string;
+	name: string;
+}
 
 interface ReviewRow {
 	action: RowAction;
@@ -107,6 +124,32 @@ function applyRowAction(
 	return { ...row, action: nextAction };
 }
 
+async function applyRow(
+	row: ReviewRow,
+	sessionParam: SessionParam
+): Promise<boolean> {
+	try {
+		if (row.action === "hero") {
+			await updateHeroSeatViaClient(sessionParam, row.seatPosition);
+		} else if (row.action === "existing" && row.existingPlayerId) {
+			await trpcClient.sessionTablePlayer.add.mutate({
+				...sessionParam,
+				playerId: row.existingPlayerId,
+				seatPosition: row.seatPosition,
+			});
+		} else if (row.action === "new") {
+			await trpcClient.sessionTablePlayer.addNew.mutate({
+				...sessionParam,
+				playerName: row.name.trim(),
+				seatPosition: row.seatPosition,
+			});
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function updateHeroSeatViaClient(
 	sessionParam: SessionParam,
 	heroSeatPosition: number | null
@@ -147,7 +190,7 @@ export function SeatFromScreenshotSheet({
 		...trpc.player.list.queryOptions(),
 		enabled: open,
 	});
-	const allPlayers = useMemo(
+	const allPlayers = useMemo<PlayerOption[]>(
 		() => playersQuery.data ?? [],
 		[playersQuery.data]
 	);
@@ -181,6 +224,11 @@ export function SeatFromScreenshotSheet({
 		}
 	}, [open, extractReset]);
 
+	const handleSourceAppSelect = (nextApp: TablePlayerSourceApp) => {
+		setSourceApp(nextApp);
+		setStep("upload");
+	};
+
 	const handlePickFile = () => {
 		fileInputRef.current?.click();
 	};
@@ -195,7 +243,7 @@ export function SeatFromScreenshotSheet({
 		}
 		const mediaType = file.type;
 		if (!isAcceptedMediaType(mediaType)) {
-			toast.error("JPEG / PNG / GIF / WEBP のみ対応しています");
+			toast.error("Only JPEG, PNG, GIF, or WEBP images are supported.");
 			return;
 		}
 
@@ -247,10 +295,28 @@ export function SeatFromScreenshotSheet({
 					name: nextName,
 					occupiedSeatPositions,
 					playersByNormalizedName,
-					preferredAction: row.action,
+					preferredAction: row.action === "existing" ? "new" : row.action,
 					seatNumber: row.seatNumber,
 					seatPosition: row.seatPosition,
 				});
+			})
+		);
+	};
+
+	const handleRowSelectExisting = (rowId: string, player: PlayerOption) => {
+		setRows((prev) =>
+			prev.map((row) => {
+				if (row.rowId !== rowId) {
+					return row;
+				}
+				return {
+					...row,
+					action: "existing",
+					existingPlayerId: player.id,
+					matchedPlayerName: player.name,
+					name: player.name,
+					ambiguous: false,
+				};
 			})
 		);
 	};
@@ -289,7 +355,7 @@ export function SeatFromScreenshotSheet({
 			(row) => row.action !== "skip" && row.warning === null
 		);
 		if (actionable.length === 0) {
-			toast.error("着席対象の行がありません");
+			toast.error("Nothing to apply.");
 			return;
 		}
 
@@ -297,24 +363,10 @@ export function SeatFromScreenshotSheet({
 		let success = 0;
 		let failure = 0;
 		for (const row of actionable) {
-			try {
-				if (row.action === "hero") {
-					await updateHeroSeatViaClient(sessionParam, row.seatPosition);
-				} else if (row.action === "existing" && row.existingPlayerId) {
-					await trpcClient.sessionTablePlayer.add.mutate({
-						...sessionParam,
-						playerId: row.existingPlayerId,
-						seatPosition: row.seatPosition,
-					});
-				} else if (row.action === "new") {
-					await trpcClient.sessionTablePlayer.addNew.mutate({
-						...sessionParam,
-						playerName: row.name.trim(),
-						seatPosition: row.seatPosition,
-					});
-				}
+			const ok = await applyRow(row, sessionParam);
+			if (ok) {
 				success += 1;
-			} catch {
+			} else {
 				failure += 1;
 			}
 		}
@@ -322,10 +374,10 @@ export function SeatFromScreenshotSheet({
 		invalidateQueries();
 
 		if (failure === 0) {
-			toast.success(`${success} 件を反映しました`);
+			toast.success(`Applied ${success} ${success === 1 ? "seat" : "seats"}.`);
 			onOpenChange(false);
 		} else {
-			toast.error(`反映 ${success} 件成功 / ${failure} 件失敗`);
+			toast.error(`Applied ${success}, failed ${failure}.`);
 		}
 	};
 
@@ -334,15 +386,15 @@ export function SeatFromScreenshotSheet({
 			return (
 				<div className="flex flex-col gap-3">
 					<p className="text-muted-foreground text-sm">
-						スクリーンショットの元となるアプリを選択してください。
+						Choose the app the screenshot came from.
 					</p>
 					<div className="flex flex-col gap-2">
 						{SOURCE_APP_ENTRIES.map(([id, config]) => (
 							<Button
 								key={id}
-								onClick={() => setSourceApp(id)}
+								onClick={() => handleSourceAppSelect(id)}
 								type="button"
-								variant={sourceApp === id ? "default" : "outline"}
+								variant="outline"
 							>
 								{config.label}
 							</Button>
@@ -354,10 +406,7 @@ export function SeatFromScreenshotSheet({
 							type="button"
 							variant="outline"
 						>
-							キャンセル
-						</Button>
-						<Button onClick={() => setStep("upload")} type="button">
-							次へ
+							Cancel
 						</Button>
 					</DialogActionRow>
 				</div>
@@ -368,24 +417,23 @@ export function SeatFromScreenshotSheet({
 			const isPending = extractMutation.isPending;
 			return (
 				<div className="flex flex-col gap-3">
-					<div className="rounded-md border border-border bg-muted/30 p-3 text-sm">
-						<p className="font-medium">
+					<p className="text-muted-foreground text-sm">
+						Upload a screenshot from{" "}
+						<span className="font-medium text-foreground">
 							{TABLE_PLAYER_SOURCE_APPS[sourceApp].label}
-						</p>
-						<p className="mt-1 whitespace-pre-wrap text-muted-foreground text-xs">
-							{TABLE_PLAYER_SOURCE_APPS[sourceApp].prompt}
-						</p>
-					</div>
+						</span>
+						.
+					</p>
 					<Button disabled={isPending} onClick={handlePickFile} type="button">
 						{isPending ? (
 							<>
 								<IconLoader2 className="animate-spin" size={16} />
-								AI 解析中...
+								Analyzing...
 							</>
 						) : (
 							<>
 								<IconPhotoUp size={16} />
-								スクリーンショットを選択
+								Choose screenshot
 							</>
 						)}
 					</Button>
@@ -403,7 +451,7 @@ export function SeatFromScreenshotSheet({
 							type="button"
 							variant="outline"
 						>
-							戻る
+							Back
 						</Button>
 					</DialogActionRow>
 				</div>
@@ -414,7 +462,7 @@ export function SeatFromScreenshotSheet({
 			return (
 				<div className="flex flex-col gap-3">
 					<p className="text-muted-foreground text-sm">
-						プレイヤーが検出されませんでした。
+						No players detected in the screenshot.
 					</p>
 					<DialogActionRow>
 						<Button
@@ -422,14 +470,14 @@ export function SeatFromScreenshotSheet({
 							type="button"
 							variant="outline"
 						>
-							別の画像を試す
+							Try another image
 						</Button>
 						<Button
 							onClick={() => onOpenChange(false)}
 							type="button"
 							variant="ghost"
 						>
-							閉じる
+							Close
 						</Button>
 					</DialogActionRow>
 				</div>
@@ -443,12 +491,13 @@ export function SeatFromScreenshotSheet({
 		return (
 			<div className="flex flex-col gap-3">
 				<p className="text-muted-foreground text-sm">
-					{rows.length} 件を検出しました。自分の席は「Hero
-					(自分)」を選択してください。内容を確認して「反映」を押してください。
+					Detected {rows.length} {rows.length === 1 ? "seat" : "seats"}. Review
+					each row, then press Apply.
 				</p>
 				<div className="flex flex-col gap-2">
 					{rows.map((row) => (
 						<ReviewRowItem
+							allPlayers={allPlayers}
 							heroAlreadySeatedElsewhere={
 								heroSeatPosition !== null &&
 								heroSeatPosition !== row.seatPosition
@@ -456,6 +505,9 @@ export function SeatFromScreenshotSheet({
 							key={row.rowId}
 							onActionChange={(next) => handleRowActionChange(row.rowId, next)}
 							onNameChange={(next) => handleRowNameChange(row.rowId, next)}
+							onSelectExisting={(player) =>
+								handleRowSelectExisting(row.rowId, player)
+							}
 							row={row}
 						/>
 					))}
@@ -467,7 +519,7 @@ export function SeatFromScreenshotSheet({
 						type="button"
 						variant="outline"
 					>
-						別の画像を試す
+						Try another image
 					</Button>
 					<Button
 						disabled={isApplying || seatablesCount === 0}
@@ -477,12 +529,12 @@ export function SeatFromScreenshotSheet({
 						{isApplying ? (
 							<>
 								<IconLoader2 className="animate-spin" size={16} />
-								反映中...
+								Applying...
 							</>
 						) : (
 							<>
 								<IconSparkles size={16} />
-								反映 ({seatablesCount})
+								Apply ({seatablesCount})
 							</>
 						)}
 					</Button>
@@ -493,84 +545,278 @@ export function SeatFromScreenshotSheet({
 
 	return (
 		<ResponsiveDialog
-			description="スクリーンショットから読み取ったプレイヤーを一括で着席させます。"
+			description="Seat players extracted from a screenshot in bulk."
 			fullHeight={step === "review"}
 			onOpenChange={onOpenChange}
 			open={open}
-			title="スクリーンショットから着席"
+			title="Seat from screenshot"
 		>
 			{renderStep()}
 		</ResponsiveDialog>
 	);
 }
 
+const ACTION_BADGE_VARIANT: Record<RowAction, "default" | "secondary"> = {
+	hero: "default",
+	existing: "secondary",
+	new: "default",
+	skip: "secondary",
+};
+
+const ACTION_BADGE_CLASS: Record<RowAction, string> = {
+	hero: "border-amber-400 bg-amber-500/80 text-white",
+	existing: "",
+	new: "bg-violet-500 text-white hover:bg-violet-500/90",
+	skip: "text-muted-foreground",
+};
+
+const ACTION_BADGE_LABEL: Record<RowAction, string> = {
+	hero: "Hero",
+	existing: "Existing",
+	new: "New",
+	skip: "Skip",
+};
+
 function ReviewRowItem({
+	allPlayers,
 	heroAlreadySeatedElsewhere,
 	onActionChange,
 	onNameChange,
+	onSelectExisting,
 	row,
 }: {
+	allPlayers: PlayerOption[];
 	heroAlreadySeatedElsewhere: boolean;
 	onActionChange: (next: RowAction) => void;
 	onNameChange: (next: string) => void;
+	onSelectExisting: (player: PlayerOption) => void;
 	row: ReviewRow;
 }) {
 	const disabled = row.warning !== null;
-	const existingLabel = row.matchedPlayerName
-		? `既存: ${row.matchedPlayerName}`
-		: "既存プレイヤー";
 
 	return (
-		<div className="flex flex-col gap-2 rounded-md border border-border p-2">
+		<div className="flex flex-col gap-1 rounded-md border border-border p-2">
 			<div className="flex items-center gap-2">
-				<Badge className="shrink-0" variant="secondary">
-					席 {row.seatNumber}
+				<Badge className="w-10 shrink-0 justify-center" variant="secondary">
+					{row.seatNumber}
 				</Badge>
-				<Input
-					className="h-8"
-					disabled={disabled || row.action === "hero"}
-					onChange={(e) => onNameChange(e.target.value)}
-					placeholder="プレイヤー名"
-					value={row.name}
+				<SeatCombobox
+					allPlayers={allPlayers}
+					disabled={disabled}
+					onActionChange={onActionChange}
+					onNameChange={onNameChange}
+					onSelectExisting={onSelectExisting}
+					row={row}
 				/>
+				<Badge
+					className={cn("shrink-0", ACTION_BADGE_CLASS[row.action])}
+					variant={ACTION_BADGE_VARIANT[row.action]}
+				>
+					{ACTION_BADGE_LABEL[row.action]}
+				</Badge>
 			</div>
 			{row.warning ? (
 				<div className="flex items-start gap-1.5 text-destructive text-xs">
 					<IconAlertTriangle className="mt-0.5 shrink-0" size={12} />
 					<span>{row.warning}</span>
 				</div>
-			) : (
-				<div className="flex flex-wrap items-center gap-2">
-					<Select
-						disabled={disabled}
-						onValueChange={(v) => onActionChange(v as RowAction)}
-						value={row.action}
-					>
-						<SelectTrigger className="h-8 w-auto min-w-[10rem] text-xs">
-							<SelectValue />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem disabled={!row.existingPlayerId} value="existing">
-								{existingLabel}
-							</SelectItem>
-							<SelectItem value="new">新規作成</SelectItem>
-							<SelectItem value="hero">Hero (自分)</SelectItem>
-							<SelectItem value="skip">スキップ</SelectItem>
-						</SelectContent>
-					</Select>
-					{row.ambiguous && (
-						<span className="text-muted-foreground text-xs">
-							同名が複数存在します
-						</span>
-					)}
-					{row.action === "hero" && heroAlreadySeatedElsewhere && (
-						<span className="text-muted-foreground text-xs">
-							既存の Hero 席は上書きされます
-						</span>
-					)}
-				</div>
-			)}
+			) : null}
+			{row.ambiguous && row.action !== "existing" ? (
+				<span className="text-muted-foreground text-xs">
+					Multiple players share this name.
+				</span>
+			) : null}
+			{row.action === "hero" && heroAlreadySeatedElsewhere ? (
+				<span className="text-muted-foreground text-xs">
+					The existing Hero seat will be overwritten.
+				</span>
+			) : null}
 		</div>
+	);
+}
+
+function getSeatDisplayValue(row: ReviewRow): string {
+	if (row.action === "hero") {
+		return "Hero (self)";
+	}
+	if (row.action === "skip") {
+		return "Skipped";
+	}
+	return row.name;
+}
+
+function SeatCombobox({
+	allPlayers,
+	disabled,
+	onActionChange,
+	onNameChange,
+	onSelectExisting,
+	row,
+}: {
+	allPlayers: PlayerOption[];
+	disabled: boolean;
+	onActionChange: (next: RowAction) => void;
+	onNameChange: (next: string) => void;
+	onSelectExisting: (player: PlayerOption) => void;
+	row: ReviewRow;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+	const [isFiltering, setIsFiltering] = useState(false);
+	const [contentWidth, setContentWidth] = useState<number>();
+	const anchorRef = useRef<HTMLDivElement>(null);
+
+	const displayValue = getSeatDisplayValue(row);
+
+	const readOnly = row.action === "hero" || row.action === "skip";
+	const normalizedInput = row.name.trim().toLowerCase();
+	const filteredPlayers = allPlayers.filter(
+		(p) =>
+			!(isFiltering && normalizedInput) ||
+			p.name.toLowerCase().includes(normalizedInput)
+	);
+
+	useEffect(() => {
+		if (!(isOpen && anchorRef.current)) {
+			return;
+		}
+		setContentWidth(anchorRef.current.offsetWidth);
+	}, [isOpen]);
+
+	const handleSelectExisting = (player: PlayerOption) => {
+		onSelectExisting(player);
+		setIsFiltering(false);
+		setIsOpen(false);
+	};
+
+	const handlePickHero = () => {
+		onActionChange("hero");
+		setIsFiltering(false);
+		setIsOpen(false);
+	};
+
+	const handlePickSkip = () => {
+		onActionChange("skip");
+		setIsFiltering(false);
+		setIsOpen(false);
+	};
+
+	const handleKeepAsNew = () => {
+		onActionChange("new");
+		setIsFiltering(false);
+		setIsOpen(false);
+	};
+
+	const handleKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Escape") {
+			setIsOpen(false);
+		}
+	};
+
+	return (
+		<Popover modal={false} onOpenChange={setIsOpen} open={isOpen}>
+			<PopoverAnchor asChild>
+				<div className="relative flex-1" ref={anchorRef}>
+					<Input
+						aria-expanded={isOpen}
+						autoComplete="off"
+						className={cn(
+							"h-8 pr-7",
+							readOnly && "cursor-pointer text-muted-foreground"
+						)}
+						disabled={disabled}
+						onChange={(e) => {
+							if (readOnly) {
+								return;
+							}
+							onNameChange(e.target.value);
+							setIsFiltering(true);
+							setIsOpen(true);
+						}}
+						onFocus={() => {
+							if (!disabled) {
+								setIsOpen(true);
+							}
+						}}
+						onKeyDown={handleKeyDown}
+						placeholder="Player name"
+						readOnly={readOnly}
+						role="combobox"
+						value={displayValue}
+					/>
+					<IconChevronDown
+						className="pointer-events-none absolute top-2 right-2 text-muted-foreground"
+						size={14}
+					/>
+				</div>
+			</PopoverAnchor>
+			{isOpen ? (
+				<PopoverContent
+					align="start"
+					className="p-0"
+					onFocusOutside={(e) => e.preventDefault()}
+					onOpenAutoFocus={(e) => e.preventDefault()}
+					style={contentWidth ? { width: contentWidth } : undefined}
+				>
+					<Command shouldFilter={false}>
+						<CommandList>
+							{filteredPlayers.length === 0 ? (
+								<CommandEmpty>No matching players.</CommandEmpty>
+							) : null}
+							{row.isHeroCandidate && row.action !== "hero" ? (
+								<CommandItem
+									onMouseDown={(e) => e.preventDefault()}
+									onSelect={handlePickHero}
+									value="__hero__"
+								>
+									<span className="text-amber-500">Hero (self)</span>
+								</CommandItem>
+							) : null}
+							{!row.isHeroCandidate && row.action !== "hero" ? (
+								<CommandItem
+									onMouseDown={(e) => e.preventDefault()}
+									onSelect={handlePickHero}
+									value="__hero__"
+								>
+									<span>Seat Hero here</span>
+								</CommandItem>
+							) : null}
+							{filteredPlayers.map((p) => (
+								<CommandItem
+									key={p.id}
+									onMouseDown={(e) => e.preventDefault()}
+									onSelect={() => handleSelectExisting(p)}
+									value={p.name}
+								>
+									{p.name}
+								</CommandItem>
+							))}
+							{row.name.trim() &&
+							row.action !== "new" &&
+							!allPlayers.some(
+								(p) => p.name.toLowerCase() === normalizedInput
+							) ? (
+								<CommandItem
+									onMouseDown={(e) => e.preventDefault()}
+									onSelect={handleKeepAsNew}
+									value="__new__"
+								>
+									<span>Create new: {row.name.trim()}</span>
+								</CommandItem>
+							) : null}
+							{row.action === "skip" ? null : (
+								<CommandItem
+									onMouseDown={(e) => e.preventDefault()}
+									onSelect={handlePickSkip}
+									value="__skip__"
+								>
+									<span className="text-muted-foreground">Skip this seat</span>
+								</CommandItem>
+							)}
+						</CommandList>
+					</Command>
+				</PopoverContent>
+			) : null}
+		</Popover>
 	);
 }
 
@@ -590,16 +836,17 @@ function computeRowWarning({
 	trimmedName: string;
 }): string | null {
 	if (seatPosition < 0 || seatPosition > 8) {
-		return `席番号 ${seatNumber} は範囲外です (1-9)`;
+		return `Seat ${seatNumber} is out of range (1-9).`;
 	}
 	const isHero =
 		effectivePreferredAction === "hero" ||
 		(effectivePreferredAction === undefined && isHeroCandidate);
-	if (!isHero && occupiedSeatPositions.has(seatPosition)) {
-		return `席 ${seatNumber} には既に着席中のプレイヤーがいます`;
+	const isSkip = effectivePreferredAction === "skip";
+	if (!(isHero || isSkip) && occupiedSeatPositions.has(seatPosition)) {
+		return `Seat ${seatNumber} is already occupied.`;
 	}
-	if (!(isHero || trimmedName)) {
-		return "名前が空です";
+	if (!(isHero || isSkip || trimmedName)) {
+		return "Name is empty.";
 	}
 	return null;
 }

--- a/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
+++ b/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
@@ -11,6 +11,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { authClient } from "@/lib/auth-client";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
@@ -45,6 +46,7 @@ interface ReviewRow {
 	action: RowAction;
 	ambiguous: boolean;
 	existingPlayerId: string | null;
+	isHeroCandidate: boolean;
 	matchedPlayerName: string | null;
 	name: string;
 	rowId: string;
@@ -100,6 +102,9 @@ function applyRowAction(
 		}
 		return row;
 	}
+	if (nextAction === "hero" && !row.isHeroCandidate) {
+		return row;
+	}
 	if (row.ambiguous && nextAction === "existing") {
 		return row;
 	}
@@ -134,6 +139,15 @@ export function SeatFromScreenshotSheet({
 }: SeatFromScreenshotSheetProps) {
 	const queryClient = useQueryClient();
 	const fileInputRef = useRef<HTMLInputElement>(null);
+	const { data: sessionData } = authClient.useSession();
+	const userNameNormalized = useMemo(() => {
+		const raw = sessionData?.user?.name;
+		if (!raw) {
+			return null;
+		}
+		const normalized = normalizeName(raw);
+		return normalized === "" ? null : normalized;
+	}, [sessionData?.user?.name]);
 
 	const [step, setStep] = useState<Step>("select-app");
 	const [sourceApp, setSourceApp] = useState<TablePlayerSourceApp>(
@@ -219,6 +233,7 @@ export function SeatFromScreenshotSheet({
 					playersByNormalizedName,
 					seatNumber: seat.seatNumber,
 					seatPosition,
+					userNameNormalized,
 				});
 				built.push(row);
 			}
@@ -242,6 +257,7 @@ export function SeatFromScreenshotSheet({
 					seatNumber: row.seatNumber,
 					seatPosition: row.seatPosition,
 					preferredAction: row.action,
+					userNameNormalized,
 				});
 			})
 		);
@@ -546,7 +562,9 @@ function ReviewRowItem({
 								{existingLabel}
 							</SelectItem>
 							<SelectItem value="new">新規作成</SelectItem>
-							<SelectItem value="hero">Hero (自分)</SelectItem>
+							<SelectItem disabled={!row.isHeroCandidate} value="hero">
+								Hero (自分)
+							</SelectItem>
 							<SelectItem value="skip">スキップ</SelectItem>
 						</SelectContent>
 					</Select>
@@ -566,6 +584,60 @@ function ReviewRowItem({
 	);
 }
 
+function computeRowWarning({
+	effectivePreferredAction,
+	isHeroCandidate,
+	occupiedSeatPositions,
+	seatNumber,
+	seatPosition,
+	trimmedName,
+}: {
+	effectivePreferredAction: RowAction | undefined;
+	isHeroCandidate: boolean;
+	occupiedSeatPositions: Set<number>;
+	seatNumber: number;
+	seatPosition: number;
+	trimmedName: string;
+}): string | null {
+	if (seatPosition < 0 || seatPosition > 8) {
+		return `席番号 ${seatNumber} は範囲外です (1-9)`;
+	}
+	const isHero =
+		effectivePreferredAction === "hero" ||
+		(effectivePreferredAction === undefined && isHeroCandidate);
+	if (!isHero && occupiedSeatPositions.has(seatPosition)) {
+		return `席 ${seatNumber} には既に着席中のプレイヤーがいます`;
+	}
+	if (!(isHero || trimmedName)) {
+		return "名前が空です";
+	}
+	return null;
+}
+
+function computeRowAction({
+	effectivePreferredAction,
+	isHeroCandidate,
+	matchedPlayer,
+}: {
+	effectivePreferredAction: RowAction | undefined;
+	isHeroCandidate: boolean;
+	matchedPlayer: { id: string; name: string } | null;
+}): RowAction {
+	if (effectivePreferredAction) {
+		if (effectivePreferredAction === "existing" && !matchedPlayer) {
+			return "new";
+		}
+		return effectivePreferredAction;
+	}
+	if (isHeroCandidate) {
+		return "hero";
+	}
+	if (matchedPlayer) {
+		return "existing";
+	}
+	return "new";
+}
+
 function buildRow({
 	name,
 	occupiedSeatPositions,
@@ -573,6 +645,7 @@ function buildRow({
 	seatNumber,
 	seatPosition,
 	preferredAction,
+	userNameNormalized,
 }: {
 	name: string;
 	occupiedSeatPositions: Set<number>;
@@ -583,6 +656,7 @@ function buildRow({
 	preferredAction?: RowAction;
 	seatNumber: number;
 	seatPosition: number;
+	userNameNormalized: string | null;
 }): ReviewRow {
 	const rowId = `seat-${seatNumber}`;
 	const trimmedName = name.trim();
@@ -590,35 +664,35 @@ function buildRow({
 	const matches = trimmedName ? (playersByNormalizedName.get(key) ?? []) : [];
 	const ambiguous = matches.length > 1;
 	const matchedPlayer = matches.length === 1 ? matches[0] : null;
+	const isHeroCandidate =
+		userNameNormalized !== null &&
+		trimmedName !== "" &&
+		key === userNameNormalized;
 
-	let warning: string | null = null;
-	if (seatPosition < 0 || seatPosition > 8) {
-		warning = `席番号 ${seatNumber} は範囲外です (1-9)`;
-	} else if (
-		preferredAction !== "hero" &&
-		occupiedSeatPositions.has(seatPosition)
-	) {
-		warning = `席 ${seatNumber} には既に着席中のプレイヤーがいます`;
-	} else if (preferredAction !== "hero" && !trimmedName) {
-		warning = "名前が空です";
-	}
+	const effectivePreferredAction =
+		preferredAction === "hero" && !isHeroCandidate
+			? undefined
+			: preferredAction;
 
-	let action: RowAction;
-	if (preferredAction) {
-		action = preferredAction;
-		if (action === "existing" && !matchedPlayer) {
-			action = "new";
-		}
-	} else if (matchedPlayer) {
-		action = "existing";
-	} else {
-		action = "new";
-	}
+	const warning = computeRowWarning({
+		effectivePreferredAction,
+		isHeroCandidate,
+		occupiedSeatPositions,
+		seatNumber,
+		seatPosition,
+		trimmedName,
+	});
+	const action = computeRowAction({
+		effectivePreferredAction,
+		isHeroCandidate,
+		matchedPlayer,
+	});
 
 	return {
 		action,
 		ambiguous,
 		existingPlayerId: matchedPlayer?.id ?? null,
+		isHeroCandidate,
 		matchedPlayerName: matchedPlayer?.name ?? null,
 		name: trimmedName,
 		rowId,

--- a/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
+++ b/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
@@ -11,7 +11,6 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { authClient } from "@/lib/auth-client";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
@@ -102,9 +101,6 @@ function applyRowAction(
 		}
 		return row;
 	}
-	if (nextAction === "hero" && !row.isHeroCandidate) {
-		return row;
-	}
 	if (row.ambiguous && nextAction === "existing") {
 		return row;
 	}
@@ -139,15 +135,6 @@ export function SeatFromScreenshotSheet({
 }: SeatFromScreenshotSheetProps) {
 	const queryClient = useQueryClient();
 	const fileInputRef = useRef<HTMLInputElement>(null);
-	const { data: sessionData } = authClient.useSession();
-	const userNameNormalized = useMemo(() => {
-		const raw = sessionData?.user?.name;
-		if (!raw) {
-			return null;
-		}
-		const normalized = normalizeName(raw);
-		return normalized === "" ? null : normalized;
-	}, [sessionData?.user?.name]);
 
 	const [step, setStep] = useState<Step>("select-app");
 	const [sourceApp, setSourceApp] = useState<TablePlayerSourceApp>(
@@ -220,6 +207,7 @@ export function SeatFromScreenshotSheet({
 			});
 
 			const seenSeatNumbers = new Set<number>();
+			let heroAssigned = false;
 			const built: ReviewRow[] = [];
 			for (const seat of result.seats) {
 				if (seenSeatNumbers.has(seat.seatNumber)) {
@@ -227,13 +215,17 @@ export function SeatFromScreenshotSheet({
 				}
 				seenSeatNumbers.add(seat.seatNumber);
 				const seatPosition = seat.seatNumber - 1;
+				const isHero = seat.isHero === true && !heroAssigned;
+				if (isHero) {
+					heroAssigned = true;
+				}
 				const row = buildRow({
+					isHero,
 					name: seat.name,
 					occupiedSeatPositions,
 					playersByNormalizedName,
 					seatNumber: seat.seatNumber,
 					seatPosition,
-					userNameNormalized,
 				});
 				built.push(row);
 			}
@@ -251,13 +243,13 @@ export function SeatFromScreenshotSheet({
 					return row;
 				}
 				return buildRow({
+					isHero: row.isHeroCandidate,
 					name: nextName,
 					occupiedSeatPositions,
 					playersByNormalizedName,
+					preferredAction: row.action,
 					seatNumber: row.seatNumber,
 					seatPosition: row.seatPosition,
-					preferredAction: row.action,
-					userNameNormalized,
 				});
 			})
 		);
@@ -562,9 +554,7 @@ function ReviewRowItem({
 								{existingLabel}
 							</SelectItem>
 							<SelectItem value="new">新規作成</SelectItem>
-							<SelectItem disabled={!row.isHeroCandidate} value="hero">
-								Hero (自分)
-							</SelectItem>
+							<SelectItem value="hero">Hero (自分)</SelectItem>
 							<SelectItem value="skip">スキップ</SelectItem>
 						</SelectContent>
 					</Select>
@@ -639,14 +629,15 @@ function computeRowAction({
 }
 
 function buildRow({
+	isHero,
 	name,
 	occupiedSeatPositions,
 	playersByNormalizedName,
+	preferredAction,
 	seatNumber,
 	seatPosition,
-	preferredAction,
-	userNameNormalized,
 }: {
+	isHero: boolean;
 	name: string;
 	occupiedSeatPositions: Set<number>;
 	playersByNormalizedName: Map<
@@ -656,7 +647,6 @@ function buildRow({
 	preferredAction?: RowAction;
 	seatNumber: number;
 	seatPosition: number;
-	userNameNormalized: string | null;
 }): ReviewRow {
 	const rowId = `seat-${seatNumber}`;
 	const trimmedName = name.trim();
@@ -664,15 +654,9 @@ function buildRow({
 	const matches = trimmedName ? (playersByNormalizedName.get(key) ?? []) : [];
 	const ambiguous = matches.length > 1;
 	const matchedPlayer = matches.length === 1 ? matches[0] : null;
-	const isHeroCandidate =
-		userNameNormalized !== null &&
-		trimmedName !== "" &&
-		key === userNameNormalized;
+	const isHeroCandidate = isHero;
 
-	const effectivePreferredAction =
-		preferredAction === "hero" && !isHeroCandidate
-			? undefined
-			: preferredAction;
+	const effectivePreferredAction = preferredAction;
 
 	const warning = computeRowWarning({
 		effectivePreferredAction,

--- a/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
+++ b/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
@@ -1,0 +1,566 @@
+import {
+	TABLE_PLAYER_SOURCE_APPS,
+	type TablePlayerSourceApp,
+} from "@sapphire2/api/routers/ai-extract-sources";
+import {
+	IconAlertTriangle,
+	IconLoader2,
+	IconPhotoUp,
+	IconSparkles,
+} from "@tabler/icons-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/shared/components/ui/badge";
+import { Button } from "@/shared/components/ui/button";
+import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
+import { Input } from "@/shared/components/ui/input";
+import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/shared/components/ui/select";
+import { trpc, trpcClient } from "@/utils/trpc";
+
+type SessionParam =
+	| { liveCashGameSessionId: string; liveTournamentSessionId?: never }
+	| { liveCashGameSessionId?: never; liveTournamentSessionId: string };
+
+interface SeatFromScreenshotSheetProps {
+	occupiedSeatPositions: Set<number>;
+	onOpenChange: (open: boolean) => void;
+	open: boolean;
+	sessionParam: SessionParam;
+}
+
+type Step = "select-app" | "upload" | "review";
+
+type RowAction = "existing" | "new" | "skip";
+
+interface ReviewRow {
+	action: RowAction;
+	ambiguous: boolean;
+	existingPlayerId: string | null;
+	matchedPlayerName: string | null;
+	name: string;
+	rowId: string;
+	seatNumber: number;
+	seatPosition: number;
+	warning: string | null;
+}
+
+const ACCEPTED_TYPES = [
+	"image/jpeg",
+	"image/png",
+	"image/gif",
+	"image/webp",
+] as const;
+type AcceptedMediaType = (typeof ACCEPTED_TYPES)[number];
+
+function isAcceptedMediaType(type: string): type is AcceptedMediaType {
+	return (ACCEPTED_TYPES as readonly string[]).includes(type);
+}
+
+function fileToBase64(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => {
+			const result = reader.result as string;
+			resolve(result.split(",")[1] ?? "");
+		};
+		reader.onerror = reject;
+		reader.readAsDataURL(file);
+	});
+}
+
+function normalizeName(name: string): string {
+	return name.trim().toLowerCase();
+}
+
+const SOURCE_APP_ENTRIES = Object.entries(TABLE_PLAYER_SOURCE_APPS) as [
+	TablePlayerSourceApp,
+	(typeof TABLE_PLAYER_SOURCE_APPS)[TablePlayerSourceApp],
+][];
+
+export function SeatFromScreenshotSheet({
+	occupiedSeatPositions,
+	onOpenChange,
+	open,
+	sessionParam,
+}: SeatFromScreenshotSheetProps) {
+	const queryClient = useQueryClient();
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const [step, setStep] = useState<Step>("select-app");
+	const [sourceApp, setSourceApp] = useState<TablePlayerSourceApp>(
+		SOURCE_APP_ENTRIES[0][0]
+	);
+	const [rows, setRows] = useState<ReviewRow[]>([]);
+	const [isApplying, setIsApplying] = useState(false);
+
+	const playersQuery = useQuery({
+		...trpc.player.list.queryOptions(),
+		enabled: open,
+	});
+	const allPlayers = useMemo(
+		() => playersQuery.data ?? [],
+		[playersQuery.data]
+	);
+
+	const playersByNormalizedName = useMemo(() => {
+		const map = new Map<
+			string,
+			{ id: string; name: string; count: number }[]
+		>();
+		for (const p of allPlayers) {
+			const key = normalizeName(p.name);
+			const bucket = map.get(key) ?? [];
+			bucket.push({ id: p.id, name: p.name, count: bucket.length + 1 });
+			map.set(key, bucket);
+		}
+		return map;
+	}, [allPlayers]);
+
+	const extractMutation = useMutation(
+		trpc.aiExtract.extractTablePlayers.mutationOptions()
+	);
+	const extractReset = extractMutation.reset;
+
+	useEffect(() => {
+		if (open) {
+			setStep("select-app");
+			setSourceApp(SOURCE_APP_ENTRIES[0][0]);
+			setRows([]);
+			extractReset();
+			setIsApplying(false);
+		}
+	}, [open, extractReset]);
+
+	const handlePickFile = () => {
+		fileInputRef.current?.click();
+	};
+
+	const handleImageSelected = async (
+		e: React.ChangeEvent<HTMLInputElement>
+	) => {
+		const file = e.target.files?.[0];
+		e.target.value = "";
+		if (!file) {
+			return;
+		}
+		const mediaType = file.type;
+		if (!isAcceptedMediaType(mediaType)) {
+			toast.error("JPEG / PNG / GIF / WEBP のみ対応しています");
+			return;
+		}
+
+		try {
+			const base64 = await fileToBase64(file);
+			const result = await extractMutation.mutateAsync({
+				sourceApp,
+				sources: [{ kind: "image", data: base64, mediaType }],
+			});
+
+			const seenSeatNumbers = new Set<number>();
+			const built: ReviewRow[] = [];
+			for (const seat of result.seats) {
+				if (seenSeatNumbers.has(seat.seatNumber)) {
+					continue;
+				}
+				seenSeatNumbers.add(seat.seatNumber);
+				const seatPosition = seat.seatNumber - 1;
+				const row = buildRow({
+					name: seat.name,
+					occupiedSeatPositions,
+					playersByNormalizedName,
+					seatNumber: seat.seatNumber,
+					seatPosition,
+				});
+				built.push(row);
+			}
+			setRows(built);
+			setStep("review");
+		} catch {
+			// toast already handled by MutationCache.onError
+		}
+	};
+
+	const handleRowNameChange = (rowId: string, nextName: string) => {
+		setRows((prev) =>
+			prev.map((row) => {
+				if (row.rowId !== rowId) {
+					return row;
+				}
+				return buildRow({
+					name: nextName,
+					occupiedSeatPositions,
+					playersByNormalizedName,
+					seatNumber: row.seatNumber,
+					seatPosition: row.seatPosition,
+					preferredAction: row.action,
+				});
+			})
+		);
+	};
+
+	const handleRowActionChange = (rowId: string, nextAction: RowAction) => {
+		setRows((prev) =>
+			prev.map((row) => {
+				if (row.rowId !== rowId) {
+					return row;
+				}
+				if (row.ambiguous && nextAction === "existing") {
+					return row;
+				}
+				return { ...row, action: nextAction };
+			})
+		);
+	};
+
+	const invalidateQueries = () => {
+		queryClient.invalidateQueries({
+			queryKey:
+				trpc.sessionTablePlayer.list.queryOptions(sessionParam).queryKey,
+		});
+		queryClient.invalidateQueries({
+			queryKey: trpc.player.list.queryOptions().queryKey,
+		});
+	};
+
+	const handleApply = async () => {
+		const actionable = rows.filter(
+			(row) => row.action !== "skip" && row.warning === null
+		);
+		if (actionable.length === 0) {
+			toast.error("着席対象の行がありません");
+			return;
+		}
+
+		setIsApplying(true);
+		let success = 0;
+		let failure = 0;
+		for (const row of actionable) {
+			try {
+				if (row.action === "existing" && row.existingPlayerId) {
+					await trpcClient.sessionTablePlayer.add.mutate({
+						...sessionParam,
+						playerId: row.existingPlayerId,
+						seatPosition: row.seatPosition,
+					});
+				} else if (row.action === "new") {
+					await trpcClient.sessionTablePlayer.addNew.mutate({
+						...sessionParam,
+						playerName: row.name.trim(),
+						seatPosition: row.seatPosition,
+					});
+				}
+				success += 1;
+			} catch {
+				failure += 1;
+			}
+		}
+		setIsApplying(false);
+		invalidateQueries();
+
+		if (failure === 0) {
+			toast.success(`${success} 人を着席させました`);
+			onOpenChange(false);
+		} else {
+			toast.error(`着席 ${success} 件成功 / ${failure} 件失敗`);
+		}
+	};
+
+	const renderStep = () => {
+		if (step === "select-app") {
+			return (
+				<div className="flex flex-col gap-3">
+					<p className="text-muted-foreground text-sm">
+						スクリーンショットの元となるアプリを選択してください。
+					</p>
+					<div className="flex flex-col gap-2">
+						{SOURCE_APP_ENTRIES.map(([id, config]) => (
+							<Button
+								key={id}
+								onClick={() => setSourceApp(id)}
+								type="button"
+								variant={sourceApp === id ? "default" : "outline"}
+							>
+								{config.label}
+							</Button>
+						))}
+					</div>
+					<DialogActionRow>
+						<Button
+							onClick={() => onOpenChange(false)}
+							type="button"
+							variant="outline"
+						>
+							キャンセル
+						</Button>
+						<Button onClick={() => setStep("upload")} type="button">
+							次へ
+						</Button>
+					</DialogActionRow>
+				</div>
+			);
+		}
+
+		if (step === "upload") {
+			const isPending = extractMutation.isPending;
+			return (
+				<div className="flex flex-col gap-3">
+					<div className="rounded-md border border-border bg-muted/30 p-3 text-sm">
+						<p className="font-medium">
+							{TABLE_PLAYER_SOURCE_APPS[sourceApp].label}
+						</p>
+						<p className="mt-1 whitespace-pre-wrap text-muted-foreground text-xs">
+							{TABLE_PLAYER_SOURCE_APPS[sourceApp].prompt}
+						</p>
+					</div>
+					<Button disabled={isPending} onClick={handlePickFile} type="button">
+						{isPending ? (
+							<>
+								<IconLoader2 className="animate-spin" size={16} />
+								AI 解析中...
+							</>
+						) : (
+							<>
+								<IconPhotoUp size={16} />
+								スクリーンショットを選択
+							</>
+						)}
+					</Button>
+					<input
+						accept="image/jpeg,image/png,image/gif,image/webp"
+						className="hidden"
+						onChange={handleImageSelected}
+						ref={fileInputRef}
+						type="file"
+					/>
+					<DialogActionRow>
+						<Button
+							disabled={isPending}
+							onClick={() => setStep("select-app")}
+							type="button"
+							variant="outline"
+						>
+							戻る
+						</Button>
+					</DialogActionRow>
+				</div>
+			);
+		}
+
+		if (rows.length === 0) {
+			return (
+				<div className="flex flex-col gap-3">
+					<p className="text-muted-foreground text-sm">
+						プレイヤーが検出されませんでした。
+					</p>
+					<DialogActionRow>
+						<Button
+							onClick={() => setStep("upload")}
+							type="button"
+							variant="outline"
+						>
+							別の画像を試す
+						</Button>
+						<Button
+							onClick={() => onOpenChange(false)}
+							type="button"
+							variant="ghost"
+						>
+							閉じる
+						</Button>
+					</DialogActionRow>
+				</div>
+			);
+		}
+
+		const seatablesCount = rows.filter(
+			(row) => row.action !== "skip" && row.warning === null
+		).length;
+
+		return (
+			<div className="flex flex-col gap-3">
+				<p className="text-muted-foreground text-sm">
+					{rows.length}{" "}
+					件を検出しました。内容を確認して「着席」を押してください。
+				</p>
+				<div className="flex flex-col gap-2">
+					{rows.map((row) => (
+						<ReviewRowItem
+							key={row.rowId}
+							onActionChange={(next) => handleRowActionChange(row.rowId, next)}
+							onNameChange={(next) => handleRowNameChange(row.rowId, next)}
+							row={row}
+						/>
+					))}
+				</div>
+				<DialogActionRow>
+					<Button
+						disabled={isApplying}
+						onClick={() => setStep("upload")}
+						type="button"
+						variant="outline"
+					>
+						別の画像を試す
+					</Button>
+					<Button
+						disabled={isApplying || seatablesCount === 0}
+						onClick={handleApply}
+						type="button"
+					>
+						{isApplying ? (
+							<>
+								<IconLoader2 className="animate-spin" size={16} />
+								着席中...
+							</>
+						) : (
+							<>
+								<IconSparkles size={16} />
+								着席 ({seatablesCount})
+							</>
+						)}
+					</Button>
+				</DialogActionRow>
+			</div>
+		);
+	};
+
+	return (
+		<ResponsiveDialog
+			description="スクリーンショットから読み取ったプレイヤーを一括で着席させます。"
+			fullHeight={step === "review"}
+			onOpenChange={onOpenChange}
+			open={open}
+			title="スクリーンショットから着席"
+		>
+			{renderStep()}
+		</ResponsiveDialog>
+	);
+}
+
+function ReviewRowItem({
+	onActionChange,
+	onNameChange,
+	row,
+}: {
+	onActionChange: (next: RowAction) => void;
+	onNameChange: (next: string) => void;
+	row: ReviewRow;
+}) {
+	const disabled = row.warning !== null;
+	const existingLabel = row.matchedPlayerName
+		? `既存: ${row.matchedPlayerName}`
+		: "既存プレイヤー";
+
+	return (
+		<div className="flex flex-col gap-2 rounded-md border border-border p-2">
+			<div className="flex items-center gap-2">
+				<Badge className="shrink-0" variant="secondary">
+					席 {row.seatNumber}
+				</Badge>
+				<Input
+					className="h-8"
+					disabled={disabled}
+					onChange={(e) => onNameChange(e.target.value)}
+					placeholder="プレイヤー名"
+					value={row.name}
+				/>
+			</div>
+			{row.warning ? (
+				<div className="flex items-start gap-1.5 text-destructive text-xs">
+					<IconAlertTriangle className="mt-0.5 shrink-0" size={12} />
+					<span>{row.warning}</span>
+				</div>
+			) : (
+				<div className="flex flex-wrap items-center gap-2">
+					<Select
+						disabled={disabled}
+						onValueChange={(v) => onActionChange(v as RowAction)}
+						value={row.action}
+					>
+						<SelectTrigger className="h-8 w-auto min-w-[10rem] text-xs">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem disabled={!row.existingPlayerId} value="existing">
+								{existingLabel}
+							</SelectItem>
+							<SelectItem value="new">新規作成</SelectItem>
+							<SelectItem value="skip">スキップ</SelectItem>
+						</SelectContent>
+					</Select>
+					{row.ambiguous && (
+						<span className="text-muted-foreground text-xs">
+							同名が複数存在します
+						</span>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function buildRow({
+	name,
+	occupiedSeatPositions,
+	playersByNormalizedName,
+	seatNumber,
+	seatPosition,
+	preferredAction,
+}: {
+	name: string;
+	occupiedSeatPositions: Set<number>;
+	playersByNormalizedName: Map<
+		string,
+		{ id: string; name: string; count: number }[]
+	>;
+	preferredAction?: RowAction;
+	seatNumber: number;
+	seatPosition: number;
+}): ReviewRow {
+	const rowId = `seat-${seatNumber}`;
+	const trimmedName = name.trim();
+	const key = normalizeName(trimmedName);
+	const matches = trimmedName ? (playersByNormalizedName.get(key) ?? []) : [];
+	const ambiguous = matches.length > 1;
+	const matchedPlayer = matches.length === 1 ? matches[0] : null;
+
+	let warning: string | null = null;
+	if (seatPosition < 0 || seatPosition > 8) {
+		warning = `席番号 ${seatNumber} は範囲外です (1-9)`;
+	} else if (occupiedSeatPositions.has(seatPosition)) {
+		warning = `席 ${seatNumber} には既に着席中のプレイヤーがいます`;
+	} else if (!trimmedName) {
+		warning = "名前が空です";
+	}
+
+	let action: RowAction;
+	if (preferredAction) {
+		action = preferredAction;
+		if (action === "existing" && !matchedPlayer) {
+			action = "new";
+		}
+	} else if (matchedPlayer) {
+		action = "existing";
+	} else {
+		action = "new";
+	}
+
+	return {
+		action,
+		ambiguous,
+		existingPlayerId: matchedPlayer?.id ?? null,
+		matchedPlayerName: matchedPlayer?.name ?? null,
+		name: trimmedName,
+		rowId,
+		seatNumber,
+		seatPosition,
+		warning,
+	};
+}

--- a/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
+++ b/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
@@ -754,10 +754,21 @@ function SeatCombobox({
 					className="p-0"
 					onFocusOutside={(e) => e.preventDefault()}
 					onOpenAutoFocus={(e) => e.preventDefault()}
+					onPointerDownOutside={(e) => {
+						// Drawer + Radix Popover conflict: keep the drawer from capturing
+						// touches inside the popover on mobile.
+						e.preventDefault();
+					}}
 					style={contentWidth ? { width: contentWidth } : undefined}
 				>
 					<Command shouldFilter={false}>
-						<CommandList className="max-h-64 overflow-y-auto overscroll-contain">
+						<CommandList
+							className="max-h-64 overflow-y-auto overscroll-contain"
+							data-vaul-no-drag=""
+							onTouchMove={(e) => e.stopPropagation()}
+							onTouchStart={(e) => e.stopPropagation()}
+							style={{ touchAction: "pan-y" }}
+						>
 							{heroAvailable && row.action !== "hero" ? (
 								<CommandItem
 									className={row.isHeroCandidate ? "text-amber-500" : ""}

--- a/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
+++ b/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
@@ -290,12 +290,14 @@ export function SeatFromScreenshotSheet({
 				if (row.rowId !== rowId) {
 					return row;
 				}
+				const trimmed = nextName.trim();
+				const nextAction: RowAction = trimmed === "" ? "skip" : "new";
 				return buildRow({
 					isHero: row.isHeroCandidate,
 					name: nextName,
 					occupiedSeatPositions,
 					playersByNormalizedName,
-					preferredAction: row.action === "existing" ? "new" : row.action,
+					preferredAction: nextAction,
 					seatNumber: row.seatNumber,
 					seatPosition: row.seatPosition,
 				});
@@ -487,6 +489,8 @@ export function SeatFromScreenshotSheet({
 		const seatablesCount = rows.filter(
 			(row) => row.action !== "skip" && row.warning === null
 		).length;
+		const heroAssignedRowId =
+			rows.find((r) => r.action === "hero")?.rowId ?? null;
 
 		return (
 			<div className="flex flex-col gap-3">
@@ -501,6 +505,9 @@ export function SeatFromScreenshotSheet({
 							heroAlreadySeatedElsewhere={
 								heroSeatPosition !== null &&
 								heroSeatPosition !== row.seatPosition
+							}
+							heroAvailable={
+								heroAssignedRowId === null || heroAssignedRowId === row.rowId
 							}
 							key={row.rowId}
 							onActionChange={(next) => handleRowActionChange(row.rowId, next)}
@@ -580,6 +587,7 @@ const ACTION_BADGE_LABEL: Record<RowAction, string> = {
 function ReviewRowItem({
 	allPlayers,
 	heroAlreadySeatedElsewhere,
+	heroAvailable,
 	onActionChange,
 	onNameChange,
 	onSelectExisting,
@@ -587,6 +595,7 @@ function ReviewRowItem({
 }: {
 	allPlayers: PlayerOption[];
 	heroAlreadySeatedElsewhere: boolean;
+	heroAvailable: boolean;
 	onActionChange: (next: RowAction) => void;
 	onNameChange: (next: string) => void;
 	onSelectExisting: (player: PlayerOption) => void;
@@ -603,13 +612,17 @@ function ReviewRowItem({
 				<SeatCombobox
 					allPlayers={allPlayers}
 					disabled={disabled}
+					heroAvailable={heroAvailable}
 					onActionChange={onActionChange}
 					onNameChange={onNameChange}
 					onSelectExisting={onSelectExisting}
 					row={row}
 				/>
 				<Badge
-					className={cn("shrink-0", ACTION_BADGE_CLASS[row.action])}
+					className={cn(
+						"w-16 shrink-0 justify-center",
+						ACTION_BADGE_CLASS[row.action]
+					)}
 					variant={ACTION_BADGE_VARIANT[row.action]}
 				>
 					{ACTION_BADGE_LABEL[row.action]}
@@ -639,15 +652,13 @@ function getSeatDisplayValue(row: ReviewRow): string {
 	if (row.action === "hero") {
 		return "Hero (self)";
 	}
-	if (row.action === "skip") {
-		return "Skipped";
-	}
 	return row.name;
 }
 
 function SeatCombobox({
 	allPlayers,
 	disabled,
+	heroAvailable,
 	onActionChange,
 	onNameChange,
 	onSelectExisting,
@@ -655,25 +666,23 @@ function SeatCombobox({
 }: {
 	allPlayers: PlayerOption[];
 	disabled: boolean;
+	heroAvailable: boolean;
 	onActionChange: (next: RowAction) => void;
 	onNameChange: (next: string) => void;
 	onSelectExisting: (player: PlayerOption) => void;
 	row: ReviewRow;
 }) {
 	const [isOpen, setIsOpen] = useState(false);
-	const [isFiltering, setIsFiltering] = useState(false);
 	const [contentWidth, setContentWidth] = useState<number>();
 	const anchorRef = useRef<HTMLDivElement>(null);
 
 	const displayValue = getSeatDisplayValue(row);
-
-	const readOnly = row.action === "hero" || row.action === "skip";
+	const readOnly = row.action === "hero";
 	const normalizedInput = row.name.trim().toLowerCase();
-	const filteredPlayers = allPlayers.filter(
-		(p) =>
-			!(isFiltering && normalizedInput) ||
-			p.name.toLowerCase().includes(normalizedInput)
-	);
+	const filteredPlayers = normalizedInput
+		? allPlayers.filter((p) => p.name.toLowerCase().includes(normalizedInput))
+		: allPlayers;
+	const trimmedName = row.name.trim();
 
 	useEffect(() => {
 		if (!(isOpen && anchorRef.current)) {
@@ -684,25 +693,16 @@ function SeatCombobox({
 
 	const handleSelectExisting = (player: PlayerOption) => {
 		onSelectExisting(player);
-		setIsFiltering(false);
 		setIsOpen(false);
 	};
 
 	const handlePickHero = () => {
 		onActionChange("hero");
-		setIsFiltering(false);
-		setIsOpen(false);
-	};
-
-	const handlePickSkip = () => {
-		onActionChange("skip");
-		setIsFiltering(false);
 		setIsOpen(false);
 	};
 
 	const handleKeepAsNew = () => {
 		onActionChange("new");
-		setIsFiltering(false);
 		setIsOpen(false);
 	};
 
@@ -729,7 +729,6 @@ function SeatCombobox({
 								return;
 							}
 							onNameChange(e.target.value);
-							setIsFiltering(true);
 							setIsOpen(true);
 						}}
 						onFocus={() => {
@@ -758,27 +757,28 @@ function SeatCombobox({
 					style={contentWidth ? { width: contentWidth } : undefined}
 				>
 					<Command shouldFilter={false}>
-						<CommandList>
+						<CommandList className="max-h-64 overflow-y-auto overscroll-contain">
+							{heroAvailable && row.action !== "hero" ? (
+								<CommandItem
+									className={row.isHeroCandidate ? "text-amber-500" : ""}
+									onMouseDown={(e) => e.preventDefault()}
+									onSelect={handlePickHero}
+									value="__hero__"
+								>
+									Seat Hero here
+								</CommandItem>
+							) : null}
+							{trimmedName && row.action !== "new" ? (
+								<CommandItem
+									onMouseDown={(e) => e.preventDefault()}
+									onSelect={handleKeepAsNew}
+									value="__new__"
+								>
+									Create new: {trimmedName}
+								</CommandItem>
+							) : null}
 							{filteredPlayers.length === 0 ? (
 								<CommandEmpty>No matching players.</CommandEmpty>
-							) : null}
-							{row.isHeroCandidate && row.action !== "hero" ? (
-								<CommandItem
-									onMouseDown={(e) => e.preventDefault()}
-									onSelect={handlePickHero}
-									value="__hero__"
-								>
-									<span className="text-amber-500">Hero (self)</span>
-								</CommandItem>
-							) : null}
-							{!row.isHeroCandidate && row.action !== "hero" ? (
-								<CommandItem
-									onMouseDown={(e) => e.preventDefault()}
-									onSelect={handlePickHero}
-									value="__hero__"
-								>
-									<span>Seat Hero here</span>
-								</CommandItem>
 							) : null}
 							{filteredPlayers.map((p) => (
 								<CommandItem
@@ -790,28 +790,6 @@ function SeatCombobox({
 									{p.name}
 								</CommandItem>
 							))}
-							{row.name.trim() &&
-							row.action !== "new" &&
-							!allPlayers.some(
-								(p) => p.name.toLowerCase() === normalizedInput
-							) ? (
-								<CommandItem
-									onMouseDown={(e) => e.preventDefault()}
-									onSelect={handleKeepAsNew}
-									value="__new__"
-								>
-									<span>Create new: {row.name.trim()}</span>
-								</CommandItem>
-							) : null}
-							{row.action === "skip" ? null : (
-								<CommandItem
-									onMouseDown={(e) => e.preventDefault()}
-									onSelect={handlePickSkip}
-									value="__skip__"
-								>
-									<span className="text-muted-foreground">Skip this seat</span>
-								</CommandItem>
-							)}
 						</CommandList>
 					</Command>
 				</PopoverContent>
@@ -821,32 +799,25 @@ function SeatCombobox({
 }
 
 function computeRowWarning({
-	effectivePreferredAction,
-	isHeroCandidate,
+	action,
 	occupiedSeatPositions,
 	seatNumber,
 	seatPosition,
-	trimmedName,
 }: {
-	effectivePreferredAction: RowAction | undefined;
-	isHeroCandidate: boolean;
+	action: RowAction;
 	occupiedSeatPositions: Set<number>;
 	seatNumber: number;
 	seatPosition: number;
-	trimmedName: string;
 }): string | null {
 	if (seatPosition < 0 || seatPosition > 8) {
 		return `Seat ${seatNumber} is out of range (1-9).`;
 	}
-	const isHero =
-		effectivePreferredAction === "hero" ||
-		(effectivePreferredAction === undefined && isHeroCandidate);
-	const isSkip = effectivePreferredAction === "skip";
-	if (!(isHero || isSkip) && occupiedSeatPositions.has(seatPosition)) {
+	if (
+		action !== "hero" &&
+		action !== "skip" &&
+		occupiedSeatPositions.has(seatPosition)
+	) {
 		return `Seat ${seatNumber} is already occupied.`;
-	}
-	if (!(isHero || isSkip || trimmedName)) {
-		return "Name is empty.";
 	}
 	return null;
 }
@@ -855,19 +826,27 @@ function computeRowAction({
 	effectivePreferredAction,
 	isHeroCandidate,
 	matchedPlayer,
+	trimmedName,
 }: {
 	effectivePreferredAction: RowAction | undefined;
 	isHeroCandidate: boolean;
 	matchedPlayer: { id: string; name: string } | null;
+	trimmedName: string;
 }): RowAction {
 	if (effectivePreferredAction) {
 		if (effectivePreferredAction === "existing" && !matchedPlayer) {
 			return "new";
 		}
+		if (effectivePreferredAction === "new" && trimmedName === "") {
+			return "skip";
+		}
 		return effectivePreferredAction;
 	}
 	if (isHeroCandidate) {
 		return "hero";
+	}
+	if (trimmedName === "") {
+		return "skip";
 	}
 	if (matchedPlayer) {
 		return "existing";
@@ -905,18 +884,17 @@ function buildRow({
 
 	const effectivePreferredAction = preferredAction;
 
-	const warning = computeRowWarning({
-		effectivePreferredAction,
-		isHeroCandidate,
-		occupiedSeatPositions,
-		seatNumber,
-		seatPosition,
-		trimmedName,
-	});
 	const action = computeRowAction({
 		effectivePreferredAction,
 		isHeroCandidate,
 		matchedPlayer,
+		trimmedName,
+	});
+	const warning = computeRowWarning({
+		action,
+		occupiedSeatPositions,
+		seatNumber,
+		seatPosition,
 	});
 
 	return {

--- a/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
+++ b/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
@@ -30,6 +30,7 @@ type SessionParam =
 	| { liveCashGameSessionId?: never; liveTournamentSessionId: string };
 
 interface SeatFromScreenshotSheetProps {
+	heroSeatPosition: number | null;
 	occupiedSeatPositions: Set<number>;
 	onOpenChange: (open: boolean) => void;
 	open: boolean;
@@ -38,7 +39,7 @@ interface SeatFromScreenshotSheetProps {
 
 type Step = "select-app" | "upload" | "review";
 
-type RowAction = "existing" | "new" | "skip";
+type RowAction = "existing" | "new" | "hero" | "skip";
 
 interface ReviewRow {
 	action: RowAction;
@@ -85,7 +86,47 @@ const SOURCE_APP_ENTRIES = Object.entries(TABLE_PLAYER_SOURCE_APPS) as [
 	(typeof TABLE_PLAYER_SOURCE_APPS)[TablePlayerSourceApp],
 ][];
 
+function applyRowAction(
+	row: ReviewRow,
+	targetRowId: string,
+	nextAction: RowAction
+): ReviewRow {
+	if (row.rowId !== targetRowId) {
+		if (nextAction === "hero" && row.action === "hero") {
+			return {
+				...row,
+				action: row.existingPlayerId ? "existing" : "new",
+			};
+		}
+		return row;
+	}
+	if (row.ambiguous && nextAction === "existing") {
+		return row;
+	}
+	return { ...row, action: nextAction };
+}
+
+function updateHeroSeatViaClient(
+	sessionParam: SessionParam,
+	heroSeatPosition: number | null
+): Promise<unknown> {
+	if (sessionParam.liveCashGameSessionId !== undefined) {
+		return trpcClient.liveCashGameSession.updateHeroSeat.mutate({
+			id: sessionParam.liveCashGameSessionId,
+			heroSeatPosition,
+		});
+	}
+	if (sessionParam.liveTournamentSessionId !== undefined) {
+		return trpcClient.liveTournamentSession.updateHeroSeat.mutate({
+			id: sessionParam.liveTournamentSessionId,
+			heroSeatPosition,
+		});
+	}
+	throw new Error("Invalid sessionParam: neither cash game nor tournament");
+}
+
 export function SeatFromScreenshotSheet({
+	heroSeatPosition,
 	occupiedSeatPositions,
 	onOpenChange,
 	open,
@@ -208,15 +249,7 @@ export function SeatFromScreenshotSheet({
 
 	const handleRowActionChange = (rowId: string, nextAction: RowAction) => {
 		setRows((prev) =>
-			prev.map((row) => {
-				if (row.rowId !== rowId) {
-					return row;
-				}
-				if (row.ambiguous && nextAction === "existing") {
-					return row;
-				}
-				return { ...row, action: nextAction };
-			})
+			prev.map((row) => applyRowAction(row, rowId, nextAction))
 		);
 	};
 
@@ -228,6 +261,19 @@ export function SeatFromScreenshotSheet({
 		queryClient.invalidateQueries({
 			queryKey: trpc.player.list.queryOptions().queryKey,
 		});
+		if (sessionParam.liveCashGameSessionId !== undefined) {
+			queryClient.invalidateQueries({
+				queryKey: trpc.liveCashGameSession.getById.queryOptions({
+					id: sessionParam.liveCashGameSessionId,
+				}).queryKey,
+			});
+		} else if (sessionParam.liveTournamentSessionId !== undefined) {
+			queryClient.invalidateQueries({
+				queryKey: trpc.liveTournamentSession.getById.queryOptions({
+					id: sessionParam.liveTournamentSessionId,
+				}).queryKey,
+			});
+		}
 	};
 
 	const handleApply = async () => {
@@ -244,7 +290,9 @@ export function SeatFromScreenshotSheet({
 		let failure = 0;
 		for (const row of actionable) {
 			try {
-				if (row.action === "existing" && row.existingPlayerId) {
+				if (row.action === "hero") {
+					await updateHeroSeatViaClient(sessionParam, row.seatPosition);
+				} else if (row.action === "existing" && row.existingPlayerId) {
 					await trpcClient.sessionTablePlayer.add.mutate({
 						...sessionParam,
 						playerId: row.existingPlayerId,
@@ -266,10 +314,10 @@ export function SeatFromScreenshotSheet({
 		invalidateQueries();
 
 		if (failure === 0) {
-			toast.success(`${success} 人を着席させました`);
+			toast.success(`${success} 件を反映しました`);
 			onOpenChange(false);
 		} else {
-			toast.error(`着席 ${success} 件成功 / ${failure} 件失敗`);
+			toast.error(`反映 ${success} 件成功 / ${failure} 件失敗`);
 		}
 	};
 
@@ -387,12 +435,16 @@ export function SeatFromScreenshotSheet({
 		return (
 			<div className="flex flex-col gap-3">
 				<p className="text-muted-foreground text-sm">
-					{rows.length}{" "}
-					件を検出しました。内容を確認して「着席」を押してください。
+					{rows.length} 件を検出しました。自分の席は「Hero
+					(自分)」を選択してください。内容を確認して「反映」を押してください。
 				</p>
 				<div className="flex flex-col gap-2">
 					{rows.map((row) => (
 						<ReviewRowItem
+							heroAlreadySeatedElsewhere={
+								heroSeatPosition !== null &&
+								heroSeatPosition !== row.seatPosition
+							}
 							key={row.rowId}
 							onActionChange={(next) => handleRowActionChange(row.rowId, next)}
 							onNameChange={(next) => handleRowNameChange(row.rowId, next)}
@@ -417,12 +469,12 @@ export function SeatFromScreenshotSheet({
 						{isApplying ? (
 							<>
 								<IconLoader2 className="animate-spin" size={16} />
-								着席中...
+								反映中...
 							</>
 						) : (
 							<>
 								<IconSparkles size={16} />
-								着席 ({seatablesCount})
+								反映 ({seatablesCount})
 							</>
 						)}
 					</Button>
@@ -445,10 +497,12 @@ export function SeatFromScreenshotSheet({
 }
 
 function ReviewRowItem({
+	heroAlreadySeatedElsewhere,
 	onActionChange,
 	onNameChange,
 	row,
 }: {
+	heroAlreadySeatedElsewhere: boolean;
 	onActionChange: (next: RowAction) => void;
 	onNameChange: (next: string) => void;
 	row: ReviewRow;
@@ -466,7 +520,7 @@ function ReviewRowItem({
 				</Badge>
 				<Input
 					className="h-8"
-					disabled={disabled}
+					disabled={disabled || row.action === "hero"}
 					onChange={(e) => onNameChange(e.target.value)}
 					placeholder="プレイヤー名"
 					value={row.name}
@@ -492,12 +546,18 @@ function ReviewRowItem({
 								{existingLabel}
 							</SelectItem>
 							<SelectItem value="new">新規作成</SelectItem>
+							<SelectItem value="hero">Hero (自分)</SelectItem>
 							<SelectItem value="skip">スキップ</SelectItem>
 						</SelectContent>
 					</Select>
 					{row.ambiguous && (
 						<span className="text-muted-foreground text-xs">
 							同名が複数存在します
+						</span>
+					)}
+					{row.action === "hero" && heroAlreadySeatedElsewhere && (
+						<span className="text-muted-foreground text-xs">
+							既存の Hero 席は上書きされます
 						</span>
 					)}
 				</div>
@@ -534,9 +594,12 @@ function buildRow({
 	let warning: string | null = null;
 	if (seatPosition < 0 || seatPosition > 8) {
 		warning = `席番号 ${seatNumber} は範囲外です (1-9)`;
-	} else if (occupiedSeatPositions.has(seatPosition)) {
+	} else if (
+		preferredAction !== "hero" &&
+		occupiedSeatPositions.has(seatPosition)
+	) {
 		warning = `席 ${seatNumber} には既に着席中のプレイヤーがいます`;
-	} else if (!trimmedName) {
+	} else if (preferredAction !== "hero" && !trimmedName) {
 		warning = "名前が空です";
 	}
 

--- a/apps/web/src/shared/components/filter-dialog-shell.tsx
+++ b/apps/web/src/shared/components/filter-dialog-shell.tsx
@@ -66,9 +66,7 @@ export function FilterDialogShell({
 						<Button onClick={onReset} variant="outline">
 							{resetLabel}
 						</Button>
-						<Button onClick={onApply}>
-							{applyLabel}
-						</Button>
+						<Button onClick={onApply}>{applyLabel}</Button>
 					</DialogActionRow>
 				</div>
 			</ResponsiveDialog>

--- a/bun.lock
+++ b/bun.lock
@@ -179,7 +179,7 @@
     },
   },
   "catalog": {
-    "@anthropic-ai/sdk": "^0.51.0",
+    "@anthropic-ai/sdk": "^0.90.0",
     "@mixmark-io/domino": "^2.2.0",
     "@trpc/client": "^11.16.0",
     "@trpc/server": "^11.16.0",
@@ -196,7 +196,7 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.51.0", "", { "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-fAFC/uHhyzfw7rs65EPVV+scXDytGNm5BjttxHf6rP/YGvaBRKEvp2lwyuMigTwMI95neeG4bzrZigz7KCikjw=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.90.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg=="],
 
     "@apideck/better-ajv-errors": ["@apideck/better-ajv-errors@0.3.6", "", { "dependencies": { "json-schema": "^0.4.0", "jsonpointer": "^5.0.0", "leven": "^3.1.0" }, "peerDependencies": { "ajv": ">=8" } }, "sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA=="],
 
@@ -1656,6 +1656,8 @@
 
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
@@ -2163,6 +2165,8 @@
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "better-auth": "^1.6.0",
       "@trpc/client": "^11.16.0",
       "drizzle-orm": "^0.45.2",
-      "@anthropic-ai/sdk": "^0.51.0",
+      "@anthropic-ai/sdk": "^0.90.0",
       "@mixmark-io/domino": "^2.2.0",
       "turndown": "^7.2.0",
       "turndown-plugin-gfm": "^1.0.2"

--- a/packages/api/src/__tests__/ai-extract.test.ts
+++ b/packages/api/src/__tests__/ai-extract.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { appRouter } from "../routers";
+
+describe("aiExtract router", () => {
+	it("appRouter has aiExtract namespace", () => {
+		expect(appRouter.aiExtract).toBeDefined();
+	});
+
+	it("has extractTournamentData procedure", () => {
+		expect(appRouter.aiExtract.extractTournamentData).toBeDefined();
+	});
+
+	it("has extractTablePlayers procedure", () => {
+		expect(appRouter.aiExtract.extractTablePlayers).toBeDefined();
+	});
+});

--- a/packages/api/src/routers/ai-extract-sources.ts
+++ b/packages/api/src/routers/ai-extract-sources.ts
@@ -1,0 +1,27 @@
+export const TABLE_PLAYER_SOURCE_APP_IDS = ["dmm_waitinglist"] as const;
+
+export type TablePlayerSourceApp = (typeof TABLE_PLAYER_SOURCE_APP_IDS)[number];
+
+interface TablePlayerSourceAppConfig {
+	label: string;
+	prompt: string;
+}
+
+export const TABLE_PLAYER_SOURCE_APPS: Record<
+	TablePlayerSourceApp,
+	TablePlayerSourceAppConfig
+> = {
+	dmm_waitinglist: {
+		label: "DMM Waitinglist",
+		prompt: `画像は DMM Waitinglist アプリのテーブルビューです。
+各席のプレイヤー名を抽出してください。
+席番号の採番規則:
+- 画面下中央の切り欠き(ノッチ)のある席を 1 番とします。
+- そこから時計回り(右回り)に 2, 3, 4, ... と採番します。
+- テーブル最大 9 席まで (seatNumber は 1-9 の整数)。
+抽出条件:
+- 名前が読み取れた席のみ seats 配列に含めてください。
+- 空席や名前が不鮮明な席は省略してください。
+- 名前の前後の記号・装飾・残スタック表示などは除去し、プレイヤー名のみを返してください。`,
+	},
+};

--- a/packages/api/src/routers/ai-extract-sources.ts
+++ b/packages/api/src/routers/ai-extract-sources.ts
@@ -19,7 +19,12 @@ Extract the player name at each seat.
 Seat numbering rules:
 - The seat with the notch at the bottom-center of the screen is seat number 1.
 - Number the remaining seats clockwise: 2, 3, 4, ...
-- Up to 9 seats per table (seatNumber is an integer from 1 to 9).
+
+Hero detection:
+- The name of the user who is using this app is displayed at the top area of the screen (typically next to an account icon / header).
+- For each seat in the \`seats\` array, set \`isHero: true\` when that seat's player name is identical to the user name displayed at the top of the screen. Otherwise set \`isHero: false\`.
+- If you cannot confidently read the user name at the top, or you cannot confidently match it to any seat, set \`isHero: null\` for every seat you return.
+- At most one seat should have \`isHero: true\`.
 
 Extraction rules:
 - Include only seats whose names are readable in the \`seats\` array.

--- a/packages/api/src/routers/ai-extract-sources.ts
+++ b/packages/api/src/routers/ai-extract-sources.ts
@@ -13,15 +13,18 @@ export const TABLE_PLAYER_SOURCE_APPS: Record<
 > = {
 	dmm_waitinglist: {
 		label: "DMM Waitinglist",
-		prompt: `画像は DMM Waitinglist アプリのテーブルビューです。
-各席のプレイヤー名を抽出してください。
-席番号の採番規則:
-- 画面下中央の切り欠き(ノッチ)のある席を 1 番とします。
-- そこから時計回り(右回り)に 2, 3, 4, ... と採番します。
-- テーブル最大 9 席まで (seatNumber は 1-9 の整数)。
-抽出条件:
-- 名前が読み取れた席のみ seats 配列に含めてください。
-- 空席や名前が不鮮明な席は省略してください。
-- 名前の前後の記号・装飾・残スタック表示などは除去し、プレイヤー名のみを返してください。`,
+		prompt: `The image is a table view from the DMM Waitinglist app.
+Extract the player name at each seat.
+
+Seat numbering rules:
+- The seat with the notch at the bottom-center of the screen is seat number 1.
+- Number the remaining seats clockwise: 2, 3, 4, ...
+- Up to 9 seats per table (seatNumber is an integer from 1 to 9).
+
+Extraction rules:
+- Include only seats whose names are readable in the \`seats\` array.
+- Omit empty seats and seats whose names are unclear.
+- Return only the player name; strip surrounding symbols, decorations, and stack / chip count displays.
+- Player names may be in Japanese (hiragana, katakana, kanji), English, or a mix. Preserve the exact characters as shown, do not translate or romanize.`,
 	},
 };

--- a/packages/api/src/routers/ai-extract.ts
+++ b/packages/api/src/routers/ai-extract.ts
@@ -1,5 +1,6 @@
 /// <reference path="../types/turndown.d.ts" />
 import Anthropic from "@anthropic-ai/sdk";
+import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
 // Cloudflare Workers には DOMParser が存在しないため、Turndown の内部 HTML 解析の
 // 代わりに純粋 JS DOM 実装の domino を使用する（Turndown の依存として同梱済み）
 import domino from "@mixmark-io/domino";
@@ -82,36 +83,6 @@ const ExtractedTablePlayersSchema = z.object({
 });
 
 export type ExtractedTablePlayers = z.infer<typeof ExtractedTablePlayersSchema>;
-
-const TABLE_PLAYERS_TOOL_INPUT_SCHEMA = {
-	type: "object" as const,
-	required: ["seats"] as string[],
-	properties: {
-		seats: {
-			type: "array",
-			description:
-				"席番号とプレイヤー名のリスト。名前が読み取れた席のみ含める。空席は省略する。",
-			items: {
-				type: "object",
-				properties: {
-					seatNumber: {
-						type: "integer",
-						minimum: 1,
-						maximum: MAX_SEAT_NUMBER,
-						description:
-							"アプリ固有の採番規約に従った 1-indexed の席番号 (1-9)。",
-					},
-					name: {
-						type: "string",
-						description:
-							"その席に表示されているプレイヤー名。前後の記号・残スタック表示などは除去し、名前のみを返す。",
-					},
-				},
-				required: ["seatNumber", "name"],
-			},
-		},
-	},
-};
 
 const TOOL_INPUT_SCHEMA = {
 	type: "object" as const,
@@ -368,43 +339,29 @@ export const aiExtractRouter = router({
 				...imageBlocks,
 				{
 					type: "text",
-					text: `${appConfig.prompt}\n\n抽出結果は必ず extract_table_players ツールで返してください。`,
+					text: appConfig.prompt,
 				},
 			];
 
-			const response = await client.messages.create({
-				model: "claude-sonnet-4-6",
+			const response = await client.messages.parse({
+				model: "claude-opus-4-7",
 				max_tokens: 1024,
-				tools: [
-					{
-						name: "extract_table_players",
-						description:
-							"ポーカーテーブルのスクリーンショットから、各席のプレイヤー名を抽出する。席番号は当該ソースアプリの採番規約に従った 1-indexed の整数。",
-						input_schema: TABLE_PLAYERS_TOOL_INPUT_SCHEMA,
-					},
-				],
-				tool_choice: { type: "tool", name: "extract_table_players" },
+				output_config: {
+					format: zodOutputFormat(ExtractedTablePlayersSchema),
+				},
 				messages: [{ role: "user", content: contentBlocks }],
 			});
 
-			const toolUse = response.content.find((c) => c.type === "tool_use");
-			if (!toolUse || toolUse.type !== "tool_use") {
+			const parsedOutput = response.parsed_output;
+			if (!parsedOutput) {
 				throw new TRPCError({
 					code: "INTERNAL_SERVER_ERROR",
 					message: "AI did not return structured data",
 				});
 			}
 
-			const parsed = ExtractedTablePlayersSchema.safeParse(toolUse.input);
-			if (!parsed.success) {
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message: "Failed to parse AI response",
-				});
-			}
-
 			const seenSeatNumbers = new Set<number>();
-			const deduped = parsed.data.seats.filter((seat) => {
+			const deduped = parsedOutput.seats.filter((seat) => {
 				if (seenSeatNumbers.has(seat.seatNumber)) {
 					return false;
 				}

--- a/packages/api/src/routers/ai-extract.ts
+++ b/packages/api/src/routers/ai-extract.ts
@@ -77,6 +77,7 @@ const ExtractedTablePlayersSchema = z.object({
 			z.object({
 				seatNumber: z.number().int().min(1).max(MAX_SEAT_NUMBER),
 				name: z.string().min(1),
+				isHero: z.boolean().nullable(),
 			})
 		)
 		.default([]),
@@ -298,7 +299,7 @@ export const aiExtractRouter = router({
 		.input(
 			z.object({
 				sourceApp: z.enum(TABLE_PLAYER_SOURCE_APP_IDS),
-				sources: z.array(SourceSchema).min(1).max(5),
+				sources: z.array(SourceSchema).length(1),
 			})
 		)
 		.mutation(async ({ ctx, input }) => {

--- a/packages/api/src/routers/ai-extract.ts
+++ b/packages/api/src/routers/ai-extract.ts
@@ -8,6 +8,10 @@ import TurndownService from "turndown";
 import { tables } from "turndown-plugin-gfm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
+import {
+	TABLE_PLAYER_SOURCE_APP_IDS,
+	TABLE_PLAYER_SOURCE_APPS,
+} from "./ai-extract-sources";
 
 const IMAGE_URL_RE = /\.(jpg|jpeg|png|gif|webp)(\?.*)?$/i;
 
@@ -63,6 +67,51 @@ const ExtractedTournamentDataSchema = z.object({
 export type ExtractedTournamentData = z.infer<
 	typeof ExtractedTournamentDataSchema
 >;
+
+const MAX_SEAT_NUMBER = 9;
+
+const ExtractedTablePlayersSchema = z.object({
+	seats: z
+		.array(
+			z.object({
+				seatNumber: z.number().int().min(1).max(MAX_SEAT_NUMBER),
+				name: z.string().min(1),
+			})
+		)
+		.default([]),
+});
+
+export type ExtractedTablePlayers = z.infer<typeof ExtractedTablePlayersSchema>;
+
+const TABLE_PLAYERS_TOOL_INPUT_SCHEMA = {
+	type: "object" as const,
+	required: ["seats"] as string[],
+	properties: {
+		seats: {
+			type: "array",
+			description:
+				"席番号とプレイヤー名のリスト。名前が読み取れた席のみ含める。空席は省略する。",
+			items: {
+				type: "object",
+				properties: {
+					seatNumber: {
+						type: "integer",
+						minimum: 1,
+						maximum: MAX_SEAT_NUMBER,
+						description:
+							"アプリ固有の採番規約に従った 1-indexed の席番号 (1-9)。",
+					},
+					name: {
+						type: "string",
+						description:
+							"その席に表示されているプレイヤー名。前後の記号・残スタック表示などは除去し、名前のみを返す。",
+					},
+				},
+				required: ["seatNumber", "name"],
+			},
+		},
+	},
+};
 
 const TOOL_INPUT_SCHEMA = {
 	type: "object" as const,
@@ -272,5 +321,97 @@ export const aiExtractRouter = router({
 			}
 
 			return parsed.data;
+		}),
+
+	extractTablePlayers: protectedProcedure
+		.input(
+			z.object({
+				sourceApp: z.enum(TABLE_PLAYER_SOURCE_APP_IDS),
+				sources: z.array(SourceSchema).min(1).max(5),
+			})
+		)
+		.mutation(async ({ ctx, input }) => {
+			if (!ctx.anthropicApiKey) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message:
+						"AI extraction is not configured (missing ANTHROPIC_API_KEY)",
+				});
+			}
+
+			const client = new Anthropic({ apiKey: ctx.anthropicApiKey });
+			const appConfig = TABLE_PLAYER_SOURCE_APPS[input.sourceApp];
+
+			const imageBlocks: Anthropic.ImageBlockParam[] = input.sources.map(
+				(source) => {
+					if (source.kind === "image") {
+						return {
+							type: "image",
+							source: {
+								type: "base64",
+								media_type: source.mediaType as MediaType,
+								data: source.data,
+							},
+						};
+					}
+					return {
+						type: "image",
+						source: { type: "url", url: source.url },
+					};
+				}
+			);
+
+			const contentBlocks: (
+				| Anthropic.ImageBlockParam
+				| Anthropic.TextBlockParam
+			)[] = [
+				...imageBlocks,
+				{
+					type: "text",
+					text: `${appConfig.prompt}\n\n抽出結果は必ず extract_table_players ツールで返してください。`,
+				},
+			];
+
+			const response = await client.messages.create({
+				model: "claude-sonnet-4-6",
+				max_tokens: 1024,
+				tools: [
+					{
+						name: "extract_table_players",
+						description:
+							"ポーカーテーブルのスクリーンショットから、各席のプレイヤー名を抽出する。席番号は当該ソースアプリの採番規約に従った 1-indexed の整数。",
+						input_schema: TABLE_PLAYERS_TOOL_INPUT_SCHEMA,
+					},
+				],
+				tool_choice: { type: "tool", name: "extract_table_players" },
+				messages: [{ role: "user", content: contentBlocks }],
+			});
+
+			const toolUse = response.content.find((c) => c.type === "tool_use");
+			if (!toolUse || toolUse.type !== "tool_use") {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "AI did not return structured data",
+				});
+			}
+
+			const parsed = ExtractedTablePlayersSchema.safeParse(toolUse.input);
+			if (!parsed.success) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Failed to parse AI response",
+				});
+			}
+
+			const seenSeatNumbers = new Set<number>();
+			const deduped = parsed.data.seats.filter((seat) => {
+				if (seenSeatNumbers.has(seat.seatNumber)) {
+					return false;
+				}
+				seenSeatNumbers.add(seat.seatNumber);
+				return true;
+			});
+
+			return { seats: deduped };
 		}),
 });


### PR DESCRIPTION
Closes #110

## Summary
- テーブルビュー内に「AI 着席」ボタン（`IconSparkles`）を追加し、ウェイティングリストのスクリーンショットから Claude Vision で OCR して一括着席できるようにした
- 現状は DMM Waitinglist のみ対応。ソースアプリ単位でプロンプト規約を差し替えられるよう `packages/api/src/routers/ai-extract-sources.ts` に設定を分離し、将来的なアプリ追加が容易
- OCR は `{ seatNumber, name }[]` を返し、フロントで `seatPosition = seatNumber - 1` として内部席インデックスにそのまま投影（アプリ上の位置合わせは行わない）
- レビューステップで既存プレイヤーとの完全一致マッチを表示し、ユーザーが「既存使用 / 新規作成 / スキップ」を選択してから `sessionTablePlayer.add` / `addNew` で順次着席

## 仕様ハイライト
- **採番規約 (DMM Waitinglist)**: 画面下中央の切り欠きを 1 番とし、時計回りに 2, 3, ... と採番 → 内部 `seatPosition` は `seatNumber - 1`
- **マッチング**: 完全一致のみ（trim + 大文字小文字区別なし）。同名が複数存在する場合は「スキップ / 新規作成」のみ選択可
- **衝突検知**: 既に着席中の席・名前空の行は警告付きで disabled

## Test plan
- [x] `bun run test`（全 507 件パス）
- [x] `bun run check-types`
- [x] `bun x ultracite check`
- [ ] 手動 E2E: キャッシュ/トーナメント両セッションで AI 着席ボタンから DMM Waitinglist スクショをアップロードし、レビュー → 着席までの一連の流れ
- [ ] 席衝突・名前空・同名複数の警告表示確認

https://claude.ai/code/session_01N1zP1rMPRsAvbFBhPVmyBu