### PR TITLE
refactor(sessions): extract session-form logic into use-session-form-state hook

### DIFF
--- a/apps/web/src/sessions/components/session-form.tsx
+++ b/apps/web/src/sessions/components/session-form.tsx
@@ -1,6 +1,10 @@
-import { useForm } from "@tanstack/react-form";
-import { useState } from "react";
-import { z } from "zod";
+import { useSessionFormState } from "@/sessions/hooks/use-session-form-state";
+import type {
+	RingGameOption,
+	SessionFormDefaults,
+	SessionFormValues,
+	TournamentOption,
+} from "@/sessions/utils/session-form-helpers";
 import { Alert, AlertDescription } from "@/shared/components/ui/alert";
 import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
@@ -9,7 +13,6 @@ import { Label } from "@/shared/components/ui/label";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/components/ui/tabs";
 import { TagInput } from "@/shared/components/ui/tag-input";
 import { Textarea } from "@/shared/components/ui/textarea";
-import { optionalNumericString } from "@/shared/lib/form-fields";
 import { CashGameFields } from "./cash-game-fields";
 import { FormAccordion } from "./form-section";
 import { StoreGameSelectors } from "./link-selectors";
@@ -18,107 +21,14 @@ import {
 	TournamentPrimaryFields,
 } from "./tournament-fields";
 
-interface CashGameFormValues {
-	ante?: number;
-	anteType?: string;
-	blind1?: number;
-	blind2?: number;
-	blind3?: number;
-	breakMinutes?: number;
-	buyIn: number;
-	cashOut: number;
-	currencyId?: string;
-	endTime?: string;
-	evCashOut?: number;
-	memo?: string;
-	ringGameId?: string;
-	sessionDate: string;
-	startTime?: string;
-	storeId?: string;
-	tableSize?: number;
-	tagIds?: string[];
-	type: "cash_game";
-	variant: string;
-}
-
-interface TournamentFormValues {
-	addonCost?: number;
-	beforeDeadline?: boolean;
-	bountyPrizes?: number;
-	breakMinutes?: number;
-	currencyId?: string;
-	endTime?: string;
-	entryFee?: number;
-	memo?: string;
-	placement?: number;
-	prizeMoney?: number;
-	rebuyCost?: number;
-	rebuyCount?: number;
-	sessionDate: string;
-	startTime?: string;
-	storeId?: string;
-	tagIds?: string[];
-	totalEntries?: number;
-	tournamentBuyIn: number;
-	tournamentId?: string;
-	type: "tournament";
-}
-
-type SessionFormValues = CashGameFormValues | TournamentFormValues;
-
-interface RingGameOption {
-	ante?: number | null;
-	anteType?: string | null;
-	blind1?: number | null;
-	blind2?: number | null;
-	blind3?: number | null;
-	currencyId?: string | null;
-	id: string;
-	name: string;
-	tableSize?: number | null;
-	variant?: string | null;
-}
-
-interface TournamentOption {
-	buyIn?: number | null;
-	entryFee?: number | null;
-	id: string;
-	name: string;
-}
-
-interface SessionFormDefaults {
-	addonCost?: number;
-	ante?: number;
-	anteType?: string;
-	beforeDeadline?: boolean;
-	blind1?: number;
-	blind2?: number;
-	blind3?: number;
-	bountyPrizes?: number;
-	breakMinutes?: number;
-	buyIn?: number;
-	cashOut?: number;
-	currencyId?: string;
-	endTime?: string;
-	entryFee?: number;
-	evCashOut?: number;
-	memo?: string;
-	placement?: number;
-	prizeMoney?: number;
-	rebuyCost?: number;
-	rebuyCount?: number;
-	ringGameId?: string;
-	sessionDate?: string;
-	startTime?: string;
-	storeId?: string;
-	tableSize?: number;
-	tagIds?: string[];
-	totalEntries?: number;
-	tournamentBuyIn?: number;
-	tournamentId?: string;
-	type?: "cash_game" | "tournament";
-	variant?: string;
-}
+export type {
+	CashGameFormValues,
+	RingGameOption,
+	SessionFormDefaults,
+	SessionFormValues,
+	TournamentFormValues,
+	TournamentOption,
+} from "@/sessions/utils/session-form-helpers";
 
 interface SessionFormProps {
 	currencies?: Array<{ id: string; name: string }>;
@@ -134,86 +44,6 @@ interface SessionFormProps {
 	tournaments?: TournamentOption[];
 }
 
-function getTodayDateString(): string {
-	const today = new Date();
-	const year = today.getFullYear();
-	const month = String(today.getMonth() + 1).padStart(2, "0");
-	const day = String(today.getDate()).padStart(2, "0");
-	return `${year}-${month}-${day}`;
-}
-
-function numStrOrEmpty(value: number | undefined): string {
-	return value === undefined ? "" : String(value);
-}
-
-function parseOptInt(value: string): number | undefined {
-	if (value === "") {
-		return undefined;
-	}
-	const parsed = Number.parseInt(value, 10);
-	return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-const NONE_VALUE = "__none__";
-
-const sessionFormSchema = z.object({
-	sessionDate: z.string().min(1, "Date is required"),
-	startTime: z.string(),
-	endTime: z.string(),
-	breakMinutes: optionalNumericString({ integer: true, min: 0 }),
-	memo: z.string(),
-	buyIn: optionalNumericString({ integer: true, min: 0 }),
-	cashOut: optionalNumericString({ integer: true, min: 0 }),
-	evCashOut: optionalNumericString({ integer: true, min: 0 }),
-	variant: z.string(),
-	blind1: optionalNumericString({ integer: true, min: 0 }),
-	blind2: optionalNumericString({ integer: true, min: 0 }),
-	blind3: optionalNumericString({ integer: true, min: 0 }),
-	ante: optionalNumericString({ integer: true, min: 0 }),
-	anteType: z.string(),
-	tableSize: z.string(),
-	tournamentBuyIn: optionalNumericString({ integer: true, min: 0 }),
-	entryFee: optionalNumericString({ integer: true, min: 0 }),
-	beforeDeadline: z.boolean(),
-	placement: optionalNumericString({ integer: true, min: 1 }),
-	totalEntries: optionalNumericString({ integer: true, min: 1 }),
-	prizeMoney: optionalNumericString({ integer: true, min: 0 }),
-	rebuyCount: optionalNumericString({ integer: true, min: 0 }),
-	rebuyCost: optionalNumericString({ integer: true, min: 0 }),
-	addonCost: optionalNumericString({ integer: true, min: 0 }),
-	bountyPrizes: optionalNumericString({ integer: true, min: 0 }),
-});
-
-function buildDefaults(defaults: SessionFormDefaults | undefined) {
-	return {
-		sessionDate: defaults?.sessionDate ?? getTodayDateString(),
-		startTime: defaults?.startTime ?? "",
-		endTime: defaults?.endTime ?? "",
-		breakMinutes: numStrOrEmpty(defaults?.breakMinutes),
-		memo: defaults?.memo ?? "",
-		buyIn: numStrOrEmpty(defaults?.buyIn),
-		cashOut: numStrOrEmpty(defaults?.cashOut),
-		evCashOut: numStrOrEmpty(defaults?.evCashOut),
-		variant: defaults?.variant ?? "nlh",
-		blind1: numStrOrEmpty(defaults?.blind1),
-		blind2: numStrOrEmpty(defaults?.blind2),
-		blind3: numStrOrEmpty(defaults?.blind3),
-		ante: numStrOrEmpty(defaults?.ante),
-		anteType: defaults?.anteType ?? "none",
-		tableSize: defaults?.tableSize?.toString() ?? "",
-		tournamentBuyIn: numStrOrEmpty(defaults?.tournamentBuyIn),
-		entryFee: numStrOrEmpty(defaults?.entryFee),
-		beforeDeadline: defaults?.beforeDeadline === true,
-		placement: numStrOrEmpty(defaults?.placement),
-		totalEntries: numStrOrEmpty(defaults?.totalEntries),
-		prizeMoney: numStrOrEmpty(defaults?.prizeMoney),
-		rebuyCount: numStrOrEmpty(defaults?.rebuyCount),
-		rebuyCost: numStrOrEmpty(defaults?.rebuyCost),
-		addonCost: numStrOrEmpty(defaults?.addonCost),
-		bountyPrizes: numStrOrEmpty(defaults?.bountyPrizes),
-	};
-}
-
 export function SessionForm({
 	currencies,
 	defaultValues,
@@ -227,145 +57,28 @@ export function SessionForm({
 	tags,
 	tournaments,
 }: SessionFormProps) {
-	const [sessionType, setSessionType] = useState<"cash_game" | "tournament">(
-		defaultValues?.type ?? "cash_game"
-	);
-	const [selectedTagIds, setSelectedTagIds] = useState<string[]>(
-		defaultValues?.tagIds ?? []
-	);
-	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(
-		defaultValues?.storeId
-	);
-	const [selectedGameId, setSelectedGameId] = useState<string | undefined>(
-		defaultValues?.ringGameId ?? defaultValues?.tournamentId
-	);
-	const [selectedCurrencyId, setSelectedCurrencyId] = useState<
-		string | undefined
-	>(defaultValues?.currencyId);
-
-	const isCashGame = sessionType === "cash_game";
-	const gameOptions = isCashGame ? ringGames : tournaments;
-
-	const form = useForm({
-		defaultValues: buildDefaults(defaultValues),
-		onSubmit: ({ value }) => {
-			const common = {
-				sessionDate: value.sessionDate,
-				startTime: value.startTime || undefined,
-				endTime: value.endTime || undefined,
-				breakMinutes: parseOptInt(value.breakMinutes),
-				tagIds: selectedTagIds,
-				memo: value.memo || undefined,
-				storeId: selectedStoreId,
-				currencyId: selectedCurrencyId,
-			};
-
-			if (isCashGame) {
-				onSubmit({
-					...common,
-					type: "cash_game",
-					buyIn: Number(value.buyIn),
-					cashOut: Number(value.cashOut),
-					evCashOut: parseOptInt(value.evCashOut),
-					variant: value.variant || "nlh",
-					blind1: parseOptInt(value.blind1),
-					blind2: parseOptInt(value.blind2),
-					blind3: parseOptInt(value.blind3),
-					ante: value.anteType === "none" ? undefined : parseOptInt(value.ante),
-					anteType: value.anteType || undefined,
-					tableSize: parseOptInt(value.tableSize),
-					ringGameId: selectedGameId,
-				});
-			} else {
-				const beforeDeadline = value.beforeDeadline === true;
-				onSubmit({
-					...common,
-					type: "tournament",
-					tournamentBuyIn: Number(value.tournamentBuyIn),
-					entryFee: parseOptInt(value.entryFee),
-					beforeDeadline,
-					placement: beforeDeadline ? undefined : parseOptInt(value.placement),
-					totalEntries: beforeDeadline
-						? undefined
-						: parseOptInt(value.totalEntries),
-					prizeMoney: parseOptInt(value.prizeMoney),
-					rebuyCount: parseOptInt(value.rebuyCount),
-					rebuyCost: parseOptInt(value.rebuyCost),
-					addonCost: parseOptInt(value.addonCost),
-					bountyPrizes: parseOptInt(value.bountyPrizes),
-					tournamentId: selectedGameId,
-				});
-			}
-		},
-		validators: {
-			onSubmit: sessionFormSchema,
-		},
+	const {
+		form,
+		sessionType,
+		setSessionType,
+		selectedTagIds,
+		setSelectedTagIds,
+		selectedStoreId,
+		selectedGameId,
+		selectedCurrencyId,
+		setSelectedCurrencyId,
+		handleStoreChange,
+		handleGameChange,
+		gameOptions,
+		gameLabel,
+		isCashGame,
+	} = useSessionFormState({
+		defaultValues,
+		onStoreChange,
+		onSubmit,
+		ringGames,
+		tournaments,
 	});
-
-	const applyOverrides = (
-		overrides: Partial<ReturnType<typeof buildDefaults>>
-	) => {
-		for (const [key, value] of Object.entries(overrides)) {
-			if (value !== undefined) {
-				form.setFieldValue(
-					key as keyof ReturnType<typeof buildDefaults>,
-					value as string
-				);
-			}
-		}
-	};
-
-	const handleStoreChange = (value: string) => {
-		const storeId = value === NONE_VALUE ? undefined : value;
-		setSelectedStoreId(storeId);
-		setSelectedGameId(undefined);
-		onStoreChange?.(storeId);
-	};
-
-	const applyRingGameDefaults = (gameId: string) => {
-		const game = ringGames?.find((g) => g.id === gameId);
-		if (!game) {
-			return;
-		}
-		if (game.currencyId) {
-			setSelectedCurrencyId(game.currencyId);
-		}
-		applyOverrides({
-			variant: game.variant ?? undefined,
-			blind1: numStrOrEmpty(game.blind1 ?? undefined),
-			blind2: numStrOrEmpty(game.blind2 ?? undefined),
-			blind3: numStrOrEmpty(game.blind3 ?? undefined),
-			ante: numStrOrEmpty(game.ante ?? undefined),
-			anteType: game.anteType ?? undefined,
-			tableSize: game.tableSize?.toString() ?? undefined,
-		});
-	};
-
-	const applyTournamentDefaults = (gameId: string) => {
-		const game = tournaments?.find((t) => t.id === gameId);
-		if (!game) {
-			return;
-		}
-		applyOverrides({
-			tournamentBuyIn: numStrOrEmpty(game.buyIn ?? undefined),
-			entryFee: numStrOrEmpty(game.entryFee ?? undefined),
-		});
-	};
-
-	const handleGameChange = (value: string) => {
-		const gameId = value === NONE_VALUE ? undefined : value;
-		setSelectedGameId(gameId);
-		if (!gameId) {
-			return;
-		}
-		if (isCashGame) {
-			applyRingGameDefaults(gameId);
-		} else {
-			applyTournamentDefaults(gameId);
-		}
-	};
-
-	const gameLabel = isCashGame ? "Cash Game" : "Tournament";
 
 	const detailContent = isCashGame ? (
 		<CashGameFields

--- a/apps/web/src/sessions/hooks/use-session-form-state.ts
+++ b/apps/web/src/sessions/hooks/use-session-form-state.ts
@@ -1,0 +1,185 @@
+import { useForm } from "@tanstack/react-form";
+import { useState } from "react";
+import {
+	buildDefaults,
+	NONE_VALUE,
+	numStrOrEmpty,
+	parseOptInt,
+	type RingGameOption,
+	type SessionFormDefaults,
+	type SessionFormFieldValues,
+	type SessionFormValues,
+	sessionFormSchema,
+	type TournamentOption,
+} from "@/sessions/utils/session-form-helpers";
+
+interface UseSessionFormStateArgs {
+	defaultValues?: SessionFormDefaults;
+	onStoreChange?: (storeId: string | undefined) => void;
+	onSubmit: (values: SessionFormValues) => void;
+	ringGames?: RingGameOption[];
+	tournaments?: TournamentOption[];
+}
+
+export function useSessionFormState({
+	defaultValues,
+	onStoreChange,
+	onSubmit,
+	ringGames,
+	tournaments,
+}: UseSessionFormStateArgs) {
+	const [sessionType, setSessionType] = useState<"cash_game" | "tournament">(
+		defaultValues?.type ?? "cash_game"
+	);
+	const [selectedTagIds, setSelectedTagIds] = useState<string[]>(
+		defaultValues?.tagIds ?? []
+	);
+	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(
+		defaultValues?.storeId
+	);
+	const [selectedGameId, setSelectedGameId] = useState<string | undefined>(
+		defaultValues?.ringGameId ?? defaultValues?.tournamentId
+	);
+	const [selectedCurrencyId, setSelectedCurrencyId] = useState<
+		string | undefined
+	>(defaultValues?.currencyId);
+
+	const isCashGame = sessionType === "cash_game";
+	const gameOptions = isCashGame ? ringGames : tournaments;
+	const gameLabel = isCashGame ? "Cash Game" : "Tournament";
+
+	const form = useForm({
+		defaultValues: buildDefaults(defaultValues),
+		onSubmit: ({ value }) => {
+			const common = {
+				sessionDate: value.sessionDate,
+				startTime: value.startTime || undefined,
+				endTime: value.endTime || undefined,
+				breakMinutes: parseOptInt(value.breakMinutes),
+				tagIds: selectedTagIds,
+				memo: value.memo || undefined,
+				storeId: selectedStoreId,
+				currencyId: selectedCurrencyId,
+			};
+
+			if (isCashGame) {
+				onSubmit({
+					...common,
+					type: "cash_game",
+					buyIn: Number(value.buyIn),
+					cashOut: Number(value.cashOut),
+					evCashOut: parseOptInt(value.evCashOut),
+					variant: value.variant || "nlh",
+					blind1: parseOptInt(value.blind1),
+					blind2: parseOptInt(value.blind2),
+					blind3: parseOptInt(value.blind3),
+					ante: value.anteType === "none" ? undefined : parseOptInt(value.ante),
+					anteType: value.anteType || undefined,
+					tableSize: parseOptInt(value.tableSize),
+					ringGameId: selectedGameId,
+				});
+				return;
+			}
+
+			const beforeDeadline = value.beforeDeadline === true;
+			onSubmit({
+				...common,
+				type: "tournament",
+				tournamentBuyIn: Number(value.tournamentBuyIn),
+				entryFee: parseOptInt(value.entryFee),
+				beforeDeadline,
+				placement: beforeDeadline ? undefined : parseOptInt(value.placement),
+				totalEntries: beforeDeadline
+					? undefined
+					: parseOptInt(value.totalEntries),
+				prizeMoney: parseOptInt(value.prizeMoney),
+				rebuyCount: parseOptInt(value.rebuyCount),
+				rebuyCost: parseOptInt(value.rebuyCost),
+				addonCost: parseOptInt(value.addonCost),
+				bountyPrizes: parseOptInt(value.bountyPrizes),
+				tournamentId: selectedGameId,
+			});
+		},
+		validators: {
+			onSubmit: sessionFormSchema,
+		},
+	});
+
+	const applyOverrides = (overrides: Partial<SessionFormFieldValues>) => {
+		for (const [key, value] of Object.entries(overrides)) {
+			if (value !== undefined) {
+				form.setFieldValue(
+					key as keyof SessionFormFieldValues,
+					value as string
+				);
+			}
+		}
+	};
+
+	const applyRingGameDefaults = (gameId: string) => {
+		const game = ringGames?.find((g) => g.id === gameId);
+		if (!game) {
+			return;
+		}
+		if (game.currencyId) {
+			setSelectedCurrencyId(game.currencyId);
+		}
+		applyOverrides({
+			variant: game.variant ?? undefined,
+			blind1: numStrOrEmpty(game.blind1 ?? undefined),
+			blind2: numStrOrEmpty(game.blind2 ?? undefined),
+			blind3: numStrOrEmpty(game.blind3 ?? undefined),
+			ante: numStrOrEmpty(game.ante ?? undefined),
+			anteType: game.anteType ?? undefined,
+			tableSize: game.tableSize?.toString() ?? undefined,
+		});
+	};
+
+	const applyTournamentDefaults = (gameId: string) => {
+		const game = tournaments?.find((t) => t.id === gameId);
+		if (!game) {
+			return;
+		}
+		applyOverrides({
+			tournamentBuyIn: numStrOrEmpty(game.buyIn ?? undefined),
+			entryFee: numStrOrEmpty(game.entryFee ?? undefined),
+		});
+	};
+
+	const handleStoreChange = (value: string) => {
+		const storeId = value === NONE_VALUE ? undefined : value;
+		setSelectedStoreId(storeId);
+		setSelectedGameId(undefined);
+		onStoreChange?.(storeId);
+	};
+
+	const handleGameChange = (value: string) => {
+		const gameId = value === NONE_VALUE ? undefined : value;
+		setSelectedGameId(gameId);
+		if (!gameId) {
+			return;
+		}
+		if (isCashGame) {
+			applyRingGameDefaults(gameId);
+		} else {
+			applyTournamentDefaults(gameId);
+		}
+	};
+
+	return {
+		form,
+		sessionType,
+		setSessionType,
+		selectedTagIds,
+		setSelectedTagIds,
+		selectedStoreId,
+		selectedGameId,
+		selectedCurrencyId,
+		setSelectedCurrencyId,
+		handleStoreChange,
+		handleGameChange,
+		gameOptions,
+		gameLabel,
+		isCashGame,
+	};
+}

--- a/apps/web/src/sessions/utils/session-form-helpers.ts
+++ b/apps/web/src/sessions/utils/session-form-helpers.ts
@@ -1,0 +1,186 @@
+import { z } from "zod";
+import { optionalNumericString } from "@/shared/lib/form-fields";
+
+export interface CashGameFormValues {
+	ante?: number;
+	anteType?: string;
+	blind1?: number;
+	blind2?: number;
+	blind3?: number;
+	breakMinutes?: number;
+	buyIn: number;
+	cashOut: number;
+	currencyId?: string;
+	endTime?: string;
+	evCashOut?: number;
+	memo?: string;
+	ringGameId?: string;
+	sessionDate: string;
+	startTime?: string;
+	storeId?: string;
+	tableSize?: number;
+	tagIds?: string[];
+	type: "cash_game";
+	variant: string;
+}
+
+export interface TournamentFormValues {
+	addonCost?: number;
+	beforeDeadline?: boolean;
+	bountyPrizes?: number;
+	breakMinutes?: number;
+	currencyId?: string;
+	endTime?: string;
+	entryFee?: number;
+	memo?: string;
+	placement?: number;
+	prizeMoney?: number;
+	rebuyCost?: number;
+	rebuyCount?: number;
+	sessionDate: string;
+	startTime?: string;
+	storeId?: string;
+	tagIds?: string[];
+	totalEntries?: number;
+	tournamentBuyIn: number;
+	tournamentId?: string;
+	type: "tournament";
+}
+
+export type SessionFormValues = CashGameFormValues | TournamentFormValues;
+
+export interface RingGameOption {
+	ante?: number | null;
+	anteType?: string | null;
+	blind1?: number | null;
+	blind2?: number | null;
+	blind3?: number | null;
+	currencyId?: string | null;
+	id: string;
+	name: string;
+	tableSize?: number | null;
+	variant?: string | null;
+}
+
+export interface TournamentOption {
+	buyIn?: number | null;
+	entryFee?: number | null;
+	id: string;
+	name: string;
+}
+
+export interface SessionFormDefaults {
+	addonCost?: number;
+	ante?: number;
+	anteType?: string;
+	beforeDeadline?: boolean;
+	blind1?: number;
+	blind2?: number;
+	blind3?: number;
+	bountyPrizes?: number;
+	breakMinutes?: number;
+	buyIn?: number;
+	cashOut?: number;
+	currencyId?: string;
+	endTime?: string;
+	entryFee?: number;
+	evCashOut?: number;
+	memo?: string;
+	placement?: number;
+	prizeMoney?: number;
+	rebuyCost?: number;
+	rebuyCount?: number;
+	ringGameId?: string;
+	sessionDate?: string;
+	startTime?: string;
+	storeId?: string;
+	tableSize?: number;
+	tagIds?: string[];
+	totalEntries?: number;
+	tournamentBuyIn?: number;
+	tournamentId?: string;
+	type?: "cash_game" | "tournament";
+	variant?: string;
+}
+
+export const NONE_VALUE = "__none__";
+
+export function getTodayDateString(): string {
+	const today = new Date();
+	const year = today.getFullYear();
+	const month = String(today.getMonth() + 1).padStart(2, "0");
+	const day = String(today.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+export function numStrOrEmpty(value: number | undefined): string {
+	return value === undefined ? "" : String(value);
+}
+
+export function parseOptInt(value: string): number | undefined {
+	if (value === "") {
+		return undefined;
+	}
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export const sessionFormSchema = z.object({
+	sessionDate: z.string().min(1, "Date is required"),
+	startTime: z.string(),
+	endTime: z.string(),
+	breakMinutes: optionalNumericString({ integer: true, min: 0 }),
+	memo: z.string(),
+	buyIn: optionalNumericString({ integer: true, min: 0 }),
+	cashOut: optionalNumericString({ integer: true, min: 0 }),
+	evCashOut: optionalNumericString({ integer: true, min: 0 }),
+	variant: z.string(),
+	blind1: optionalNumericString({ integer: true, min: 0 }),
+	blind2: optionalNumericString({ integer: true, min: 0 }),
+	blind3: optionalNumericString({ integer: true, min: 0 }),
+	ante: optionalNumericString({ integer: true, min: 0 }),
+	anteType: z.string(),
+	tableSize: z.string(),
+	tournamentBuyIn: optionalNumericString({ integer: true, min: 0 }),
+	entryFee: optionalNumericString({ integer: true, min: 0 }),
+	beforeDeadline: z.boolean(),
+	placement: optionalNumericString({ integer: true, min: 1 }),
+	totalEntries: optionalNumericString({ integer: true, min: 1 }),
+	prizeMoney: optionalNumericString({ integer: true, min: 0 }),
+	rebuyCount: optionalNumericString({ integer: true, min: 0 }),
+	rebuyCost: optionalNumericString({ integer: true, min: 0 }),
+	addonCost: optionalNumericString({ integer: true, min: 0 }),
+	bountyPrizes: optionalNumericString({ integer: true, min: 0 }),
+});
+
+export function buildDefaults(defaults: SessionFormDefaults | undefined) {
+	return {
+		sessionDate: defaults?.sessionDate ?? getTodayDateString(),
+		startTime: defaults?.startTime ?? "",
+		endTime: defaults?.endTime ?? "",
+		breakMinutes: numStrOrEmpty(defaults?.breakMinutes),
+		memo: defaults?.memo ?? "",
+		buyIn: numStrOrEmpty(defaults?.buyIn),
+		cashOut: numStrOrEmpty(defaults?.cashOut),
+		evCashOut: numStrOrEmpty(defaults?.evCashOut),
+		variant: defaults?.variant ?? "nlh",
+		blind1: numStrOrEmpty(defaults?.blind1),
+		blind2: numStrOrEmpty(defaults?.blind2),
+		blind3: numStrOrEmpty(defaults?.blind3),
+		ante: numStrOrEmpty(defaults?.ante),
+		anteType: defaults?.anteType ?? "none",
+		tableSize: defaults?.tableSize?.toString() ?? "",
+		tournamentBuyIn: numStrOrEmpty(defaults?.tournamentBuyIn),
+		entryFee: numStrOrEmpty(defaults?.entryFee),
+		beforeDeadline: defaults?.beforeDeadline === true,
+		placement: numStrOrEmpty(defaults?.placement),
+		totalEntries: numStrOrEmpty(defaults?.totalEntries),
+		prizeMoney: numStrOrEmpty(defaults?.prizeMoney),
+		rebuyCount: numStrOrEmpty(defaults?.rebuyCount),
+		rebuyCost: numStrOrEmpty(defaults?.rebuyCost),
+		addonCost: numStrOrEmpty(defaults?.addonCost),
+		bountyPrizes: numStrOrEmpty(defaults?.bountyPrizes),
+	};
+}
+
+export type SessionFormFieldValues = ReturnType<typeof buildDefaults>;


### PR DESCRIPTION
## Summary

- `apps/web/src/sessions/components/session-form.tsx` からフォーム状態・`useForm` セットアップ・派生ロジック (`applyRingGameDefaults`, `applyTournamentDefaults`, `handleStoreChange`, `handleGameChange` 等) を切り出し、新規 `use-session-form-state.ts` hook に集約
- pure helpers (`NONE_VALUE`, `sessionFormSchema`, `buildDefaults`, `numStrOrEmpty`, `parseOptInt`, 型定義) を `apps/web/src/sessions/utils/session-form-helpers.ts` に分離
- コンポーネントは 652 → 360 行の Props 表示層に。`SessionForm` の公開インターフェイスは維持

これは `apps/web/` 全体の「UI表示とロジックを hooks で分離」方針に揃えるリファクタシリーズの Phase 1。

## Test plan

- [x] `bun x vitest run` で全 569 テスト通過
- [x] `bun x vitest run src/sessions/components/__tests__/session-form.test.tsx` で 18/18 通過
- [x] `bun x ultracite check` で該当 3 ファイル lint クリア
- [ ] 手動: /sessions/new, /sessions/\[id\]/edit で store→game 選択時に default 値が入る、cash game↔tournament 切替、タグ操作、保存

🤖 Generated with [Claude Code](https://claude.com/claude-code)