### PR TITLE
feat: セッション終了後のイベント編集画面に戻るボタンを追加

### DIFF
--- a/apps/web/src/live-sessions/components/session-events-scene.tsx
+++ b/apps/web/src/live-sessions/components/session-events-scene.tsx
@@ -1,4 +1,5 @@
-import { IconPencil, IconTrash, IconX } from "@tabler/icons-react";
+import { IconArrowLeft, IconPencil, IconTrash, IconX } from "@tabler/icons-react";
+import { Link } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
 import { EventEditor } from "@/live-sessions/components/event-editors/event-editor";
 import { toTimeInputValue } from "@/live-sessions/components/stack-editor-time";
@@ -38,6 +39,7 @@ const LIFECYCLE_EVENTS = new Set(["session_start", "session_end"]);
 type SessionType = "cash_game" | "tournament";
 
 interface SessionEventsSceneProps {
+	backTo?: string;
 	emptySessionMessage?: string;
 	refetchInterval?: number;
 	sessionId: string;
@@ -194,6 +196,7 @@ function groupEventsForDisplay(events: SessionEvent[]): EventGroup[] {
 }
 
 export function SessionEventsScene({
+	backTo,
 	emptySessionMessage = "No active session",
 	refetchInterval,
 	sessionId,
@@ -319,6 +322,14 @@ export function SessionEventsScene({
 	return (
 		<div className="p-4 md:p-6">
 			<div className="mb-4 flex flex-wrap items-center gap-2">
+				{backTo && (
+					<Button asChild size="sm" variant="ghost" className="-ml-2 mr-1">
+						<Link to={backTo}>
+							<IconArrowLeft size={16} />
+							Back
+						</Link>
+					</Button>
+				)}
 				<h1 className="font-bold text-2xl">Events</h1>
 				<Badge variant="outline">{events.length}</Badge>
 			</div>

--- a/apps/web/src/routes/live-sessions/$sessionType/$sessionId/events.tsx
+++ b/apps/web/src/routes/live-sessions/$sessionType/$sessionId/events.tsx
@@ -12,6 +12,7 @@ function SessionEventsPage() {
 
 	return (
 		<SessionEventsScene
+			backTo="/sessions"
 			sessionId={sessionId}
 			sessionType={sessionType === "tournament" ? "tournament" : "cash_game"}
 		/>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `SessionEventsScene` に `backTo` オプション prop を追加
- `/live-sessions/$sessionType/$sessionId/events` ルートで `backTo="/sessions"` を渡し、ヘッダーに「Back」ボタンを表示
- アクティブセッションのイベント画面 (`/active-session/events`) は変更なし（`backTo` を渡さないため表示されない）

## Test plan

- [ ] セッション一覧 (`/sessions`) のセッションカードから「Events」リンクを開く
- [ ] ヘッダーに「← Back」ボタンが表示されることを確認
- [ ] ボタンをクリックして `/sessions` に戻れることを確認
- [ ] アクティブセッションのイベント画面 (`/active-session/events`) にバックボタンが表示されないことを確認

Closes #187

https://claude.ai/code/session_01JpJLAiQH8UNcRud4NusGim
EOF
)