### PR TITLE
docs: add UI/Logic Separation (MANDATORY) rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,18 @@ TypeScript (strict mode): Follow standard conventions
 - Attach validation via `validators.onSubmit: zodSchema` (and/or `onChange` per-field). Keep the schema close to the form.
 - **Number inputs must not use `type="number"`.** Keep inputs as `type="text"` + `inputMode="numeric"`, store the raw string in form state, and validate/convert via Zod. `type="number"` has inconsistent cross-browser behavior (scroll-to-change, locale handling, allowed characters) and hides errors behind silent coercion.
 - Use helpers from `@/shared/lib/form-fields` (`requiredNumericString`, `optionalNumericString`, `parseOptionalInt`, etc.) to keep numeric validation uniform.
-- Reference implementations: `apps/web/src/shared/components/sign-in-form.tsx`, `apps/web/src/players/components/player-form.tsx`, `apps/web/src/live-sessions/components/event-editors/update-stack-editor.tsx`.
+- Reference implementations: `apps/web/src/shared/hooks/use-sign-in.ts`, `apps/web/src/players/components/player-form.tsx`, `apps/web/src/live-sessions/components/event-editors/update-stack-editor.tsx`.
+
+## UI/Logic Separation (MANDATORY)
+
+**All non-trivial logic in `apps/web` MUST live in a custom hook, so components stay Props-driven presentational views.**
+
+- **File layout:** React hooks go in `apps/web/src/<feature>/hooks/use-*.ts` (or `.tsx` when JSX is returned). Pure helpers, constants, and types go in `apps/web/src/<feature>/utils/*.ts`. Never colocate `useQuery`/`useMutation`/complex `useState`+`useEffect` chains inside a component file.
+- **Component responsibility:** Components receive data and handlers from a hook via destructuring and render JSX. Do **not** call `useQueryClient` in a component — keep it inside the hook. Derived values (filters, sorts, aggregates, view-model shaping) belong in the hook, not in JSX.
+- **Hook return shape:** Return `{ data系, is*Pending, on*Handler }`. Reference: [use-players.ts](apps/web/src/players/hooks/use-players.ts) + [routes/players/index.tsx](apps/web/src/routes/players/index.tsx), [use-currencies.ts](apps/web/src/currencies/hooks/use-currencies.ts), [use-cash-game-session.ts](apps/web/src/live-sessions/hooks/use-cash-game-session.ts).
+- **Optimistic updates / invalidation:** Use the shared helpers in [apps/web/src/utils/optimistic-update.ts](apps/web/src/utils/optimistic-update.ts) (`snapshotQuery`, `snapshotQueries`, `restoreSnapshots`, `cancelTargets`, `invalidateTargets`). Do not hand-roll chains of `queryClient.invalidateQueries(...)` / `setQueryData(...)` inside components.
+- **Forms:** The `useForm` call from `@tanstack/react-form` lives in a hook. The component receives `form` and renders `<form.Field>` / `<form.Subscribe>` only. Satisfies the Forms (MANDATORY) rule above.
+- **Acceptable colocation:** Purely presentational subcomponents (`DetailRow`, `XxxCard`, etc.) may stay in the same file. Pure helper functions that are already module-level (not inside the component body) need not be moved to `utils/` unless they grow or become shared.
+- **Reference refactor series (2026-04-21):** PRs [#207](https://github.com/HIRO15254/sapphire2/pull/207) session-form, [#208](https://github.com/HIRO15254/sapphire2/pull/208) seat-from-screenshot, [#209](https://github.com/HIRO15254/sapphire2/pull/209) active-session-game-scene, [#210](https://github.com/HIRO15254/sapphire2/pull/210) misc (sign-in / add-player / assign-tournament / session-events).
 
 <!-- MANUAL ADDITIONS END -->


### PR DESCRIPTION
## Summary

PR #207–#210 で確立した「UI 表示とロジックを hooks に分離する」ルールを、リポジトリに checkin された `CLAUDE.md` に MANDATORY セクションとして追加。

従来はローカルの auto-memory (`~/.claude/projects/.../memory/`) にだけ保存していたが、クラウドセッションやチームメンバーからも参照できるよう `CLAUDE.md` に昇格する。

## 内容

- ファイル配置 (`hooks/` vs `utils/`)
- コンポーネントの責務 (`useQueryClient` はコンポーネント外)
- hook の戻り値形 (`{ data系, is*Pending, on*Handler }`)
- `@/utils/optimistic-update.ts` 共通ヘルパーの使用
- `@tanstack/react-form` の hook 化（Forms MANDATORY と両立）
- 許容される同居パターン
- リファレンス実装へのリンク & リファクタシリーズの履歴

加えて Forms セクションのリファレンスを `sign-in-form.tsx` → `use-sign-in.ts` に更新（PR #210 で useForm が hook に移った）。

## Test plan

- [x] ドキュメントのみの変更、コード変更なし
- [x] lint-staged で `bun x ultracite fix` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)