### PR TITLE
refactor(web): extract misc hooks from mid-size components

### DIFF
--- a/apps/web/src/live-sessions/components/add-player-sheet.tsx
+++ b/apps/web/src/live-sessions/components/add-player-sheet.tsx
@@ -1,6 +1,5 @@
 import { IconPlus, IconSearch, IconUserQuestion } from "@tabler/icons-react";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import { useDeferredValue, useEffect, useState } from "react";
+import { useAddPlayerSearch } from "@/live-sessions/hooks/use-add-player-search";
 import { ColorBadge } from "@/players/components/color-badge";
 import { PlayerAvatar } from "@/players/components/player-avatar";
 import { PlayerTagInput } from "@/players/components/player-tag-input";
@@ -8,7 +7,6 @@ import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { Input } from "@/shared/components/ui/input";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
-import { trpc } from "@/utils/trpc";
 
 interface TagWithColor {
 	color: string;
@@ -41,32 +39,15 @@ export function AddPlayerSheet({
 	onOpenChange,
 	open,
 }: AddPlayerSheetProps) {
-	const [search, setSearch] = useState("");
-	const [selectedTags, setSelectedTags] = useState<TagWithColor[]>([]);
-
-	useEffect(() => {
-		if (open) {
-			setSearch("");
-			setSelectedTags([]);
-		}
-	}, [open]);
-
-	const deferredSearch = useDeferredValue(search);
-	const selectedTagIds = selectedTags.map((t) => t.id);
-	const queryInput = {
-		...(deferredSearch ? { search: deferredSearch } : {}),
-		...(selectedTagIds.length > 0 ? { tagIds: selectedTagIds } : {}),
-	};
-
-	const playersQuery = useQuery({
-		...trpc.player.list.queryOptions(queryInput),
-		enabled: open,
-		placeholderData: keepPreviousData,
-	});
-
-	const allPlayers = playersQuery.data ?? [];
-	const excludeSet = new Set(excludePlayerIds);
-	const filteredPlayers = allPlayers.filter((p) => !excludeSet.has(p.id));
+	const {
+		search,
+		setSearch,
+		selectedTags,
+		selectedTagIds,
+		addSelectedTag,
+		removeSelectedTag,
+		filteredPlayers,
+	} = useAddPlayerSearch({ excludePlayerIds, open });
 
 	const handleAddExisting = (playerId: string, playerName: string) => {
 		onAddExisting(playerId, playerName);
@@ -115,11 +96,9 @@ export function AddPlayerSheet({
 
 				<PlayerTagInput
 					availableTags={availableTags}
-					onAdd={(tag) => setSelectedTags((prev) => [...prev, tag])}
+					onAdd={addSelectedTag}
 					onCreateTag={onCreateTag}
-					onRemove={(tag) =>
-						setSelectedTags((prev) => prev.filter((t) => t.id !== tag.id))
-					}
+					onRemove={removeSelectedTag}
 					placeholder="Filter by tags..."
 					selectedTags={selectedTags}
 				/>

--- a/apps/web/src/live-sessions/components/assign-tournament-dialog.tsx
+++ b/apps/web/src/live-sessions/components/assign-tournament-dialog.tsx
@@ -1,6 +1,8 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
-import { toast } from "sonner";
+import {
+	type AssignTournamentMode,
+	type TournamentListItem,
+	useAssignTournament,
+} from "@/live-sessions/hooks/use-assign-tournament";
 import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { Field } from "@/shared/components/ui/field";
@@ -14,33 +16,12 @@ import {
 } from "@/shared/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/components/ui/tabs";
 import { TournamentEditDialog } from "@/stores/components/tournament-edit-dialog";
-import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
-import type { TournamentFormValues } from "@/stores/hooks/use-tournaments";
-import { trpc, trpcClient } from "@/utils/trpc";
 
 interface AssignTournamentDialogProps {
 	onOpenChange: (open: boolean) => void;
 	open: boolean;
 	sessionId: string;
 	sessionStoreId: string | null;
-}
-
-type Mode = "existing" | "create";
-
-interface TournamentListItem {
-	id: string;
-	name: string;
-}
-
-function levelsToPayload(levels: BlindLevelRow[]) {
-	return levels.map((l) => ({
-		isBreak: l.isBreak,
-		blind1: l.blind1,
-		blind2: l.blind2,
-		blind3: l.blind3,
-		ante: l.ante,
-		minutes: l.minutes,
-	}));
 }
 
 function StoreSelectField({
@@ -136,140 +117,29 @@ export function AssignTournamentDialog({
 	sessionId,
 	sessionStoreId,
 }: AssignTournamentDialogProps) {
-	const [mode, setMode] = useState<Mode>("existing");
-	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(
-		sessionStoreId ?? undefined
-	);
-	const [selectedTournamentId, setSelectedTournamentId] = useState<
-		string | undefined
-	>(undefined);
-	const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
-	const queryClient = useQueryClient();
-
-	const storesQuery = useQuery({
-		...trpc.store.list.queryOptions(),
-		enabled: open,
+	const {
+		mode,
+		setMode,
+		selectedStoreId,
+		selectedTournamentId,
+		setSelectedTournamentId,
+		isCreateDialogOpen,
+		setIsCreateDialogOpen,
+		stores,
+		tournaments,
+		effectiveStoreId,
+		isAssignPending,
+		isCreatePending,
+		isBusy,
+		handleStoreChange,
+		handleAssign,
+		handleCreate,
+	} = useAssignTournament({
+		onOpenChange,
+		open,
+		sessionId,
+		sessionStoreId,
 	});
-	const stores = storesQuery.data ?? [];
-
-	const effectiveStoreId = sessionStoreId ?? selectedStoreId;
-
-	const tournamentsQuery = useQuery({
-		...trpc.tournament.listByStore.queryOptions({
-			storeId: effectiveStoreId ?? "",
-			includeArchived: false,
-		}),
-		enabled: open && !!effectiveStoreId,
-	});
-	const tournaments = (tournamentsQuery.data ?? []) as TournamentListItem[];
-
-	const invalidateSession = async () => {
-		await Promise.all([
-			queryClient.invalidateQueries({
-				queryKey: trpc.liveTournamentSession.getById.queryOptions({
-					id: sessionId,
-				}).queryKey,
-			}),
-			queryClient.invalidateQueries({
-				queryKey: trpc.liveTournamentSession.list.queryOptions({}).queryKey,
-			}),
-			queryClient.invalidateQueries({
-				queryKey: trpc.session.list.queryOptions({}).queryKey,
-			}),
-		]);
-	};
-
-	const assignMutation = useMutation({
-		mutationFn: (tournamentId: string) =>
-			trpcClient.liveTournamentSession.update.mutate({
-				id: sessionId,
-				tournamentId,
-			}),
-		onSuccess: async () => {
-			await invalidateSession();
-			toast.success("Tournament assigned");
-			onOpenChange(false);
-		},
-		onError: (error) => {
-			toast.error(error.message || "Failed to assign tournament");
-		},
-	});
-
-	const createAndAssignMutation = useMutation({
-		mutationFn: async ({
-			storeId,
-			values,
-			levels,
-		}: {
-			storeId: string;
-			values: TournamentFormValues;
-			levels: BlindLevelRow[];
-		}) => {
-			const created = await trpcClient.tournament.createWithLevels.mutate({
-				storeId,
-				name: values.name,
-				variant: values.variant,
-				buyIn: values.buyIn,
-				entryFee: values.entryFee,
-				startingStack: values.startingStack,
-				bountyAmount: values.bountyAmount,
-				tableSize: values.tableSize,
-				currencyId: values.currencyId,
-				memo: values.memo,
-				tags: values.tags,
-				chipPurchases: values.chipPurchases,
-				blindLevels: levelsToPayload(levels),
-			});
-			await trpcClient.liveTournamentSession.update.mutate({
-				id: sessionId,
-				tournamentId: created.id,
-			});
-			return created;
-		},
-		onSuccess: async () => {
-			await Promise.all([
-				invalidateSession(),
-				queryClient.invalidateQueries({
-					queryKey: trpc.tournament.listByStore.queryOptions({
-						storeId: effectiveStoreId ?? "",
-						includeArchived: false,
-					}).queryKey,
-				}),
-			]);
-			toast.success("Tournament created and assigned");
-			setIsCreateDialogOpen(false);
-			onOpenChange(false);
-		},
-		onError: (error) => {
-			toast.error(error.message || "Failed to create tournament");
-		},
-	});
-
-	const isAssignPending = assignMutation.isPending;
-	const isCreatePending = createAndAssignMutation.isPending;
-	const isBusy = isAssignPending || isCreatePending;
-
-	const handleAssign = () => {
-		if (!selectedTournamentId) {
-			return;
-		}
-		assignMutation.mutate(selectedTournamentId);
-	};
-
-	const handleCreate = async (
-		values: TournamentFormValues,
-		levels: BlindLevelRow[]
-	) => {
-		if (!effectiveStoreId) {
-			toast.error("Select a store first");
-			return;
-		}
-		await createAndAssignMutation.mutateAsync({
-			storeId: effectiveStoreId,
-			values,
-			levels,
-		});
-	};
 
 	const renderExistingTab = () => (
 		<div className="flex flex-col gap-4">
@@ -323,7 +193,7 @@ export function AssignTournamentDialog({
 			>
 				<Tabs
 					className="mb-4"
-					onValueChange={(value) => setMode(value as Mode)}
+					onValueChange={(value) => setMode(value as AssignTournamentMode)}
 					value={mode}
 				>
 					<TabsList className="grid w-full grid-cols-2">
@@ -334,10 +204,7 @@ export function AssignTournamentDialog({
 
 				{sessionStoreId ? null : (
 					<StoreSelectField
-						onChange={(value) => {
-							setSelectedStoreId(value);
-							setSelectedTournamentId(undefined);
-						}}
+						onChange={handleStoreChange}
 						stores={stores}
 						value={selectedStoreId}
 					/>

--- a/apps/web/src/live-sessions/components/session-events-scene.tsx
+++ b/apps/web/src/live-sessions/components/session-events-scene.tsx
@@ -7,6 +7,13 @@ import {
 	useSessionEvents,
 } from "@/live-sessions/hooks/use-session-events";
 import {
+	formatEventLabel,
+	formatPayloadSummary,
+	getTimeBounds,
+	groupEventsForDisplay,
+	LIFECYCLE_EVENTS,
+} from "@/live-sessions/utils/session-events-formatters";
+import {
 	Accordion,
 	AccordionContent,
 	AccordionItem,
@@ -17,24 +24,6 @@ import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 
-const EVENT_TYPE_LABELS: Record<string, string> = {
-	chips_add_remove: "Chips Add/Remove",
-	update_stack: "Stack Update",
-	all_in: "All-in",
-	purchase_chips: "Purchase Chips",
-	update_tournament_info: "Tournament Info",
-	memo: "Memo",
-	session_pause: "Session Pause",
-	session_resume: "Session Resume",
-	session_start: "Session Start",
-	session_end: "Session End",
-	player_join: "Player Join",
-	player_leave: "Player Leave",
-};
-
-// Events that cannot be deleted (lifecycle only)
-const LIFECYCLE_EVENTS = new Set(["session_start", "session_end"]);
-
 type SessionType = "cash_game" | "tournament";
 
 interface SessionEventsSceneProps {
@@ -43,161 +32,6 @@ interface SessionEventsSceneProps {
 	sessionId: string;
 	sessionLoading?: boolean;
 	sessionType: SessionType;
-}
-
-function formatEventLabel(eventType: string) {
-	return EVENT_TYPE_LABELS[eventType] ?? eventType;
-}
-
-function formatChipsAddRemoveSummary(p: Record<string, unknown>) {
-	const amount = typeof p.amount === "number" ? p.amount : null;
-	let type: string | null = null;
-	if (p.type === "add") {
-		type = "Add";
-	} else if (p.type === "remove") {
-		type = "Remove";
-	}
-	if (amount !== null && type !== null) {
-		return `${type}: ${amount.toLocaleString()}`;
-	}
-	return null;
-}
-
-function formatAllInSummary(p: Record<string, unknown>) {
-	const parts: string[] = [];
-	if (typeof p.potSize === "number") {
-		parts.push(`Pot: ${p.potSize.toLocaleString()}`);
-	}
-	if (typeof p.equity === "number") {
-		parts.push(`Equity: ${p.equity}%`);
-	}
-	return parts.length > 0 ? parts.join(" · ") : null;
-}
-
-function formatSessionEndSummary(p: Record<string, unknown>) {
-	if (typeof p.cashOutAmount === "number") {
-		return `Cash-out: ${p.cashOutAmount.toLocaleString()}`;
-	}
-	if (p.beforeDeadline === true) {
-		return "- / - entries";
-	}
-	if (typeof p.placement === "number" && typeof p.totalEntries === "number") {
-		return `#${p.placement} / ${p.totalEntries}`;
-	}
-	if (typeof p.placement === "number") {
-		return `#${p.placement}`;
-	}
-	return null;
-}
-
-function formatPurchaseChipsSummary(p: Record<string, unknown>) {
-	const name = typeof p.name === "string" ? p.name : null;
-	const cost = typeof p.cost === "number" ? p.cost : null;
-	return name !== null && cost !== null
-		? `${name}: ${cost.toLocaleString()}`
-		: null;
-}
-
-function formatUpdateTournamentInfoSummary(p: Record<string, unknown>) {
-	if (typeof p.remainingPlayers === "number") {
-		return `Remaining: ${p.remainingPlayers}`;
-	}
-	if (typeof p.totalEntries === "number") {
-		return `Entries: ${p.totalEntries}`;
-	}
-	return null;
-}
-
-function formatMemoSummary(p: Record<string, unknown>) {
-	if (typeof p.text !== "string") {
-		return null;
-	}
-	const text = p.text.trim();
-	return text.length > 60 ? `${text.slice(0, 60)}…` : text;
-}
-
-type PayloadSummarizer = (p: Record<string, unknown>) => string | null;
-
-const PAYLOAD_SUMMARIZERS: Record<string, PayloadSummarizer> = {
-	chips_add_remove: formatChipsAddRemoveSummary,
-	update_stack: (p) =>
-		typeof p.stackAmount === "number"
-			? `Stack: ${p.stackAmount.toLocaleString()}`
-			: null,
-	all_in: formatAllInSummary,
-	purchase_chips: formatPurchaseChipsSummary,
-	update_tournament_info: formatUpdateTournamentInfoSummary,
-	memo: formatMemoSummary,
-	session_start: (p) => {
-		if (typeof p.buyInAmount === "number") {
-			return `Buy-in: ${p.buyInAmount.toLocaleString()}`;
-		}
-		if (typeof p.timerStartedAt === "number") {
-			const date = new Date(p.timerStartedAt * 1000);
-			const pad = (n: number) => String(n).padStart(2, "0");
-			return `Timer: ${pad(date.getHours())}:${pad(date.getMinutes())}`;
-		}
-		return null;
-	},
-	session_end: formatSessionEndSummary,
-	player_join: (p) => (p.isHero === true ? "Hero" : null),
-	player_leave: (p) => (p.isHero === true ? "Hero" : null),
-};
-
-function formatPayloadSummary(eventType: string, payload: unknown) {
-	if (!payload || typeof payload !== "object") {
-		return null;
-	}
-	const summarizer = PAYLOAD_SUMMARIZERS[eventType];
-	return summarizer ? summarizer(payload as Record<string, unknown>) : null;
-}
-
-function getTimeBounds(
-	events: SessionEvent[],
-	targetId: string
-): { minTime: Date | null; maxTime: Date | null } {
-	const index = events.findIndex((event) => event.id === targetId);
-	const previous = index > 0 ? events[index - 1] : null;
-	const next = index < events.length - 1 ? events[index + 1] : null;
-	return {
-		minTime: previous ? new Date(previous.occurredAt) : null,
-		maxTime: next ? new Date(next.occurredAt) : null,
-	};
-}
-
-type EventGroup =
-	| { type: "single"; event: SessionEvent }
-	| { type: "player_group"; events: SessionEvent[] };
-
-function groupEventsForDisplay(events: SessionEvent[]): EventGroup[] {
-	const groups: EventGroup[] = [];
-	let i = 0;
-	while (i < events.length) {
-		const event = events[i];
-		if (
-			event.eventType === "player_join" ||
-			event.eventType === "player_leave"
-		) {
-			const clusterStart = i;
-			while (
-				i < events.length &&
-				(events[i].eventType === "player_join" ||
-					events[i].eventType === "player_leave")
-			) {
-				i++;
-			}
-			const cluster = events.slice(clusterStart, i);
-			if (cluster.length >= 2) {
-				groups.push({ type: "player_group", events: cluster });
-			} else {
-				groups.push({ type: "single", event: cluster[0] });
-			}
-		} else {
-			groups.push({ type: "single", event });
-			i++;
-		}
-	}
-	return groups;
 }
 
 export function SessionEventsScene({

--- a/apps/web/src/live-sessions/hooks/use-add-player-search.ts
+++ b/apps/web/src/live-sessions/hooks/use-add-player-search.ts
@@ -1,0 +1,62 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useDeferredValue, useEffect, useState } from "react";
+import { trpc } from "@/utils/trpc";
+
+interface TagWithColor {
+	color: string;
+	id: string;
+	name: string;
+}
+
+interface UseAddPlayerSearchArgs {
+	excludePlayerIds: string[];
+	open: boolean;
+}
+
+export function useAddPlayerSearch({
+	excludePlayerIds,
+	open,
+}: UseAddPlayerSearchArgs) {
+	const [search, setSearch] = useState("");
+	const [selectedTags, setSelectedTags] = useState<TagWithColor[]>([]);
+
+	useEffect(() => {
+		if (open) {
+			setSearch("");
+			setSelectedTags([]);
+		}
+	}, [open]);
+
+	const deferredSearch = useDeferredValue(search);
+	const selectedTagIds = selectedTags.map((t) => t.id);
+	const queryInput = {
+		...(deferredSearch ? { search: deferredSearch } : {}),
+		...(selectedTagIds.length > 0 ? { tagIds: selectedTagIds } : {}),
+	};
+
+	const playersQuery = useQuery({
+		...trpc.player.list.queryOptions(queryInput),
+		enabled: open,
+		placeholderData: keepPreviousData,
+	});
+
+	const allPlayers = playersQuery.data ?? [];
+	const excludeSet = new Set(excludePlayerIds);
+	const filteredPlayers = allPlayers.filter((p) => !excludeSet.has(p.id));
+
+	const addSelectedTag = (tag: TagWithColor) =>
+		setSelectedTags((prev) => [...prev, tag]);
+
+	const removeSelectedTag = (tag: TagWithColor) =>
+		setSelectedTags((prev) => prev.filter((t) => t.id !== tag.id));
+
+	return {
+		search,
+		setSearch,
+		selectedTags,
+		selectedTagIds,
+		addSelectedTag,
+		removeSelectedTag,
+		filteredPlayers,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-assign-tournament.ts
+++ b/apps/web/src/live-sessions/hooks/use-assign-tournament.ts
@@ -1,0 +1,198 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+import type { TournamentFormValues } from "@/stores/hooks/use-tournaments";
+import { invalidateTargets } from "@/utils/optimistic-update";
+import { trpc, trpcClient } from "@/utils/trpc";
+
+export type AssignTournamentMode = "existing" | "create";
+
+export interface TournamentListItem {
+	id: string;
+	name: string;
+}
+
+function levelsToPayload(levels: BlindLevelRow[]) {
+	return levels.map((l) => ({
+		isBreak: l.isBreak,
+		blind1: l.blind1,
+		blind2: l.blind2,
+		blind3: l.blind3,
+		ante: l.ante,
+		minutes: l.minutes,
+	}));
+}
+
+interface UseAssignTournamentArgs {
+	onOpenChange: (open: boolean) => void;
+	open: boolean;
+	sessionId: string;
+	sessionStoreId: string | null;
+}
+
+export function useAssignTournament({
+	onOpenChange,
+	open,
+	sessionId,
+	sessionStoreId,
+}: UseAssignTournamentArgs) {
+	const queryClient = useQueryClient();
+	const [mode, setMode] = useState<AssignTournamentMode>("existing");
+	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(
+		sessionStoreId ?? undefined
+	);
+	const [selectedTournamentId, setSelectedTournamentId] = useState<
+		string | undefined
+	>(undefined);
+	const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+
+	const storesQuery = useQuery({
+		...trpc.store.list.queryOptions(),
+		enabled: open,
+	});
+	const stores = storesQuery.data ?? [];
+
+	const effectiveStoreId = sessionStoreId ?? selectedStoreId;
+
+	const tournamentsQuery = useQuery({
+		...trpc.tournament.listByStore.queryOptions({
+			storeId: effectiveStoreId ?? "",
+			includeArchived: false,
+		}),
+		enabled: open && !!effectiveStoreId,
+	});
+	const tournaments = (tournamentsQuery.data ?? []) as TournamentListItem[];
+
+	const invalidateSession = async () => {
+		await invalidateTargets(queryClient, [
+			{
+				queryKey: trpc.liveTournamentSession.getById.queryOptions({
+					id: sessionId,
+				}).queryKey,
+			},
+			{
+				queryKey: trpc.liveTournamentSession.list.queryOptions({}).queryKey,
+			},
+			{ queryKey: trpc.session.list.queryOptions({}).queryKey },
+		]);
+	};
+
+	const assignMutation = useMutation({
+		mutationFn: (tournamentId: string) =>
+			trpcClient.liveTournamentSession.update.mutate({
+				id: sessionId,
+				tournamentId,
+			}),
+		onSuccess: async () => {
+			await invalidateSession();
+			toast.success("Tournament assigned");
+			onOpenChange(false);
+		},
+		onError: (error) => {
+			toast.error(error.message || "Failed to assign tournament");
+		},
+	});
+
+	const createAndAssignMutation = useMutation({
+		mutationFn: async ({
+			storeId,
+			values,
+			levels,
+		}: {
+			storeId: string;
+			values: TournamentFormValues;
+			levels: BlindLevelRow[];
+		}) => {
+			const created = await trpcClient.tournament.createWithLevels.mutate({
+				storeId,
+				name: values.name,
+				variant: values.variant,
+				buyIn: values.buyIn,
+				entryFee: values.entryFee,
+				startingStack: values.startingStack,
+				bountyAmount: values.bountyAmount,
+				tableSize: values.tableSize,
+				currencyId: values.currencyId,
+				memo: values.memo,
+				tags: values.tags,
+				chipPurchases: values.chipPurchases,
+				blindLevels: levelsToPayload(levels),
+			});
+			await trpcClient.liveTournamentSession.update.mutate({
+				id: sessionId,
+				tournamentId: created.id,
+			});
+			return created;
+		},
+		onSuccess: async () => {
+			await Promise.all([
+				invalidateSession(),
+				invalidateTargets(queryClient, [
+					{
+						queryKey: trpc.tournament.listByStore.queryOptions({
+							storeId: effectiveStoreId ?? "",
+							includeArchived: false,
+						}).queryKey,
+					},
+				]),
+			]);
+			toast.success("Tournament created and assigned");
+			setIsCreateDialogOpen(false);
+			onOpenChange(false);
+		},
+		onError: (error) => {
+			toast.error(error.message || "Failed to create tournament");
+		},
+	});
+
+	const isAssignPending = assignMutation.isPending;
+	const isCreatePending = createAndAssignMutation.isPending;
+	const isBusy = isAssignPending || isCreatePending;
+
+	const handleStoreChange = (value: string) => {
+		setSelectedStoreId(value);
+		setSelectedTournamentId(undefined);
+	};
+
+	const handleAssign = () => {
+		if (!selectedTournamentId) {
+			return;
+		}
+		assignMutation.mutate(selectedTournamentId);
+	};
+
+	const handleCreate = async (
+		values: TournamentFormValues,
+		levels: BlindLevelRow[]
+	) => {
+		if (!effectiveStoreId) {
+			toast.error("Select a store first");
+			return;
+		}
+		await createAndAssignMutation.mutateAsync({
+			storeId: effectiveStoreId,
+			values,
+			levels,
+		});
+	};
+
+	return {
+		mode,
+		setMode,
+		selectedStoreId,
+		selectedTournamentId,
+		setSelectedTournamentId,
+		isCreateDialogOpen,
+		setIsCreateDialogOpen,
+		stores,
+		tournaments,
+		effectiveStoreId,
+		isAssignPending,
+		isCreatePending,
+		isBusy,
+		handleStoreChange,
+		handleAssign,
+		handleCreate,
+	};
+}

--- a/apps/web/src/live-sessions/utils/session-events-formatters.ts
+++ b/apps/web/src/live-sessions/utils/session-events-formatters.ts
@@ -1,0 +1,173 @@
+import type { SessionEvent } from "@/live-sessions/hooks/use-session-events";
+
+const EVENT_TYPE_LABELS: Record<string, string> = {
+	chips_add_remove: "Chips Add/Remove",
+	update_stack: "Stack Update",
+	all_in: "All-in",
+	purchase_chips: "Purchase Chips",
+	update_tournament_info: "Tournament Info",
+	memo: "Memo",
+	session_pause: "Session Pause",
+	session_resume: "Session Resume",
+	session_start: "Session Start",
+	session_end: "Session End",
+	player_join: "Player Join",
+	player_leave: "Player Leave",
+};
+
+export const LIFECYCLE_EVENTS = new Set(["session_start", "session_end"]);
+
+export function formatEventLabel(eventType: string) {
+	return EVENT_TYPE_LABELS[eventType] ?? eventType;
+}
+
+function formatChipsAddRemoveSummary(p: Record<string, unknown>) {
+	const amount = typeof p.amount === "number" ? p.amount : null;
+	let type: string | null = null;
+	if (p.type === "add") {
+		type = "Add";
+	} else if (p.type === "remove") {
+		type = "Remove";
+	}
+	if (amount !== null && type !== null) {
+		return `${type}: ${amount.toLocaleString()}`;
+	}
+	return null;
+}
+
+function formatAllInSummary(p: Record<string, unknown>) {
+	const parts: string[] = [];
+	if (typeof p.potSize === "number") {
+		parts.push(`Pot: ${p.potSize.toLocaleString()}`);
+	}
+	if (typeof p.equity === "number") {
+		parts.push(`Equity: ${p.equity}%`);
+	}
+	return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+function formatSessionEndSummary(p: Record<string, unknown>) {
+	if (typeof p.cashOutAmount === "number") {
+		return `Cash-out: ${p.cashOutAmount.toLocaleString()}`;
+	}
+	if (p.beforeDeadline === true) {
+		return "- / - entries";
+	}
+	if (typeof p.placement === "number" && typeof p.totalEntries === "number") {
+		return `#${p.placement} / ${p.totalEntries}`;
+	}
+	if (typeof p.placement === "number") {
+		return `#${p.placement}`;
+	}
+	return null;
+}
+
+function formatPurchaseChipsSummary(p: Record<string, unknown>) {
+	const name = typeof p.name === "string" ? p.name : null;
+	const cost = typeof p.cost === "number" ? p.cost : null;
+	return name !== null && cost !== null
+		? `${name}: ${cost.toLocaleString()}`
+		: null;
+}
+
+function formatUpdateTournamentInfoSummary(p: Record<string, unknown>) {
+	if (typeof p.remainingPlayers === "number") {
+		return `Remaining: ${p.remainingPlayers}`;
+	}
+	if (typeof p.totalEntries === "number") {
+		return `Entries: ${p.totalEntries}`;
+	}
+	return null;
+}
+
+function formatMemoSummary(p: Record<string, unknown>) {
+	if (typeof p.text !== "string") {
+		return null;
+	}
+	const text = p.text.trim();
+	return text.length > 60 ? `${text.slice(0, 60)}…` : text;
+}
+
+type PayloadSummarizer = (p: Record<string, unknown>) => string | null;
+
+const PAYLOAD_SUMMARIZERS: Record<string, PayloadSummarizer> = {
+	chips_add_remove: formatChipsAddRemoveSummary,
+	update_stack: (p) =>
+		typeof p.stackAmount === "number"
+			? `Stack: ${p.stackAmount.toLocaleString()}`
+			: null,
+	all_in: formatAllInSummary,
+	purchase_chips: formatPurchaseChipsSummary,
+	update_tournament_info: formatUpdateTournamentInfoSummary,
+	memo: formatMemoSummary,
+	session_start: (p) => {
+		if (typeof p.buyInAmount === "number") {
+			return `Buy-in: ${p.buyInAmount.toLocaleString()}`;
+		}
+		if (typeof p.timerStartedAt === "number") {
+			const date = new Date(p.timerStartedAt * 1000);
+			const pad = (n: number) => String(n).padStart(2, "0");
+			return `Timer: ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+		}
+		return null;
+	},
+	session_end: formatSessionEndSummary,
+	player_join: (p) => (p.isHero === true ? "Hero" : null),
+	player_leave: (p) => (p.isHero === true ? "Hero" : null),
+};
+
+export function formatPayloadSummary(eventType: string, payload: unknown) {
+	if (!payload || typeof payload !== "object") {
+		return null;
+	}
+	const summarizer = PAYLOAD_SUMMARIZERS[eventType];
+	return summarizer ? summarizer(payload as Record<string, unknown>) : null;
+}
+
+export function getTimeBounds(
+	events: SessionEvent[],
+	targetId: string
+): { minTime: Date | null; maxTime: Date | null } {
+	const index = events.findIndex((event) => event.id === targetId);
+	const previous = index > 0 ? events[index - 1] : null;
+	const next = index < events.length - 1 ? events[index + 1] : null;
+	return {
+		minTime: previous ? new Date(previous.occurredAt) : null,
+		maxTime: next ? new Date(next.occurredAt) : null,
+	};
+}
+
+export type EventGroup =
+	| { type: "single"; event: SessionEvent }
+	| { type: "player_group"; events: SessionEvent[] };
+
+export function groupEventsForDisplay(events: SessionEvent[]): EventGroup[] {
+	const groups: EventGroup[] = [];
+	let i = 0;
+	while (i < events.length) {
+		const event = events[i];
+		if (
+			event.eventType === "player_join" ||
+			event.eventType === "player_leave"
+		) {
+			const clusterStart = i;
+			while (
+				i < events.length &&
+				(events[i].eventType === "player_join" ||
+					events[i].eventType === "player_leave")
+			) {
+				i++;
+			}
+			const cluster = events.slice(clusterStart, i);
+			if (cluster.length >= 2) {
+				groups.push({ type: "player_group", events: cluster });
+			} else {
+				groups.push({ type: "single", event: cluster[0] });
+			}
+		} else {
+			groups.push({ type: "single", event });
+			i++;
+		}
+	}
+	return groups;
+}

--- a/apps/web/src/shared/components/sign-in-form.tsx
+++ b/apps/web/src/shared/components/sign-in-form.tsx
@@ -1,9 +1,4 @@
-import { useForm } from "@tanstack/react-form";
-import { useNavigate } from "@tanstack/react-router";
-import { toast } from "sonner";
-import z from "zod";
-
-import { authClient } from "@/lib/auth-client";
+import { useSignIn } from "@/shared/hooks/use-sign-in";
 import { AuthFormShell, authSubmitLabels } from "./auth-form-shell";
 import { DiscordIcon } from "./icons/discord";
 import { GoogleIcon } from "./icons/google";
@@ -17,44 +12,10 @@ export default function SignInForm({
 }: {
 	onSwitchToSignUp: () => void;
 }) {
-	const navigate = useNavigate({
-		from: "/",
-	});
-	const { isPending } = authClient.useSession();
+	const { form, isSessionPending, signInWithGoogle, signInWithDiscord } =
+		useSignIn();
 
-	const form = useForm({
-		defaultValues: {
-			email: "",
-			password: "",
-		},
-		onSubmit: async ({ value }) => {
-			await authClient.signIn.email(
-				{
-					email: value.email,
-					password: value.password,
-				},
-				{
-					onSuccess: () => {
-						navigate({
-							to: "/dashboard",
-						});
-						toast.success("Sign in successful");
-					},
-					onError: (error) => {
-						toast.error(error.error.message || error.error.statusText);
-					},
-				}
-			);
-		},
-		validators: {
-			onSubmit: z.object({
-				email: z.email("Invalid email address"),
-				password: z.string().min(8, "Password must be at least 8 characters"),
-			}),
-		},
-	});
-
-	if (isPending) {
+	if (isSessionPending) {
 		return <Loader />;
 	}
 
@@ -62,28 +23,12 @@ export default function SignInForm({
 		{
 			label: "Sign in with Google",
 			icon: <GoogleIcon className="mr-2 h-4 w-4" />,
-			onClick: async () => {
-				const result = await authClient.signIn.social({
-					provider: "google",
-					callbackURL: `${window.location.origin}/dashboard`,
-				});
-				if (result.error) {
-					toast.error(result.error.message || "Google sign in unavailable");
-				}
-			},
+			onClick: signInWithGoogle,
 		},
 		{
 			label: "Sign in with Discord",
 			icon: <DiscordIcon className="mr-2 h-4 w-4" />,
-			onClick: async () => {
-				const result = await authClient.signIn.social({
-					provider: "discord",
-					callbackURL: `${window.location.origin}/dashboard`,
-				});
-				if (result.error) {
-					toast.error(result.error.message || "Discord sign in unavailable");
-				}
-			},
+			onClick: signInWithDiscord,
 		},
 	];
 

--- a/apps/web/src/shared/hooks/use-sign-in.ts
+++ b/apps/web/src/shared/hooks/use-sign-in.ts
@@ -1,0 +1,69 @@
+import { useForm } from "@tanstack/react-form";
+import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
+import z from "zod";
+import { authClient } from "@/lib/auth-client";
+
+const signInSchema = z.object({
+	email: z.email("Invalid email address"),
+	password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+export function useSignIn() {
+	const navigate = useNavigate({ from: "/" });
+	const { isPending } = authClient.useSession();
+
+	const form = useForm({
+		defaultValues: {
+			email: "",
+			password: "",
+		},
+		onSubmit: async ({ value }) => {
+			await authClient.signIn.email(
+				{
+					email: value.email,
+					password: value.password,
+				},
+				{
+					onSuccess: () => {
+						navigate({ to: "/dashboard" });
+						toast.success("Sign in successful");
+					},
+					onError: (error) => {
+						toast.error(error.error.message || error.error.statusText);
+					},
+				}
+			);
+		},
+		validators: {
+			onSubmit: signInSchema,
+		},
+	});
+
+	const signInWithGoogle = async () => {
+		const result = await authClient.signIn.social({
+			provider: "google",
+			callbackURL: `${window.location.origin}/dashboard`,
+		});
+		if (result.error) {
+			toast.error(result.error.message || "Google sign in unavailable");
+		}
+	};
+
+	const signInWithDiscord = async () => {
+		const result = await authClient.signIn.social({
+			provider: "discord",
+			callbackURL: `${window.location.origin}/dashboard`,
+		});
+		if (result.error) {
+			toast.error(result.error.message || "Discord sign in unavailable");
+		}
+	};
+
+	return {
+		form,
+		isSessionPending: isPending,
+		signInWithGoogle,
+		signInWithDiscord,
+	};
+}


### PR DESCRIPTION
## Summary

`apps/web/` 全体の「UI表示とロジックを hooks で分離」方針に揃えるリファクタシリーズの Phase 4。中規模コンポーネントから hook / utils を切り出す:

- `use-sign-in` (shared): TanStack Form + `authClient` + toast を `sign-in-form.tsx` から分離
- `use-add-player-search` (live-sessions): `useQuery` + `useDeferredValue` + フィルタ/リセット状態を `add-player-sheet.tsx` から分離
- `use-assign-tournament` (live-sessions): `useMutation` + `useQuery` + ダイアログ状態 + create-and-assign フローを `assign-tournament-dialog.tsx` から分離
- `session-events-formatters` (live-sessions utils): pure formatter / payload summarizer / time bounds / event grouping を `session-events-scene.tsx` から分離

`use-assign-tournament` は `@/utils/optimistic-update.ts` の `invalidateTargets` に統一。

**対象外:**
- `session-card.tsx`: pure helper はすでに module-level 関数として整理済みでロジック/UI 混在ではないと判断

## Test plan

- [x] `bun x vitest run` で全 569 テスト通過
- [x] `bun x ultracite check` で該当 8 ファイル lint クリア
- [ ] 手動: sign-in フォーム / add-player シート / assign-tournament ダイアログ / session-events 画面それぞれの golden path

🤖 Generated with [Claude Code](https://claude.com/claude-code)