### PR TITLE
refactor(web): extract shared P&L / date / elapsed-time formatters

### DIFF
--- a/apps/web/src/currencies/components/transaction-list.tsx
+++ b/apps/web/src/currencies/components/transaction-list.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/shared/components/management/expandable-item-list";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
-import { createGroupFormatter } from "@/utils/format-number";
+import { createGroupFormatter, formatYmdSlash } from "@/utils/format-number";
 
 interface Transaction {
 	amount: number;
@@ -58,8 +58,7 @@ export function TransactionList({
 					const amountDisplay = isPositive
 						? `+${fmt(tx.amount)}`
 						: fmt(tx.amount);
-					const txDate = new Date(tx.transactedAt);
-					const dateDisplay = `${txDate.getFullYear()}/${String(txDate.getMonth() + 1).padStart(2, "0")}/${String(txDate.getDate()).padStart(2, "0")}`;
+					const dateDisplay = formatYmdSlash(new Date(tx.transactedAt));
 					const isSessionGenerated = !!tx.sessionId;
 					const isConfirmingDelete = confirmingDeleteId === tx.id;
 

--- a/apps/web/src/dashboard/widgets/active-session-widget.tsx
+++ b/apps/web/src/dashboard/widgets/active-session-widget.tsx
@@ -1,7 +1,7 @@
 import { IconBolt, IconPokerChip, IconTrophy } from "@tabler/icons-react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type {
 	WidgetEditProps,
 	WidgetRenderProps,
@@ -10,6 +10,7 @@ import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Label } from "@/shared/components/ui/label";
 import { Skeleton } from "@/shared/components/ui/skeleton";
+import { useElapsedTime } from "@/shared/hooks/use-elapsed-time";
 import { formatCompactNumber } from "@/utils/format-number";
 import { trpc } from "@/utils/trpc";
 
@@ -27,35 +28,56 @@ function parseConfig(raw: Record<string, unknown>): ParsedConfig {
 	return { sessionType };
 }
 
-function formatElapsed(startedAt: string | Date | null): string {
-	if (!startedAt) {
-		return "—";
-	}
-	const start = typeof startedAt === "string" ? new Date(startedAt) : startedAt;
-	const diffMs = Date.now() - start.getTime();
-	if (diffMs < 0) {
-		return "—";
-	}
-	const totalMinutes = Math.floor(diffMs / 60_000);
-	const hours = Math.floor(totalMinutes / 60);
-	const minutes = totalMinutes % 60;
-	if (hours === 0) {
-		return `${minutes}m`;
-	}
-	return `${hours}h ${minutes}m`;
+interface ActiveSessionRowProps {
+	latestStackAmount: number | null;
+	name: string;
+	sessionId: string;
+	sessionType: "cash-game" | "tournament";
+	startedAt: string | Date | null;
 }
 
-function useTicker(intervalMs = 30_000): void {
-	const [, setTick] = useState(0);
-	useEffect(() => {
-		const id = setInterval(() => setTick((t) => t + 1), intervalMs);
-		return () => clearInterval(id);
-	}, [intervalMs]);
+function ActiveSessionRow({
+	sessionType,
+	sessionId,
+	name,
+	startedAt,
+	latestStackAmount,
+}: ActiveSessionRowProps) {
+	const elapsed = useElapsedTime(startedAt, 30_000);
+	return (
+		<Link
+			className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-accent"
+			params={{ sessionType, sessionId }}
+			to="/live-sessions/$sessionType/$sessionId/events"
+		>
+			<div className="flex min-w-0 items-center gap-2">
+				{sessionType === "tournament" ? (
+					<IconTrophy
+						className="shrink-0 text-yellow-500 dark:text-yellow-400"
+						size={14}
+					/>
+				) : (
+					<IconPokerChip
+						className="shrink-0 text-blue-500 dark:text-blue-400"
+						size={14}
+					/>
+				)}
+				<div className="flex min-w-0 flex-col">
+					<span className="truncate font-medium text-sm">{name}</span>
+					<span className="text-muted-foreground text-xs">{elapsed}</span>
+				</div>
+			</div>
+			<span className="shrink-0 font-semibold text-sm">
+				{latestStackAmount === null
+					? "—"
+					: formatCompactNumber(latestStackAmount)}
+			</span>
+		</Link>
+	);
 }
 
 export function ActiveSessionWidget({ config }: WidgetRenderProps) {
 	const parsed = parseConfig(config);
-	useTicker();
 
 	const cashQuery = useQuery({
 		...trpc.liveCashGameSession.list.queryOptions({
@@ -107,66 +129,24 @@ export function ActiveSessionWidget({ config }: WidgetRenderProps) {
 	return (
 		<div className="flex h-full flex-col gap-1 overflow-auto p-2">
 			{cashItems.map((item) => (
-				<Link
-					className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-accent"
+				<ActiveSessionRow
 					key={item.id}
-					params={{
-						sessionType: "cash-game",
-						sessionId: item.id,
-					}}
-					to="/live-sessions/$sessionType/$sessionId/events"
-				>
-					<div className="flex min-w-0 items-center gap-2">
-						<IconPokerChip
-							className="shrink-0 text-blue-500 dark:text-blue-400"
-							size={14}
-						/>
-						<div className="flex min-w-0 flex-col">
-							<span className="truncate font-medium text-sm">
-								{item.ringGameName ?? "Cash Game"}
-							</span>
-							<span className="text-muted-foreground text-xs">
-								{formatElapsed(item.startedAt)}
-							</span>
-						</div>
-					</div>
-					<span className="shrink-0 font-semibold text-sm">
-						{item.latestStackAmount === null
-							? "—"
-							: formatCompactNumber(item.latestStackAmount)}
-					</span>
-				</Link>
+					latestStackAmount={item.latestStackAmount}
+					name={item.ringGameName ?? "Cash Game"}
+					sessionId={item.id}
+					sessionType="cash-game"
+					startedAt={item.startedAt}
+				/>
 			))}
 			{tournamentItems.map((item) => (
-				<Link
-					className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-accent"
+				<ActiveSessionRow
 					key={item.id}
-					params={{
-						sessionType: "tournament",
-						sessionId: item.id,
-					}}
-					to="/live-sessions/$sessionType/$sessionId/events"
-				>
-					<div className="flex min-w-0 items-center gap-2">
-						<IconTrophy
-							className="shrink-0 text-yellow-500 dark:text-yellow-400"
-							size={14}
-						/>
-						<div className="flex min-w-0 flex-col">
-							<span className="truncate font-medium text-sm">
-								{item.tournamentName ?? "Tournament"}
-							</span>
-							<span className="text-muted-foreground text-xs">
-								{formatElapsed(item.startedAt)}
-							</span>
-						</div>
-					</div>
-					<span className="shrink-0 font-semibold text-sm">
-						{item.latestStackAmount === null
-							? "—"
-							: formatCompactNumber(item.latestStackAmount)}
-					</span>
-				</Link>
+					latestStackAmount={item.latestStackAmount}
+					name={item.tournamentName ?? "Tournament"}
+					sessionId={item.id}
+					sessionType="tournament"
+					startedAt={item.startedAt}
+				/>
 			))}
 		</div>
 	);

--- a/apps/web/src/dashboard/widgets/currency-balance-widget.tsx
+++ b/apps/web/src/dashboard/widgets/currency-balance-widget.tsx
@@ -10,6 +10,7 @@ import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Label } from "@/shared/components/ui/label";
 import { Skeleton } from "@/shared/components/ui/skeleton";
 import { formatCompactNumber } from "@/utils/format-number";
+import { profitLossColorClass } from "@/utils/format-profit-loss";
 import { trpc } from "@/utils/trpc";
 
 interface ParsedConfig {
@@ -19,13 +20,6 @@ interface ParsedConfig {
 function parseConfig(raw: Record<string, unknown>): ParsedConfig {
 	const currencyId = typeof raw.currencyId === "string" ? raw.currencyId : null;
 	return { currencyId };
-}
-
-function balanceColor(value: number): string {
-	if (value === 0) {
-		return "text-foreground";
-	}
-	return value > 0 ? "text-green-600" : "text-red-600";
 }
 
 export function CurrencyBalanceWidget({ config }: WidgetRenderProps) {
@@ -70,7 +64,7 @@ export function CurrencyBalanceWidget({ config }: WidgetRenderProps) {
 				<span className="truncate">{selected.name}</span>
 			</div>
 			<div
-				className={`font-semibold text-xl tabular-nums ${balanceColor(balance)}`}
+				className={`font-semibold text-xl tabular-nums ${profitLossColorClass(balance)}`}
 			>
 				{formatCompactNumber(balance)}
 				{selected.unit ? (

--- a/apps/web/src/dashboard/widgets/recent-sessions-widget.tsx
+++ b/apps/web/src/dashboard/widgets/recent-sessions-widget.tsx
@@ -10,7 +10,11 @@ import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Label } from "@/shared/components/ui/label";
 import { Skeleton } from "@/shared/components/ui/skeleton";
-import { formatCompactNumber } from "@/utils/format-number";
+import { formatYmdSlash } from "@/utils/format-number";
+import {
+	formatProfitLoss,
+	profitLossColorClass,
+} from "@/utils/format-profit-loss";
 import { trpc } from "@/utils/trpc";
 
 type TypeFilter = "all" | "cash_game" | "tournament";
@@ -30,29 +34,6 @@ function parseConfig(raw: Record<string, unknown>): ParsedConfig {
 			? (raw.type as TypeFilter)
 			: ("all" as TypeFilter);
 	return { limit, type };
-}
-
-function formatPL(value: number | null): string {
-	if (value === null) {
-		return "—";
-	}
-	const sign = value >= 0 ? "+" : "";
-	return `${sign}${formatCompactNumber(value)}`;
-}
-
-function plColor(value: number | null): string {
-	if (value === null || value === 0) {
-		return "text-foreground";
-	}
-	return value > 0 ? "text-green-600" : "text-red-600";
-}
-
-function formatDate(date: string | Date): string {
-	const d = typeof date === "string" ? new Date(date) : date;
-	const y = d.getFullYear();
-	const m = String(d.getMonth() + 1).padStart(2, "0");
-	const day = String(d.getDate()).padStart(2, "0");
-	return `${y}/${m}/${day}`;
 }
 
 export function RecentSessionsWidget({ config }: WidgetRenderProps) {
@@ -110,14 +91,14 @@ export function RecentSessionsWidget({ config }: WidgetRenderProps) {
 							<div className="flex min-w-0 flex-col">
 								<span className="truncate font-medium text-sm">{name}</span>
 								<span className="text-muted-foreground text-xs">
-									{formatDate(session.sessionDate)}
+									{formatYmdSlash(session.sessionDate)}
 								</span>
 							</div>
 						</div>
 						<span
-							className={`shrink-0 font-semibold text-sm ${plColor(session.profitLoss)}`}
+							className={`shrink-0 font-semibold text-sm ${profitLossColorClass(session.profitLoss)}`}
 						>
-							{formatPL(session.profitLoss)}
+							{formatProfitLoss(session.profitLoss)}
 						</span>
 					</Link>
 				);

--- a/apps/web/src/dashboard/widgets/summary-stats-widget.tsx
+++ b/apps/web/src/dashboard/widgets/summary-stats-widget.tsx
@@ -8,7 +8,10 @@ import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Label } from "@/shared/components/ui/label";
 import { Skeleton } from "@/shared/components/ui/skeleton";
-import { formatCompactNumber } from "@/utils/format-number";
+import {
+	formatProfitLoss,
+	profitLossColorClass,
+} from "@/utils/format-profit-loss";
 import { trpc } from "@/utils/trpc";
 
 type StatsType = "all" | "cash_game" | "tournament";
@@ -61,13 +64,6 @@ function parseConfig(raw: Record<string, unknown>): ParsedConfig {
 	};
 }
 
-function plColorClass(value: number | null | undefined): string {
-	if (value === null || value === undefined || value === 0) {
-		return "";
-	}
-	return value > 0 ? "text-green-600" : "text-red-600";
-}
-
 function formatMetricValue(
 	key: MetricKey,
 	summary: {
@@ -82,33 +78,20 @@ function formatMetricValue(
 	switch (key) {
 		case "totalSessions":
 			return summary.totalSessions.toString();
-		case "totalProfitLoss": {
-			const sign = summary.totalProfitLoss >= 0 ? "+" : "";
-			return `${sign}${formatCompactNumber(summary.totalProfitLoss)}`;
-		}
+		case "totalProfitLoss":
+			return formatProfitLoss(summary.totalProfitLoss);
 		case "winRate":
 			return `${summary.winRate.toFixed(1)}%`;
-		case "avgProfitLoss": {
-			if (summary.avgProfitLoss === null) {
-				return "—";
-			}
-			const sign = summary.avgProfitLoss >= 0 ? "+" : "";
-			return `${sign}${formatCompactNumber(Math.round(summary.avgProfitLoss))}`;
-		}
-		case "totalEvProfitLoss": {
-			if (summary.totalEvProfitLoss === null) {
-				return "—";
-			}
-			const sign = summary.totalEvProfitLoss >= 0 ? "+" : "";
-			return `${sign}${formatCompactNumber(summary.totalEvProfitLoss)}`;
-		}
-		case "totalEvDiff": {
-			if (summary.totalEvDiff === null) {
-				return "—";
-			}
-			const sign = summary.totalEvDiff >= 0 ? "+" : "";
-			return `${sign}${formatCompactNumber(summary.totalEvDiff)}`;
-		}
+		case "avgProfitLoss":
+			return formatProfitLoss(
+				summary.avgProfitLoss === null
+					? null
+					: Math.round(summary.avgProfitLoss)
+			);
+		case "totalEvProfitLoss":
+			return formatProfitLoss(summary.totalEvProfitLoss);
+		case "totalEvDiff":
+			return formatProfitLoss(summary.totalEvDiff);
 		default:
 			return "—";
 	}
@@ -125,13 +108,13 @@ function metricColor(
 ): string {
 	switch (key) {
 		case "totalProfitLoss":
-			return plColorClass(summary.totalProfitLoss);
+			return profitLossColorClass(summary.totalProfitLoss);
 		case "avgProfitLoss":
-			return plColorClass(summary.avgProfitLoss);
+			return profitLossColorClass(summary.avgProfitLoss);
 		case "totalEvProfitLoss":
-			return plColorClass(summary.totalEvProfitLoss);
+			return profitLossColorClass(summary.totalEvProfitLoss);
 		case "totalEvDiff":
-			return plColorClass(summary.totalEvDiff);
+			return profitLossColorClass(summary.totalEvDiff);
 		default:
 			return "";
 	}

--- a/apps/web/src/live-sessions/components/session-summary.tsx
+++ b/apps/web/src/live-sessions/components/session-summary.tsx
@@ -1,6 +1,10 @@
 import { cn } from "@/lib/utils";
 import { Card, CardContent } from "@/shared/components/ui/card";
 import { formatCompactNumber } from "@/utils/format-number";
+import {
+	formatProfitLoss,
+	profitLossColorClass,
+} from "@/utils/format-profit-loss";
 
 interface SessionSummaryProps {
 	summary: {
@@ -13,16 +17,6 @@ interface SessionSummaryProps {
 		minStack: number | null;
 		currentStack: number | null;
 	};
-}
-
-function plColorClass(value: number): string {
-	if (value > 0) {
-		return "text-green-600 dark:text-green-400";
-	}
-	if (value < 0) {
-		return "text-red-600 dark:text-red-400";
-	}
-	return "";
 }
 
 function StatCard({
@@ -42,11 +36,6 @@ function StatCard({
 			</CardContent>
 		</Card>
 	);
-}
-
-function formatPl(value: number): string {
-	const sign = value >= 0 ? "+" : "";
-	return `${sign}${formatCompactNumber(value)}`;
 }
 
 export function SessionSummary({ summary }: SessionSummaryProps) {
@@ -70,10 +59,14 @@ export function SessionSummary({ summary }: SessionSummaryProps) {
 				colorClass={
 					summary.profitLoss === null
 						? undefined
-						: plColorClass(summary.profitLoss)
+						: profitLossColorClass(summary.profitLoss)
 				}
 				label="P&L"
-				value={summary.profitLoss === null ? "-" : formatPl(summary.profitLoss)}
+				value={
+					summary.profitLoss === null
+						? "-"
+						: formatProfitLoss(summary.profitLoss)
+				}
 			/>
 
 			{summary.evCashOut !== null && (

--- a/apps/web/src/routes/active-session/index.tsx
+++ b/apps/web/src/routes/active-session/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { cn } from "@/lib/utils";
 import {
 	ActiveSessionScene,
@@ -13,50 +13,16 @@ import { useCashGameSession } from "@/live-sessions/hooks/use-cash-game-session"
 import { useTournamentSession } from "@/live-sessions/hooks/use-tournament-session";
 import type { TournamentBlindLevel } from "@/live-sessions/utils/tournament-timer";
 import { EmptyState } from "@/shared/components/ui/empty-state";
+import { useElapsedTime } from "@/shared/hooks/use-elapsed-time";
 import { formatCompactNumber } from "@/utils/format-number";
+import {
+	formatProfitLoss,
+	profitLossColorClass,
+} from "@/utils/format-profit-loss";
 
 export const Route = createFileRoute("/active-session/")({
 	component: ActiveSessionPage,
 });
-
-function plColorClass(value: number): string {
-	if (value > 0) {
-		return "text-green-600 dark:text-green-400";
-	}
-	if (value < 0) {
-		return "text-red-600 dark:text-red-400";
-	}
-	return "";
-}
-
-function formatPl(value: number): string {
-	const sign = value >= 0 ? "+" : "";
-	return `${sign}${formatCompactNumber(value)}`;
-}
-
-function formatDuration(startedAt: Date | string | number): string {
-	const start = new Date(startedAt);
-	const elapsed = Math.floor((Date.now() - start.getTime()) / 60_000);
-	const hours = Math.floor(elapsed / 60);
-	const minutes = elapsed % 60;
-	if (hours > 0) {
-		return `${hours}h ${minutes}m`;
-	}
-	return `${minutes}m`;
-}
-
-function useSessionDuration(startedAt: Date | string | number): string {
-	const [duration, setDuration] = useState(() => formatDuration(startedAt));
-
-	useEffect(() => {
-		const id = setInterval(() => {
-			setDuration(formatDuration(startedAt));
-		}, 60_000);
-		return () => clearInterval(id);
-	}, [startedAt]);
-
-	return duration;
-}
 
 function CashGameCompactSummary({
 	summary,
@@ -68,7 +34,7 @@ function CashGameCompactSummary({
 		totalBuyIn: number;
 	};
 }) {
-	const duration = useSessionDuration(summary.startedAt);
+	const duration = useElapsedTime(summary.startedAt);
 
 	// Use currentStack-based running P&L during the active session.
 	// profitLoss (from cashOut) is only available at session end.
@@ -101,14 +67,14 @@ function CashGameCompactSummary({
 				<p
 					className={cn(
 						"font-semibold",
-						displayPL === null ? undefined : plColorClass(displayPL)
+						displayPL === null ? undefined : profitLossColorClass(displayPL)
 					)}
 				>
-					{displayPL === null ? "-" : formatPl(displayPL)}
+					{displayPL === null ? "-" : formatProfitLoss(displayPL)}
 				</p>
 				{showEvPL ? (
-					<p className={cn("text-xs", plColorClass(evPL))}>
-						EV: {formatPl(evPL)}
+					<p className={cn("text-xs", profitLossColorClass(evPL))}>
+						EV: {formatProfitLoss(evPL)}
 					</p>
 				) : null}
 			</div>
@@ -126,7 +92,7 @@ function TournamentCompactSummary({
 		totalEntries: number | null;
 	};
 }) {
-	const duration = useSessionDuration(summary.startedAt);
+	const duration = useElapsedTime(summary.startedAt);
 	const fieldEntry =
 		summary.remainingPlayers === null && summary.totalEntries === null
 			? "-"

--- a/apps/web/src/sessions/components/session-card.tsx
+++ b/apps/web/src/sessions/components/session-card.tsx
@@ -15,7 +15,11 @@ import { shareSession } from "@/sessions/utils/share-session";
 import { EntityListItem } from "@/shared/components/management/entity-list-item";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
-import { formatCompactNumber } from "@/utils/format-number";
+import { formatCompactNumber, formatYmdSlash } from "@/utils/format-number";
+import {
+	formatProfitLoss,
+	profitLossColorClass,
+} from "@/utils/format-profit-loss";
 
 interface SessionCardProps {
 	bbBiMode?: boolean;
@@ -63,14 +67,6 @@ interface SessionCardProps {
 	};
 }
 
-function formatSessionDate(date: string): string {
-	const d = new Date(date);
-	const y = d.getFullYear();
-	const m = String(d.getMonth() + 1).padStart(2, "0");
-	const day = String(d.getDate()).padStart(2, "0");
-	return `${y}/${m}/${day}`;
-}
-
 function getGameName(session: SessionCardProps["session"]): string {
 	if (session.type === "tournament" && session.tournamentName) {
 		return session.tournamentName;
@@ -79,18 +75,6 @@ function getGameName(session: SessionCardProps["session"]): string {
 		return session.ringGameName;
 	}
 	return session.type === "tournament" ? "Tournament" : "Cash Game";
-}
-
-function formatProfitLoss(
-	profitLoss: number,
-	currencyUnit: string | null
-): string {
-	const sign = profitLoss >= 0 ? "+" : "";
-	const value = formatCompactNumber(profitLoss);
-	if (currencyUnit) {
-		return `${sign}${value} ${currencyUnit}`;
-	}
-	return `${sign}${value}`;
 }
 
 function toBB(value: number, blind2: number | null): number | null {
@@ -194,10 +178,10 @@ function CashGameDetails({
 			? (() => {
 					const bb = toBB(session.evProfitLoss, session.ringGameBlind2);
 					return bb === null
-						? `${session.evProfitLoss >= 0 ? "+" : ""}${formatCompactNumber(session.evProfitLoss)}`
+						? formatProfitLoss(session.evProfitLoss)
 						: formatBBBI(bb, "BB");
 				})()
-			: `${session.evProfitLoss >= 0 ? "+" : ""}${formatCompactNumber(session.evProfitLoss)}`;
+			: formatProfitLoss(session.evProfitLoss);
 		rows.push({
 			label: "EV P&L",
 			value: evValue,
@@ -296,17 +280,17 @@ function getPlDisplay(
 	bbBiMode?: boolean
 ): string {
 	if (!bbBiMode) {
-		return formatProfitLoss(profitLoss, session.currencyUnit);
+		return formatProfitLoss(profitLoss, { currencyUnit: session.currencyUnit });
 	}
 	if (session.type === "tournament") {
 		const bi = toBI(profitLoss, computeTotalCost(session));
 		return bi === null
-			? formatProfitLoss(profitLoss, session.currencyUnit)
+			? formatProfitLoss(profitLoss, { currencyUnit: session.currencyUnit })
 			: formatBBBI(bi, "BI");
 	}
 	const bb = toBB(profitLoss, session.ringGameBlind2);
 	return bb === null
-		? formatProfitLoss(profitLoss, session.currencyUnit)
+		? formatProfitLoss(profitLoss, { currencyUnit: session.currencyUnit })
 		: formatBBBI(bb, "BB");
 }
 
@@ -318,22 +302,16 @@ function getEvDisplay(
 		return null;
 	}
 	if (!bbBiMode) {
-		return formatProfitLoss(session.evProfitLoss, session.currencyUnit);
+		return formatProfitLoss(session.evProfitLoss, {
+			currencyUnit: session.currencyUnit,
+		});
 	}
 	const evBB = toBB(session.evProfitLoss, session.ringGameBlind2);
 	return evBB === null
-		? formatProfitLoss(session.evProfitLoss, session.currencyUnit)
+		? formatProfitLoss(session.evProfitLoss, {
+				currencyUnit: session.currencyUnit,
+			})
 		: formatBBBI(evBB, "BB");
-}
-
-function getProfitColorClass(profitLoss: number): string {
-	if (profitLoss > 0) {
-		return "text-green-600";
-	}
-	if (profitLoss < 0) {
-		return "text-red-600";
-	}
-	return "text-foreground";
 }
 
 function SessionHeader({
@@ -349,7 +327,7 @@ function SessionHeader({
 		session.liveCashGameSessionId !== null ||
 		session.liveTournamentSessionId !== null;
 	const plDisplay = getPlDisplay(session, profitLoss, bbBiMode);
-	const profitColorClass = getProfitColorClass(profitLoss);
+	const profitColorClass = profitLossColorClass(profitLoss);
 	const gameName = getGameName(session);
 	const evDisplay = getEvDisplay(session, bbBiMode);
 
@@ -387,7 +365,7 @@ function SessionHeader({
 					<div className="flex items-center gap-3">
 						<span className="flex items-center gap-0.5">
 							<IconCalendar className="shrink-0" size={12} />
-							{formatSessionDate(session.sessionDate)}
+							{formatYmdSlash(session.sessionDate)}
 						</span>
 						{session.startedAt && session.endedAt && (
 							<span className="flex items-center gap-0.5">

--- a/apps/web/src/sessions/components/session-summary.tsx
+++ b/apps/web/src/sessions/components/session-summary.tsx
@@ -1,4 +1,8 @@
 import { formatCompactNumber } from "@/utils/format-number";
+import {
+	formatProfitLoss,
+	profitLossColorClass,
+} from "@/utils/format-profit-loss";
 
 interface SessionSummaryProps {
 	summary: {
@@ -33,16 +37,6 @@ function StatCard({
 	);
 }
 
-function plColorClass(value: number): string {
-	if (value > 0) {
-		return "text-green-600";
-	}
-	if (value < 0) {
-		return "text-red-600";
-	}
-	return "";
-}
-
 export function SessionSummary({ summary }: SessionSummaryProps) {
 	if (summary.totalSessions === 0) {
 		return null;
@@ -55,16 +49,16 @@ export function SessionSummary({ summary }: SessionSummaryProps) {
 				value={summary.totalSessions.toString()}
 			/>
 			<StatCard
-				colorClass={plColorClass(summary.totalProfitLoss)}
+				colorClass={profitLossColorClass(summary.totalProfitLoss)}
 				label="Total P&L"
-				value={`${summary.totalProfitLoss >= 0 ? "+" : ""}${formatCompactNumber(summary.totalProfitLoss)}`}
+				value={formatProfitLoss(summary.totalProfitLoss)}
 			/>
 			<StatCard label="Win Rate" value={`${summary.winRate.toFixed(1)}%`} />
 			{summary.avgProfitLoss !== null && (
 				<StatCard
-					colorClass={plColorClass(summary.avgProfitLoss)}
+					colorClass={profitLossColorClass(summary.avgProfitLoss)}
 					label="Avg P&L"
-					value={`${summary.avgProfitLoss >= 0 ? "+" : ""}${formatCompactNumber(Math.round(summary.avgProfitLoss))}`}
+					value={formatProfitLoss(Math.round(summary.avgProfitLoss))}
 				/>
 			)}
 			{summary.avgPlacement !== null && (
@@ -84,16 +78,16 @@ export function SessionSummary({ summary }: SessionSummaryProps) {
 			)}
 			{summary.totalEvProfitLoss !== null && (
 				<StatCard
-					colorClass={plColorClass(summary.totalEvProfitLoss)}
+					colorClass={profitLossColorClass(summary.totalEvProfitLoss)}
 					label="Total EV P&L"
-					value={`${summary.totalEvProfitLoss >= 0 ? "+" : ""}${formatCompactNumber(summary.totalEvProfitLoss)}`}
+					value={formatProfitLoss(summary.totalEvProfitLoss)}
 				/>
 			)}
 			{summary.totalEvDiff !== null && (
 				<StatCard
-					colorClass={plColorClass(summary.totalEvDiff)}
+					colorClass={profitLossColorClass(summary.totalEvDiff)}
 					label="Total EV Diff"
-					value={`${summary.totalEvDiff >= 0 ? "+" : ""}${formatCompactNumber(summary.totalEvDiff)}`}
+					value={formatProfitLoss(summary.totalEvDiff)}
 				/>
 			)}
 		</div>

--- a/apps/web/src/shared/hooks/use-elapsed-time.ts
+++ b/apps/web/src/shared/hooks/use-elapsed-time.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+import { formatElapsedTime } from "@/utils/format-elapsed-time";
+
+export function useElapsedTime(
+	startedAt: Date | string | number | null | undefined,
+	intervalMs = 60_000
+): string {
+	const [text, setText] = useState(() => formatElapsedTime(startedAt));
+	useEffect(() => {
+		setText(formatElapsedTime(startedAt));
+		const id = setInterval(
+			() => setText(formatElapsedTime(startedAt)),
+			intervalMs
+		);
+		return () => clearInterval(id);
+	}, [startedAt, intervalMs]);
+	return text;
+}

--- a/apps/web/src/utils/__tests__/format-elapsed-time.test.ts
+++ b/apps/web/src/utils/__tests__/format-elapsed-time.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatElapsedTime } from "../format-elapsed-time";
+
+const NOW = new Date("2026-04-22T12:00:00Z");
+
+describe("formatElapsedTime", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(NOW);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("returns em dash for null", () => {
+		expect(formatElapsedTime(null)).toBe("—");
+	});
+
+	it("returns em dash for undefined", () => {
+		expect(formatElapsedTime(undefined)).toBe("—");
+	});
+
+	it("returns em dash for future dates", () => {
+		const future = new Date(NOW.getTime() + 60_000);
+		expect(formatElapsedTime(future)).toBe("—");
+	});
+
+	it("formats sub-hour elapsed as minutes only", () => {
+		const past = new Date(NOW.getTime() - 30 * 60_000);
+		expect(formatElapsedTime(past)).toBe("30m");
+	});
+
+	it("formats multi-hour elapsed as hours and minutes", () => {
+		const past = new Date(NOW.getTime() - (90 * 60_000 + 45_000));
+		expect(formatElapsedTime(past)).toBe("1h 30m");
+	});
+
+	it("accepts ISO string input", () => {
+		const iso = new Date(NOW.getTime() - 15 * 60_000).toISOString();
+		expect(formatElapsedTime(iso)).toBe("15m");
+	});
+
+	it("accepts number (epoch ms) input", () => {
+		const epoch = NOW.getTime() - 60 * 60_000;
+		expect(formatElapsedTime(epoch)).toBe("1h 0m");
+	});
+});

--- a/apps/web/src/utils/__tests__/format-profit-loss.test.ts
+++ b/apps/web/src/utils/__tests__/format-profit-loss.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { formatProfitLoss, profitLossColorClass } from "../format-profit-loss";
+
+describe("formatProfitLoss", () => {
+	it("formats positive values with + sign", () => {
+		expect(formatProfitLoss(500)).toBe("+500");
+	});
+
+	it("formats zero with + sign", () => {
+		expect(formatProfitLoss(0)).toBe("+0");
+	});
+
+	it("formats negative values with - sign intact", () => {
+		expect(formatProfitLoss(-500)).toBe("-500");
+	});
+
+	it("returns em dash for null", () => {
+		expect(formatProfitLoss(null)).toBe("—");
+	});
+
+	it("returns em dash for undefined", () => {
+		expect(formatProfitLoss(undefined)).toBe("—");
+	});
+
+	it("uses custom nullDisplay", () => {
+		expect(formatProfitLoss(null, { nullDisplay: "-" })).toBe("-");
+	});
+
+	it("appends currency unit", () => {
+		expect(formatProfitLoss(-500, { currencyUnit: "JPY" })).toBe("-500 JPY");
+	});
+
+	it("does not append currency unit when null value", () => {
+		expect(formatProfitLoss(null, { currencyUnit: "JPY" })).toBe("—");
+	});
+
+	it("uses compact notation for large values", () => {
+		expect(formatProfitLoss(15_000)).toBe("+15k");
+	});
+});
+
+describe("profitLossColorClass", () => {
+	it("returns green for positive", () => {
+		expect(profitLossColorClass(100)).toBe(
+			"text-green-600 dark:text-green-400"
+		);
+	});
+
+	it("returns red for negative", () => {
+		expect(profitLossColorClass(-100)).toBe("text-red-600 dark:text-red-400");
+	});
+
+	it("returns empty for zero", () => {
+		expect(profitLossColorClass(0)).toBe("");
+	});
+
+	it("returns empty for null", () => {
+		expect(profitLossColorClass(null)).toBe("");
+	});
+
+	it("returns empty for undefined", () => {
+		expect(profitLossColorClass(undefined)).toBe("");
+	});
+});

--- a/apps/web/src/utils/format-elapsed-time.ts
+++ b/apps/web/src/utils/format-elapsed-time.ts
@@ -1,0 +1,16 @@
+export function formatElapsedTime(
+	startedAt: Date | string | number | null | undefined
+): string {
+	if (startedAt === null || startedAt === undefined) {
+		return "—";
+	}
+	const start = new Date(startedAt);
+	const diffMs = Date.now() - start.getTime();
+	if (Number.isNaN(diffMs) || diffMs < 0) {
+		return "—";
+	}
+	const totalMinutes = Math.floor(diffMs / 60_000);
+	const hours = Math.floor(totalMinutes / 60);
+	const minutes = totalMinutes % 60;
+	return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}

--- a/apps/web/src/utils/format-number.ts
+++ b/apps/web/src/utils/format-number.ts
@@ -56,3 +56,11 @@ export function createGroupFormatter(
 	const tier = TIERS.find((t) => maxAbs >= t.threshold);
 	return (value: number) => formatWithTier(value, tier);
 }
+
+export function formatYmdSlash(input: string | Date): string {
+	const d = typeof input === "string" ? new Date(input) : input;
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, "0");
+	const day = String(d.getDate()).padStart(2, "0");
+	return `${y}/${m}/${day}`;
+}

--- a/apps/web/src/utils/format-profit-loss.ts
+++ b/apps/web/src/utils/format-profit-loss.ts
@@ -1,0 +1,29 @@
+import { formatCompactNumber } from "@/utils/format-number";
+
+interface FormatProfitLossOptions {
+	currencyUnit?: string | null;
+	nullDisplay?: string;
+}
+
+export function formatProfitLoss(
+	value: number | null | undefined,
+	options?: FormatProfitLossOptions
+): string {
+	if (value === null || value === undefined) {
+		return options?.nullDisplay ?? "—";
+	}
+	const sign = value >= 0 ? "+" : "";
+	const body = formatCompactNumber(value);
+	return options?.currencyUnit
+		? `${sign}${body} ${options.currencyUnit}`
+		: `${sign}${body}`;
+}
+
+export function profitLossColorClass(value: number | null | undefined): string {
+	if (value === null || value === undefined || value === 0) {
+		return "";
+	}
+	return value > 0
+		? "text-green-600 dark:text-green-400"
+		: "text-red-600 dark:text-red-400";
+}


### PR DESCRIPTION
## Summary
- `apps/web/` を俯瞰して再利用可能コンポーネント・ユーティリティが実際に使い回されているか監査した結果、ドメイン固有のフォーマッタ（P&L 記号・色クラス・`YYYY/MM/DD`・経過時間）が 7 ファイル以上で重複していたため、`apps/web/src/utils/` と `apps/web/src/shared/hooks/` に集約した。
- 新規ユーティリティ: `formatProfitLoss` / `profitLossColorClass` / `formatElapsedTime` / `useElapsedTime` / `formatYmdSlash`
- 置換対象: dashboard widgets 4 つ、session-card / session-summary / live-sessions/session-summary、active-session ルート、transaction-list
- 既存の UI テスト（`session-card.test.tsx` / `session-summary.test.tsx`）はダークモード対応の color class に変わっても `toContain("text-red-600")` で通る

## 監査で再利用が確認できたもの（変更不要）
- shadcn UI プリミティブ（27 個）、`formatCompactNumber` / `createGroupFormatter`、`optimistic-update` ヘルパー、`form-fields` ヘルパー、`EntityListItem` / `TagManager`

## 別 PR 推奨（本 PR の範囲外）
CLAUDE.md の「UI/Logic Separation (MANDATORY)」違反が 8 ファイル以上に残っている（dashboard widgets 4 個、`assign-ring-game-dialog.tsx`、`stores/` 系 3 個、`update-notes-sheet.tsx`）。構造リファクタなので独立した PR として切り出すべき。

## Test plan
- [x] `bun run test` — 590 tests passed
- [x] `bunx ultracite check apps/web/src` — no issues
- [x] 新規ユーティリティに対する unit test 追加（`format-profit-loss.test.ts` / `format-elapsed-time.test.ts`）
- [ ] `/dashboard` — 各 widget の P&L 記号・色・日時が従来と変わらないこと（目視）
- [ ] `/sessions` — SessionCard / Summary Stats の P&L 表示・色・日付が従来と変わらないこと（目視）
- [ ] `/active-session` — 稼働中セッションのタイマーが 1 分毎に更新されること（目視）
- [ ] `/live-sessions/:type/:id/events` — Session Summary の色・P&L 表記が従来と変わらないこと（目視）
- [ ] `/currencies` — TransactionList の日付・金額表示が従来と変わらないこと（目視）

🤖 Generated with [Claude Code](https://claude.com/claude-code)