### PR TITLE
refactor(live-sessions): extract seat-from-screenshot logic into hook

### DIFF
--- a/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
+++ b/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
@@ -1,7 +1,4 @@
-import {
-	TABLE_PLAYER_SOURCE_APPS,
-	type TablePlayerSourceApp,
-} from "@sapphire2/api/routers/ai-extract-sources";
+import { TABLE_PLAYER_SOURCE_APPS } from "@sapphire2/api/routers/ai-extract-sources";
 import {
 	IconAlertTriangle,
 	IconChevronDown,
@@ -9,16 +6,21 @@ import {
 	IconPhotoUp,
 	IconSparkles,
 } from "@tabler/icons-react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
 	type KeyboardEvent as ReactKeyboardEvent,
 	useEffect,
-	useMemo,
 	useRef,
 	useState,
 } from "react";
-import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { useSeatFromScreenshot } from "@/live-sessions/hooks/use-seat-from-screenshot";
+import {
+	type PlayerOption,
+	type ReviewRow,
+	type RowAction,
+	type SessionParam,
+	SOURCE_APP_ENTRIES,
+} from "@/live-sessions/utils/seat-screenshot";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import {
@@ -35,11 +37,6 @@ import {
 	PopoverContent,
 } from "@/shared/components/ui/popover";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
-import { trpc, trpcClient } from "@/utils/trpc";
-
-type SessionParam =
-	| { liveCashGameSessionId: string; liveTournamentSessionId?: never }
-	| { liveCashGameSessionId?: never; liveTournamentSessionId: string };
 
 interface SeatFromScreenshotSheetProps {
 	heroSeatPosition: number | null;
@@ -49,126 +46,6 @@ interface SeatFromScreenshotSheetProps {
 	sessionParam: SessionParam;
 }
 
-type Step = "select-app" | "upload" | "review";
-
-type RowAction = "existing" | "new" | "hero" | "skip";
-
-interface PlayerOption {
-	id: string;
-	name: string;
-}
-
-interface ReviewRow {
-	action: RowAction;
-	ambiguous: boolean;
-	existingPlayerId: string | null;
-	isHeroCandidate: boolean;
-	matchedPlayerName: string | null;
-	name: string;
-	rowId: string;
-	seatNumber: number;
-	seatPosition: number;
-	warning: string | null;
-}
-
-const ACCEPTED_TYPES = [
-	"image/jpeg",
-	"image/png",
-	"image/gif",
-	"image/webp",
-] as const;
-type AcceptedMediaType = (typeof ACCEPTED_TYPES)[number];
-
-function isAcceptedMediaType(type: string): type is AcceptedMediaType {
-	return (ACCEPTED_TYPES as readonly string[]).includes(type);
-}
-
-function fileToBase64(file: File): Promise<string> {
-	return new Promise((resolve, reject) => {
-		const reader = new FileReader();
-		reader.onload = () => {
-			const result = reader.result as string;
-			resolve(result.split(",")[1] ?? "");
-		};
-		reader.onerror = reject;
-		reader.readAsDataURL(file);
-	});
-}
-
-function normalizeName(name: string): string {
-	return name.trim().toLowerCase();
-}
-
-const SOURCE_APP_ENTRIES = Object.entries(TABLE_PLAYER_SOURCE_APPS) as [
-	TablePlayerSourceApp,
-	(typeof TABLE_PLAYER_SOURCE_APPS)[TablePlayerSourceApp],
-][];
-
-function applyRowAction(
-	row: ReviewRow,
-	targetRowId: string,
-	nextAction: RowAction
-): ReviewRow {
-	if (row.rowId !== targetRowId) {
-		if (nextAction === "hero" && row.action === "hero") {
-			return {
-				...row,
-				action: row.existingPlayerId ? "existing" : "new",
-			};
-		}
-		return row;
-	}
-	if (row.ambiguous && nextAction === "existing") {
-		return row;
-	}
-	return { ...row, action: nextAction };
-}
-
-async function applyRow(
-	row: ReviewRow,
-	sessionParam: SessionParam
-): Promise<boolean> {
-	try {
-		if (row.action === "hero") {
-			await updateHeroSeatViaClient(sessionParam, row.seatPosition);
-		} else if (row.action === "existing" && row.existingPlayerId) {
-			await trpcClient.sessionTablePlayer.add.mutate({
-				...sessionParam,
-				playerId: row.existingPlayerId,
-				seatPosition: row.seatPosition,
-			});
-		} else if (row.action === "new") {
-			await trpcClient.sessionTablePlayer.addNew.mutate({
-				...sessionParam,
-				playerName: row.name.trim(),
-				seatPosition: row.seatPosition,
-			});
-		}
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-function updateHeroSeatViaClient(
-	sessionParam: SessionParam,
-	heroSeatPosition: number | null
-): Promise<unknown> {
-	if (sessionParam.liveCashGameSessionId !== undefined) {
-		return trpcClient.liveCashGameSession.updateHeroSeat.mutate({
-			id: sessionParam.liveCashGameSessionId,
-			heroSeatPosition,
-		});
-	}
-	if (sessionParam.liveTournamentSessionId !== undefined) {
-		return trpcClient.liveTournamentSession.updateHeroSeat.mutate({
-			id: sessionParam.liveTournamentSessionId,
-			heroSeatPosition,
-		});
-	}
-	throw new Error("Invalid sessionParam: neither cash game nor tournament");
-}
-
 export function SeatFromScreenshotSheet({
 	heroSeatPosition,
 	occupiedSeatPositions,
@@ -176,212 +53,29 @@ export function SeatFromScreenshotSheet({
 	open,
 	sessionParam,
 }: SeatFromScreenshotSheetProps) {
-	const queryClient = useQueryClient();
-	const fileInputRef = useRef<HTMLInputElement>(null);
-
-	const [step, setStep] = useState<Step>("select-app");
-	const [sourceApp, setSourceApp] = useState<TablePlayerSourceApp>(
-		SOURCE_APP_ENTRIES[0][0]
-	);
-	const [rows, setRows] = useState<ReviewRow[]>([]);
-	const [isApplying, setIsApplying] = useState(false);
-
-	const playersQuery = useQuery({
-		...trpc.player.list.queryOptions(),
-		enabled: open,
+	const {
+		step,
+		sourceApp,
+		rows,
+		isApplying,
+		fileInputRef,
+		isExtracting,
+		allPlayers,
+		onSourceAppSelect,
+		onPickFile,
+		onImageSelected,
+		onRowNameChange,
+		onRowSelectExisting,
+		onRowActionChange,
+		onApply,
+		onBackToSelectApp,
+		onBackToUpload,
+	} = useSeatFromScreenshot({
+		occupiedSeatPositions,
+		onOpenChange,
+		open,
+		sessionParam,
 	});
-	const allPlayers = useMemo<PlayerOption[]>(
-		() => playersQuery.data ?? [],
-		[playersQuery.data]
-	);
-
-	const playersByNormalizedName = useMemo(() => {
-		const map = new Map<
-			string,
-			{ id: string; name: string; count: number }[]
-		>();
-		for (const p of allPlayers) {
-			const key = normalizeName(p.name);
-			const bucket = map.get(key) ?? [];
-			bucket.push({ id: p.id, name: p.name, count: bucket.length + 1 });
-			map.set(key, bucket);
-		}
-		return map;
-	}, [allPlayers]);
-
-	const extractMutation = useMutation(
-		trpc.aiExtract.extractTablePlayers.mutationOptions()
-	);
-	const extractReset = extractMutation.reset;
-
-	useEffect(() => {
-		if (open) {
-			setStep("select-app");
-			setSourceApp(SOURCE_APP_ENTRIES[0][0]);
-			setRows([]);
-			extractReset();
-			setIsApplying(false);
-		}
-	}, [open, extractReset]);
-
-	const handleSourceAppSelect = (nextApp: TablePlayerSourceApp) => {
-		setSourceApp(nextApp);
-		setStep("upload");
-	};
-
-	const handlePickFile = () => {
-		fileInputRef.current?.click();
-	};
-
-	const handleImageSelected = async (
-		e: React.ChangeEvent<HTMLInputElement>
-	) => {
-		const file = e.target.files?.[0];
-		e.target.value = "";
-		if (!file) {
-			return;
-		}
-		const mediaType = file.type;
-		if (!isAcceptedMediaType(mediaType)) {
-			toast.error("Only JPEG, PNG, GIF, or WEBP images are supported.");
-			return;
-		}
-
-		try {
-			const base64 = await fileToBase64(file);
-			const result = await extractMutation.mutateAsync({
-				sourceApp,
-				sources: [{ kind: "image", data: base64, mediaType }],
-			});
-
-			const seenSeatNumbers = new Set<number>();
-			let heroAssigned = false;
-			const built: ReviewRow[] = [];
-			for (const seat of result.seats) {
-				if (seenSeatNumbers.has(seat.seatNumber)) {
-					continue;
-				}
-				seenSeatNumbers.add(seat.seatNumber);
-				const seatPosition = seat.seatNumber - 1;
-				const isHero = seat.isHero === true && !heroAssigned;
-				if (isHero) {
-					heroAssigned = true;
-				}
-				const row = buildRow({
-					isHero,
-					name: seat.name,
-					occupiedSeatPositions,
-					playersByNormalizedName,
-					seatNumber: seat.seatNumber,
-					seatPosition,
-				});
-				built.push(row);
-			}
-			setRows(built);
-			setStep("review");
-		} catch {
-			// toast already handled by MutationCache.onError
-		}
-	};
-
-	const handleRowNameChange = (rowId: string, nextName: string) => {
-		setRows((prev) =>
-			prev.map((row) => {
-				if (row.rowId !== rowId) {
-					return row;
-				}
-				const trimmed = nextName.trim();
-				const nextAction: RowAction = trimmed === "" ? "skip" : "new";
-				return buildRow({
-					isHero: row.isHeroCandidate,
-					name: nextName,
-					occupiedSeatPositions,
-					playersByNormalizedName,
-					preferredAction: nextAction,
-					seatNumber: row.seatNumber,
-					seatPosition: row.seatPosition,
-				});
-			})
-		);
-	};
-
-	const handleRowSelectExisting = (rowId: string, player: PlayerOption) => {
-		setRows((prev) =>
-			prev.map((row) => {
-				if (row.rowId !== rowId) {
-					return row;
-				}
-				return {
-					...row,
-					action: "existing",
-					existingPlayerId: player.id,
-					matchedPlayerName: player.name,
-					name: player.name,
-					ambiguous: false,
-				};
-			})
-		);
-	};
-
-	const handleRowActionChange = (rowId: string, nextAction: RowAction) => {
-		setRows((prev) =>
-			prev.map((row) => applyRowAction(row, rowId, nextAction))
-		);
-	};
-
-	const invalidateQueries = () => {
-		queryClient.invalidateQueries({
-			queryKey:
-				trpc.sessionTablePlayer.list.queryOptions(sessionParam).queryKey,
-		});
-		queryClient.invalidateQueries({
-			queryKey: trpc.player.list.queryOptions().queryKey,
-		});
-		if (sessionParam.liveCashGameSessionId !== undefined) {
-			queryClient.invalidateQueries({
-				queryKey: trpc.liveCashGameSession.getById.queryOptions({
-					id: sessionParam.liveCashGameSessionId,
-				}).queryKey,
-			});
-		} else if (sessionParam.liveTournamentSessionId !== undefined) {
-			queryClient.invalidateQueries({
-				queryKey: trpc.liveTournamentSession.getById.queryOptions({
-					id: sessionParam.liveTournamentSessionId,
-				}).queryKey,
-			});
-		}
-	};
-
-	const handleApply = async () => {
-		const actionable = rows.filter(
-			(row) => row.action !== "skip" && row.warning === null
-		);
-		if (actionable.length === 0) {
-			toast.error("Nothing to apply.");
-			return;
-		}
-
-		setIsApplying(true);
-		let success = 0;
-		let failure = 0;
-		for (const row of actionable) {
-			const ok = await applyRow(row, sessionParam);
-			if (ok) {
-				success += 1;
-			} else {
-				failure += 1;
-			}
-		}
-		setIsApplying(false);
-		invalidateQueries();
-
-		if (failure === 0) {
-			toast.success(`Applied ${success} ${success === 1 ? "seat" : "seats"}.`);
-			onOpenChange(false);
-		} else {
-			toast.error(`Applied ${success}, failed ${failure}.`);
-		}
-	};
 
 	const renderStep = () => {
 		if (step === "select-app") {
@@ -394,7 +88,7 @@ export function SeatFromScreenshotSheet({
 						{SOURCE_APP_ENTRIES.map(([id, config]) => (
 							<Button
 								key={id}
-								onClick={() => handleSourceAppSelect(id)}
+								onClick={() => onSourceAppSelect(id)}
 								type="button"
 								variant="outline"
 							>
@@ -416,7 +110,6 @@ export function SeatFromScreenshotSheet({
 		}
 
 		if (step === "upload") {
-			const isPending = extractMutation.isPending;
 			return (
 				<div className="flex flex-col gap-3">
 					<p className="text-muted-foreground text-sm">
@@ -426,8 +119,8 @@ export function SeatFromScreenshotSheet({
 						</span>
 						.
 					</p>
-					<Button disabled={isPending} onClick={handlePickFile} type="button">
-						{isPending ? (
+					<Button disabled={isExtracting} onClick={onPickFile} type="button">
+						{isExtracting ? (
 							<>
 								<IconLoader2 className="animate-spin" size={16} />
 								Analyzing...
@@ -442,14 +135,14 @@ export function SeatFromScreenshotSheet({
 					<input
 						accept="image/jpeg,image/png,image/gif,image/webp"
 						className="hidden"
-						onChange={handleImageSelected}
+						onChange={onImageSelected}
 						ref={fileInputRef}
 						type="file"
 					/>
 					<DialogActionRow>
 						<Button
-							disabled={isPending}
-							onClick={() => setStep("select-app")}
+							disabled={isExtracting}
+							onClick={onBackToSelectApp}
 							type="button"
 							variant="outline"
 						>
@@ -467,11 +160,7 @@ export function SeatFromScreenshotSheet({
 						No players detected in the screenshot.
 					</p>
 					<DialogActionRow>
-						<Button
-							onClick={() => setStep("upload")}
-							type="button"
-							variant="outline"
-						>
+						<Button onClick={onBackToUpload} type="button" variant="outline">
 							Try another image
 						</Button>
 						<Button
@@ -510,10 +199,10 @@ export function SeatFromScreenshotSheet({
 								heroAssignedRowId === null || heroAssignedRowId === row.rowId
 							}
 							key={row.rowId}
-							onActionChange={(next) => handleRowActionChange(row.rowId, next)}
-							onNameChange={(next) => handleRowNameChange(row.rowId, next)}
+							onActionChange={(next) => onRowActionChange(row.rowId, next)}
+							onNameChange={(next) => onRowNameChange(row.rowId, next)}
 							onSelectExisting={(player) =>
-								handleRowSelectExisting(row.rowId, player)
+								onRowSelectExisting(row.rowId, player)
 							}
 							row={row}
 						/>
@@ -522,7 +211,7 @@ export function SeatFromScreenshotSheet({
 				<DialogActionRow>
 					<Button
 						disabled={isApplying}
-						onClick={() => setStep("upload")}
+						onClick={onBackToUpload}
 						type="button"
 						variant="outline"
 					>
@@ -530,7 +219,7 @@ export function SeatFromScreenshotSheet({
 					</Button>
 					<Button
 						disabled={isApplying || seatablesCount === 0}
-						onClick={handleApply}
+						onClick={onApply}
 						type="button"
 					>
 						{isApplying ? (
@@ -755,8 +444,6 @@ function SeatCombobox({
 					onFocusOutside={(e) => e.preventDefault()}
 					onOpenAutoFocus={(e) => e.preventDefault()}
 					onPointerDownOutside={(e) => {
-						// Drawer + Radix Popover conflict: keep the drawer from capturing
-						// touches inside the popover on mobile.
 						e.preventDefault();
 					}}
 					style={contentWidth ? { width: contentWidth } : undefined}
@@ -807,117 +494,4 @@ function SeatCombobox({
 			) : null}
 		</Popover>
 	);
-}
-
-function computeRowWarning({
-	action,
-	occupiedSeatPositions,
-	seatNumber,
-	seatPosition,
-}: {
-	action: RowAction;
-	occupiedSeatPositions: Set<number>;
-	seatNumber: number;
-	seatPosition: number;
-}): string | null {
-	if (seatPosition < 0 || seatPosition > 8) {
-		return `Seat ${seatNumber} is out of range (1-9).`;
-	}
-	if (
-		action !== "hero" &&
-		action !== "skip" &&
-		occupiedSeatPositions.has(seatPosition)
-	) {
-		return `Seat ${seatNumber} is already occupied.`;
-	}
-	return null;
-}
-
-function computeRowAction({
-	effectivePreferredAction,
-	isHeroCandidate,
-	matchedPlayer,
-	trimmedName,
-}: {
-	effectivePreferredAction: RowAction | undefined;
-	isHeroCandidate: boolean;
-	matchedPlayer: { id: string; name: string } | null;
-	trimmedName: string;
-}): RowAction {
-	if (effectivePreferredAction) {
-		if (effectivePreferredAction === "existing" && !matchedPlayer) {
-			return "new";
-		}
-		if (effectivePreferredAction === "new" && trimmedName === "") {
-			return "skip";
-		}
-		return effectivePreferredAction;
-	}
-	if (isHeroCandidate) {
-		return "hero";
-	}
-	if (trimmedName === "") {
-		return "skip";
-	}
-	if (matchedPlayer) {
-		return "existing";
-	}
-	return "new";
-}
-
-function buildRow({
-	isHero,
-	name,
-	occupiedSeatPositions,
-	playersByNormalizedName,
-	preferredAction,
-	seatNumber,
-	seatPosition,
-}: {
-	isHero: boolean;
-	name: string;
-	occupiedSeatPositions: Set<number>;
-	playersByNormalizedName: Map<
-		string,
-		{ id: string; name: string; count: number }[]
-	>;
-	preferredAction?: RowAction;
-	seatNumber: number;
-	seatPosition: number;
-}): ReviewRow {
-	const rowId = `seat-${seatNumber}`;
-	const trimmedName = name.trim();
-	const key = normalizeName(trimmedName);
-	const matches = trimmedName ? (playersByNormalizedName.get(key) ?? []) : [];
-	const ambiguous = matches.length > 1;
-	const matchedPlayer = matches.length === 1 ? matches[0] : null;
-	const isHeroCandidate = isHero;
-
-	const effectivePreferredAction = preferredAction;
-
-	const action = computeRowAction({
-		effectivePreferredAction,
-		isHeroCandidate,
-		matchedPlayer,
-		trimmedName,
-	});
-	const warning = computeRowWarning({
-		action,
-		occupiedSeatPositions,
-		seatNumber,
-		seatPosition,
-	});
-
-	return {
-		action,
-		ambiguous,
-		existingPlayerId: matchedPlayer?.id ?? null,
-		isHeroCandidate,
-		matchedPlayerName: matchedPlayer?.name ?? null,
-		name: trimmedName,
-		rowId,
-		seatNumber,
-		seatPosition,
-		warning,
-	};
 }

--- a/apps/web/src/live-sessions/hooks/use-seat-from-screenshot.ts
+++ b/apps/web/src/live-sessions/hooks/use-seat-from-screenshot.ts
@@ -1,0 +1,262 @@
+import type { TablePlayerSourceApp } from "@sapphire2/api/routers/ai-extract-sources";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+	applyRow,
+	applyRowAction,
+	buildRow,
+	fileToBase64,
+	isAcceptedMediaType,
+	normalizeName,
+	type PlayerOption,
+	type ReviewRow,
+	type RowAction,
+	type SessionParam,
+	SOURCE_APP_ENTRIES,
+	type Step,
+} from "@/live-sessions/utils/seat-screenshot";
+import { invalidateTargets } from "@/utils/optimistic-update";
+import { trpc } from "@/utils/trpc";
+
+interface UseSeatFromScreenshotArgs {
+	occupiedSeatPositions: Set<number>;
+	onOpenChange: (open: boolean) => void;
+	open: boolean;
+	sessionParam: SessionParam;
+}
+
+export function useSeatFromScreenshot({
+	occupiedSeatPositions,
+	onOpenChange,
+	open,
+	sessionParam,
+}: UseSeatFromScreenshotArgs) {
+	const queryClient = useQueryClient();
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const [step, setStep] = useState<Step>("select-app");
+	const [sourceApp, setSourceApp] = useState<TablePlayerSourceApp>(
+		SOURCE_APP_ENTRIES[0][0]
+	);
+	const [rows, setRows] = useState<ReviewRow[]>([]);
+	const [isApplying, setIsApplying] = useState(false);
+
+	const playersQuery = useQuery({
+		...trpc.player.list.queryOptions(),
+		enabled: open,
+	});
+	const allPlayers = useMemo<PlayerOption[]>(
+		() => playersQuery.data ?? [],
+		[playersQuery.data]
+	);
+
+	const playersByNormalizedName = useMemo(() => {
+		const map = new Map<
+			string,
+			{ id: string; name: string; count: number }[]
+		>();
+		for (const p of allPlayers) {
+			const key = normalizeName(p.name);
+			const bucket = map.get(key) ?? [];
+			bucket.push({ id: p.id, name: p.name, count: bucket.length + 1 });
+			map.set(key, bucket);
+		}
+		return map;
+	}, [allPlayers]);
+
+	const extractMutation = useMutation(
+		trpc.aiExtract.extractTablePlayers.mutationOptions()
+	);
+	const extractReset = extractMutation.reset;
+
+	useEffect(() => {
+		if (open) {
+			setStep("select-app");
+			setSourceApp(SOURCE_APP_ENTRIES[0][0]);
+			setRows([]);
+			extractReset();
+			setIsApplying(false);
+		}
+	}, [open, extractReset]);
+
+	const onSourceAppSelect = (nextApp: TablePlayerSourceApp) => {
+		setSourceApp(nextApp);
+		setStep("upload");
+	};
+
+	const onPickFile = () => {
+		fileInputRef.current?.click();
+	};
+
+	const onImageSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		e.target.value = "";
+		if (!file) {
+			return;
+		}
+		const mediaType = file.type;
+		if (!isAcceptedMediaType(mediaType)) {
+			toast.error("Only JPEG, PNG, GIF, or WEBP images are supported.");
+			return;
+		}
+
+		try {
+			const base64 = await fileToBase64(file);
+			const result = await extractMutation.mutateAsync({
+				sourceApp,
+				sources: [{ kind: "image", data: base64, mediaType }],
+			});
+
+			const seenSeatNumbers = new Set<number>();
+			let heroAssigned = false;
+			const built: ReviewRow[] = [];
+			for (const seat of result.seats) {
+				if (seenSeatNumbers.has(seat.seatNumber)) {
+					continue;
+				}
+				seenSeatNumbers.add(seat.seatNumber);
+				const seatPosition = seat.seatNumber - 1;
+				const isHero = seat.isHero === true && !heroAssigned;
+				if (isHero) {
+					heroAssigned = true;
+				}
+				const row = buildRow({
+					isHero,
+					name: seat.name,
+					occupiedSeatPositions,
+					playersByNormalizedName,
+					seatNumber: seat.seatNumber,
+					seatPosition,
+				});
+				built.push(row);
+			}
+			setRows(built);
+			setStep("review");
+		} catch {
+			// toast already handled by MutationCache.onError
+		}
+	};
+
+	const onRowNameChange = (rowId: string, nextName: string) => {
+		setRows((prev) =>
+			prev.map((row) => {
+				if (row.rowId !== rowId) {
+					return row;
+				}
+				const trimmed = nextName.trim();
+				const nextAction: RowAction = trimmed === "" ? "skip" : "new";
+				return buildRow({
+					isHero: row.isHeroCandidate,
+					name: nextName,
+					occupiedSeatPositions,
+					playersByNormalizedName,
+					preferredAction: nextAction,
+					seatNumber: row.seatNumber,
+					seatPosition: row.seatPosition,
+				});
+			})
+		);
+	};
+
+	const onRowSelectExisting = (rowId: string, player: PlayerOption) => {
+		setRows((prev) =>
+			prev.map((row) => {
+				if (row.rowId !== rowId) {
+					return row;
+				}
+				return {
+					...row,
+					action: "existing",
+					existingPlayerId: player.id,
+					matchedPlayerName: player.name,
+					name: player.name,
+					ambiguous: false,
+				};
+			})
+		);
+	};
+
+	const onRowActionChange = (rowId: string, nextAction: RowAction) => {
+		setRows((prev) =>
+			prev.map((row) => applyRowAction(row, rowId, nextAction))
+		);
+	};
+
+	const invalidateSessionQueries = async () => {
+		const targets = [
+			{
+				queryKey:
+					trpc.sessionTablePlayer.list.queryOptions(sessionParam).queryKey,
+			},
+			{ queryKey: trpc.player.list.queryOptions().queryKey },
+		];
+		if (sessionParam.liveCashGameSessionId !== undefined) {
+			targets.push({
+				queryKey: trpc.liveCashGameSession.getById.queryOptions({
+					id: sessionParam.liveCashGameSessionId,
+				}).queryKey,
+			});
+		} else if (sessionParam.liveTournamentSessionId !== undefined) {
+			targets.push({
+				queryKey: trpc.liveTournamentSession.getById.queryOptions({
+					id: sessionParam.liveTournamentSessionId,
+				}).queryKey,
+			});
+		}
+		await invalidateTargets(queryClient, targets);
+	};
+
+	const onApply = async () => {
+		const actionable = rows.filter(
+			(row) => row.action !== "skip" && row.warning === null
+		);
+		if (actionable.length === 0) {
+			toast.error("Nothing to apply.");
+			return;
+		}
+
+		setIsApplying(true);
+		let success = 0;
+		let failure = 0;
+		for (const row of actionable) {
+			const ok = await applyRow(row, sessionParam);
+			if (ok) {
+				success += 1;
+			} else {
+				failure += 1;
+			}
+		}
+		setIsApplying(false);
+		await invalidateSessionQueries();
+
+		if (failure === 0) {
+			toast.success(`Applied ${success} ${success === 1 ? "seat" : "seats"}.`);
+			onOpenChange(false);
+		} else {
+			toast.error(`Applied ${success}, failed ${failure}.`);
+		}
+	};
+
+	const onBackToSelectApp = () => setStep("select-app");
+	const onBackToUpload = () => setStep("upload");
+
+	return {
+		step,
+		sourceApp,
+		rows,
+		isApplying,
+		fileInputRef,
+		isExtracting: extractMutation.isPending,
+		allPlayers,
+		onSourceAppSelect,
+		onPickFile,
+		onImageSelected,
+		onRowNameChange,
+		onRowSelectExisting,
+		onRowActionChange,
+		onApply,
+		onBackToSelectApp,
+		onBackToUpload,
+	};
+}

--- a/apps/web/src/live-sessions/utils/seat-screenshot.ts
+++ b/apps/web/src/live-sessions/utils/seat-screenshot.ts
@@ -1,0 +1,242 @@
+import {
+	TABLE_PLAYER_SOURCE_APPS,
+	type TablePlayerSourceApp,
+} from "@sapphire2/api/routers/ai-extract-sources";
+import { trpcClient } from "@/utils/trpc";
+
+export type SessionParam =
+	| { liveCashGameSessionId: string; liveTournamentSessionId?: never }
+	| { liveCashGameSessionId?: never; liveTournamentSessionId: string };
+
+export type Step = "select-app" | "upload" | "review";
+
+export type RowAction = "existing" | "new" | "hero" | "skip";
+
+export interface PlayerOption {
+	id: string;
+	name: string;
+}
+
+export interface ReviewRow {
+	action: RowAction;
+	ambiguous: boolean;
+	existingPlayerId: string | null;
+	isHeroCandidate: boolean;
+	matchedPlayerName: string | null;
+	name: string;
+	rowId: string;
+	seatNumber: number;
+	seatPosition: number;
+	warning: string | null;
+}
+
+export const ACCEPTED_TYPES = [
+	"image/jpeg",
+	"image/png",
+	"image/gif",
+	"image/webp",
+] as const;
+export type AcceptedMediaType = (typeof ACCEPTED_TYPES)[number];
+
+export const SOURCE_APP_ENTRIES = Object.entries(TABLE_PLAYER_SOURCE_APPS) as [
+	TablePlayerSourceApp,
+	(typeof TABLE_PLAYER_SOURCE_APPS)[TablePlayerSourceApp],
+][];
+
+export function isAcceptedMediaType(type: string): type is AcceptedMediaType {
+	return (ACCEPTED_TYPES as readonly string[]).includes(type);
+}
+
+export function fileToBase64(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => {
+			const result = reader.result as string;
+			resolve(result.split(",")[1] ?? "");
+		};
+		reader.onerror = reject;
+		reader.readAsDataURL(file);
+	});
+}
+
+export function normalizeName(name: string): string {
+	return name.trim().toLowerCase();
+}
+
+export function applyRowAction(
+	row: ReviewRow,
+	targetRowId: string,
+	nextAction: RowAction
+): ReviewRow {
+	if (row.rowId !== targetRowId) {
+		if (nextAction === "hero" && row.action === "hero") {
+			return {
+				...row,
+				action: row.existingPlayerId ? "existing" : "new",
+			};
+		}
+		return row;
+	}
+	if (row.ambiguous && nextAction === "existing") {
+		return row;
+	}
+	return { ...row, action: nextAction };
+}
+
+export function updateHeroSeatViaClient(
+	sessionParam: SessionParam,
+	heroSeatPosition: number | null
+): Promise<unknown> {
+	if (sessionParam.liveCashGameSessionId !== undefined) {
+		return trpcClient.liveCashGameSession.updateHeroSeat.mutate({
+			id: sessionParam.liveCashGameSessionId,
+			heroSeatPosition,
+		});
+	}
+	if (sessionParam.liveTournamentSessionId !== undefined) {
+		return trpcClient.liveTournamentSession.updateHeroSeat.mutate({
+			id: sessionParam.liveTournamentSessionId,
+			heroSeatPosition,
+		});
+	}
+	throw new Error("Invalid sessionParam: neither cash game nor tournament");
+}
+
+export async function applyRow(
+	row: ReviewRow,
+	sessionParam: SessionParam
+): Promise<boolean> {
+	try {
+		if (row.action === "hero") {
+			await updateHeroSeatViaClient(sessionParam, row.seatPosition);
+		} else if (row.action === "existing" && row.existingPlayerId) {
+			await trpcClient.sessionTablePlayer.add.mutate({
+				...sessionParam,
+				playerId: row.existingPlayerId,
+				seatPosition: row.seatPosition,
+			});
+		} else if (row.action === "new") {
+			await trpcClient.sessionTablePlayer.addNew.mutate({
+				...sessionParam,
+				playerName: row.name.trim(),
+				seatPosition: row.seatPosition,
+			});
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function computeRowWarning({
+	action,
+	occupiedSeatPositions,
+	seatNumber,
+	seatPosition,
+}: {
+	action: RowAction;
+	occupiedSeatPositions: Set<number>;
+	seatNumber: number;
+	seatPosition: number;
+}): string | null {
+	if (seatPosition < 0 || seatPosition > 8) {
+		return `Seat ${seatNumber} is out of range (1-9).`;
+	}
+	if (
+		action !== "hero" &&
+		action !== "skip" &&
+		occupiedSeatPositions.has(seatPosition)
+	) {
+		return `Seat ${seatNumber} is already occupied.`;
+	}
+	return null;
+}
+
+export function computeRowAction({
+	effectivePreferredAction,
+	isHeroCandidate,
+	matchedPlayer,
+	trimmedName,
+}: {
+	effectivePreferredAction: RowAction | undefined;
+	isHeroCandidate: boolean;
+	matchedPlayer: { id: string; name: string } | null;
+	trimmedName: string;
+}): RowAction {
+	if (effectivePreferredAction) {
+		if (effectivePreferredAction === "existing" && !matchedPlayer) {
+			return "new";
+		}
+		if (effectivePreferredAction === "new" && trimmedName === "") {
+			return "skip";
+		}
+		return effectivePreferredAction;
+	}
+	if (isHeroCandidate) {
+		return "hero";
+	}
+	if (trimmedName === "") {
+		return "skip";
+	}
+	if (matchedPlayer) {
+		return "existing";
+	}
+	return "new";
+}
+
+export function buildRow({
+	isHero,
+	name,
+	occupiedSeatPositions,
+	playersByNormalizedName,
+	preferredAction,
+	seatNumber,
+	seatPosition,
+}: {
+	isHero: boolean;
+	name: string;
+	occupiedSeatPositions: Set<number>;
+	playersByNormalizedName: Map<
+		string,
+		{ id: string; name: string; count: number }[]
+	>;
+	preferredAction?: RowAction;
+	seatNumber: number;
+	seatPosition: number;
+}): ReviewRow {
+	const rowId = `seat-${seatNumber}`;
+	const trimmedName = name.trim();
+	const key = normalizeName(trimmedName);
+	const matches = trimmedName ? (playersByNormalizedName.get(key) ?? []) : [];
+	const ambiguous = matches.length > 1;
+	const matchedPlayer = matches.length === 1 ? matches[0] : null;
+	const isHeroCandidate = isHero;
+
+	const effectivePreferredAction = preferredAction;
+
+	const action = computeRowAction({
+		effectivePreferredAction,
+		isHeroCandidate,
+		matchedPlayer,
+		trimmedName,
+	});
+	const warning = computeRowWarning({
+		action,
+		occupiedSeatPositions,
+		seatNumber,
+		seatPosition,
+	});
+
+	return {
+		action,
+		ambiguous,
+		existingPlayerId: matchedPlayer?.id ?? null,
+		isHeroCandidate,
+		matchedPlayerName: matchedPlayer?.name ?? null,
+		name: trimmedName,
+		rowId,
+		seatNumber,
+		seatPosition,
+		warning,
+	};
+}


### PR DESCRIPTION
## Summary

- `apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx` から state machine (step/sourceApp/rows/isApplying)・tRPC query+mutation・行処理・invalidation を `use-seat-from-screenshot.ts` hook に抽出
- pure helper (`normalizeName`, `buildRow`, `applyRow`, `applyRowAction`, `fileToBase64`, `computeRowAction`, `computeRowWarning`, 定数, 型定義) を `seat-screenshot.ts` utils に分離
- invalidation は `@/utils/optimistic-update.ts` の `invalidateTargets` に統一
- コンポーネントは 923 → 460 行。`ReviewRowItem` / `SeatCombobox` は表示用サブコンポーネントとして同居を継続

これは `apps/web/` 全体の「UI表示とロジックを hooks で分離」方針に揃えるリファクタシリーズの Phase 2。

## Test plan

- [x] `bun x vitest run` で全 569 テスト通過
- [x] `bun x ultracite check` で該当 3 ファイル lint クリア
- [ ] 手動: ライブセッション詳細の「Seat from screenshot」でアプリ選択 → 画像アップ → レビュー → 適用まで golden path

🤖 Generated with [Claude Code](https://claude.com/claude-code)