### PR TITLE
feat: add game details screen for active live session (#92)

### DIFF
--- a/apps/web/src/__tests__/mobile-nav.test.tsx
+++ b/apps/web/src/__tests__/mobile-nav.test.tsx
@@ -72,6 +72,9 @@ function createTestRouter(initialPath: string) {
 		"/sessions",
 		"/live-sessions",
 		"/live-sessions/$sessionType/$sessionId/events",
+		"/active-session",
+		"/active-session/events",
+		"/active-session/game",
 		"/players",
 		"/settings",
 	].map((path) =>
@@ -170,10 +173,19 @@ describe("MobileNav - Live Session Mode (active session)", () => {
 		render(<RouterProvider router={router} />);
 
 		await screen.findByText("Events");
-		expect(screen.getByText("Players")).toBeInTheDocument();
+		expect(screen.getByText("Game")).toBeInTheDocument();
 		expect(screen.getByText("Overview")).toBeInTheDocument();
 		expect(screen.getByText("Settings")).toBeInTheDocument();
 		expect(screen.getByText("Stack")).toBeInTheDocument();
+	});
+
+	it("renders a Game link pointing to /active-session/game", async () => {
+		const router = createTestRouter("/active-session");
+		render(<RouterProvider router={router} />);
+
+		const gameLink = await screen.findByText("Game");
+		const anchor = gameLink.closest("a");
+		expect(anchor?.getAttribute("href")).toBe("/active-session/game");
 	});
 
 	it("center button has green styling in live mode", async () => {

--- a/apps/web/src/live-sessions/components/__tests__/active-session-game-scene.test.tsx
+++ b/apps/web/src/live-sessions/components/__tests__/active-session-game-scene.test.tsx
@@ -69,8 +69,8 @@ vi.mock("@/stores/components/ring-game-form", () => ({
 	RingGameForm: () => <div data-testid="ring-game-form" />,
 }));
 
-vi.mock("@/stores/components/tournament-modal-content", () => ({
-	TournamentModalContent: () => <div data-testid="tournament-modal-content" />,
+vi.mock("@/stores/components/tournament-edit-dialog", () => ({
+	TournamentEditDialog: () => <div data-testid="tournament-edit-dialog" />,
 }));
 
 vi.mock("@/shared/components/ui/responsive-dialog", () => ({

--- a/apps/web/src/live-sessions/components/__tests__/active-session-game-scene.test.tsx
+++ b/apps/web/src/live-sessions/components/__tests__/active-session-game-scene.test.tsx
@@ -1,0 +1,248 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActiveSessionGameScene } from "@/live-sessions/components/active-session-game-scene";
+
+const mocks = vi.hoisted(() => ({
+	activeSession: null as null | {
+		id: string;
+		type: "cash_game" | "tournament";
+		status: "active" | "paused";
+	},
+	cashSession: null as null | {
+		id: string;
+		storeId: string;
+		ringGameId: string | null;
+	},
+	tournamentSession: null as null | {
+		id: string;
+		storeId: string;
+		tournamentId: string | null;
+	},
+	ringGames: [] as unknown[],
+	tournament: null as null | Record<string, unknown>,
+	levels: [] as unknown[],
+	chipPurchases: [] as unknown[],
+	currencies: [] as unknown[],
+}));
+
+vi.mock("@/live-sessions/hooks/use-active-session", () => ({
+	useActiveSession: () => ({
+		activeSession: mocks.activeSession,
+		hasActive: mocks.activeSession !== null,
+		isLoading: false,
+	}),
+}));
+
+vi.mock("@/live-sessions/hooks/use-cash-game-session", () => ({
+	useCashGameSession: () => ({
+		session: mocks.cashSession,
+		ringGames: mocks.ringGames,
+		isDiscardPending: false,
+		discard: vi.fn(),
+	}),
+}));
+
+vi.mock("@/live-sessions/hooks/use-tournament-session", () => ({
+	useTournamentSession: () => ({
+		session: mocks.tournamentSession,
+		isDiscardPending: false,
+		discard: vi.fn(),
+	}),
+}));
+
+vi.mock("@/stores/hooks/use-ring-games", () => ({
+	useRingGames: () => ({
+		update: vi.fn(async () => undefined),
+		isUpdatePending: false,
+		currencies: mocks.currencies,
+	}),
+}));
+
+vi.mock("@/stores/hooks/use-tournaments", () => ({
+	useTournaments: () => ({
+		isUpdateWithLevelsPending: false,
+	}),
+}));
+
+vi.mock("@/stores/components/ring-game-form", () => ({
+	RingGameForm: () => <div data-testid="ring-game-form" />,
+}));
+
+vi.mock("@/stores/components/tournament-modal-content", () => ({
+	TournamentModalContent: () => <div data-testid="tournament-modal-content" />,
+}));
+
+vi.mock("@/shared/components/ui/responsive-dialog", () => ({
+	ResponsiveDialog: ({
+		children,
+		open,
+	}: {
+		children: ReactNode;
+		open: boolean;
+	}) => (open ? <div>{children}</div> : null),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+	useQuery: (options: { queryKey: unknown[] }) => {
+		const [scope] = options.queryKey as [string];
+		if (scope === "tournament") {
+			return { data: mocks.tournament, isLoading: false };
+		}
+		if (scope === "blindLevel") {
+			return { data: mocks.levels, isLoading: false };
+		}
+		if (scope === "tournamentChipPurchase") {
+			return { data: mocks.chipPurchases, isLoading: false };
+		}
+		if (scope === "currency") {
+			return { data: mocks.currencies, isLoading: false };
+		}
+		return { data: undefined, isLoading: false };
+	},
+	useQueryClient: () => ({
+		invalidateQueries: vi.fn(async () => undefined),
+	}),
+}));
+
+vi.mock("@/utils/trpc", () => {
+	const makeProc = (name: string) => ({
+		queryOptions: () => ({ queryKey: [name] }),
+	});
+	return {
+		trpc: {
+			tournament: {
+				getById: makeProc("tournament"),
+				listByStore: makeProc("tournament"),
+			},
+			tournamentChipPurchase: {
+				listByTournament: makeProc("tournamentChipPurchase"),
+			},
+			blindLevel: {
+				listByTournament: makeProc("blindLevel"),
+			},
+			liveCashGameSession: {
+				getById: makeProc("liveCashGameSession"),
+			},
+			liveTournamentSession: {
+				getById: makeProc("liveTournamentSession"),
+			},
+			currency: {
+				list: makeProc("currency"),
+			},
+		},
+		trpcClient: {
+			tournament: {
+				updateWithLevels: { mutate: vi.fn() },
+			},
+		},
+	};
+});
+
+describe("ActiveSessionGameScene", () => {
+	beforeEach(() => {
+		mocks.activeSession = null;
+		mocks.cashSession = null;
+		mocks.tournamentSession = null;
+		mocks.ringGames = [];
+		mocks.tournament = null;
+		mocks.levels = [];
+		mocks.chipPurchases = [];
+		mocks.currencies = [{ id: "currency-1", name: "USD", unit: "$" }];
+	});
+
+	it("shows the no-active-session empty state when there is no session", () => {
+		render(<ActiveSessionGameScene />);
+		expect(screen.getByText("No active session")).toBeInTheDocument();
+	});
+
+	it("renders ring game details for a cash game session", () => {
+		mocks.activeSession = {
+			id: "session-1",
+			type: "cash_game",
+			status: "active",
+		};
+		mocks.cashSession = {
+			id: "session-1",
+			storeId: "store-1",
+			ringGameId: "ring-1",
+		};
+		mocks.ringGames = [
+			{
+				ante: null,
+				anteType: "none",
+				archivedAt: null,
+				blind1: 1,
+				blind2: 2,
+				blind3: null,
+				createdAt: "",
+				currencyId: "currency-1",
+				id: "ring-1",
+				maxBuyIn: 400,
+				memo: "deep stack",
+				minBuyIn: 100,
+				name: "1/2 NLH",
+				storeId: "store-1",
+				tableSize: 9,
+				updatedAt: "",
+				variant: "nlh",
+			},
+		];
+
+		render(<ActiveSessionGameScene />);
+		expect(screen.getByText("1/2 NLH")).toBeInTheDocument();
+		expect(screen.getByText("Cash Game")).toBeInTheDocument();
+		expect(screen.getByText("deep stack")).toBeInTheDocument();
+	});
+
+	it("shows a fallback when the cash session has no ring game linked", () => {
+		mocks.activeSession = {
+			id: "session-1",
+			type: "cash_game",
+			status: "active",
+		};
+		mocks.cashSession = {
+			id: "session-1",
+			storeId: "store-1",
+			ringGameId: null,
+		};
+
+		render(<ActiveSessionGameScene />);
+		expect(screen.getByText("Game not linked")).toBeInTheDocument();
+	});
+
+	it("renders tournament details", () => {
+		mocks.activeSession = {
+			id: "session-2",
+			type: "tournament",
+			status: "active",
+		};
+		mocks.tournamentSession = {
+			id: "session-2",
+			storeId: "store-1",
+			tournamentId: "tour-1",
+		};
+		mocks.tournament = {
+			archivedAt: null,
+			bountyAmount: null,
+			buyIn: 10_000,
+			createdAt: "",
+			currencyId: "currency-1",
+			entryFee: 1000,
+			id: "tour-1",
+			memo: null,
+			name: "Weekly Deepstack",
+			startingStack: 20_000,
+			storeId: "store-1",
+			tableSize: 9,
+			tags: [],
+			updatedAt: "",
+			variant: "nlh",
+		};
+		mocks.levels = [];
+
+		render(<ActiveSessionGameScene />);
+		expect(screen.getByText("Weekly Deepstack")).toBeInTheDocument();
+		expect(screen.getByText("Tournament")).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/live-sessions/components/active-session-game-scene.tsx
+++ b/apps/web/src/live-sessions/components/active-session-game-scene.tsx
@@ -15,7 +15,7 @@ import {
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 import { RingGameForm } from "@/stores/components/ring-game-form";
-import { TournamentModalContent } from "@/stores/components/tournament-modal-content";
+import { TournamentEditDialog } from "@/stores/components/tournament-edit-dialog";
 import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
 import type {
 	RingGame,
@@ -674,20 +674,17 @@ function TournamentDetailsBody({
 			<ChipPurchasesCard chipPurchases={chipPurchases} />
 			<StructureCard isLoading={isLevelsLoading} levels={levels} />
 
-			<ResponsiveDialog
-				fullHeight
+			<TournamentEditDialog
+				aiMode="edit"
+				initialBlindLevels={levels}
+				initialFormValues={toInitialFormValues(tournament, chipPurchases)}
+				isLoading={isSaving || isUpdateWithLevelsPending}
 				onOpenChange={setIsEditOpen}
+				onSave={handleSave}
 				open={isEditOpen}
+				resetKey={tournament.id}
 				title="Edit Tournament"
-			>
-				<TournamentModalContent
-					initialBlindLevels={levels}
-					initialFormValues={toInitialFormValues(tournament, chipPurchases)}
-					isLoading={isSaving || isUpdateWithLevelsPending}
-					key={tournament.id}
-					onSave={handleSave}
-				/>
-			</ResponsiveDialog>
+			/>
 		</GameSceneShell>
 	);
 }

--- a/apps/web/src/live-sessions/components/active-session-game-scene.tsx
+++ b/apps/web/src/live-sessions/components/active-session-game-scene.tsx
@@ -1,0 +1,789 @@
+import { IconEdit } from "@tabler/icons-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useActiveSession } from "@/live-sessions/hooks/use-active-session";
+import { useCashGameSession } from "@/live-sessions/hooks/use-cash-game-session";
+import { useTournamentSession } from "@/live-sessions/hooks/use-tournament-session";
+import { Badge } from "@/shared/components/ui/badge";
+import { Button } from "@/shared/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardHeader,
+	CardTitle,
+} from "@/shared/components/ui/card";
+import { EmptyState } from "@/shared/components/ui/empty-state";
+import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
+import { RingGameForm } from "@/stores/components/ring-game-form";
+import { TournamentModalContent } from "@/stores/components/tournament-modal-content";
+import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+import type {
+	RingGame,
+	RingGameFormValues,
+} from "@/stores/hooks/use-ring-games";
+import { useRingGames } from "@/stores/hooks/use-ring-games";
+import type { TournamentFormValues } from "@/stores/hooks/use-tournaments";
+import { useTournaments } from "@/stores/hooks/use-tournaments";
+import { createGroupFormatter } from "@/utils/format-number";
+import { getTableSizeClassName } from "@/utils/table-size-colors";
+import { trpc, trpcClient } from "@/utils/trpc";
+
+const VARIANT_LABELS: Record<string, string> = {
+	nlh: "NLH",
+};
+
+function variantLabel(variant: string): string {
+	return VARIANT_LABELS[variant] ?? variant.toUpperCase();
+}
+
+function GameSceneShell({
+	children,
+	title,
+	action,
+}: {
+	children: React.ReactNode;
+	title: string;
+	action?: React.ReactNode;
+}) {
+	return (
+		<div className="flex h-full flex-col gap-3 overflow-y-auto pb-6">
+			<div className="flex items-center justify-between gap-2">
+				<h1 className="font-semibold text-lg">{title}</h1>
+				{action}
+			</div>
+			{children}
+		</div>
+	);
+}
+
+function DetailRow({
+	label,
+	value,
+}: {
+	label: string;
+	value: React.ReactNode;
+}) {
+	return (
+		<div className="flex items-baseline justify-between gap-4 py-1">
+			<span className="text-muted-foreground text-xs">{label}</span>
+			<span className="text-right font-medium text-sm">{value}</span>
+		</div>
+	);
+}
+
+function formatBlindParts(game: RingGame): string {
+	const fmt = createGroupFormatter([
+		game.blind1,
+		game.blind2,
+		game.blind3,
+		game.ante,
+	]);
+	const parts: string[] = [];
+	if (game.blind1 != null) {
+		parts.push(fmt(game.blind1));
+	}
+	if (game.blind2 != null) {
+		parts.push(fmt(game.blind2));
+	} else if (parts.length > 0) {
+		parts.push("—");
+	}
+	if (game.blind3 != null) {
+		parts.push(fmt(game.blind3));
+	}
+	return parts.join("/");
+}
+
+function formatAnteSuffix(game: RingGame): string {
+	if (game.ante == null || game.anteType == null || game.anteType === "none") {
+		return "";
+	}
+	const fmt = createGroupFormatter([game.ante]);
+	if (game.anteType === "bb") {
+		return `(BBA:${fmt(game.ante)})`;
+	}
+	if (game.anteType === "all") {
+		return `(Ante:${fmt(game.ante)})`;
+	}
+	return "";
+}
+
+function RingGameDetailsCard({
+	game,
+	currencyUnit,
+	currencyName,
+}: {
+	game: RingGame;
+	currencyUnit: string | null | undefined;
+	currencyName: string | null | undefined;
+}) {
+	const blindsStr = formatBlindParts(game);
+	const anteStr = formatAnteSuffix(game);
+	const fmt = createGroupFormatter([game.minBuyIn, game.maxBuyIn]);
+	const buyInStr = (() => {
+		if (game.minBuyIn == null && game.maxBuyIn == null) {
+			return "—";
+		}
+		const min = game.minBuyIn == null ? "—" : fmt(game.minBuyIn);
+		const max = game.maxBuyIn == null ? "—" : fmt(game.maxBuyIn);
+		return `${min} - ${max}${currencyUnit ? ` ${currencyUnit}` : ""}`;
+	})();
+
+	return (
+		<Card size="sm">
+			<CardHeader>
+				<CardTitle className="flex flex-wrap items-center gap-1.5">
+					<span className="truncate">{game.name}</span>
+					<Badge className="px-1 py-0 text-[10px]" variant="secondary">
+						{variantLabel(game.variant)}
+					</Badge>
+					{game.tableSize == null ? null : (
+						<Badge
+							className={`px-1 py-0 text-[10px] ${getTableSizeClassName(game.tableSize)}`}
+						>
+							{game.tableSize}-max
+						</Badge>
+					)}
+				</CardTitle>
+			</CardHeader>
+			<CardContent className="divide-y">
+				<DetailRow
+					label="Blinds"
+					value={
+						blindsStr
+							? `${blindsStr}${anteStr ? ` ${anteStr}` : ""}${currencyUnit ? ` ${currencyUnit}` : ""}`
+							: "—"
+					}
+				/>
+				<DetailRow label="Buy-in" value={buyInStr} />
+				<DetailRow
+					label="Table"
+					value={game.tableSize == null ? "—" : `${game.tableSize}-max`}
+				/>
+				<DetailRow label="Currency" value={currencyName ?? "—"} />
+				{game.memo ? (
+					<div className="py-2">
+						<p className="text-muted-foreground text-xs">Memo</p>
+						<p className="whitespace-pre-wrap text-sm">{game.memo}</p>
+					</div>
+				) : null}
+			</CardContent>
+		</Card>
+	);
+}
+
+function CashGameDetails({ sessionId }: { sessionId: string }) {
+	const queryClient = useQueryClient();
+	const [isEditOpen, setIsEditOpen] = useState(false);
+	const { session, ringGames } = useCashGameSession(sessionId);
+	const storeId = session?.storeId ?? "";
+	const { update, isUpdatePending, currencies } = useRingGames({
+		storeId,
+		showArchived: false,
+	});
+
+	if (!session) {
+		return (
+			<GameSceneShell title="Cash Game">
+				<EmptyState
+					className="border-none bg-transparent"
+					description="Loading session..."
+					heading="Loading"
+				/>
+			</GameSceneShell>
+		);
+	}
+
+	const ringGame = session.ringGameId
+		? ringGames.find((candidate) => candidate.id === session.ringGameId)
+		: undefined;
+
+	if (!(session.ringGameId && ringGame)) {
+		return (
+			<GameSceneShell title="Cash Game">
+				<EmptyState
+					description="このセッションにはキャッシュゲームが紐付いていません。"
+					heading="Game not linked"
+				/>
+			</GameSceneShell>
+		);
+	}
+
+	const currency = currencies.find((c) => c.id === ringGame.currencyId);
+
+	const handleUpdate = async (values: RingGameFormValues) => {
+		await update({ id: ringGame.id, ...values });
+		await queryClient.invalidateQueries({
+			queryKey: trpc.liveCashGameSession.getById.queryOptions({ id: sessionId })
+				.queryKey,
+		});
+		setIsEditOpen(false);
+	};
+
+	return (
+		<GameSceneShell
+			action={
+				<Button
+					onClick={() => setIsEditOpen(true)}
+					size="sm"
+					type="button"
+					variant="outline"
+				>
+					<IconEdit size={14} />
+					Edit
+				</Button>
+			}
+			title="Cash Game"
+		>
+			<RingGameDetailsCard
+				currencyName={currency?.name}
+				currencyUnit={currency?.unit}
+				game={ringGame}
+			/>
+
+			<ResponsiveDialog
+				onOpenChange={setIsEditOpen}
+				open={isEditOpen}
+				title="Edit Cash Game"
+			>
+				<RingGameForm
+					defaultValues={{
+						name: ringGame.name,
+						variant: ringGame.variant,
+						blind1: ringGame.blind1 ?? undefined,
+						blind2: ringGame.blind2 ?? undefined,
+						blind3: ringGame.blind3 ?? undefined,
+						ante: ringGame.ante ?? undefined,
+						anteType: (ringGame.anteType ?? undefined) as
+							| "all"
+							| "bb"
+							| "none"
+							| undefined,
+						minBuyIn: ringGame.minBuyIn ?? undefined,
+						maxBuyIn: ringGame.maxBuyIn ?? undefined,
+						tableSize: ringGame.tableSize ?? undefined,
+						currencyId: ringGame.currencyId ?? undefined,
+						memo: ringGame.memo ?? undefined,
+					}}
+					isLoading={isUpdatePending}
+					onSubmit={handleUpdate}
+				/>
+			</ResponsiveDialog>
+		</GameSceneShell>
+	);
+}
+
+function TournamentStructureTable({ levels }: { levels: BlindLevelRow[] }) {
+	if (levels.length === 0) {
+		return (
+			<p className="py-4 text-center text-muted-foreground text-xs">
+				No blind levels yet.
+			</p>
+		);
+	}
+
+	return (
+		<div className="w-full overflow-x-auto">
+			<table className="w-full table-fixed border-collapse text-[11px]">
+				<thead>
+					<tr>
+						<th className="w-6 pb-0.5 text-center font-medium text-muted-foreground">
+							#
+						</th>
+						<th className="pb-0.5 text-center font-medium text-muted-foreground">
+							SB
+						</th>
+						<th className="pb-0.5 text-center font-medium text-muted-foreground">
+							BB
+						</th>
+						<th className="pb-0.5 text-center font-medium text-muted-foreground">
+							Ante
+						</th>
+						<th className="w-8 pb-0.5 text-center font-medium text-muted-foreground">
+							Min
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{levels.map((row) => {
+						if (row.isBreak) {
+							return (
+								<tr className="bg-muted/30" key={row.id}>
+									<td className="py-0.5 text-center text-muted-foreground">
+										{row.level}
+									</td>
+									<td
+										className="py-0.5 text-center text-muted-foreground"
+										colSpan={3}
+									>
+										Break
+									</td>
+									<td className="py-0.5 text-center text-muted-foreground">
+										{row.minutes ?? "—"}
+									</td>
+								</tr>
+							);
+						}
+						const fmt = createGroupFormatter([
+							row.blind1,
+							row.blind2,
+							row.ante,
+						]);
+						return (
+							<tr key={row.id}>
+								<td className="py-0.5 text-center text-muted-foreground">
+									{row.level}
+								</td>
+								<td className="py-0.5 text-center">
+									{row.blind1 == null ? "—" : fmt(row.blind1)}
+								</td>
+								<td className="py-0.5 text-center">
+									{row.blind2 == null ? "—" : fmt(row.blind2)}
+								</td>
+								<td className="py-0.5 text-center">
+									{row.ante == null ? "—" : fmt(row.ante)}
+								</td>
+								<td className="py-0.5 text-center text-muted-foreground">
+									{row.minutes ?? "—"}
+								</td>
+							</tr>
+						);
+					})}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+type TournamentDetail = NonNullable<
+	ReturnType<typeof useTournamentDetail>["tournament"]
+>;
+
+interface ChipPurchaseRow {
+	chips: number;
+	cost: number;
+	id: string;
+	name: string;
+}
+
+function useTournamentDetail(tournamentId: string) {
+	const tournamentQuery = useQuery({
+		...trpc.tournament.getById.queryOptions({ id: tournamentId }),
+		enabled: !!tournamentId,
+	});
+	const chipPurchasesQuery = useQuery({
+		...trpc.tournamentChipPurchase.listByTournament.queryOptions({
+			tournamentId,
+		}),
+		enabled: !!tournamentId,
+	});
+	const levelsQuery = useQuery({
+		...trpc.blindLevel.listByTournament.queryOptions({ tournamentId }),
+		enabled: !!tournamentId,
+	});
+	const currenciesQuery = useQuery(trpc.currency.list.queryOptions());
+
+	return {
+		tournament: tournamentQuery.data,
+		isTournamentLoading: tournamentQuery.isLoading,
+		chipPurchases: (chipPurchasesQuery.data ?? []) as ChipPurchaseRow[],
+		levels: (levelsQuery.data ?? []) as BlindLevelRow[],
+		isLevelsLoading: levelsQuery.isLoading,
+		currencies: currenciesQuery.data ?? [],
+	};
+}
+
+function TournamentInfoCard({
+	tournament,
+	currencyName,
+}: {
+	tournament: TournamentDetail;
+	currencyName: string | null | undefined;
+}) {
+	const fmt = createGroupFormatter([
+		tournament.buyIn,
+		tournament.entryFee,
+		tournament.bountyAmount,
+		tournament.startingStack,
+	]);
+
+	return (
+		<Card size="sm">
+			<CardHeader>
+				<CardTitle className="flex flex-wrap items-center gap-1.5">
+					<span className="truncate">{tournament.name}</span>
+					<Badge className="px-1 py-0 text-[10px]" variant="secondary">
+						{variantLabel(tournament.variant)}
+					</Badge>
+					{tournament.tableSize == null ? null : (
+						<Badge
+							className={`px-1 py-0 text-[10px] ${getTableSizeClassName(tournament.tableSize)}`}
+						>
+							{tournament.tableSize}-max
+						</Badge>
+					)}
+					{tournament.tags.map((tag) => (
+						<Badge
+							className="px-1 py-0 text-[10px]"
+							key={tag.id}
+							variant="outline"
+						>
+							{tag.name}
+						</Badge>
+					))}
+				</CardTitle>
+			</CardHeader>
+			<CardContent className="divide-y">
+				<DetailRow
+					label="Buy-in"
+					value={tournament.buyIn == null ? "—" : fmt(tournament.buyIn)}
+				/>
+				<DetailRow
+					label="Entry Fee"
+					value={tournament.entryFee == null ? "—" : fmt(tournament.entryFee)}
+				/>
+				<DetailRow
+					label="Starting Stack"
+					value={
+						tournament.startingStack == null
+							? "—"
+							: fmt(tournament.startingStack)
+					}
+				/>
+				<DetailRow
+					label="Bounty"
+					value={
+						tournament.bountyAmount == null ? "—" : fmt(tournament.bountyAmount)
+					}
+				/>
+				<DetailRow label="Currency" value={currencyName ?? "—"} />
+				{tournament.memo ? (
+					<div className="py-2">
+						<p className="text-muted-foreground text-xs">Memo</p>
+						<p className="whitespace-pre-wrap text-sm">{tournament.memo}</p>
+					</div>
+				) : null}
+			</CardContent>
+		</Card>
+	);
+}
+
+function ChipPurchasesCard({
+	chipPurchases,
+}: {
+	chipPurchases: ChipPurchaseRow[];
+}) {
+	if (chipPurchases.length === 0) {
+		return null;
+	}
+	const fmt = createGroupFormatter(
+		chipPurchases.flatMap((cp) => [cp.cost, cp.chips])
+	);
+	return (
+		<Card size="sm">
+			<CardHeader>
+				<CardTitle>Chip Purchases</CardTitle>
+			</CardHeader>
+			<CardContent className="divide-y">
+				{chipPurchases.map((cp) => (
+					<DetailRow
+						key={cp.id}
+						label={cp.name}
+						value={`${fmt(cp.cost)} → ${fmt(cp.chips)} chips`}
+					/>
+				))}
+			</CardContent>
+		</Card>
+	);
+}
+
+function StructureCard({
+	levels,
+	isLoading,
+}: {
+	levels: BlindLevelRow[];
+	isLoading: boolean;
+}) {
+	return (
+		<Card size="sm">
+			<CardHeader>
+				<CardTitle>Structure</CardTitle>
+			</CardHeader>
+			<CardContent>
+				{isLoading ? (
+					<p className="py-2 text-center text-muted-foreground text-xs">
+						Loading levels...
+					</p>
+				) : (
+					<TournamentStructureTable levels={levels} />
+				)}
+			</CardContent>
+		</Card>
+	);
+}
+
+function toInitialFormValues(
+	tournament: TournamentDetail,
+	chipPurchases: ChipPurchaseRow[]
+) {
+	return {
+		name: tournament.name,
+		variant: tournament.variant,
+		buyIn: tournament.buyIn ?? undefined,
+		entryFee: tournament.entryFee ?? undefined,
+		startingStack: tournament.startingStack ?? undefined,
+		bountyAmount: tournament.bountyAmount ?? undefined,
+		tableSize: tournament.tableSize ?? undefined,
+		currencyId: tournament.currencyId ?? undefined,
+		memo: tournament.memo ?? undefined,
+		tags: tournament.tags.map((t) => t.name),
+		chipPurchases: chipPurchases.map((cp) => ({
+			name: cp.name,
+			cost: cp.cost,
+			chips: cp.chips,
+		})),
+	};
+}
+
+function useTournamentUpdate({
+	sessionId,
+	storeId,
+	tournamentId,
+}: {
+	sessionId: string;
+	storeId: string;
+	tournamentId: string;
+}) {
+	const queryClient = useQueryClient();
+	const [isSaving, setIsSaving] = useState(false);
+
+	const save = async (
+		values: TournamentFormValues,
+		updatedLevels: BlindLevelRow[]
+	) => {
+		setIsSaving(true);
+		try {
+			await trpcClient.tournament.updateWithLevels.mutate({
+				id: tournamentId,
+				name: values.name,
+				variant: values.variant,
+				buyIn: values.buyIn ?? null,
+				entryFee: values.entryFee ?? null,
+				startingStack: values.startingStack ?? null,
+				bountyAmount: values.bountyAmount ?? null,
+				tableSize: values.tableSize ?? null,
+				currencyId: values.currencyId ?? null,
+				memo: values.memo ?? null,
+				tags: values.tags,
+				chipPurchases: values.chipPurchases,
+				blindLevels: updatedLevels.map((l) => ({
+					isBreak: l.isBreak,
+					blind1: l.blind1,
+					blind2: l.blind2,
+					blind3: l.blind3,
+					ante: l.ante,
+					minutes: l.minutes,
+				})),
+			});
+			await Promise.all([
+				queryClient.invalidateQueries({
+					queryKey: trpc.tournament.getById.queryOptions({ id: tournamentId })
+						.queryKey,
+				}),
+				queryClient.invalidateQueries({
+					queryKey: trpc.tournament.listByStore.queryOptions({
+						storeId,
+						includeArchived: false,
+					}).queryKey,
+				}),
+				queryClient.invalidateQueries({
+					queryKey: trpc.blindLevel.listByTournament.queryOptions({
+						tournamentId,
+					}).queryKey,
+				}),
+				queryClient.invalidateQueries({
+					queryKey: trpc.tournamentChipPurchase.listByTournament.queryOptions({
+						tournamentId,
+					}).queryKey,
+				}),
+				queryClient.invalidateQueries({
+					queryKey: trpc.liveTournamentSession.getById.queryOptions({
+						id: sessionId,
+					}).queryKey,
+				}),
+			]);
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	return { save, isSaving };
+}
+
+function TournamentDetailsBody({
+	sessionId,
+	storeId,
+	tournament,
+	chipPurchases,
+	levels,
+	isLevelsLoading,
+	currencyName,
+}: {
+	sessionId: string;
+	storeId: string;
+	tournament: TournamentDetail;
+	chipPurchases: ChipPurchaseRow[];
+	levels: BlindLevelRow[];
+	isLevelsLoading: boolean;
+	currencyName: string | null | undefined;
+}) {
+	const [isEditOpen, setIsEditOpen] = useState(false);
+	const { save, isSaving } = useTournamentUpdate({
+		sessionId,
+		storeId,
+		tournamentId: tournament.id,
+	});
+	const { isUpdateWithLevelsPending } = useTournaments({
+		storeId,
+		showArchived: false,
+	});
+
+	const handleSave = async (
+		values: TournamentFormValues,
+		updatedLevels: BlindLevelRow[]
+	) => {
+		await save(values, updatedLevels);
+		setIsEditOpen(false);
+	};
+
+	return (
+		<GameSceneShell
+			action={
+				<Button
+					onClick={() => setIsEditOpen(true)}
+					size="sm"
+					type="button"
+					variant="outline"
+				>
+					<IconEdit size={14} />
+					Edit
+				</Button>
+			}
+			title="Tournament"
+		>
+			<TournamentInfoCard currencyName={currencyName} tournament={tournament} />
+			<ChipPurchasesCard chipPurchases={chipPurchases} />
+			<StructureCard isLoading={isLevelsLoading} levels={levels} />
+
+			<ResponsiveDialog
+				fullHeight
+				onOpenChange={setIsEditOpen}
+				open={isEditOpen}
+				title="Edit Tournament"
+			>
+				<TournamentModalContent
+					initialBlindLevels={levels}
+					initialFormValues={toInitialFormValues(tournament, chipPurchases)}
+					isLoading={isSaving || isUpdateWithLevelsPending}
+					key={tournament.id}
+					onSave={handleSave}
+				/>
+			</ResponsiveDialog>
+		</GameSceneShell>
+	);
+}
+
+function TournamentDetails({ sessionId }: { sessionId: string }) {
+	const { session } = useTournamentSession(sessionId);
+	const tournamentId = session?.tournamentId ?? "";
+	const storeId = session?.storeId ?? "";
+	const detail = useTournamentDetail(tournamentId);
+
+	if (!session) {
+		return (
+			<GameSceneShell title="Tournament">
+				<EmptyState
+					className="border-none bg-transparent"
+					description="Loading session..."
+					heading="Loading"
+				/>
+			</GameSceneShell>
+		);
+	}
+
+	if (!(tournamentId && storeId)) {
+		return (
+			<GameSceneShell title="Tournament">
+				<EmptyState
+					description="このセッションにはトーナメントが紐付いていません。"
+					heading="Game not linked"
+				/>
+			</GameSceneShell>
+		);
+	}
+
+	if (detail.isTournamentLoading || !detail.tournament) {
+		return (
+			<GameSceneShell title="Tournament">
+				<EmptyState
+					className="border-none bg-transparent"
+					description="Loading tournament details..."
+					heading="Loading"
+				/>
+			</GameSceneShell>
+		);
+	}
+
+	const currency = detail.currencies.find(
+		(c) => c.id === detail.tournament?.currencyId
+	);
+
+	return (
+		<TournamentDetailsBody
+			chipPurchases={detail.chipPurchases}
+			currencyName={currency?.name}
+			isLevelsLoading={detail.isLevelsLoading}
+			levels={detail.levels}
+			sessionId={sessionId}
+			storeId={storeId}
+			tournament={detail.tournament}
+		/>
+	);
+}
+
+export function ActiveSessionGameScene() {
+	const { activeSession, isLoading } = useActiveSession();
+
+	if (isLoading) {
+		return (
+			<div className="flex h-[100dvh] items-center justify-center pb-16">
+				<EmptyState
+					className="border-none bg-transparent py-0"
+					description="Fetching the current active session."
+					heading="Loading..."
+				/>
+			</div>
+		);
+	}
+
+	if (!activeSession) {
+		return (
+			<div className="flex h-[100dvh] items-center justify-center pb-16">
+				<EmptyState
+					className="border-none bg-transparent py-0"
+					description="Start a live session from the sessions screen."
+					heading="No active session"
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex h-[calc(100dvh-4rem)] flex-col px-4 pt-2 pb-0 md:px-6 md:pt-4">
+			{activeSession.type === "cash_game" ? (
+				<CashGameDetails sessionId={activeSession.id} />
+			) : (
+				<TournamentDetails sessionId={activeSession.id} />
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as PlayersIndexRouteImport } from './routes/players/index'
 import { Route as CurrenciesIndexRouteImport } from './routes/currencies/index'
 import { Route as ActiveSessionIndexRouteImport } from './routes/active-session/index'
 import { Route as StoresStoreIdRouteImport } from './routes/stores/$storeId'
+import { Route as ActiveSessionGameRouteImport } from './routes/active-session/game'
 import { Route as ActiveSessionEventsRouteImport } from './routes/active-session/events'
 import { Route as LiveSessionsSessionTypeSessionIdEventsRouteImport } from './routes/live-sessions/$sessionType/$sessionId/events'
 
@@ -84,6 +85,11 @@ const StoresStoreIdRoute = StoresStoreIdRouteImport.update({
   path: '/stores/$storeId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ActiveSessionGameRoute = ActiveSessionGameRouteImport.update({
+  id: '/game',
+  path: '/game',
+  getParentRoute: () => ActiveSessionRoute,
+} as any)
 const ActiveSessionEventsRoute = ActiveSessionEventsRouteImport.update({
   id: '/events',
   path: '/events',
@@ -104,6 +110,7 @@ export interface FileRoutesByFullPath {
   '/search': typeof SearchRoute
   '/settings': typeof SettingsRoute
   '/active-session/events': typeof ActiveSessionEventsRoute
+  '/active-session/game': typeof ActiveSessionGameRoute
   '/stores/$storeId': typeof StoresStoreIdRoute
   '/active-session/': typeof ActiveSessionIndexRoute
   '/currencies/': typeof CurrenciesIndexRoute
@@ -119,6 +126,7 @@ export interface FileRoutesByTo {
   '/search': typeof SearchRoute
   '/settings': typeof SettingsRoute
   '/active-session/events': typeof ActiveSessionEventsRoute
+  '/active-session/game': typeof ActiveSessionGameRoute
   '/stores/$storeId': typeof StoresStoreIdRoute
   '/active-session': typeof ActiveSessionIndexRoute
   '/currencies': typeof CurrenciesIndexRoute
@@ -136,6 +144,7 @@ export interface FileRoutesById {
   '/search': typeof SearchRoute
   '/settings': typeof SettingsRoute
   '/active-session/events': typeof ActiveSessionEventsRoute
+  '/active-session/game': typeof ActiveSessionGameRoute
   '/stores/$storeId': typeof StoresStoreIdRoute
   '/active-session/': typeof ActiveSessionIndexRoute
   '/currencies/': typeof CurrenciesIndexRoute
@@ -154,6 +163,7 @@ export interface FileRouteTypes {
     | '/search'
     | '/settings'
     | '/active-session/events'
+    | '/active-session/game'
     | '/stores/$storeId'
     | '/active-session/'
     | '/currencies/'
@@ -169,6 +179,7 @@ export interface FileRouteTypes {
     | '/search'
     | '/settings'
     | '/active-session/events'
+    | '/active-session/game'
     | '/stores/$storeId'
     | '/active-session'
     | '/currencies'
@@ -185,6 +196,7 @@ export interface FileRouteTypes {
     | '/search'
     | '/settings'
     | '/active-session/events'
+    | '/active-session/game'
     | '/stores/$storeId'
     | '/active-session/'
     | '/currencies/'
@@ -295,6 +307,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof StoresStoreIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/active-session/game': {
+      id: '/active-session/game'
+      path: '/game'
+      fullPath: '/active-session/game'
+      preLoaderRoute: typeof ActiveSessionGameRouteImport
+      parentRoute: typeof ActiveSessionRoute
+    }
     '/active-session/events': {
       id: '/active-session/events'
       path: '/events'
@@ -314,11 +333,13 @@ declare module '@tanstack/react-router' {
 
 interface ActiveSessionRouteChildren {
   ActiveSessionEventsRoute: typeof ActiveSessionEventsRoute
+  ActiveSessionGameRoute: typeof ActiveSessionGameRoute
   ActiveSessionIndexRoute: typeof ActiveSessionIndexRoute
 }
 
 const ActiveSessionRouteChildren: ActiveSessionRouteChildren = {
   ActiveSessionEventsRoute: ActiveSessionEventsRoute,
+  ActiveSessionGameRoute: ActiveSessionGameRoute,
   ActiveSessionIndexRoute: ActiveSessionIndexRoute,
 }
 

--- a/apps/web/src/routes/active-session/game.tsx
+++ b/apps/web/src/routes/active-session/game.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ActiveSessionGameScene } from "@/live-sessions/components/active-session-game-scene";
+
+export const Route = createFileRoute("/active-session/game")({
+	component: ActiveSessionGamePage,
+});
+
+function ActiveSessionGamePage() {
+	return <ActiveSessionGameScene />;
+}

--- a/apps/web/src/shared/components/app-navigation.tsx
+++ b/apps/web/src/shared/components/app-navigation.tsx
@@ -62,7 +62,7 @@ const NORMAL_RIGHT_ITEMS: readonly NavigationItem[] = [
 
 const LIVE_LEFT_ITEMS: readonly NavigationItem[] = [
 	{ to: "/active-session/events", label: "Events", icon: IconList },
-	{ to: "/players", label: "Players", icon: IconUsers },
+	{ to: "/active-session/game", label: "Game", icon: IconCards },
 ] as const;
 
 const LIVE_RIGHT_ITEMS: readonly NavigationItem[] = [

--- a/apps/web/src/stores/components/tournament-edit-dialog.tsx
+++ b/apps/web/src/stores/components/tournament-edit-dialog.tsx
@@ -1,0 +1,181 @@
+import type { ExtractedTournamentData } from "@sapphire2/api/routers/ai-extract";
+import { IconSparkles } from "@tabler/icons-react";
+import { useEffect, useState } from "react";
+import { Badge } from "@/shared/components/ui/badge";
+import { Button } from "@/shared/components/ui/button";
+import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
+import { AiExtractInput } from "@/stores/components/ai-extract-input";
+import {
+	TournamentModalContent,
+	type TournamentPartialFormValues,
+} from "@/stores/components/tournament-modal-content";
+import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+import type { TournamentFormValues } from "@/stores/hooks/use-tournaments";
+
+export type TournamentEditDialogMode = "create" | "edit";
+
+interface TournamentEditDialogProps {
+	aiMode?: TournamentEditDialogMode;
+	initialBlindLevels: BlindLevelRow[];
+	initialFormValues?: TournamentPartialFormValues;
+	isInitializing?: boolean;
+	isLoading: boolean;
+	onOpenChange: (open: boolean) => void;
+	onSave: (
+		values: TournamentFormValues,
+		levels: BlindLevelRow[]
+	) => void | Promise<void>;
+	open: boolean;
+	resetKey?: string;
+	title: string;
+}
+
+function extractedToBlindLevels(
+	data: ExtractedTournamentData
+): BlindLevelRow[] {
+	return (data.blindLevels ?? []).map((l, i) => ({
+		id: crypto.randomUUID(),
+		tournamentId: "",
+		level: i + 1,
+		isBreak: l.isBreak,
+		blind1: l.blind1 ?? null,
+		blind2: l.blind2 ?? null,
+		blind3: l.blind3 ?? null,
+		ante: l.ante ?? null,
+		minutes: l.minutes ?? null,
+	}));
+}
+
+function extractedToCreateFormValues(
+	data: ExtractedTournamentData
+): TournamentPartialFormValues {
+	return {
+		name: data.name ?? "",
+		buyIn: data.buyIn,
+		entryFee: data.entryFee,
+		startingStack: data.startingStack,
+		tableSize: data.tableSize,
+		chipPurchases: data.chipPurchases ?? [],
+		variant: "nlh",
+	};
+}
+
+function mergeExtractedIntoEditFormValues(
+	data: ExtractedTournamentData,
+	base: TournamentPartialFormValues | undefined
+): TournamentPartialFormValues {
+	return {
+		...base,
+		// Use || so empty strings fall back to the existing value
+		name: data.name || base?.name || "",
+		variant: base?.variant ?? "nlh",
+		...(data.buyIn !== undefined && { buyIn: data.buyIn }),
+		...(data.entryFee !== undefined && { entryFee: data.entryFee }),
+		...(data.startingStack !== undefined && {
+			startingStack: data.startingStack,
+		}),
+		...(data.tableSize !== undefined && { tableSize: data.tableSize }),
+		...(data.chipPurchases?.length && { chipPurchases: data.chipPurchases }),
+	};
+}
+
+export function TournamentEditDialog({
+	aiMode,
+	initialBlindLevels,
+	initialFormValues,
+	isInitializing = false,
+	isLoading,
+	onOpenChange,
+	onSave,
+	open,
+	resetKey,
+	title,
+}: TournamentEditDialogProps) {
+	const [aiSheetOpen, setAiSheetOpen] = useState(false);
+	const [aiFormValues, setAiFormValues] = useState<
+		TournamentPartialFormValues | undefined
+	>();
+	const [aiBlindLevels, setAiBlindLevels] = useState<BlindLevelRow[]>([]);
+	const [aiKey, setAiKey] = useState(0);
+
+	useEffect(() => {
+		if (!open) {
+			setAiFormValues(undefined);
+			setAiBlindLevels([]);
+			setAiKey(0);
+			setAiSheetOpen(false);
+		}
+	}, [open]);
+
+	const aiButton = aiMode ? (
+		<Button
+			onClick={() => setAiSheetOpen(true)}
+			size="xs"
+			type="button"
+			variant="outline"
+		>
+			<IconSparkles size={12} />
+			AI自動入力
+			<Badge className="px-1 py-0 text-[10px]" variant="secondary">
+				beta
+			</Badge>
+		</Button>
+	) : undefined;
+
+	const handleAiExtracted = (data: ExtractedTournamentData) => {
+		const extractedLevels = extractedToBlindLevels(data);
+		if (aiMode === "create") {
+			setAiFormValues(extractedToCreateFormValues(data));
+			setAiBlindLevels(extractedLevels);
+		} else {
+			setAiFormValues(
+				mergeExtractedIntoEditFormValues(data, initialFormValues)
+			);
+			setAiBlindLevels(
+				extractedLevels.length > 0 ? extractedLevels : initialBlindLevels
+			);
+		}
+		setAiKey((k) => k + 1);
+		setAiSheetOpen(false);
+	};
+
+	const effectiveFormValues = aiKey > 0 ? aiFormValues : initialFormValues;
+	const effectiveLevels = aiKey > 0 ? aiBlindLevels : initialBlindLevels;
+	const contentKey = `${resetKey ?? "tournament"}-${aiKey}`;
+
+	return (
+		<>
+			{aiMode ? (
+				<ResponsiveDialog
+					onOpenChange={setAiSheetOpen}
+					open={aiSheetOpen}
+					title="AI自動入力"
+				>
+					<AiExtractInput onExtracted={handleAiExtracted} />
+				</ResponsiveDialog>
+			) : null}
+
+			<ResponsiveDialog
+				fullHeight
+				headerAction={aiButton}
+				onOpenChange={onOpenChange}
+				open={open}
+				title={title}
+			>
+				{isInitializing && aiKey === 0 ? (
+					<p className="py-8 text-center text-muted-foreground text-sm">
+						Loading...
+					</p>
+				) : (
+					<TournamentModalContent
+						initialBlindLevels={effectiveLevels}
+						initialFormValues={effectiveFormValues}
+						isLoading={isLoading}
+						key={contentKey}
+						onSave={onSave}
+					/>
+				)}
+			</ResponsiveDialog>
+		</>
+	);
+}

--- a/apps/web/src/stores/components/tournament-modal-content.tsx
+++ b/apps/web/src/stores/components/tournament-modal-content.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import {
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
+} from "@/shared/components/ui/tabs";
+import { LocalBlindStructureContent } from "@/stores/components/blind-level-editor";
+import { TournamentForm } from "@/stores/components/tournament-form";
+import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+import type { TournamentFormValues } from "@/stores/hooks/use-tournaments";
+
+export type TournamentPartialFormValues = Omit<
+	TournamentFormValues,
+	"tags" | "chipPurchases"
+> & {
+	chipPurchases?: Array<{ name: string; cost: number; chips: number }>;
+	tags?: string[];
+};
+
+interface TournamentModalContentProps {
+	initialBlindLevels: BlindLevelRow[];
+	initialFormValues?: TournamentPartialFormValues;
+	isLoading: boolean;
+	onSave: (
+		values: TournamentFormValues,
+		levels: BlindLevelRow[]
+	) => void | Promise<void>;
+}
+
+export function TournamentModalContent({
+	initialBlindLevels,
+	initialFormValues,
+	isLoading,
+	onSave,
+}: TournamentModalContentProps) {
+	const [localBlindLevels, setLocalBlindLevels] =
+		useState<BlindLevelRow[]>(initialBlindLevels);
+
+	return (
+		<Tabs defaultValue="details">
+			<TabsList className="w-full">
+				<TabsTrigger value="details">Details</TabsTrigger>
+				<TabsTrigger value="structure">Structure</TabsTrigger>
+			</TabsList>
+			<TabsContent value="details">
+				<TournamentForm
+					defaultValues={initialFormValues}
+					isLoading={isLoading}
+					onSubmit={(values) => onSave(values, localBlindLevels)}
+				/>
+			</TabsContent>
+			<TabsContent value="structure">
+				<LocalBlindStructureContent
+					onChange={setLocalBlindLevels}
+					value={localBlindLevels}
+					variant={initialFormValues?.variant ?? "nlh"}
+				/>
+			</TabsContent>
+		</Tabs>
+	);
+}

--- a/apps/web/src/stores/components/tournament-tab.tsx
+++ b/apps/web/src/stores/components/tournament-tab.tsx
@@ -1,10 +1,8 @@
-import type { ExtractedTournamentData } from "@sapphire2/api/routers/ai-extract";
 import {
 	IconArchive,
 	IconArchiveOff,
 	IconEdit,
 	IconPlus,
-	IconSparkles,
 	IconTrash,
 	IconX,
 } from "@tabler/icons-react";
@@ -18,12 +16,8 @@ import { ManagementSectionHeader } from "@/shared/components/management/manageme
 import { ManagementSectionState } from "@/shared/components/management/management-section-state";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
-import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
-import { AiExtractInput } from "@/stores/components/ai-extract-input";
-import {
-	TournamentModalContent,
-	type TournamentPartialFormValues,
-} from "@/stores/components/tournament-modal-content";
+import { TournamentEditDialog } from "@/stores/components/tournament-edit-dialog";
+import type { TournamentPartialFormValues } from "@/stores/components/tournament-modal-content";
 import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
 import type {
 	Tournament,
@@ -549,6 +543,39 @@ function BlindStructureSummary({ tournamentId }: { tournamentId: string }) {
 
 // ---- Main tab component ----
 
+function tournamentToInitialFormValues(
+	tournament: Tournament
+): TournamentPartialFormValues {
+	return {
+		name: tournament.name,
+		variant: tournament.variant,
+		buyIn: tournament.buyIn ?? undefined,
+		entryFee: tournament.entryFee ?? undefined,
+		startingStack: tournament.startingStack ?? undefined,
+		chipPurchases: tournament.chipPurchases.map((cp) => ({
+			name: cp.name,
+			cost: cp.cost,
+			chips: cp.chips,
+		})),
+		bountyAmount: tournament.bountyAmount ?? undefined,
+		tableSize: tournament.tableSize ?? undefined,
+		currencyId: tournament.currencyId ?? undefined,
+		memo: tournament.memo ?? undefined,
+		tags: tournament.tags.map((t) => t.name),
+	};
+}
+
+function levelsToPayload(levels: BlindLevelRow[]) {
+	return levels.map((l) => ({
+		isBreak: l.isBreak,
+		blind1: l.blind1,
+		blind2: l.blind2,
+		blind3: l.blind3,
+		ante: l.ante,
+		minutes: l.minutes,
+	}));
+}
+
 export function TournamentTab({
 	storeId,
 	expandedGameId,
@@ -560,19 +587,6 @@ export function TournamentTab({
 	const [editingTournament, setEditingTournament] = useState<Tournament | null>(
 		null
 	);
-
-	// AI state (shared — only one modal is open at a time)
-	const [aiSheetOpen, setAiSheetOpen] = useState(false);
-	const [aiInitialFormValues, setAiInitialFormValues] = useState<
-		TournamentPartialFormValues | undefined
-	>();
-	const [aiInitialLevels, setAiInitialLevels] = useState<BlindLevelRow[]>([]);
-
-	// Keys to force-remount TournamentModalContent when AI data arrives
-	const [createKey, setCreateKey] = useState(0);
-	const [editKey, setEditKey] = useState(0);
-
-	// Loading states for the combined mutations
 	const [isCreateLoading, setIsCreateLoading] = useState(false);
 	const [isUpdateLoading, setIsUpdateLoading] = useState(false);
 
@@ -587,75 +601,12 @@ export function TournamentTab({
 		delete: deleteTournament,
 	} = useTournaments({ storeId, showArchived });
 
-	// Fetch blind levels for the tournament being edited
 	const editBlindLevelsQuery = useQuery({
 		...trpc.blindLevel.listByTournament.queryOptions({
 			tournamentId: editingTournament?.id ?? "",
 		}),
 		enabled: editingTournament !== null,
 	});
-
-	const resetAiState = () => {
-		setAiInitialFormValues(undefined);
-		setAiInitialLevels([]);
-	};
-
-	const toBlindLevelRows = (data: ExtractedTournamentData): BlindLevelRow[] =>
-		(data.blindLevels ?? []).map((l, i) => ({
-			id: crypto.randomUUID(),
-			tournamentId: "",
-			level: i + 1,
-			isBreak: l.isBreak,
-			blind1: l.blind1 ?? null,
-			blind2: l.blind2 ?? null,
-			blind3: l.blind3 ?? null,
-			ante: l.ante ?? null,
-			minutes: l.minutes ?? null,
-		}));
-
-	const mergeAiIntoEditFormValues = (
-		data: ExtractedTournamentData,
-		base: TournamentPartialFormValues | undefined
-	): TournamentPartialFormValues => ({
-		...base,
-		// Use || so that empty strings fall back to the existing value
-		name: data.name || base?.name || "",
-		variant: base?.variant ?? "nlh",
-		...(data.buyIn !== undefined && { buyIn: data.buyIn }),
-		...(data.entryFee !== undefined && { entryFee: data.entryFee }),
-		...(data.startingStack !== undefined && {
-			startingStack: data.startingStack,
-		}),
-		...(data.tableSize !== undefined && { tableSize: data.tableSize }),
-		// Only override chip purchases if AI actually extracted some entries
-		...(data.chipPurchases?.length && { chipPurchases: data.chipPurchases }),
-	});
-
-	const handleAiExtracted = (data: ExtractedTournamentData) => {
-		const extractedLevels = toBlindLevelRows(data);
-		if (isCreateOpen) {
-			setAiInitialFormValues({
-				name: data.name ?? "",
-				buyIn: data.buyIn,
-				entryFee: data.entryFee,
-				startingStack: data.startingStack,
-				tableSize: data.tableSize,
-				chipPurchases: data.chipPurchases ?? [],
-				variant: "nlh",
-			});
-			setAiInitialLevels(extractedLevels);
-			setCreateKey((k) => k + 1);
-		} else {
-			setAiInitialFormValues(mergeAiIntoEditFormValues(data, editFormValues));
-			setAiInitialLevels(
-				extractedLevels.length > 0
-					? extractedLevels
-					: ((editBlindLevelsQuery.data ?? []) as BlindLevelRow[])
-			);
-			setEditKey((k) => k + 1);
-		}
-		setAiSheetOpen(false);
-	};
 
 	const invalidateTournamentLists = async () => {
 		await Promise.all([
@@ -693,19 +644,10 @@ export function TournamentTab({
 				memo: values.memo,
 				tags: values.tags,
 				chipPurchases: values.chipPurchases,
-				blindLevels: levels.map((l) => ({
-					isBreak: l.isBreak,
-					blind1: l.blind1,
-					blind2: l.blind2,
-					blind3: l.blind3,
-					ante: l.ante,
-					minutes: l.minutes,
-				})),
+				blindLevels: levelsToPayload(levels),
 			});
 			await invalidateTournamentLists();
 			setIsCreateOpen(false);
-			resetAiState();
-			setCreateKey(0);
 		} finally {
 			setIsCreateLoading(false);
 		}
@@ -733,14 +675,7 @@ export function TournamentTab({
 				memo: values.memo ?? null,
 				tags: values.tags,
 				chipPurchases: values.chipPurchases,
-				blindLevels: levels.map((l) => ({
-					isBreak: l.isBreak,
-					blind1: l.blind1,
-					blind2: l.blind2,
-					blind3: l.blind3,
-					ante: l.ante,
-					minutes: l.minutes,
-				})),
+				blindLevels: levelsToPayload(levels),
 			});
 			await Promise.all([
 				invalidateTournamentLists(),
@@ -751,56 +686,16 @@ export function TournamentTab({
 				}),
 			]);
 			setEditingTournament(null);
-			resetAiState();
-			setEditKey(0);
 		} finally {
 			setIsUpdateLoading(false);
 		}
 	};
 
-	const aiButton = (
-		<Button
-			onClick={() => setAiSheetOpen(true)}
-			size="xs"
-			type="button"
-			variant="outline"
-		>
-			<IconSparkles size={12} />
-			AI自動入力
-			<Badge className="px-1 py-0 text-[10px]" variant="secondary">
-				beta
-			</Badge>
-		</Button>
-	);
-
-	// Edit modal initial values: AI overrides when editKey > 0
-	const editFormValues: TournamentPartialFormValues | undefined =
-		editingTournament
-			? {
-					name: editingTournament.name,
-					variant: editingTournament.variant,
-					buyIn: editingTournament.buyIn ?? undefined,
-					entryFee: editingTournament.entryFee ?? undefined,
-					startingStack: editingTournament.startingStack ?? undefined,
-					chipPurchases: editingTournament.chipPurchases.map((cp) => ({
-						name: cp.name,
-						cost: cp.cost,
-						chips: cp.chips,
-					})),
-					bountyAmount: editingTournament.bountyAmount ?? undefined,
-					tableSize: editingTournament.tableSize ?? undefined,
-					currencyId: editingTournament.currencyId ?? undefined,
-					memo: editingTournament.memo ?? undefined,
-					tags: editingTournament.tags.map((t) => t.name),
-				}
-			: undefined;
-
-	const editInitialFormValues =
-		editKey > 0 ? aiInitialFormValues : editFormValues;
-	const editInitialLevels =
-		editKey > 0
-			? aiInitialLevels
-			: ((editBlindLevelsQuery.data ?? []) as BlindLevelRow[]);
+	const editInitialFormValues = editingTournament
+		? tournamentToInitialFormValues(editingTournament)
+		: undefined;
+	const editInitialLevels = (editBlindLevelsQuery.data ??
+		[]) as BlindLevelRow[];
 
 	return (
 		<div>
@@ -850,67 +745,32 @@ export function TournamentTab({
 				showArchived={showArchived}
 			/>
 
-			{/* Shared AI extract sheet */}
-			<ResponsiveDialog
-				onOpenChange={setAiSheetOpen}
-				open={aiSheetOpen}
-				title="AI自動入力"
-			>
-				<AiExtractInput onExtracted={handleAiExtracted} />
-			</ResponsiveDialog>
-
-			{/* Create Tournament modal */}
-			<ResponsiveDialog
-				fullHeight
-				headerAction={aiButton}
-				onOpenChange={(open) => {
-					setIsCreateOpen(open);
-					if (!open) {
-						resetAiState();
-						setCreateKey(0);
-					}
-				}}
+			<TournamentEditDialog
+				aiMode="create"
+				initialBlindLevels={[]}
+				isLoading={isCreateLoading}
+				onOpenChange={setIsCreateOpen}
+				onSave={handleCreate}
 				open={isCreateOpen}
 				title="Add Tournament"
-			>
-				<TournamentModalContent
-					initialBlindLevels={createKey > 0 ? aiInitialLevels : []}
-					initialFormValues={createKey > 0 ? aiInitialFormValues : undefined}
-					isLoading={isCreateLoading}
-					key={createKey}
-					onSave={handleCreate}
-				/>
-			</ResponsiveDialog>
+			/>
 
-			{/* Edit Tournament modal */}
-			<ResponsiveDialog
-				fullHeight
-				headerAction={aiButton}
+			<TournamentEditDialog
+				aiMode="edit"
+				initialBlindLevels={editInitialLevels}
+				initialFormValues={editInitialFormValues}
+				isInitializing={editBlindLevelsQuery.isLoading}
+				isLoading={isUpdateLoading}
 				onOpenChange={(open) => {
 					if (!open) {
 						setEditingTournament(null);
-						resetAiState();
-						setEditKey(0);
 					}
 				}}
+				onSave={handleUpdate}
 				open={editingTournament !== null}
+				resetKey={editingTournament?.id}
 				title="Edit Tournament"
-			>
-				{editingTournament &&
-					(editBlindLevelsQuery.isLoading && editKey === 0 ? (
-						<p className="py-8 text-center text-muted-foreground text-sm">
-							Loading...
-						</p>
-					) : (
-						<TournamentModalContent
-							initialBlindLevels={editInitialLevels}
-							initialFormValues={editInitialFormValues}
-							isLoading={isUpdateLoading}
-							key={`${editingTournament.id}-${editKey}`}
-							onSave={handleUpdate}
-						/>
-					))}
-			</ResponsiveDialog>
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/stores/components/tournament-tab.tsx
+++ b/apps/web/src/stores/components/tournament-tab.tsx
@@ -19,15 +19,11 @@ import { ManagementSectionState } from "@/shared/components/management/managemen
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
-import {
-	Tabs,
-	TabsContent,
-	TabsList,
-	TabsTrigger,
-} from "@/shared/components/ui/tabs";
 import { AiExtractInput } from "@/stores/components/ai-extract-input";
-import { LocalBlindStructureContent } from "@/stores/components/blind-level-editor";
-import { TournamentForm } from "@/stores/components/tournament-form";
+import {
+	TournamentModalContent,
+	type TournamentPartialFormValues,
+} from "@/stores/components/tournament-modal-content";
 import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
 import type {
 	Tournament,
@@ -551,59 +547,6 @@ function BlindStructureSummary({ tournamentId }: { tournamentId: string }) {
 	);
 }
 
-// ---- Shared modal content (used by both create and edit dialogs) ----
-
-type PartialFormValues = Omit<
-	TournamentFormValues,
-	"tags" | "chipPurchases"
-> & {
-	chipPurchases?: Array<{ name: string; cost: number; chips: number }>;
-	tags?: string[];
-};
-
-interface TournamentModalContentProps {
-	initialBlindLevels: BlindLevelRow[];
-	initialFormValues?: PartialFormValues;
-	isLoading: boolean;
-	onSave: (
-		values: TournamentFormValues,
-		levels: BlindLevelRow[]
-	) => void | Promise<void>;
-}
-
-function TournamentModalContent({
-	initialBlindLevels,
-	initialFormValues,
-	isLoading,
-	onSave,
-}: TournamentModalContentProps) {
-	const [localBlindLevels, setLocalBlindLevels] =
-		useState<BlindLevelRow[]>(initialBlindLevels);
-
-	return (
-		<Tabs defaultValue="details">
-			<TabsList className="w-full">
-				<TabsTrigger value="details">Details</TabsTrigger>
-				<TabsTrigger value="structure">Structure</TabsTrigger>
-			</TabsList>
-			<TabsContent value="details">
-				<TournamentForm
-					defaultValues={initialFormValues}
-					isLoading={isLoading}
-					onSubmit={(values) => onSave(values, localBlindLevels)}
-				/>
-			</TabsContent>
-			<TabsContent value="structure">
-				<LocalBlindStructureContent
-					onChange={setLocalBlindLevels}
-					value={localBlindLevels}
-					variant={initialFormValues?.variant ?? "nlh"}
-				/>
-			</TabsContent>
-		</Tabs>
-	);
-}
-
 // ---- Main tab component ----
 
 export function TournamentTab({
@@ -621,7 +564,7 @@ export function TournamentTab({
 	// AI state (shared — only one modal is open at a time)
 	const [aiSheetOpen, setAiSheetOpen] = useState(false);
 	const [aiInitialFormValues, setAiInitialFormValues] = useState<
-		PartialFormValues | undefined
+		TournamentPartialFormValues | undefined
 	>();
 	const [aiInitialLevels, setAiInitialLevels] = useState<BlindLevelRow[]>([]);
 
@@ -672,8 +615,8 @@ export function TournamentTab({
 
 	const mergeAiIntoEditFormValues = (
 		data: ExtractedTournamentData,
-		base: PartialFormValues | undefined
-	): PartialFormValues => ({
+		base: TournamentPartialFormValues | undefined
+	): TournamentPartialFormValues => ({
 		...base,
 		// Use || so that empty strings fall back to the existing value
 		name: data.name || base?.name || "",
@@ -831,25 +774,26 @@ export function TournamentTab({
 	);
 
 	// Edit modal initial values: AI overrides when editKey > 0
-	const editFormValues: PartialFormValues | undefined = editingTournament
-		? {
-				name: editingTournament.name,
-				variant: editingTournament.variant,
-				buyIn: editingTournament.buyIn ?? undefined,
-				entryFee: editingTournament.entryFee ?? undefined,
-				startingStack: editingTournament.startingStack ?? undefined,
-				chipPurchases: editingTournament.chipPurchases.map((cp) => ({
-					name: cp.name,
-					cost: cp.cost,
-					chips: cp.chips,
-				})),
-				bountyAmount: editingTournament.bountyAmount ?? undefined,
-				tableSize: editingTournament.tableSize ?? undefined,
-				currencyId: editingTournament.currencyId ?? undefined,
-				memo: editingTournament.memo ?? undefined,
-				tags: editingTournament.tags.map((t) => t.name),
-			}
-		: undefined;
+	const editFormValues: TournamentPartialFormValues | undefined =
+		editingTournament
+			? {
+					name: editingTournament.name,
+					variant: editingTournament.variant,
+					buyIn: editingTournament.buyIn ?? undefined,
+					entryFee: editingTournament.entryFee ?? undefined,
+					startingStack: editingTournament.startingStack ?? undefined,
+					chipPurchases: editingTournament.chipPurchases.map((cp) => ({
+						name: cp.name,
+						cost: cp.cost,
+						chips: cp.chips,
+					})),
+					bountyAmount: editingTournament.bountyAmount ?? undefined,
+					tableSize: editingTournament.tableSize ?? undefined,
+					currencyId: editingTournament.currencyId ?? undefined,
+					memo: editingTournament.memo ?? undefined,
+					tags: editingTournament.tags.map((t) => t.name),
+				}
+			: undefined;
 
 	const editInitialFormValues =
 		editKey > 0 ? aiInitialFormValues : editFormValues;


### PR DESCRIPTION
Closes #92

## Summary
- ライブセッション中のボトムナビに **Game** タブを追加し、進行中セッションが参照する ring game / tournament の詳細を直接確認・編集できる `/active-session/game` 画面を新設しました。
- 5スロット構成を維持するため、ライブモード時の `Players` を `Game` に差し替え。
- キャッシュゲームは `RingGameForm` を、トーナメントはストア画面と同等の Details + Structure タブ（`TournamentModalContent`）を `ResponsiveDialog` で開いて編集します。
- `TournamentModalContent` を `tournament-tab.tsx` から `tournament-modal-content.tsx` に切り出し、`TournamentTab` と新シーンの両方から再利用しています。

## Changes
- `apps/web/src/routes/active-session/game.tsx` — 新規ルート
- `apps/web/src/live-sessions/components/active-session-game-scene.tsx` — シーン本体（cash/tournament 分岐 + 編集モーダル）
- `apps/web/src/stores/components/tournament-modal-content.tsx` — 切り出した共通モーダル
- `apps/web/src/stores/components/tournament-tab.tsx` — 上記の import 差し替え
- `apps/web/src/shared/components/app-navigation.tsx` — `LIVE_LEFT_ITEMS` の `Players` → `Game` 差し替え
- テスト: `mobile-nav.test.tsx` 更新、`active-session-game-scene.test.tsx` 追加

## Test plan
- [x] `bun run check-types`（server / web ともに通過）
- [x] `bun run lint` (`ultracite check`、389 ファイル通過)
- [x] `bun run test`（vitest run、512 テスト全件 pass）
- [x] 手動確認: モバイル幅でキャッシュ／トーナメントの live session を開始 → bottom-nav の `Game` タップ → 詳細表示・編集保存が反映されることを確認
- [x] 手動確認: live session が無い状態で `/active-session/game` を直接開いた際に EmptyState が出ることを確認
