### PR TITLE
refactor(live-sessions): extract active-session-game-scene hooks

### DIFF
--- a/apps/web/src/live-sessions/components/active-session-game-scene.tsx
+++ b/apps/web/src/live-sessions/components/active-session-game-scene.tsx
@@ -1,11 +1,22 @@
 import { IconEdit } from "@tabler/icons-react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { AssignRingGameDialog } from "@/live-sessions/components/assign-ring-game-dialog";
 import { AssignTournamentDialog } from "@/live-sessions/components/assign-tournament-dialog";
 import { useActiveSession } from "@/live-sessions/hooks/use-active-session";
 import { useCashGameSession } from "@/live-sessions/hooks/use-cash-game-session";
+import { useRingGameSceneActions } from "@/live-sessions/hooks/use-ring-game-scene-actions";
+import {
+	type ChipPurchaseRow,
+	type TournamentDetail,
+	useTournamentDetail,
+} from "@/live-sessions/hooks/use-tournament-detail";
+import { useTournamentSceneActions } from "@/live-sessions/hooks/use-tournament-scene-actions";
 import { useTournamentSession } from "@/live-sessions/hooks/use-tournament-session";
+import {
+	formatAnteSuffix,
+	formatBlindParts,
+	variantLabel,
+} from "@/live-sessions/utils/game-scene-formatters";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import {
@@ -19,24 +30,9 @@ import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 import { RingGameForm } from "@/stores/components/ring-game-form";
 import { TournamentEditDialog } from "@/stores/components/tournament-edit-dialog";
 import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
-import type {
-	RingGame,
-	RingGameFormValues,
-} from "@/stores/hooks/use-ring-games";
-import { useRingGames } from "@/stores/hooks/use-ring-games";
-import type { TournamentFormValues } from "@/stores/hooks/use-tournaments";
-import { useTournaments } from "@/stores/hooks/use-tournaments";
+import type { RingGame } from "@/stores/hooks/use-ring-games";
 import { createGroupFormatter } from "@/utils/format-number";
 import { getTableSizeClassName } from "@/utils/table-size-colors";
-import { trpc, trpcClient } from "@/utils/trpc";
-
-const VARIANT_LABELS: Record<string, string> = {
-	nlh: "NLH",
-};
-
-function variantLabel(variant: string): string {
-	return VARIANT_LABELS[variant] ?? variant.toUpperCase();
-}
 
 function GameSceneShell({
 	children,
@@ -71,42 +67,6 @@ function DetailRow({
 			<span className="text-right font-medium text-sm">{value}</span>
 		</div>
 	);
-}
-
-function formatBlindParts(game: RingGame): string {
-	const fmt = createGroupFormatter([
-		game.blind1,
-		game.blind2,
-		game.blind3,
-		game.ante,
-	]);
-	const parts: string[] = [];
-	if (game.blind1 != null) {
-		parts.push(fmt(game.blind1));
-	}
-	if (game.blind2 != null) {
-		parts.push(fmt(game.blind2));
-	} else if (parts.length > 0) {
-		parts.push("—");
-	}
-	if (game.blind3 != null) {
-		parts.push(fmt(game.blind3));
-	}
-	return parts.join("/");
-}
-
-function formatAnteSuffix(game: RingGame): string {
-	if (game.ante == null || game.anteType == null || game.anteType === "none") {
-		return "";
-	}
-	const fmt = createGroupFormatter([game.ante]);
-	if (game.anteType === "bb") {
-		return `(BBA:${fmt(game.ante)})`;
-	}
-	if (game.anteType === "all") {
-		return `(Ante:${fmt(game.ante)})`;
-	}
-	return "";
 }
 
 function RingGameDetailsCard({
@@ -203,13 +163,20 @@ function CashGameNotLinked({
 }
 
 function CashGameDetails({ sessionId }: { sessionId: string }) {
-	const queryClient = useQueryClient();
-	const [isEditOpen, setIsEditOpen] = useState(false);
 	const { session, ringGames } = useCashGameSession(sessionId);
 	const storeId = session?.storeId ?? "";
-	const { update, isUpdatePending, currencies } = useRingGames({
+	const ringGameId = session?.ringGameId ?? "";
+
+	const {
+		isEditOpen,
+		setIsEditOpen,
+		handleUpdate,
+		isUpdatePending,
+		currencies,
+	} = useRingGameSceneActions({
+		ringGameId,
+		sessionId,
 		storeId,
-		showArchived: false,
 	});
 
 	if (!session) {
@@ -238,15 +205,6 @@ function CashGameDetails({ sessionId }: { sessionId: string }) {
 	}
 
 	const currency = currencies.find((c) => c.id === ringGame.currencyId);
-
-	const handleUpdate = async (values: RingGameFormValues) => {
-		await update({ id: ringGame.id, ...values });
-		await queryClient.invalidateQueries({
-			queryKey: trpc.liveCashGameSession.getById.queryOptions({ id: sessionId })
-				.queryKey,
-		});
-		setIsEditOpen(false);
-	};
 
 	return (
 		<GameSceneShell
@@ -381,44 +339,6 @@ function TournamentStructureTable({ levels }: { levels: BlindLevelRow[] }) {
 			</table>
 		</div>
 	);
-}
-
-type TournamentDetail = NonNullable<
-	ReturnType<typeof useTournamentDetail>["tournament"]
->;
-
-interface ChipPurchaseRow {
-	chips: number;
-	cost: number;
-	id: string;
-	name: string;
-}
-
-function useTournamentDetail(tournamentId: string) {
-	const tournamentQuery = useQuery({
-		...trpc.tournament.getById.queryOptions({ id: tournamentId }),
-		enabled: !!tournamentId,
-	});
-	const chipPurchasesQuery = useQuery({
-		...trpc.tournamentChipPurchase.listByTournament.queryOptions({
-			tournamentId,
-		}),
-		enabled: !!tournamentId,
-	});
-	const levelsQuery = useQuery({
-		...trpc.blindLevel.listByTournament.queryOptions({ tournamentId }),
-		enabled: !!tournamentId,
-	});
-	const currenciesQuery = useQuery(trpc.currency.list.queryOptions());
-
-	return {
-		tournament: tournamentQuery.data,
-		isTournamentLoading: tournamentQuery.isLoading,
-		chipPurchases: (chipPurchasesQuery.data ?? []) as ChipPurchaseRow[],
-		levels: (levelsQuery.data ?? []) as BlindLevelRow[],
-		isLevelsLoading: levelsQuery.isLoading,
-		currencies: currenciesQuery.data ?? [],
-	};
 }
 
 function TournamentInfoCard({
@@ -573,81 +493,6 @@ function toInitialFormValues(
 	};
 }
 
-function useTournamentUpdate({
-	sessionId,
-	storeId,
-	tournamentId,
-}: {
-	sessionId: string;
-	storeId: string;
-	tournamentId: string;
-}) {
-	const queryClient = useQueryClient();
-	const [isSaving, setIsSaving] = useState(false);
-
-	const save = async (
-		values: TournamentFormValues,
-		updatedLevels: BlindLevelRow[]
-	) => {
-		setIsSaving(true);
-		try {
-			await trpcClient.tournament.updateWithLevels.mutate({
-				id: tournamentId,
-				name: values.name,
-				variant: values.variant,
-				buyIn: values.buyIn ?? null,
-				entryFee: values.entryFee ?? null,
-				startingStack: values.startingStack ?? null,
-				bountyAmount: values.bountyAmount ?? null,
-				tableSize: values.tableSize ?? null,
-				currencyId: values.currencyId ?? null,
-				memo: values.memo ?? null,
-				tags: values.tags,
-				chipPurchases: values.chipPurchases,
-				blindLevels: updatedLevels.map((l) => ({
-					isBreak: l.isBreak,
-					blind1: l.blind1,
-					blind2: l.blind2,
-					blind3: l.blind3,
-					ante: l.ante,
-					minutes: l.minutes,
-				})),
-			});
-			await Promise.all([
-				queryClient.invalidateQueries({
-					queryKey: trpc.tournament.getById.queryOptions({ id: tournamentId })
-						.queryKey,
-				}),
-				queryClient.invalidateQueries({
-					queryKey: trpc.tournament.listByStore.queryOptions({
-						storeId,
-						includeArchived: false,
-					}).queryKey,
-				}),
-				queryClient.invalidateQueries({
-					queryKey: trpc.blindLevel.listByTournament.queryOptions({
-						tournamentId,
-					}).queryKey,
-				}),
-				queryClient.invalidateQueries({
-					queryKey: trpc.tournamentChipPurchase.listByTournament.queryOptions({
-						tournamentId,
-					}).queryKey,
-				}),
-				queryClient.invalidateQueries({
-					queryKey: trpc.liveTournamentSession.getById.queryOptions({
-						id: sessionId,
-					}).queryKey,
-				}),
-			]);
-		} finally {
-			setIsSaving(false);
-		}
-	};
-
-	return { save, isSaving };
-}
-
 function TournamentDetailsBody({
 	sessionId,
 	storeId,
@@ -665,24 +510,17 @@ function TournamentDetailsBody({
 	isLevelsLoading: boolean;
 	currencyName: string | null | undefined;
 }) {
-	const [isEditOpen, setIsEditOpen] = useState(false);
-	const { save, isSaving } = useTournamentUpdate({
+	const {
+		isEditOpen,
+		setIsEditOpen,
+		handleSave,
+		isSaving,
+		isUpdateWithLevelsPending,
+	} = useTournamentSceneActions({
 		sessionId,
 		storeId,
 		tournamentId: tournament.id,
 	});
-	const { isUpdateWithLevelsPending } = useTournaments({
-		storeId,
-		showArchived: false,
-	});
-
-	const handleSave = async (
-		values: TournamentFormValues,
-		updatedLevels: BlindLevelRow[]
-	) => {
-		await save(values, updatedLevels);
-		setIsEditOpen(false);
-	};
 
 	return (
 		<GameSceneShell

--- a/apps/web/src/live-sessions/hooks/use-ring-game-scene-actions.ts
+++ b/apps/web/src/live-sessions/hooks/use-ring-game-scene-actions.ts
@@ -1,0 +1,45 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import type { RingGameFormValues } from "@/stores/hooks/use-ring-games";
+import { useRingGames } from "@/stores/hooks/use-ring-games";
+import { invalidateTargets } from "@/utils/optimistic-update";
+import { trpc } from "@/utils/trpc";
+
+interface UseRingGameSceneActionsArgs {
+	ringGameId: string;
+	sessionId: string;
+	storeId: string;
+}
+
+export function useRingGameSceneActions({
+	ringGameId,
+	sessionId,
+	storeId,
+}: UseRingGameSceneActionsArgs) {
+	const queryClient = useQueryClient();
+	const [isEditOpen, setIsEditOpen] = useState(false);
+	const { update, isUpdatePending, currencies } = useRingGames({
+		storeId,
+		showArchived: false,
+	});
+
+	const handleUpdate = async (values: RingGameFormValues) => {
+		await update({ id: ringGameId, ...values });
+		await invalidateTargets(queryClient, [
+			{
+				queryKey: trpc.liveCashGameSession.getById.queryOptions({
+					id: sessionId,
+				}).queryKey,
+			},
+		]);
+		setIsEditOpen(false);
+	};
+
+	return {
+		isEditOpen,
+		setIsEditOpen,
+		handleUpdate,
+		isUpdatePending,
+		currencies,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-tournament-detail.ts
+++ b/apps/web/src/live-sessions/hooks/use-tournament-detail.ts
@@ -1,0 +1,41 @@
+import { useQuery } from "@tanstack/react-query";
+import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+import { trpc } from "@/utils/trpc";
+
+export interface ChipPurchaseRow {
+	chips: number;
+	cost: number;
+	id: string;
+	name: string;
+}
+
+export function useTournamentDetail(tournamentId: string) {
+	const tournamentQuery = useQuery({
+		...trpc.tournament.getById.queryOptions({ id: tournamentId }),
+		enabled: !!tournamentId,
+	});
+	const chipPurchasesQuery = useQuery({
+		...trpc.tournamentChipPurchase.listByTournament.queryOptions({
+			tournamentId,
+		}),
+		enabled: !!tournamentId,
+	});
+	const levelsQuery = useQuery({
+		...trpc.blindLevel.listByTournament.queryOptions({ tournamentId }),
+		enabled: !!tournamentId,
+	});
+	const currenciesQuery = useQuery(trpc.currency.list.queryOptions());
+
+	return {
+		tournament: tournamentQuery.data,
+		isTournamentLoading: tournamentQuery.isLoading,
+		chipPurchases: (chipPurchasesQuery.data ?? []) as ChipPurchaseRow[],
+		levels: (levelsQuery.data ?? []) as BlindLevelRow[],
+		isLevelsLoading: levelsQuery.isLoading,
+		currencies: currenciesQuery.data ?? [],
+	};
+}
+
+export type TournamentDetail = NonNullable<
+	ReturnType<typeof useTournamentDetail>["tournament"]
+>;

--- a/apps/web/src/live-sessions/hooks/use-tournament-scene-actions.ts
+++ b/apps/web/src/live-sessions/hooks/use-tournament-scene-actions.ts
@@ -1,0 +1,103 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+import type { TournamentFormValues } from "@/stores/hooks/use-tournaments";
+import { useTournaments } from "@/stores/hooks/use-tournaments";
+import { invalidateTargets } from "@/utils/optimistic-update";
+import { trpc, trpcClient } from "@/utils/trpc";
+
+interface UseTournamentSceneActionsArgs {
+	sessionId: string;
+	storeId: string;
+	tournamentId: string;
+}
+
+export function useTournamentSceneActions({
+	sessionId,
+	storeId,
+	tournamentId,
+}: UseTournamentSceneActionsArgs) {
+	const queryClient = useQueryClient();
+	const [isEditOpen, setIsEditOpen] = useState(false);
+	const [isSaving, setIsSaving] = useState(false);
+	const { isUpdateWithLevelsPending } = useTournaments({
+		storeId,
+		showArchived: false,
+	});
+
+	const save = async (
+		values: TournamentFormValues,
+		updatedLevels: BlindLevelRow[]
+	) => {
+		setIsSaving(true);
+		try {
+			await trpcClient.tournament.updateWithLevels.mutate({
+				id: tournamentId,
+				name: values.name,
+				variant: values.variant,
+				buyIn: values.buyIn ?? null,
+				entryFee: values.entryFee ?? null,
+				startingStack: values.startingStack ?? null,
+				bountyAmount: values.bountyAmount ?? null,
+				tableSize: values.tableSize ?? null,
+				currencyId: values.currencyId ?? null,
+				memo: values.memo ?? null,
+				tags: values.tags,
+				chipPurchases: values.chipPurchases,
+				blindLevels: updatedLevels.map((l) => ({
+					isBreak: l.isBreak,
+					blind1: l.blind1,
+					blind2: l.blind2,
+					blind3: l.blind3,
+					ante: l.ante,
+					minutes: l.minutes,
+				})),
+			});
+			await invalidateTargets(queryClient, [
+				{
+					queryKey: trpc.tournament.getById.queryOptions({ id: tournamentId })
+						.queryKey,
+				},
+				{
+					queryKey: trpc.tournament.listByStore.queryOptions({
+						storeId,
+						includeArchived: false,
+					}).queryKey,
+				},
+				{
+					queryKey: trpc.blindLevel.listByTournament.queryOptions({
+						tournamentId,
+					}).queryKey,
+				},
+				{
+					queryKey: trpc.tournamentChipPurchase.listByTournament.queryOptions({
+						tournamentId,
+					}).queryKey,
+				},
+				{
+					queryKey: trpc.liveTournamentSession.getById.queryOptions({
+						id: sessionId,
+					}).queryKey,
+				},
+			]);
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const handleSave = async (
+		values: TournamentFormValues,
+		updatedLevels: BlindLevelRow[]
+	) => {
+		await save(values, updatedLevels);
+		setIsEditOpen(false);
+	};
+
+	return {
+		isEditOpen,
+		setIsEditOpen,
+		handleSave,
+		isSaving,
+		isUpdateWithLevelsPending,
+	};
+}

--- a/apps/web/src/live-sessions/utils/game-scene-formatters.ts
+++ b/apps/web/src/live-sessions/utils/game-scene-formatters.ts
@@ -1,0 +1,46 @@
+import type { RingGame } from "@/stores/hooks/use-ring-games";
+import { createGroupFormatter } from "@/utils/format-number";
+
+export const VARIANT_LABELS: Record<string, string> = {
+	nlh: "NLH",
+};
+
+export function variantLabel(variant: string): string {
+	return VARIANT_LABELS[variant] ?? variant.toUpperCase();
+}
+
+export function formatBlindParts(game: RingGame): string {
+	const fmt = createGroupFormatter([
+		game.blind1,
+		game.blind2,
+		game.blind3,
+		game.ante,
+	]);
+	const parts: string[] = [];
+	if (game.blind1 != null) {
+		parts.push(fmt(game.blind1));
+	}
+	if (game.blind2 != null) {
+		parts.push(fmt(game.blind2));
+	} else if (parts.length > 0) {
+		parts.push("—");
+	}
+	if (game.blind3 != null) {
+		parts.push(fmt(game.blind3));
+	}
+	return parts.join("/");
+}
+
+export function formatAnteSuffix(game: RingGame): string {
+	if (game.ante == null || game.anteType == null || game.anteType === "none") {
+		return "";
+	}
+	const fmt = createGroupFormatter([game.ante]);
+	if (game.anteType === "bb") {
+		return `(BBA:${fmt(game.ante)})`;
+	}
+	if (game.anteType === "all") {
+		return `(Ante:${fmt(game.ante)})`;
+	}
+	return "";
+}


### PR DESCRIPTION
## Summary

- `active-session-game-scene.tsx` 内に直接書かれていた hook / mutation / invalidation を独立した hook ファイルに分離:
  - `use-tournament-detail.ts`: tournament + chip purchases + blind levels + currencies の composite クエリ（ファイル内定義から昇格）
  - `use-ring-game-scene-actions.ts`: cash game 側の ring game 更新 + 編集ダイアログ state + session invalidation
  - `use-tournament-scene-actions.ts`: tournament 側の saveWithLevels + 編集ダイアログ state + 関連 invalidation
- pure formatter (`variantLabel`, `formatBlindParts`, `formatAnteSuffix`, `VARIANT_LABELS`) を `game-scene-formatters.ts` utils に分離
- scene-action hooks は `@/utils/optimistic-update.ts` の `invalidateTargets` に統一
- 純粋表示用のサブコンポーネント (`GameSceneShell`, `RingGameDetailsCard`, `TournamentInfoCard`, `ChipPurchasesCard`, `StructureCard`, `TournamentStructureTable`) は同居を継続

これは `apps/web/` 全体の「UI表示とロジックを hooks で分離」方針に揃えるリファクタシリーズの Phase 3。

## Test plan

- [x] `bun x vitest run` で全 569 テスト通過
- [x] `bun x ultracite check` で該当 5 ファイル lint クリア
- [ ] 手動: アクティブセッション画面 (cash game / tournament) で edit ダイアログ開閉→保存→画面反映まで

🤖 Generated with [Claude Code](https://claude.com/claude-code)