### PR TITLE
feat: トーナメントライブセッションにブラインドタイマーを表示 (#96)

### DIFF
--- a/apps/web/src/live-sessions/components/__tests__/create-tournament-session-form.test.tsx
+++ b/apps/web/src/live-sessions/components/__tests__/create-tournament-session-form.test.tsx
@@ -78,6 +78,9 @@ describe("CreateTournamentSessionForm", () => {
 		expect(screen.queryByText("Buy-in")).not.toBeInTheDocument();
 		expect(screen.queryByText("Starting Stack")).not.toBeInTheDocument();
 		expect(screen.queryByText("Memo")).not.toBeInTheDocument();
+		expect(
+			screen.queryByText("Timer Start Time (optional)")
+		).not.toBeInTheDocument();
 	});
 
 	it("shows loading state when isLoading", () => {

--- a/apps/web/src/live-sessions/components/__tests__/tournament-timer.test.tsx
+++ b/apps/web/src/live-sessions/components/__tests__/tournament-timer.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TournamentBlindLevel } from "@/live-sessions/utils/tournament-timer";
+import { TournamentTimer } from "../tournament-timer";
+
+const NEXT_LEVEL_PATTERN = /Next: L2 200\/400/;
+
+const LEVELS: TournamentBlindLevel[] = [
+	{
+		ante: null,
+		blind1: 100,
+		blind2: 200,
+		blind3: null,
+		id: "l1",
+		isBreak: false,
+		level: 1,
+		minutes: 20,
+	},
+	{
+		ante: null,
+		blind1: 200,
+		blind2: 400,
+		blind3: null,
+		id: "l2",
+		isBreak: false,
+		level: 2,
+		minutes: 20,
+	},
+];
+
+describe("TournamentTimer", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T12:00:00Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("renders nothing when there are no blind levels", () => {
+		const { container } = render(
+			<TournamentTimer
+				blindLevels={[]}
+				onEditTimer={vi.fn()}
+				timerStartedAt={null}
+			/>
+		);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("shows 'Timer not started' when structure exists but timerStartedAt is null", () => {
+		const onEditTimer = vi.fn();
+		render(
+			<TournamentTimer
+				blindLevels={LEVELS}
+				onEditTimer={onEditTimer}
+				timerStartedAt={null}
+			/>
+		);
+		expect(screen.getByText("Timer not started")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Start timer" }));
+		expect(onEditTimer).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders countdown when timerStartedAt is set", () => {
+		const start = new Date("2026-01-01T11:55:00Z");
+		render(
+			<TournamentTimer
+				blindLevels={LEVELS}
+				onEditTimer={vi.fn()}
+				timerStartedAt={start}
+			/>
+		);
+		expect(screen.getByText("L1 100/200")).toBeInTheDocument();
+		expect(screen.getByText("15:00")).toBeInTheDocument();
+		expect(screen.getByText(NEXT_LEVEL_PATTERN)).toBeInTheDocument();
+	});
+
+	it("calls onEditTimer when the countdown is clicked", () => {
+		const onEditTimer = vi.fn();
+		render(
+			<TournamentTimer
+				blindLevels={LEVELS}
+				onEditTimer={onEditTimer}
+				timerStartedAt={new Date("2026-01-01T11:55:00Z")}
+			/>
+		);
+		fireEvent.click(screen.getByText("15:00").closest("button") as HTMLElement);
+		expect(onEditTimer).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/live-sessions/components/active-session-scene.tsx
+++ b/apps/web/src/live-sessions/components/active-session-scene.tsx
@@ -35,6 +35,7 @@ interface ActiveSessionSceneProps {
 	state: ActiveSessionSceneState;
 	summary: ReactNode;
 	title: string;
+	topSlot?: ReactNode;
 }
 
 interface UseActiveSessionSceneStateOptions {
@@ -233,6 +234,7 @@ export function ActiveSessionScene({
 	state,
 	summary,
 	title,
+	topSlot,
 }: ActiveSessionSceneProps) {
 	const [isDiscardOpen, setIsDiscardOpen] = useState(false);
 	const [isScanSheetOpen, setIsScanSheetOpen] = useState(false);
@@ -269,6 +271,8 @@ export function ActiveSessionScene({
 					Discard
 				</Button>
 			</div>
+
+			{topSlot ? <div className="mb-2">{topSlot}</div> : null}
 
 			<div>{summary}</div>
 

--- a/apps/web/src/live-sessions/components/create-tournament-session-form.tsx
+++ b/apps/web/src/live-sessions/components/create-tournament-session-form.tsx
@@ -29,6 +29,7 @@ interface CreateTournamentSessionFormProps {
 		memo?: string;
 		startingStack: number;
 		storeId: string;
+		timerStartedAt?: number;
 		tournamentId: string;
 	}) => void;
 	stores: Array<{ id: string; name: string }>;
@@ -47,7 +48,21 @@ const formSchema = z.object({
 	entryFee: optionalNumericString({ integer: true, min: 0 }),
 	startingStack: requiredNumericString({ integer: true, min: 0 }),
 	memo: z.string(),
+	timerStartedAt: z.string(),
 });
+
+function parseTimerStartedAt(value: string): number | undefined {
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return undefined;
+	}
+	const parsed = new Date(trimmed);
+	const ms = parsed.getTime();
+	if (Number.isNaN(ms)) {
+		return undefined;
+	}
+	return Math.floor(ms / 1000);
+}
 
 export function CreateTournamentSessionForm({
 	currencies,
@@ -73,6 +88,7 @@ export function CreateTournamentSessionForm({
 			entryFee: "",
 			startingStack: "",
 			memo: "",
+			timerStartedAt: "",
 		},
 		onSubmit: ({ value }) => {
 			if (!(selectedStoreId && selectedTournamentId)) {
@@ -86,6 +102,7 @@ export function CreateTournamentSessionForm({
 				entryFee: value.entryFee ? Number(value.entryFee) : undefined,
 				startingStack: Number(value.startingStack),
 				memo: value.memo ? value.memo : undefined,
+				timerStartedAt: parseTimerStartedAt(value.timerStartedAt),
 			});
 		},
 		validators: {
@@ -285,6 +302,25 @@ export function CreateTournamentSessionForm({
 									inputMode="numeric"
 									onBlur={field.handleBlur}
 									onChange={(e) => field.handleChange(e.target.value)}
+									value={field.state.value}
+								/>
+							</Field>
+						)}
+					</form.Field>
+
+					<form.Field name="timerStartedAt">
+						{(field) => (
+							<Field
+								error={field.state.meta.errors[0]?.message}
+								htmlFor={field.name}
+								label="Timer Start Time (optional)"
+							>
+								<Input
+									id={field.name}
+									onBlur={field.handleBlur}
+									onChange={(e) => field.handleChange(e.target.value)}
+									step={60}
+									type="datetime-local"
 									value={field.state.value}
 								/>
 							</Field>

--- a/apps/web/src/live-sessions/components/event-editors/session-start-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/session-start-editor.tsx
@@ -24,18 +24,42 @@ const cashGameStartSchema = z.object({
 	buyInAmount: requiredNumericString({ integer: true, min: 0 }),
 });
 
-export function SessionStartEditor({
+const tournamentStartSchema = z.object({
+	time: z.string(),
+	timerStartedAt: z.string(),
+});
+
+function toDatetimeLocalValue(value: Date | string | number | null): string {
+	if (value === null || value === undefined) {
+		return "";
+	}
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		return "";
+	}
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function toTimerSeconds(value: string): number | null {
+	if (!value) {
+		return null;
+	}
+	const ms = new Date(value).getTime();
+	if (Number.isNaN(ms)) {
+		return null;
+	}
+	return Math.floor(ms / 1000);
+}
+
+function CashGameStartEditor({
 	event,
 	isLoading,
 	maxTime,
 	minTime,
 	onSubmit,
-	onTimeUpdate,
-	sessionType,
 }: Props) {
 	const payload = (event.payload ?? {}) as Record<string, unknown>;
-
-	const isCashGame = sessionType === "cash_game";
 
 	const form = useForm({
 		defaultValues: {
@@ -47,13 +71,11 @@ export function SessionStartEditor({
 		},
 		onSubmit: ({ value }) => {
 			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
-			if (isCashGame) {
-				onSubmit({ buyInAmount: Number(value.buyInAmount) }, occurredAt);
-			} else if (occurredAt !== undefined) {
-				onTimeUpdate(occurredAt);
-			}
+			onSubmit({ buyInAmount: Number(value.buyInAmount) }, occurredAt);
 		},
-		validators: isCashGame ? { onSubmit: cashGameStartSchema } : undefined,
+		validators: {
+			onSubmit: cashGameStartSchema,
+		},
 	});
 
 	return (
@@ -81,28 +103,26 @@ export function SessionStartEditor({
 					/>
 				)}
 			</form.Field>
-			{isCashGame && (
-				<form.Field name="buyInAmount">
-					{(field) => (
-						<Field
-							error={field.state.meta.errors[0]?.message}
-							htmlFor={field.name}
-							label="Buy-in Amount"
-							required
-						>
-							<Input
-								id={field.name}
-								inputMode="numeric"
-								name={field.name}
-								onBlur={field.handleBlur}
-								onChange={(e) => field.handleChange(e.target.value)}
-								placeholder="0"
-								value={field.state.value}
-							/>
-						</Field>
-					)}
-				</form.Field>
-			)}
+			<form.Field name="buyInAmount">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Buy-in Amount"
+						required
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="0"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
 			<form.Subscribe
 				selector={(state) => [state.canSubmit, state.isSubmitting]}
 			>
@@ -119,4 +139,103 @@ export function SessionStartEditor({
 			</form.Subscribe>
 		</form>
 	);
+}
+
+function TournamentStartEditor({
+	event,
+	isLoading,
+	maxTime,
+	minTime,
+	onSubmit,
+}: Props) {
+	const payload = (event.payload ?? {}) as Record<string, unknown>;
+	const initialTimer =
+		typeof payload.timerStartedAt === "number"
+			? toDatetimeLocalValue(payload.timerStartedAt * 1000)
+			: "";
+
+	const form = useForm({
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			timerStartedAt: initialTimer,
+		},
+		onSubmit: ({ value }) => {
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			onSubmit(
+				{ timerStartedAt: toTimerSeconds(value.timerStartedAt) },
+				occurredAt
+			);
+		},
+		validators: {
+			onSubmit: tournamentStartSchema,
+		},
+	});
+
+	return (
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field
+				name="time"
+				validators={{
+					onChange: ({ value }) =>
+						validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
+						undefined,
+				}}
+			>
+				{(field) => (
+					<TimeField
+						error={field.state.meta.errors[0]?.toString() ?? null}
+						onChange={(v) => field.handleChange(v)}
+						value={field.state.value}
+					/>
+				)}
+			</form.Field>
+			<form.Field name="timerStartedAt">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Blind Timer Start"
+					>
+						<Input
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							step={60}
+							type="datetime-local"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
+			<form.Subscribe
+				selector={(state) => [state.canSubmit, state.isSubmitting]}
+			>
+				{([canSubmit, isSubmitting]) => (
+					<DialogActionRow>
+						<Button
+							disabled={!canSubmit || isSubmitting || isLoading}
+							type="submit"
+						>
+							{isLoading ? "Saving..." : "Save"}
+						</Button>
+					</DialogActionRow>
+				)}
+			</form.Subscribe>
+		</form>
+	);
+}
+
+export function SessionStartEditor(props: Props) {
+	if (props.sessionType === "cash_game") {
+		return <CashGameStartEditor {...props} />;
+	}
+	return <TournamentStartEditor {...props} />;
 }

--- a/apps/web/src/live-sessions/components/session-events-scene.tsx
+++ b/apps/web/src/live-sessions/components/session-events-scene.tsx
@@ -128,10 +128,17 @@ const PAYLOAD_SUMMARIZERS: Record<string, PayloadSummarizer> = {
 	purchase_chips: formatPurchaseChipsSummary,
 	update_tournament_info: formatUpdateTournamentInfoSummary,
 	memo: formatMemoSummary,
-	session_start: (p) =>
-		typeof p.buyInAmount === "number"
-			? `Buy-in: ${p.buyInAmount.toLocaleString()}`
-			: null,
+	session_start: (p) => {
+		if (typeof p.buyInAmount === "number") {
+			return `Buy-in: ${p.buyInAmount.toLocaleString()}`;
+		}
+		if (typeof p.timerStartedAt === "number") {
+			const date = new Date(p.timerStartedAt * 1000);
+			const pad = (n: number) => String(n).padStart(2, "0");
+			return `Timer: ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+		}
+		return null;
+	},
 	session_end: formatSessionEndSummary,
 	player_join: (p) => (p.isHero === true ? "Hero" : null),
 	player_leave: (p) => (p.isHero === true ? "Hero" : null),

--- a/apps/web/src/live-sessions/components/tournament-timer-dialog.tsx
+++ b/apps/web/src/live-sessions/components/tournament-timer-dialog.tsx
@@ -1,0 +1,124 @@
+import { useForm } from "@tanstack/react-form";
+import { useEffect } from "react";
+import { z } from "zod";
+import { Button } from "@/shared/components/ui/button";
+import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
+import { Field } from "@/shared/components/ui/field";
+import { Input } from "@/shared/components/ui/input";
+import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
+
+interface TournamentTimerDialogProps {
+	isLoading?: boolean;
+	onClear?: () => void;
+	onOpenChange: (open: boolean) => void;
+	onSubmit: (timerStartedAt: Date) => void;
+	open: boolean;
+	timerStartedAt: Date | string | number | null;
+}
+
+function toDatetimeLocalValue(value: Date | string | number | null): string {
+	const date = value ? new Date(value) : new Date();
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+const schema = z.object({
+	timerStartedAt: z.string().min(1, "Required"),
+});
+
+export function TournamentTimerDialog({
+	isLoading = false,
+	onClear,
+	onOpenChange,
+	onSubmit,
+	open,
+	timerStartedAt,
+}: TournamentTimerDialogProps) {
+	const form = useForm({
+		defaultValues: {
+			timerStartedAt: toDatetimeLocalValue(timerStartedAt),
+		},
+		onSubmit: ({ value }) => {
+			const parsed = new Date(value.timerStartedAt);
+			if (!Number.isNaN(parsed.getTime())) {
+				onSubmit(parsed);
+			}
+		},
+		validators: {
+			onSubmit: schema,
+		},
+	});
+
+	useEffect(() => {
+		if (open) {
+			form.setFieldValue(
+				"timerStartedAt",
+				toDatetimeLocalValue(timerStartedAt)
+			);
+		}
+	}, [open, timerStartedAt, form]);
+
+	return (
+		<ResponsiveDialog
+			description="Set the time when the tournament blind timer began. Leave in the past to reflect a late-start entry."
+			onOpenChange={onOpenChange}
+			open={open}
+			title={timerStartedAt ? "Edit Timer Start" : "Start Tournament Timer"}
+		>
+			<form
+				className="flex flex-col gap-4"
+				onSubmit={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					form.handleSubmit();
+				}}
+			>
+				<form.Field name="timerStartedAt">
+					{(field) => (
+						<Field
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label="Timer start time"
+							required
+						>
+							<Input
+								id={field.name}
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) => field.handleChange(e.target.value)}
+								step={60}
+								type="datetime-local"
+								value={field.state.value}
+							/>
+						</Field>
+					)}
+				</form.Field>
+
+				<DialogActionRow>
+					{timerStartedAt && onClear ? (
+						<Button
+							disabled={isLoading}
+							onClick={onClear}
+							type="button"
+							variant="outline"
+						>
+							Clear
+						</Button>
+					) : null}
+					<form.Subscribe
+						selector={(state) => [state.canSubmit, state.isSubmitting]}
+					>
+						{([canSubmit, isSubmitting]) => (
+							<Button
+								disabled={!canSubmit || isSubmitting || isLoading}
+								type="submit"
+							>
+								{isLoading ? "Saving..." : "Save"}
+							</Button>
+						)}
+					</form.Subscribe>
+				</DialogActionRow>
+			</form>
+		</ResponsiveDialog>
+	);
+}

--- a/apps/web/src/live-sessions/components/tournament-timer.tsx
+++ b/apps/web/src/live-sessions/components/tournament-timer.tsx
@@ -6,8 +6,11 @@ import {
 	formatBlindLevelLabel,
 	formatTimerDuration,
 	type TournamentBlindLevel,
+	type TournamentTimerState,
 } from "@/live-sessions/utils/tournament-timer";
 import { Button } from "@/shared/components/ui/button";
+
+const SECONDS_PER_MINUTE = 60;
 
 interface TournamentTimerProps {
 	blindLevels: readonly TournamentBlindLevel[];
@@ -24,6 +27,127 @@ function useNowTick(intervalMs: number): number {
 	return now;
 }
 
+function TimerNotStarted({ onEditTimer }: { onEditTimer: () => void }) {
+	return (
+		<div className="flex items-center justify-between gap-2 rounded-md border border-dashed bg-muted/40 px-3 py-2">
+			<div className="flex items-center gap-2 text-muted-foreground text-xs">
+				<IconClock size={14} />
+				<span>Timer not started</span>
+			</div>
+			<Button onClick={onEditTimer} size="sm" type="button" variant="outline">
+				Start timer
+			</Button>
+		</div>
+	);
+}
+
+function computeLevelProgress(state: TournamentTimerState): number | null {
+	const remaining = state.remainingSecondsInLevel;
+	const minutes = state.currentLevel?.minutes ?? null;
+	if (remaining === null || typeof minutes !== "number" || minutes <= 0) {
+		return null;
+	}
+	const total = minutes * SECONDS_PER_MINUTE;
+	return Math.min(1, Math.max(0, 1 - remaining / total));
+}
+
+function LevelProgressBar({
+	isBreak,
+	progress,
+}: {
+	isBreak: boolean;
+	progress: number;
+}) {
+	return (
+		<div
+			aria-label="Level progress"
+			aria-valuemax={100}
+			aria-valuemin={0}
+			aria-valuenow={Math.round(progress * 100)}
+			className="h-1 w-full bg-muted"
+			role="progressbar"
+		>
+			<div
+				className={cn(
+					"h-full bg-primary transition-[width] duration-1000 ease-linear",
+					isBreak && "bg-amber-500"
+				)}
+				style={{ width: `${progress * 100}%` }}
+			/>
+		</div>
+	);
+}
+
+interface ActiveTimerProps {
+	isBreak: boolean;
+	isFinished: boolean;
+	levelLabel: string;
+	levelProgress: number | null;
+	mainTime: string;
+	nextLabel: string | null;
+	onEditTimer: () => void;
+}
+
+function ActiveTimer({
+	isBreak,
+	isFinished,
+	levelLabel,
+	levelProgress,
+	mainTime,
+	nextLabel,
+	onEditTimer,
+}: ActiveTimerProps) {
+	return (
+		<button
+			className={cn(
+				"flex w-full flex-col overflow-hidden rounded-md border text-left transition-colors hover:bg-muted/40",
+				isBreak &&
+					"border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/40",
+				isFinished && "border-muted bg-muted/40"
+			)}
+			onClick={onEditTimer}
+			type="button"
+		>
+			<div className="flex w-full items-center justify-between gap-3 px-3 py-2">
+				<div className="flex min-w-0 flex-col gap-0.5">
+					<span
+						className={cn(
+							"truncate font-bold text-base tabular-nums leading-tight",
+							isBreak && "text-amber-800 dark:text-amber-200",
+							isFinished && "text-muted-foreground"
+						)}
+					>
+						{isFinished ? "Structure complete" : levelLabel}
+					</span>
+					{nextLabel && !isFinished ? (
+						<span className="truncate text-[10px] text-muted-foreground">
+							Next: {nextLabel}
+						</span>
+					) : null}
+				</div>
+				<div className="flex items-center gap-2">
+					<IconClock
+						className={cn("text-muted-foreground", isBreak && "text-amber-600")}
+						size={16}
+					/>
+					<span
+						className={cn(
+							"font-mono font-semibold text-sm tabular-nums",
+							isBreak && "text-amber-700 dark:text-amber-300",
+							isFinished && "text-muted-foreground"
+						)}
+					>
+						{isFinished ? "DONE" : mainTime}
+					</span>
+				</div>
+			</div>
+			{levelProgress === null ? null : (
+				<LevelProgressBar isBreak={isBreak} progress={levelProgress} />
+			)}
+		</button>
+	);
+}
+
 export function TournamentTimer({
 	blindLevels,
 	onEditTimer,
@@ -35,17 +159,7 @@ export function TournamentTimer({
 		if (blindLevels.length === 0) {
 			return null;
 		}
-		return (
-			<div className="flex items-center justify-between gap-2 rounded-md border border-dashed bg-muted/40 px-3 py-2">
-				<div className="flex items-center gap-2 text-muted-foreground text-xs">
-					<IconClock size={14} />
-					<span>Timer not started</span>
-				</div>
-				<Button onClick={onEditTimer} size="sm" type="button" variant="outline">
-					Start timer
-				</Button>
-			</div>
-		);
+		return <TimerNotStarted onEditTimer={onEditTimer} />;
 	}
 
 	if (blindLevels.length === 0) {
@@ -53,56 +167,25 @@ export function TournamentTimer({
 	}
 
 	const state = computeTournamentTimerState(blindLevels, timerStartedAt, now);
-
 	const remaining = state.remainingSecondsInLevel;
-	const isBreak = state.currentLevel?.isBreak ?? false;
 	const isFinished =
 		state.nextLevel === null && remaining !== null && remaining <= 0;
-	const mainTime =
-		remaining === null ? "—" : formatTimerDuration(Math.max(0, remaining));
-	const levelLabel = state.currentLevel
-		? formatBlindLevelLabel(state.currentLevel)
-		: "—";
-	const nextLabel = state.nextLevel
-		? formatBlindLevelLabel(state.nextLevel)
-		: null;
 
 	return (
-		<button
-			className={cn(
-				"flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2 text-left transition-colors hover:bg-muted/40",
-				isBreak &&
-					"border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/40",
-				isFinished && "border-muted bg-muted/40"
-			)}
-			onClick={onEditTimer}
-			type="button"
-		>
-			<div className="flex min-w-0 flex-col gap-0.5">
-				<span className="text-muted-foreground text-xs">
-					{isFinished ? "Structure complete" : levelLabel}
-				</span>
-				{nextLabel && !isFinished ? (
-					<span className="truncate text-[10px] text-muted-foreground">
-						Next: {nextLabel}
-					</span>
-				) : null}
-			</div>
-			<div className="flex items-center gap-2">
-				<IconClock
-					className={cn("text-muted-foreground", isBreak && "text-amber-600")}
-					size={16}
-				/>
-				<span
-					className={cn(
-						"font-mono font-semibold text-base tabular-nums",
-						isBreak && "text-amber-700 dark:text-amber-300",
-						isFinished && "text-muted-foreground"
-					)}
-				>
-					{isFinished ? "DONE" : mainTime}
-				</span>
-			</div>
-		</button>
+		<ActiveTimer
+			isBreak={state.currentLevel?.isBreak ?? false}
+			isFinished={isFinished}
+			levelLabel={
+				state.currentLevel ? formatBlindLevelLabel(state.currentLevel) : "—"
+			}
+			levelProgress={isFinished ? null : computeLevelProgress(state)}
+			mainTime={
+				remaining === null ? "—" : formatTimerDuration(Math.max(0, remaining))
+			}
+			nextLabel={
+				state.nextLevel ? formatBlindLevelLabel(state.nextLevel) : null
+			}
+			onEditTimer={onEditTimer}
+		/>
 	);
 }

--- a/apps/web/src/live-sessions/components/tournament-timer.tsx
+++ b/apps/web/src/live-sessions/components/tournament-timer.tsx
@@ -1,0 +1,108 @@
+import { IconClock } from "@tabler/icons-react";
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+	computeTournamentTimerState,
+	formatBlindLevelLabel,
+	formatTimerDuration,
+	type TournamentBlindLevel,
+} from "@/live-sessions/utils/tournament-timer";
+import { Button } from "@/shared/components/ui/button";
+
+interface TournamentTimerProps {
+	blindLevels: readonly TournamentBlindLevel[];
+	onEditTimer: () => void;
+	timerStartedAt: Date | string | number | null;
+}
+
+function useNowTick(intervalMs: number): number {
+	const [now, setNow] = useState(() => Date.now());
+	useEffect(() => {
+		const id = setInterval(() => setNow(Date.now()), intervalMs);
+		return () => clearInterval(id);
+	}, [intervalMs]);
+	return now;
+}
+
+export function TournamentTimer({
+	blindLevels,
+	onEditTimer,
+	timerStartedAt,
+}: TournamentTimerProps) {
+	const now = useNowTick(1000);
+
+	if (!timerStartedAt) {
+		if (blindLevels.length === 0) {
+			return null;
+		}
+		return (
+			<div className="flex items-center justify-between gap-2 rounded-md border border-dashed bg-muted/40 px-3 py-2">
+				<div className="flex items-center gap-2 text-muted-foreground text-xs">
+					<IconClock size={14} />
+					<span>Timer not started</span>
+				</div>
+				<Button onClick={onEditTimer} size="sm" type="button" variant="outline">
+					Start timer
+				</Button>
+			</div>
+		);
+	}
+
+	if (blindLevels.length === 0) {
+		return null;
+	}
+
+	const state = computeTournamentTimerState(blindLevels, timerStartedAt, now);
+
+	const remaining = state.remainingSecondsInLevel;
+	const isBreak = state.currentLevel?.isBreak ?? false;
+	const isFinished =
+		state.nextLevel === null && remaining !== null && remaining <= 0;
+	const mainTime =
+		remaining === null ? "—" : formatTimerDuration(Math.max(0, remaining));
+	const levelLabel = state.currentLevel
+		? formatBlindLevelLabel(state.currentLevel)
+		: "—";
+	const nextLabel = state.nextLevel
+		? formatBlindLevelLabel(state.nextLevel)
+		: null;
+
+	return (
+		<button
+			className={cn(
+				"flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2 text-left transition-colors hover:bg-muted/40",
+				isBreak &&
+					"border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/40",
+				isFinished && "border-muted bg-muted/40"
+			)}
+			onClick={onEditTimer}
+			type="button"
+		>
+			<div className="flex min-w-0 flex-col gap-0.5">
+				<span className="text-muted-foreground text-xs">
+					{isFinished ? "Structure complete" : levelLabel}
+				</span>
+				{nextLabel && !isFinished ? (
+					<span className="truncate text-[10px] text-muted-foreground">
+						Next: {nextLabel}
+					</span>
+				) : null}
+			</div>
+			<div className="flex items-center gap-2">
+				<IconClock
+					className={cn("text-muted-foreground", isBreak && "text-amber-600")}
+					size={16}
+				/>
+				<span
+					className={cn(
+						"font-mono font-semibold text-base tabular-nums",
+						isBreak && "text-amber-700 dark:text-amber-300",
+						isFinished && "text-muted-foreground"
+					)}
+				>
+					{isFinished ? "DONE" : mainTime}
+				</span>
+			</div>
+		</button>
+	);
+}

--- a/apps/web/src/live-sessions/hooks/use-create-session.ts
+++ b/apps/web/src/live-sessions/hooks/use-create-session.ts
@@ -88,6 +88,7 @@ export function useCreateSession({ onClose }: { onClose: () => void }) {
 			memo?: string;
 			startingStack: number;
 			storeId?: string;
+			timerStartedAt?: number;
 			tournamentId?: string;
 		}) => {
 			const { startingStack, ...createValues } = values;
@@ -137,6 +138,7 @@ export function useCreateSession({ onClose }: { onClose: () => void }) {
 			memo?: string;
 			startingStack: number;
 			storeId?: string;
+			timerStartedAt?: number;
 			tournamentId?: string;
 		}) => createTournamentMutation.mutate(values),
 		isLoading,

--- a/apps/web/src/live-sessions/hooks/use-tournament-session.ts
+++ b/apps/web/src/live-sessions/hooks/use-tournament-session.ts
@@ -6,8 +6,11 @@ export function useTournamentSession(sessionId: string) {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 
+	const sessionQueryOptions = trpc.liveTournamentSession.getById.queryOptions({
+		id: sessionId,
+	});
 	const sessionQuery = useQuery({
-		...trpc.liveTournamentSession.getById.queryOptions({ id: sessionId }),
+		...sessionQueryOptions,
 		enabled: !!sessionId,
 		refetchInterval: 5000,
 	});
@@ -29,11 +32,29 @@ export function useTournamentSession(sessionId: string) {
 		},
 	});
 
+	const updateTimerMutation = useMutation({
+		mutationFn: (timerStartedAt: Date | null) =>
+			trpcClient.liveTournamentSession.update.mutate({
+				id: sessionId,
+				timerStartedAt:
+					timerStartedAt === null
+						? null
+						: Math.floor(timerStartedAt.getTime() / 1000),
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: sessionQueryOptions.queryKey });
+		},
+	});
+
 	return {
 		session,
 		isDiscardPending: discardMutation.isPending,
 		discard: () => {
 			discardMutation.mutate();
+		},
+		isUpdatingTimer: updateTimerMutation.isPending,
+		updateTimerStartedAt: (value: Date | null) => {
+			updateTimerMutation.mutate(value);
 		},
 	};
 }

--- a/apps/web/src/live-sessions/utils/__tests__/tournament-timer.test.ts
+++ b/apps/web/src/live-sessions/utils/__tests__/tournament-timer.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+	computeTournamentTimerState,
+	formatBlindLevelLabel,
+	formatTimerDuration,
+	type TournamentBlindLevel,
+} from "../tournament-timer";
+
+function makeLevel(
+	overrides: Partial<TournamentBlindLevel> & Pick<TournamentBlindLevel, "level">
+): TournamentBlindLevel {
+	return {
+		ante: null,
+		blind1: null,
+		blind2: null,
+		blind3: null,
+		id: `lvl-${overrides.level}`,
+		isBreak: false,
+		minutes: 20,
+		...overrides,
+	};
+}
+
+const LEVELS: TournamentBlindLevel[] = [
+	makeLevel({ level: 1, blind1: 100, blind2: 200, minutes: 20 }),
+	makeLevel({ level: 2, blind1: 200, blind2: 400, minutes: 20 }),
+	makeLevel({ level: 3, isBreak: true, minutes: 10 }),
+	makeLevel({ level: 4, blind1: 400, blind2: 800, ante: 800, minutes: 20 }),
+];
+
+const T0 = new Date("2026-01-01T12:00:00Z").getTime();
+
+describe("computeTournamentTimerState", () => {
+	it("returns level 1 at elapsed=0", () => {
+		const state = computeTournamentTimerState(LEVELS, T0, T0);
+		expect(state.currentLevel?.level).toBe(1);
+		expect(state.elapsedSeconds).toBe(0);
+		expect(state.remainingSecondsInLevel).toBe(20 * 60);
+		expect(state.nextLevel?.level).toBe(2);
+		expect(state.totalDurationSeconds).toBe((20 + 20 + 10 + 20) * 60);
+	});
+
+	it("advances to level 2 after 20 minutes", () => {
+		const state = computeTournamentTimerState(LEVELS, T0, T0 + 20 * 60 * 1000);
+		expect(state.currentLevel?.level).toBe(2);
+		expect(state.remainingSecondsInLevel).toBe(20 * 60);
+		expect(state.nextLevel?.level).toBe(3);
+	});
+
+	it("mid-level countdown is correct", () => {
+		const state = computeTournamentTimerState(
+			LEVELS,
+			T0,
+			T0 + 5 * 60 * 1000 + 30_000
+		);
+		expect(state.currentLevel?.level).toBe(1);
+		expect(state.remainingSecondsInLevel).toBe(20 * 60 - 5 * 60 - 30);
+	});
+
+	it("identifies break level", () => {
+		const state = computeTournamentTimerState(LEVELS, T0, T0 + 45 * 60 * 1000);
+		expect(state.currentLevel?.level).toBe(3);
+		expect(state.currentLevel?.isBreak).toBe(true);
+	});
+
+	it("sorts levels before processing", () => {
+		const shuffled = [LEVELS[2], LEVELS[0], LEVELS[3], LEVELS[1]].filter(
+			(l): l is TournamentBlindLevel => l !== undefined
+		);
+		const state = computeTournamentTimerState(
+			shuffled,
+			T0,
+			T0 + 25 * 60 * 1000
+		);
+		expect(state.currentLevel?.level).toBe(2);
+	});
+
+	it("returns null remaining for level with missing minutes", () => {
+		const levels = [makeLevel({ level: 1, minutes: null })];
+		const state = computeTournamentTimerState(levels, T0, T0 + 5 * 60 * 1000);
+		expect(state.remainingSecondsInLevel).toBeNull();
+		expect(state.totalDurationSeconds).toBeNull();
+	});
+
+	it("returns zero remaining after structure end", () => {
+		const state = computeTournamentTimerState(
+			LEVELS,
+			T0,
+			T0 + 2 * 60 * 60 * 1000
+		);
+		expect(state.remainingSecondsInLevel).toBe(0);
+		expect(state.nextLevel).toBeNull();
+		expect(state.currentLevel?.level).toBe(4);
+	});
+
+	it("clamps negative elapsed time", () => {
+		const state = computeTournamentTimerState(LEVELS, T0, T0 - 5000);
+		expect(state.elapsedSeconds).toBe(0);
+		expect(state.currentLevel?.level).toBe(1);
+	});
+});
+
+describe("formatTimerDuration", () => {
+	it("formats under an hour as mm:ss", () => {
+		expect(formatTimerDuration(0)).toBe("00:00");
+		expect(formatTimerDuration(59)).toBe("00:59");
+		expect(formatTimerDuration(65)).toBe("01:05");
+		expect(formatTimerDuration(3599)).toBe("59:59");
+	});
+
+	it("formats at or above an hour as h:mm:ss", () => {
+		expect(formatTimerDuration(3600)).toBe("1:00:00");
+		expect(formatTimerDuration(3661)).toBe("1:01:01");
+	});
+
+	it("clamps negative inputs", () => {
+		expect(formatTimerDuration(-10)).toBe("00:00");
+	});
+});
+
+describe("formatBlindLevelLabel", () => {
+	it("renders blinds with ante", () => {
+		const label = formatBlindLevelLabel(
+			makeLevel({ level: 4, blind1: 400, blind2: 800, ante: 800 })
+		);
+		expect(label).toBe("L4 400/800 (ante 800)");
+	});
+
+	it("renders break label", () => {
+		const label = formatBlindLevelLabel(makeLevel({ level: 3, isBreak: true }));
+		expect(label).toBe("Break (L3)");
+	});
+
+	it("falls back when blinds missing", () => {
+		const label = formatBlindLevelLabel(makeLevel({ level: 1 }));
+		expect(label).toBe("L1 —");
+	});
+});

--- a/apps/web/src/live-sessions/utils/tournament-timer.ts
+++ b/apps/web/src/live-sessions/utils/tournament-timer.ts
@@ -13,12 +13,26 @@ export interface TournamentTimerState {
 	currentLevel: TournamentBlindLevel | null;
 	currentLevelIndex: number;
 	elapsedSeconds: number;
+	levelDurationSeconds: number | null;
+	levelProgressFraction: number | null;
 	nextLevel: TournamentBlindLevel | null;
 	remainingSecondsInLevel: number | null;
 	totalDurationSeconds: number | null;
 }
 
 const SECONDS_PER_MINUTE = 60;
+
+function computeLevelProgressFraction(
+	minutes: number | null,
+	remainingSeconds: number | null
+): number | null {
+	if (minutes === null || minutes <= 0 || remainingSeconds === null) {
+		return null;
+	}
+	const total = minutes * SECONDS_PER_MINUTE;
+	const elapsedInLevel = total - remainingSeconds;
+	return Math.min(1, Math.max(0, elapsedInLevel / total));
+}
 
 export function computeTournamentTimerState(
 	blindLevels: readonly TournamentBlindLevel[],
@@ -55,6 +69,8 @@ export function computeTournamentTimerState(
 				currentLevel: level,
 				currentLevelIndex: i,
 				elapsedSeconds,
+				levelDurationSeconds: null,
+				levelProgressFraction: null,
 				nextLevel: sortedLevels[i + 1] ?? null,
 				remainingSecondsInLevel: null,
 				totalDurationSeconds,
@@ -63,12 +79,18 @@ export function computeTournamentTimerState(
 
 		const levelEndSeconds = cumulativeSeconds + minutes * SECONDS_PER_MINUTE;
 		if (elapsedSeconds < levelEndSeconds) {
+			const remainingSecondsInLevel = levelEndSeconds - elapsedSeconds;
 			return {
 				currentLevel: level,
 				currentLevelIndex: i,
 				elapsedSeconds,
+				levelDurationSeconds: minutes * SECONDS_PER_MINUTE,
+				levelProgressFraction: computeLevelProgressFraction(
+					minutes,
+					remainingSecondsInLevel
+				),
 				nextLevel: sortedLevels[i + 1] ?? null,
-				remainingSecondsInLevel: levelEndSeconds - elapsedSeconds,
+				remainingSecondsInLevel,
 				totalDurationSeconds,
 			};
 		}
@@ -76,10 +98,15 @@ export function computeTournamentTimerState(
 	}
 
 	const lastLevel = sortedLevels.at(-1) ?? null;
+	const lastLevelMinutes =
+		typeof lastLevel?.minutes === "number" ? lastLevel.minutes : null;
 	return {
 		currentLevel: lastLevel,
 		currentLevelIndex: lastLevel ? sortedLevels.length - 1 : -1,
 		elapsedSeconds,
+		levelDurationSeconds:
+			lastLevelMinutes === null ? null : lastLevelMinutes * SECONDS_PER_MINUTE,
+		levelProgressFraction: lastLevelMinutes === null ? null : 1,
 		nextLevel: null,
 		remainingSecondsInLevel: 0,
 		totalDurationSeconds,
@@ -116,4 +143,18 @@ export function formatBlindLevelLabel(level: TournamentBlindLevel): string {
 	const blindsLabel = parts.length > 0 ? parts.join("/") : "—";
 	const anteLabel = level.ante ? ` (ante ${level.ante})` : "";
 	return `L${level.level} ${blindsLabel}${anteLabel}`;
+}
+
+export function formatBlindsValue(level: TournamentBlindLevel): string {
+	const parts: string[] = [];
+	if (level.blind1 !== null) {
+		parts.push(String(level.blind1));
+	}
+	if (level.blind2 !== null) {
+		parts.push(String(level.blind2));
+	}
+	if (level.blind3 !== null) {
+		parts.push(String(level.blind3));
+	}
+	return parts.length > 0 ? parts.join(" / ") : "—";
 }

--- a/apps/web/src/live-sessions/utils/tournament-timer.ts
+++ b/apps/web/src/live-sessions/utils/tournament-timer.ts
@@ -1,0 +1,119 @@
+export interface TournamentBlindLevel {
+	ante: number | null;
+	blind1: number | null;
+	blind2: number | null;
+	blind3: number | null;
+	id: string;
+	isBreak: boolean;
+	level: number;
+	minutes: number | null;
+}
+
+export interface TournamentTimerState {
+	currentLevel: TournamentBlindLevel | null;
+	currentLevelIndex: number;
+	elapsedSeconds: number;
+	nextLevel: TournamentBlindLevel | null;
+	remainingSecondsInLevel: number | null;
+	totalDurationSeconds: number | null;
+}
+
+const SECONDS_PER_MINUTE = 60;
+
+export function computeTournamentTimerState(
+	blindLevels: readonly TournamentBlindLevel[],
+	timerStartedAt: Date | string | number,
+	now: Date | number = Date.now()
+): TournamentTimerState {
+	const startMs =
+		typeof timerStartedAt === "number"
+			? timerStartedAt
+			: new Date(timerStartedAt).getTime();
+	const nowMs = typeof now === "number" ? now : now.getTime();
+	const elapsedSeconds = Math.max(0, Math.floor((nowMs - startMs) / 1000));
+
+	const sortedLevels = [...blindLevels].sort((a, b) => a.level - b.level);
+
+	const totalDurationSeconds = sortedLevels.every(
+		(level) => typeof level.minutes === "number" && level.minutes >= 0
+	)
+		? sortedLevels.reduce(
+				(acc, level) => acc + (level.minutes ?? 0) * SECONDS_PER_MINUTE,
+				0
+			)
+		: null;
+
+	let cumulativeSeconds = 0;
+	for (let i = 0; i < sortedLevels.length; i++) {
+		const level = sortedLevels[i];
+		if (!level) {
+			continue;
+		}
+		const minutes = level.minutes;
+		if (typeof minutes !== "number" || minutes <= 0) {
+			return {
+				currentLevel: level,
+				currentLevelIndex: i,
+				elapsedSeconds,
+				nextLevel: sortedLevels[i + 1] ?? null,
+				remainingSecondsInLevel: null,
+				totalDurationSeconds,
+			};
+		}
+
+		const levelEndSeconds = cumulativeSeconds + minutes * SECONDS_PER_MINUTE;
+		if (elapsedSeconds < levelEndSeconds) {
+			return {
+				currentLevel: level,
+				currentLevelIndex: i,
+				elapsedSeconds,
+				nextLevel: sortedLevels[i + 1] ?? null,
+				remainingSecondsInLevel: levelEndSeconds - elapsedSeconds,
+				totalDurationSeconds,
+			};
+		}
+		cumulativeSeconds = levelEndSeconds;
+	}
+
+	const lastLevel = sortedLevels.at(-1) ?? null;
+	return {
+		currentLevel: lastLevel,
+		currentLevelIndex: lastLevel ? sortedLevels.length - 1 : -1,
+		elapsedSeconds,
+		nextLevel: null,
+		remainingSecondsInLevel: 0,
+		totalDurationSeconds,
+	};
+}
+
+export function formatTimerDuration(seconds: number): string {
+	const safe = Math.max(0, Math.floor(seconds));
+	const hours = Math.floor(safe / 3600);
+	const minutes = Math.floor((safe % 3600) / 60);
+	const secs = safe % 60;
+	const mm = String(minutes).padStart(2, "0");
+	const ss = String(secs).padStart(2, "0");
+	if (hours > 0) {
+		return `${hours}:${mm}:${ss}`;
+	}
+	return `${mm}:${ss}`;
+}
+
+export function formatBlindLevelLabel(level: TournamentBlindLevel): string {
+	if (level.isBreak) {
+		return `Break (L${level.level})`;
+	}
+	const parts: string[] = [];
+	if (level.blind1 !== null) {
+		parts.push(String(level.blind1));
+	}
+	if (level.blind2 !== null) {
+		parts.push(String(level.blind2));
+	}
+	if (level.blind3 !== null) {
+		parts.push(String(level.blind3));
+	}
+	const blindsLabel = parts.length > 0 ? parts.join("/") : "—";
+	const anteLabel = level.ante ? ` (ante ${level.ante})` : "";
+	return `L${level.level} ${blindsLabel}${anteLabel}`;
+}

--- a/apps/web/src/routes/active-session/index.tsx
+++ b/apps/web/src/routes/active-session/index.tsx
@@ -6,9 +6,12 @@ import {
 	useActiveSessionSceneState,
 } from "@/live-sessions/components/active-session-scene";
 import type { TableGameInfo } from "@/live-sessions/components/poker-table";
+import { TournamentTimer } from "@/live-sessions/components/tournament-timer";
+import { TournamentTimerDialog } from "@/live-sessions/components/tournament-timer-dialog";
 import { useActiveSession } from "@/live-sessions/hooks/use-active-session";
 import { useCashGameSession } from "@/live-sessions/hooks/use-cash-game-session";
 import { useTournamentSession } from "@/live-sessions/hooks/use-tournament-session";
+import type { TournamentBlindLevel } from "@/live-sessions/utils/tournament-timer";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { formatCompactNumber } from "@/utils/format-number";
 
@@ -231,8 +234,14 @@ function CashGameSession({ sessionId }: { sessionId: string }) {
 }
 
 function TournamentSession({ sessionId }: { sessionId: string }) {
-	const { session, isDiscardPending, discard } =
-		useTournamentSession(sessionId);
+	const {
+		session,
+		isDiscardPending,
+		discard,
+		isUpdatingTimer,
+		updateTimerStartedAt,
+	} = useTournamentSession(sessionId);
+	const [isTimerDialogOpen, setIsTimerDialogOpen] = useState(false);
 
 	const rawHeroSeat = session?.heroSeatPosition;
 	const heroSeatPosition =
@@ -250,22 +259,56 @@ function TournamentSession({ sessionId }: { sessionId: string }) {
 		session as { summary: Record<string, unknown> }
 	);
 
+	const blindLevels = ((session as { blindLevels?: TournamentBlindLevel[] })
+		.blindLevels ?? []) as TournamentBlindLevel[];
+	const timerStartedAt =
+		(session as { timerStartedAt?: Date | string | number | null })
+			.timerStartedAt ?? null;
+	const hasStructure = blindLevels.length > 0;
+
 	return (
-		<ActiveSessionScene
-			gameInfo={{
-				name: session.tournamentId ? "Tournament" : null,
-			}}
-			isDiscardPending={isDiscardPending}
-			memo={session.memo}
-			onDiscard={discard}
-			state={sceneState}
-			summary={
-				<TournamentCompactSummary
-					summary={{ ...tournamentSummary, startedAt: session.startedAt }}
+		<>
+			<ActiveSessionScene
+				gameInfo={{
+					name: session.tournamentId ? "Tournament" : null,
+				}}
+				isDiscardPending={isDiscardPending}
+				memo={session.memo}
+				onDiscard={discard}
+				state={sceneState}
+				summary={
+					<TournamentCompactSummary
+						summary={{ ...tournamentSummary, startedAt: session.startedAt }}
+					/>
+				}
+				title="Tournament"
+				topSlot={
+					hasStructure ? (
+						<TournamentTimer
+							blindLevels={blindLevels}
+							onEditTimer={() => setIsTimerDialogOpen(true)}
+							timerStartedAt={timerStartedAt}
+						/>
+					) : undefined
+				}
+			/>
+			{hasStructure ? (
+				<TournamentTimerDialog
+					isLoading={isUpdatingTimer}
+					onClear={() => {
+						updateTimerStartedAt(null);
+						setIsTimerDialogOpen(false);
+					}}
+					onOpenChange={setIsTimerDialogOpen}
+					onSubmit={(value) => {
+						updateTimerStartedAt(value);
+						setIsTimerDialogOpen(false);
+					}}
+					open={isTimerDialogOpen}
+					timerStartedAt={timerStartedAt}
 				/>
-			}
-			title="Tournament"
-		/>
+			) : null}
+		</>
 	);
 }
 

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -9,7 +9,7 @@ import { pokerSession } from "@sapphire2/db/schema/session";
 import { sessionEvent } from "@sapphire2/db/schema/session-event";
 import { sessionTablePlayer } from "@sapphire2/db/schema/session-table-player";
 import { currency, store } from "@sapphire2/db/schema/store";
-import { tournament } from "@sapphire2/db/schema/tournament";
+import { blindLevel, tournament } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
 import { and, asc, desc, eq, max, sql } from "drizzle-orm";
 import { z } from "zod";
@@ -336,6 +336,14 @@ export const liveTournamentSessionRouter = router({
 				.from(sessionTablePlayer)
 				.where(eq(sessionTablePlayer.liveTournamentSessionId, input.id));
 
+			const blindLevels = session.tournamentId
+				? await ctx.db
+						.select()
+						.from(blindLevel)
+						.where(eq(blindLevel.tournamentId, session.tournamentId))
+						.orderBy(asc(blindLevel.level))
+				: [];
+
 			const pl = computeTournamentPLFromEvents(
 				events.map((e) => ({ eventType: e.eventType, payload: e.payload })),
 				tournamentBuyIn,
@@ -367,7 +375,7 @@ export const liveTournamentSessionRouter = router({
 				startingStack: masterData.startingStack ?? null,
 			};
 
-			return { ...session, events, tablePlayers, summary };
+			return { ...session, events, tablePlayers, blindLevels, summary };
 		}),
 
 	create: protectedProcedure
@@ -379,6 +387,7 @@ export const liveTournamentSessionRouter = router({
 				buyIn: z.number().int().min(0).optional(),
 				entryFee: z.number().int().min(0).optional(),
 				memo: z.string().optional(),
+				timerStartedAt: z.number().int().optional(),
 			})
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -400,6 +409,10 @@ export const liveTournamentSessionRouter = router({
 				entryFee: input.entryFee ?? null,
 				startedAt: now,
 				memo: input.memo ?? null,
+				timerStartedAt:
+					input.timerStartedAt === undefined
+						? null
+						: new Date(input.timerStartedAt * 1000),
 				updatedAt: now,
 			});
 
@@ -424,6 +437,7 @@ export const liveTournamentSessionRouter = router({
 				memo: z.string().nullable().optional(),
 				storeId: z.string().nullable().optional(),
 				currencyId: z.string().nullable().optional(),
+				timerStartedAt: z.number().int().nullable().optional(),
 			})
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -442,6 +456,12 @@ export const liveTournamentSessionRouter = router({
 			}
 			if (input.currencyId !== undefined) {
 				updateData.currencyId = input.currencyId;
+			}
+			if (input.timerStartedAt !== undefined) {
+				updateData.timerStartedAt =
+					input.timerStartedAt === null
+						? null
+						: new Date(input.timerStartedAt * 1000);
 			}
 
 			await ctx.db

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -423,7 +423,9 @@ export const liveTournamentSessionRouter = router({
 				eventType: "session_start",
 				occurredAt: now,
 				sortOrder: 0,
-				payload: JSON.stringify({}),
+				payload: JSON.stringify({
+					timerStartedAt: input.timerStartedAt ?? null,
+				}),
 				updatedAt: now,
 			});
 
@@ -468,6 +470,36 @@ export const liveTournamentSessionRouter = router({
 				.update(liveTournamentSession)
 				.set(updateData)
 				.where(eq(liveTournamentSession.id, input.id));
+
+			// Keep the session_start event payload's timerStartedAt in sync so that
+			// the event view and the column stay consistent.
+			if (input.timerStartedAt !== undefined) {
+				const [startEvent] = await ctx.db
+					.select()
+					.from(sessionEvent)
+					.where(
+						and(
+							eq(sessionEvent.liveTournamentSessionId, input.id),
+							eq(sessionEvent.eventType, "session_start")
+						)
+					);
+				if (startEvent) {
+					const existing = JSON.parse(startEvent.payload) as Record<
+						string,
+						unknown
+					>;
+					await ctx.db
+						.update(sessionEvent)
+						.set({
+							payload: JSON.stringify({
+								...existing,
+								timerStartedAt: input.timerStartedAt ?? null,
+							}),
+							updatedAt: new Date(),
+						})
+						.where(eq(sessionEvent.id, startEvent.id));
+				}
+			}
 
 			const [updated] = await ctx.db
 				.select()

--- a/packages/api/src/routers/session-event.ts
+++ b/packages/api/src/routers/session-event.ts
@@ -393,16 +393,46 @@ export const sessionEventRouter = router({
 			if (input.occurredAt !== undefined) {
 				updates.occurredAt = new Date(input.occurredAt * 1000);
 			}
+			let validatedPayload: unknown;
 			if (input.payload !== undefined) {
-				updates.payload = JSON.stringify(
-					validateEventPayload(eventType, input.payload, sessionType)
+				validatedPayload = validateEventPayload(
+					eventType,
+					input.payload,
+					sessionType
 				);
+				updates.payload = JSON.stringify(validatedPayload);
 			}
 
 			await ctx.db
 				.update(sessionEvent)
 				.set(updates)
 				.where(eq(sessionEvent.id, input.id));
+
+			// Session_start for tournament carries timerStartedAt in its payload.
+			// Mirror the change onto the top-level column so existing readers stay
+			// in sync.
+			if (
+				eventType === "session_start" &&
+				sessionType === "tournament" &&
+				event.liveTournamentSessionId &&
+				validatedPayload &&
+				typeof validatedPayload === "object"
+			) {
+				const timerRaw = (validatedPayload as Record<string, unknown>)
+					.timerStartedAt;
+				let timerStartedAt: Date | null | undefined;
+				if (typeof timerRaw === "number") {
+					timerStartedAt = new Date(timerRaw * 1000);
+				} else if (timerRaw === null) {
+					timerStartedAt = null;
+				}
+				if (timerStartedAt !== undefined) {
+					await ctx.db
+						.update(liveTournamentSession)
+						.set({ timerStartedAt, updatedAt: new Date() })
+						.where(eq(liveTournamentSession.id, event.liveTournamentSessionId));
+				}
+			}
 
 			await recalculateSession(
 				ctx.db,

--- a/packages/db/src/__tests__/live-tournament-session.test.ts
+++ b/packages/db/src/__tests__/live-tournament-session.test.ts
@@ -39,4 +39,10 @@ describe("LiveTournamentSession schema", () => {
 		expect(columns.endedAt.notNull).toBe(false);
 		expect(columns.memo.notNull).toBe(false);
 	});
+
+	it("has nullable timerStartedAt column for tournament timer", () => {
+		const columns = getTableColumns(liveTournamentSession);
+		expect(columns.timerStartedAt).toBeDefined();
+		expect(columns.timerStartedAt.notNull).toBe(false);
+	});
 });

--- a/packages/db/src/__tests__/session-event-types.test.ts
+++ b/packages/db/src/__tests__/session-event-types.test.ts
@@ -20,6 +20,7 @@ import {
 	SESSION_STATUSES,
 	TOURNAMENT_EVENT_TYPES,
 	tournamentSessionEndPayload,
+	tournamentSessionStartPayload,
 	updateStackPayload,
 	updateTournamentInfoPayload,
 	validateEventPayload,
@@ -122,6 +123,33 @@ describe("payload schemas", () => {
 		it("rejects negative buyInAmount", () => {
 			expect(() =>
 				cashSessionStartPayload.parse({ buyInAmount: -1 })
+			).toThrow();
+		});
+	});
+
+	describe("tournamentSessionStartPayload", () => {
+		it("accepts an empty payload", () => {
+			const result = tournamentSessionStartPayload.parse({});
+			expect(result.timerStartedAt).toBeUndefined();
+		});
+
+		it("accepts null timerStartedAt", () => {
+			const result = tournamentSessionStartPayload.parse({
+				timerStartedAt: null,
+			});
+			expect(result.timerStartedAt).toBeNull();
+		});
+
+		it("accepts an integer timerStartedAt (unix seconds)", () => {
+			const result = tournamentSessionStartPayload.parse({
+				timerStartedAt: 1_700_000_000,
+			});
+			expect(result.timerStartedAt).toBe(1_700_000_000);
+		});
+
+		it("rejects a non-integer timerStartedAt", () => {
+			expect(() =>
+				tournamentSessionStartPayload.parse({ timerStartedAt: 12.5 })
 			).toThrow();
 		});
 	});
@@ -324,7 +352,16 @@ describe("validateEventPayload", () => {
 		expect(result).toBeDefined();
 	});
 
-	it("dispatches session_start to empty schema for tournament", () => {
+	it("dispatches session_start to tournament schema carrying timerStartedAt", () => {
+		const result = validateEventPayload(
+			"session_start",
+			{ timerStartedAt: 1_700_000_000 },
+			"tournament"
+		) as { timerStartedAt?: number | null };
+		expect(result.timerStartedAt).toBe(1_700_000_000);
+	});
+
+	it("dispatches session_start for tournament with missing timerStartedAt", () => {
 		const result = validateEventPayload("session_start", {}, "tournament");
 		expect(result).toBeDefined();
 	});

--- a/packages/db/src/constants/session-event-types.ts
+++ b/packages/db/src/constants/session-event-types.ts
@@ -49,7 +49,9 @@ export const cashSessionStartPayload = z.object({
 	buyInAmount: z.number().int().min(0),
 });
 
-export const tournamentSessionStartPayload = z.object({});
+export const tournamentSessionStartPayload = z.object({
+	timerStartedAt: z.number().int().nullable().optional(),
+});
 
 export const cashSessionEndPayload = z.object({
 	cashOutAmount: z.number().int().min(0),

--- a/packages/db/src/migrations/0017_add_tournament_timer.sql
+++ b/packages/db/src/migrations/0017_add_tournament_timer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE live_tournament_session ADD COLUMN timer_started_at INTEGER;

--- a/packages/db/src/migrations/0018_backfill_session_start_timer.sql
+++ b/packages/db/src/migrations/0018_backfill_session_start_timer.sql
@@ -1,0 +1,22 @@
+-- Backfill timerStartedAt onto session_start event payloads for tournaments
+-- that already have a start time recorded on live_tournament_session.
+UPDATE session_event
+SET
+    payload = json_set(
+        COALESCE(NULLIF(session_event.payload, ''), '{}'),
+        '$.timerStartedAt',
+        (
+            SELECT lts.timer_started_at
+            FROM live_tournament_session lts
+            WHERE lts.id = session_event.live_tournament_session_id
+        )
+    ),
+    updated_at = unixepoch()
+WHERE session_event.event_type = 'session_start'
+    AND session_event.live_tournament_session_id IS NOT NULL
+    AND EXISTS (
+        SELECT 1
+        FROM live_tournament_session lts
+        WHERE lts.id = session_event.live_tournament_session_id
+            AND lts.timer_started_at IS NOT NULL
+    );

--- a/packages/db/src/schema/live-tournament-session.ts
+++ b/packages/db/src/schema/live-tournament-session.ts
@@ -25,6 +25,7 @@ export const liveTournamentSession = sqliteTable(
 		entryFee: integer("entry_fee"),
 		startedAt: integer("started_at", { mode: "timestamp" }).notNull(),
 		endedAt: integer("ended_at", { mode: "timestamp" }),
+		timerStartedAt: integer("timer_started_at", { mode: "timestamp" }),
 		heroSeatPosition: integer("hero_seat_position"),
 		memo: text("memo"),
 		createdAt: integer("created_at", { mode: "timestamp" })


### PR DESCRIPTION
Closes #96

## Summary
- `live_tournament_session` に `timer_started_at` (nullable) を追加し、セッション作成と `update` で任意に設定・クリアできるようにした。
- `liveTournamentSession.getById` のレスポンスに `blindLevels` を同梱し、フロントが追加クエリ無しで構造を参照できるようにした。
- Overview (`/active-session`) 上部に `TournamentTimer` を追加。構造が未登録の場合は非表示、登録済みかつ未設定なら「Timer not started」表示、設定済みならレベルラベル + 残り時間のカウントダウン (ブレイクはアンバー強調、構造終了後は "DONE") を表示。
- タイマー編集用の `TournamentTimerDialog` (`@tanstack/react-form` + Zod、`datetime-local` 入力、`Clear` で `null` に戻す) をタイマーをクリックで表示。
- 新規セッション作成フォームに任意入力「Timer Start Time (optional)」を追加し、トーナメント作成時にタイマー開始時刻を設定できるようにした。

## Key files
- backend: `packages/db/src/schema/live-tournament-session.ts`, `packages/db/src/migrations/0017_add_tournament_timer.sql`, `packages/api/src/routers/live-tournament-session.ts`
- frontend: `apps/web/src/live-sessions/utils/tournament-timer.ts`, `apps/web/src/live-sessions/components/tournament-timer.tsx`, `apps/web/src/live-sessions/components/tournament-timer-dialog.tsx`, `apps/web/src/routes/active-session/index.tsx`, `apps/web/src/live-sessions/components/active-session-scene.tsx`, `apps/web/src/live-sessions/hooks/use-tournament-session.ts`, `apps/web/src/live-sessions/components/create-tournament-session-form.tsx`, `apps/web/src/live-sessions/hooks/use-create-session.ts`

## Test plan
- [x] `bun run test` — 526 tests passed (+18 新規、既存 508 に加えて `tournament-timer` util/コンポーネントと `live-tournament-session` schema のテストを追加)
- [x] `bun run check-types` — server/web ともに 0
- [x] `bun run lint` (`ultracite check`) — 0 errors
- [ ] `bun run db:migrate:local` でマイグレーション適用 (UI 動作確認)
- [ ] ブラウザ手動確認:
  - ストラクチャー無しのトーナメント → タイマー非表示
  - ストラクチャー有り + 未設定 → ダッシュ付きピル表示・ダイアログから設定できる
  - 設定後 → 1秒刻みでカウントダウン、次レベルへの遷移、ブレイク強調、構造終了後の "DONE"
  - `Clear` ボタンで `null` に戻せる
  - 新規セッション作成ダイアログで Timer Start Time を指定 → Overview に即時反映

https://claude.ai/code/session_01BR1XaG3pJknybT6yg5JpVX