### PR TITLE
feat: トーナメント・キャッシュゲーム完了イベントの事後編集 (#171)

### DIFF
--- a/apps/web/src/live-sessions/components/event-editors/event-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/event-editor.tsx
@@ -20,6 +20,7 @@ export function EventEditor(props: EditorBaseProps) {
 					isLoading={props.isLoading}
 					maxTime={props.maxTime}
 					minTime={props.minTime}
+					onSubmit={props.onSubmit}
 					onTimeUpdate={props.onTimeUpdate}
 					sessionType={props.sessionType}
 				/>

--- a/apps/web/src/live-sessions/components/event-editors/event-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/event-editor.tsx
@@ -31,7 +31,7 @@ export function EventEditor(props: EditorBaseProps) {
 					isLoading={props.isLoading}
 					maxTime={props.maxTime}
 					minTime={props.minTime}
-					onTimeUpdate={props.onTimeUpdate}
+					onSubmit={props.onSubmit}
 					sessionType={props.sessionType}
 				/>
 			);

--- a/apps/web/src/live-sessions/components/event-editors/session-end-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/session-end-editor.tsx
@@ -132,7 +132,9 @@ function CashGameEndEditor({
 					</Field>
 				)}
 			</form.Field>
-			<form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+			<form.Subscribe
+				selector={(state) => [state.canSubmit, state.isSubmitting]}
+			>
 				{([canSubmit, isSubmitting]) => (
 					<DialogActionRow>
 						<Button
@@ -162,9 +164,7 @@ function TournamentEndEditor({
 			time: toTimeInputValue(event.occurredAt),
 			beforeDeadline: payload.beforeDeadline === true,
 			placement:
-				typeof payload.placement === "number"
-					? String(payload.placement)
-					: "",
+				typeof payload.placement === "number" ? String(payload.placement) : "",
 			totalEntries:
 				typeof payload.totalEntries === "number"
 					? String(payload.totalEntries)
@@ -337,7 +337,9 @@ function TournamentEndEditor({
 					</Field>
 				)}
 			</form.Field>
-			<form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+			<form.Subscribe
+				selector={(state) => [state.canSubmit, state.isSubmitting]}
+			>
 				{([canSubmit, isSubmitting]) => (
 					<DialogActionRow>
 						<Button

--- a/apps/web/src/live-sessions/components/event-editors/session-end-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/session-end-editor.tsx
@@ -1,39 +1,89 @@
 import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
 import {
 	toOccurredAtTimestamp,
 	toTimeInputValue,
 	validateOccurredAtTime,
 } from "@/live-sessions/components/stack-editor-time";
 import { Button } from "@/shared/components/ui/button";
+import { Checkbox } from "@/shared/components/ui/checkbox";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
+import { Label } from "@/shared/components/ui/label";
+import {
+	optionalNumericString,
+	requiredNumericString,
+} from "@/shared/lib/form-fields";
 import { type EditorBaseProps, type SessionType, TimeField } from "./shared";
 
 type Props = Pick<
 	EditorBaseProps,
-	"event" | "isLoading" | "maxTime" | "minTime" | "onTimeUpdate"
+	"event" | "isLoading" | "maxTime" | "minTime" | "onSubmit"
 > & {
 	sessionType: SessionType;
 };
 
-export function SessionEndEditor({
+const cashGameEndSchema = z.object({
+	time: z.string(),
+	cashOutAmount: requiredNumericString({ integer: true, min: 0 }),
+});
+
+const tournamentEndSchema = z
+	.object({
+		time: z.string(),
+		beforeDeadline: z.boolean(),
+		placement: z.string(),
+		totalEntries: z.string(),
+		prizeMoney: requiredNumericString({ integer: true, min: 0 }),
+		bountyPrizes: optionalNumericString({ integer: true, min: 0 }),
+	})
+	.superRefine((data, ctx) => {
+		if (!data.beforeDeadline) {
+			const placementResult = requiredNumericString({
+				integer: true,
+				min: 1,
+			}).safeParse(data.placement);
+			if (!placementResult.success) {
+				for (const issue of placementResult.error.issues) {
+					ctx.addIssue({ ...issue, path: ["placement"] });
+				}
+			}
+			const totalEntriesResult = requiredNumericString({
+				integer: true,
+				min: 1,
+			}).safeParse(data.totalEntries);
+			if (!totalEntriesResult.success) {
+				for (const issue of totalEntriesResult.error.issues) {
+					ctx.addIssue({ ...issue, path: ["totalEntries"] });
+				}
+			}
+		}
+	});
+
+function CashGameEndEditor({
 	event,
 	isLoading,
 	maxTime,
 	minTime,
-	onTimeUpdate,
-	sessionType,
+	onSubmit,
 }: Props) {
 	const payload = (event.payload ?? {}) as Record<string, unknown>;
 
 	const form = useForm({
-		defaultValues: { time: toTimeInputValue(event.occurredAt) },
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			cashOutAmount:
+				typeof payload.cashOutAmount === "number"
+					? String(payload.cashOutAmount)
+					: "0",
+		},
 		onSubmit: ({ value }) => {
-			const ts = toOccurredAtTimestamp(event.occurredAt, value.time);
-			if (ts !== undefined) {
-				onTimeUpdate(ts);
-			}
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			onSubmit({ cashOutAmount: Number(value.cashOutAmount) }, occurredAt);
+		},
+		validators: {
+			onSubmit: cashGameEndSchema,
 		},
 	});
 
@@ -62,69 +112,27 @@ export function SessionEndEditor({
 					/>
 				)}
 			</form.Field>
-			{sessionType === "cash_game" &&
-			typeof payload.cashOutAmount === "number" ? (
-				<Field htmlFor="edit-cashOutAmount" label="Cash-out Amount">
-					<Input
-						disabled
-						id="edit-cashOutAmount"
-						readOnly
-						type="text"
-						value={payload.cashOutAmount.toLocaleString()}
-					/>
-				</Field>
-			) : null}
-			{sessionType === "tournament" && (
-				<>
-					{typeof payload.placement === "number" ? (
-						<Field htmlFor="edit-placement" label="Placement">
-							<Input
-								disabled
-								id="edit-placement"
-								readOnly
-								type="text"
-								value={String(payload.placement)}
-							/>
-						</Field>
-					) : null}
-					{typeof payload.totalEntries === "number" ? (
-						<Field htmlFor="edit-totalEntries" label="Total Entries">
-							<Input
-								disabled
-								id="edit-totalEntries"
-								readOnly
-								type="text"
-								value={String(payload.totalEntries)}
-							/>
-						</Field>
-					) : null}
-					{typeof payload.prizeMoney === "number" ? (
-						<Field htmlFor="edit-prizeMoney" label="Prize Money">
-							<Input
-								disabled
-								id="edit-prizeMoney"
-								readOnly
-								type="text"
-								value={payload.prizeMoney.toLocaleString()}
-							/>
-						</Field>
-					) : null}
-					{typeof payload.bountyPrizes === "number" ? (
-						<Field htmlFor="edit-bountyPrizes" label="Bounty Prizes">
-							<Input
-								disabled
-								id="edit-bountyPrizes"
-								readOnly
-								type="text"
-								value={payload.bountyPrizes.toLocaleString()}
-							/>
-						</Field>
-					) : null}
-				</>
-			)}
-			<form.Subscribe
-				selector={(state) => [state.canSubmit, state.isSubmitting]}
-			>
+			<form.Field name="cashOutAmount">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Cash-out Amount"
+						required
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="0"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
+			<form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
 				{([canSubmit, isSubmitting]) => (
 					<DialogActionRow>
 						<Button
@@ -138,4 +146,216 @@ export function SessionEndEditor({
 			</form.Subscribe>
 		</form>
 	);
+}
+
+function TournamentEndEditor({
+	event,
+	isLoading,
+	maxTime,
+	minTime,
+	onSubmit,
+}: Props) {
+	const payload = (event.payload ?? {}) as Record<string, unknown>;
+
+	const form = useForm({
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			beforeDeadline: payload.beforeDeadline === true,
+			placement:
+				typeof payload.placement === "number"
+					? String(payload.placement)
+					: "",
+			totalEntries:
+				typeof payload.totalEntries === "number"
+					? String(payload.totalEntries)
+					: "",
+			prizeMoney:
+				typeof payload.prizeMoney === "number"
+					? String(payload.prizeMoney)
+					: "0",
+			bountyPrizes:
+				typeof payload.bountyPrizes === "number" && payload.bountyPrizes > 0
+					? String(payload.bountyPrizes)
+					: "",
+		},
+		onSubmit: ({ value }) => {
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			if (value.beforeDeadline) {
+				onSubmit(
+					{
+						beforeDeadline: true,
+						prizeMoney: Number(value.prizeMoney),
+						bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
+					},
+					occurredAt
+				);
+			} else {
+				onSubmit(
+					{
+						beforeDeadline: false,
+						placement: Number(value.placement),
+						totalEntries: Number(value.totalEntries),
+						prizeMoney: Number(value.prizeMoney),
+						bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
+					},
+					occurredAt
+				);
+			}
+		},
+		validators: {
+			onSubmit: tournamentEndSchema,
+		},
+	});
+
+	return (
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field
+				name="time"
+				validators={{
+					onChange: ({ value }) =>
+						validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
+						undefined,
+				}}
+			>
+				{(field) => (
+					<TimeField
+						error={field.state.meta.errors[0]?.toString() ?? null}
+						onChange={(v) => field.handleChange(v)}
+						value={field.state.value}
+					/>
+				)}
+			</form.Field>
+			<div className="flex items-center gap-2">
+				<form.Field name="beforeDeadline">
+					{(field) => (
+						<>
+							<Checkbox
+								checked={field.state.value}
+								id={field.name}
+								onCheckedChange={(checked) =>
+									field.handleChange(checked === true)
+								}
+							/>
+							<Label htmlFor={field.name}>
+								Completed before registration deadline
+							</Label>
+						</>
+					)}
+				</form.Field>
+			</div>
+			<form.Subscribe selector={(state) => state.values.beforeDeadline}>
+				{(beforeDeadline) =>
+					!beforeDeadline && (
+						<div className="grid grid-cols-2 gap-2">
+							<form.Field name="placement">
+								{(field) => (
+									<Field
+										error={field.state.meta.errors[0]?.message}
+										htmlFor={field.name}
+										label="Placement"
+										required
+									>
+										<Input
+											id={field.name}
+											inputMode="numeric"
+											name={field.name}
+											onBlur={field.handleBlur}
+											onChange={(e) => field.handleChange(e.target.value)}
+											placeholder="1"
+											value={field.state.value}
+										/>
+									</Field>
+								)}
+							</form.Field>
+							<form.Field name="totalEntries">
+								{(field) => (
+									<Field
+										error={field.state.meta.errors[0]?.message}
+										htmlFor={field.name}
+										label="Total Entries"
+										required
+									>
+										<Input
+											id={field.name}
+											inputMode="numeric"
+											name={field.name}
+											onBlur={field.handleBlur}
+											onChange={(e) => field.handleChange(e.target.value)}
+											placeholder="100"
+											value={field.state.value}
+										/>
+									</Field>
+								)}
+							</form.Field>
+						</div>
+					)
+				}
+			</form.Subscribe>
+			<form.Field name="prizeMoney">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Prize Money"
+						required
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="0"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
+			<form.Field name="bountyPrizes">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Bounty Prizes"
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="0"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
+			<form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+				{([canSubmit, isSubmitting]) => (
+					<DialogActionRow>
+						<Button
+							disabled={!canSubmit || isSubmitting || isLoading}
+							type="submit"
+						>
+							{isLoading ? "Saving..." : "Save"}
+						</Button>
+					</DialogActionRow>
+				)}
+			</form.Subscribe>
+		</form>
+	);
+}
+
+export function SessionEndEditor(props: Props) {
+	if (props.sessionType === "cash_game") {
+		return <CashGameEndEditor {...props} />;
+	}
+	return <TournamentEndEditor {...props} />;
 }

--- a/apps/web/src/live-sessions/components/event-editors/session-start-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/session-start-editor.tsx
@@ -1,4 +1,5 @@
 import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
 import {
 	toOccurredAtTimestamp,
 	toTimeInputValue,
@@ -8,33 +9,51 @@ import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
+import { requiredNumericString } from "@/shared/lib/form-fields";
 import { type EditorBaseProps, type SessionType, TimeField } from "./shared";
 
 type Props = Pick<
 	EditorBaseProps,
-	"event" | "isLoading" | "maxTime" | "minTime" | "onTimeUpdate"
+	"event" | "isLoading" | "maxTime" | "minTime" | "onSubmit" | "onTimeUpdate"
 > & {
 	sessionType: SessionType;
 };
+
+const cashGameStartSchema = z.object({
+	time: z.string(),
+	buyInAmount: requiredNumericString({ integer: true, min: 0 }),
+});
 
 export function SessionStartEditor({
 	event,
 	isLoading,
 	maxTime,
 	minTime,
+	onSubmit,
 	onTimeUpdate,
 	sessionType,
 }: Props) {
 	const payload = (event.payload ?? {}) as Record<string, unknown>;
 
+	const isCashGame = sessionType === "cash_game";
+
 	const form = useForm({
-		defaultValues: { time: toTimeInputValue(event.occurredAt) },
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			buyInAmount:
+				typeof payload.buyInAmount === "number"
+					? String(payload.buyInAmount)
+					: "0",
+		},
 		onSubmit: ({ value }) => {
-			const ts = toOccurredAtTimestamp(event.occurredAt, value.time);
-			if (ts !== undefined) {
-				onTimeUpdate(ts);
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			if (isCashGame) {
+				onSubmit({ buyInAmount: Number(value.buyInAmount) }, occurredAt);
+			} else if (occurredAt !== undefined) {
+				onTimeUpdate(occurredAt);
 			}
 		},
+		validators: isCashGame ? { onSubmit: cashGameStartSchema } : undefined,
 	});
 
 	return (
@@ -62,18 +81,28 @@ export function SessionStartEditor({
 					/>
 				)}
 			</form.Field>
-			{sessionType === "cash_game" &&
-			typeof payload.buyInAmount === "number" ? (
-				<Field htmlFor="edit-buyInAmount" label="Buy-in Amount">
-					<Input
-						disabled
-						id="edit-buyInAmount"
-						readOnly
-						type="text"
-						value={payload.buyInAmount.toLocaleString()}
-					/>
-				</Field>
-			) : null}
+			{isCashGame && (
+				<form.Field name="buyInAmount">
+					{(field) => (
+						<Field
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label="Buy-in Amount"
+							required
+						>
+							<Input
+								id={field.name}
+								inputMode="numeric"
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) => field.handleChange(e.target.value)}
+								placeholder="0"
+								value={field.state.value}
+							/>
+						</Field>
+					)}
+				</form.Field>
+			)}
 			<form.Subscribe
 				selector={(state) => [state.canSubmit, state.isSubmitting]}
 			>

--- a/apps/web/src/shared/components/filter-dialog-shell.tsx
+++ b/apps/web/src/shared/components/filter-dialog-shell.tsx
@@ -66,9 +66,7 @@ export function FilterDialogShell({
 						<Button onClick={onReset} variant="outline">
 							{resetLabel}
 						</Button>
-						<Button onClick={onApply}>
-							{applyLabel}
-						</Button>
+						<Button onClick={onApply}>{applyLabel}</Button>
 					</DialogActionRow>
 				</div>
 			</ResponsiveDialog>


### PR DESCRIPTION
## Summary

- `session_end` イベントエディターを読み取り専用から編集可能なフォームに変換
- トーナメント: `beforeDeadline`、`placement`、`totalEntries`、`prizeMoney`、`bountyPrizes` を事後編集可能にする
- キャッシュゲーム: `cashOutAmount` を事後編集可能にする
- バックエンド (`sessionEvent.update`) はすでにペイロード更新をサポートしているため、フロントエンドのみの変更

## Changes

- `session-end-editor.tsx`: 読み取り専用フィールドを `useForm` + Zod バリデーション付きの編集可能入力に置き換え。`tournament-complete-form.tsx` と同じパターンを踏襲
- `event-editor.tsx`: `session_end` ケースで `onSubmit` プロップを渡すよう修正

## Test plan

- [ ] 完了済みトーナメントセッションの `session_end` イベントを編集し、全フィールドが事前設定されて編集可能なことを確認
- [ ] `beforeDeadline` チェックボックスの切り替えで `placement`/`totalEntries` フィールドの表示/非表示が正しく動作することを確認
- [ ] 保存後にセッションサマリーの損益が正しく更新されることを確認
- [ ] 完了済みキャッシュゲームセッションの `cashOutAmount` が編集可能なことを確認
- [ ] バリデーションエラー（例: placement = 0）が正しく表示されることを確認

https://claude.ai/code/session_01YMqNv7sHeJtXZWmy8xN7Lk