### PR TITLE
fix(ci): プレビュー環境のAPI Worker削除と残存Workerの一括クリーンアップ

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -8,6 +8,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
   CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+  WORKER_PREFIX: sapphire2-api-pr-
 
 jobs:
   cleanup:
@@ -17,9 +18,56 @@ jobs:
     steps:
       - name: Delete backend Worker
         run: |
-          bunx wrangler delete \
-            --name "sapphire2-api-pr-${{ github.event.pull_request.number }}" \
-            --force
+          WORKER_NAME="${WORKER_PREFIX}${{ github.event.pull_request.number }}"
+          STATUS=$(curl -s -o /tmp/worker-delete.json -w "%{http_code}" -X DELETE \
+            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${WORKER_NAME}?force=true" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")
+          if [ "$STATUS" = "200" ]; then
+            echo "Deleted Worker: ${WORKER_NAME}"
+          elif [ "$STATUS" = "404" ]; then
+            echo "Worker ${WORKER_NAME} not found (already deleted)"
+          else
+            echo "Failed to delete Worker ${WORKER_NAME} (HTTP ${STATUS})"
+            cat /tmp/worker-delete.json
+            exit 1
+          fi
+        continue-on-error: true
+
+      - name: Delete orphan preview Workers
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          OPEN_PRS=$(gh api \
+            "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
+            --paginate \
+            --jq '.[].number' | sort -u)
+
+          WORKERS=$(curl -sf \
+            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            | jq -r --arg prefix "${WORKER_PREFIX}" \
+              '.result[] | select(.id | startswith($prefix)) | .id')
+
+          if [ -z "$WORKERS" ]; then
+            echo "No preview Workers found"
+            exit 0
+          fi
+
+          for WORKER in $WORKERS; do
+            PR_NUM="${WORKER#${WORKER_PREFIX}}"
+            if echo "$OPEN_PRS" | grep -qx "$PR_NUM"; then
+              echo "Keeping ${WORKER} (PR #${PR_NUM} still open)"
+              continue
+            fi
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+              "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${WORKER}?force=true" \
+              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")
+            if [ "$STATUS" = "200" ] || [ "$STATUS" = "404" ]; then
+              echo "Deleted orphan Worker: ${WORKER}"
+            else
+              echo "Failed to delete ${WORKER} (HTTP ${STATUS})"
+            fi
+          done
         continue-on-error: true
 
       - name: Delete frontend Pages deployments

--- a/docs/deploy.ja.md
+++ b/docs/deploy.ja.md
@@ -182,7 +182,7 @@ GitHub App 設定 > **Install App** > リポジトリを選択
 `apps/server/wrangler.toml` の `name` を変更した場合:
 
 - `.github/workflows/preview-deploy.yml` の `WORKER_NAME` 変数
-- `.github/workflows/preview-cleanup.yml` の `--name` 引数
+- `.github/workflows/preview-cleanup.yml` の `WORKER_PREFIX` 環境変数
 
 ### Pages プロジェクト名の変更
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -182,7 +182,7 @@ Add via **Settings > Secrets and variables > Actions > Secrets tab > New reposit
 If you change `name` in `apps/server/wrangler.toml`, also update:
 
 - `WORKER_NAME` variable in `.github/workflows/preview-deploy.yml`
-- `--name` argument in `.github/workflows/preview-cleanup.yml`
+- `WORKER_PREFIX` env variable in `.github/workflows/preview-cleanup.yml`
 
 ### Changing the Pages Project Name
 


### PR DESCRIPTION
## 概要

`preview-cleanup.yml` で `sapphire2-api-pr-*` Worker が削除されずに蓄積していく問題を修正し、過去の残存 Worker もまとめて掃除する仕組みを追加します。

Closes #197

## 変更内容

### 1. API Worker 削除を Cloudflare REST API に切り替え

これまでは `bunx wrangler delete --name ... --force` を使っていましたが、cleanup ジョブでは `actions/checkout` を行っていないため、wrangler がプロジェクトコンテキストを持てず削除が失敗していました (しかも `continue-on-error: true` で握り潰されていた)。

Pages / D1 と同じく `DELETE /accounts/{id}/workers/scripts/{name}?force=true` を直接叩く方式に統一しました。

### 2. 残存 Worker 一括削除ステップを追加

`cleanup` ジョブに「現在オープンな PR 番号を GitHub API で取得し、それに紐付かない `sapphire2-api-pr-*` Worker をすべて削除する」ステップを追加しました。PR クローズをトリガに毎回 sweep が走るため、過去に取り逃した分も自然に解消されます。

### 3. ドキュメント

Worker 名の変更箇所の説明 (`--name` 引数 → `WORKER_PREFIX` 環境変数) を日本語版・英語版ともに更新。

## Test plan

- [ ] この PR をクローズしたタイミングで `Preview Cleanup` ワークフローが成功し、`sapphire2-api-pr-<PR 番号>` Worker が削除されること
- [ ] 「Delete orphan preview Workers」ステップのログで、オープン中の PR 分は `Keeping ...`、それ以外は `Deleted orphan Worker: ...` と出力されること
- [ ] Cloudflare ダッシュボード上で過去の `sapphire2-api-pr-*` Worker が無くなっていること
