### PR TITLE
refactor(web): extract hooks to comply with UI/Logic Separation

### DIFF
--- a/apps/web/src/dashboard/hooks/use-active-session-widget.ts
+++ b/apps/web/src/dashboard/hooks/use-active-session-widget.ts
@@ -1,0 +1,74 @@
+import { useQuery } from "@tanstack/react-query";
+import { trpc } from "@/utils/trpc";
+
+export type ActiveSessionWidgetSessionType = "all" | "cash_game" | "tournament";
+
+interface ParsedConfig {
+	sessionType: ActiveSessionWidgetSessionType;
+}
+
+export function parseActiveSessionWidgetConfig(
+	raw: Record<string, unknown>
+): ParsedConfig {
+	const sessionType =
+		raw.sessionType === "cash_game" || raw.sessionType === "tournament"
+			? (raw.sessionType as ActiveSessionWidgetSessionType)
+			: ("all" as ActiveSessionWidgetSessionType);
+	return { sessionType };
+}
+
+interface CashItem {
+	id: string;
+	latestStackAmount: number | null;
+	ringGameName: string | null;
+	startedAt: string | Date | null;
+}
+
+interface TournamentItem {
+	id: string;
+	latestStackAmount: number | null;
+	startedAt: string | Date | null;
+	tournamentName: string | null;
+}
+
+interface UseActiveSessionWidgetResult {
+	cashItems: CashItem[];
+	isLoading: boolean;
+	tournamentItems: TournamentItem[];
+}
+
+export function useActiveSessionWidget(
+	config: Record<string, unknown>
+): UseActiveSessionWidgetResult {
+	const parsed = parseActiveSessionWidgetConfig(config);
+
+	const cashQuery = useQuery({
+		...trpc.liveCashGameSession.list.queryOptions({
+			status: "active",
+			limit: 5,
+		}),
+		refetchInterval: 5000,
+		refetchIntervalInBackground: false,
+		enabled: parsed.sessionType !== "tournament",
+	});
+
+	const tournamentQuery = useQuery({
+		...trpc.liveTournamentSession.list.queryOptions({
+			status: "active",
+			limit: 5,
+		}),
+		refetchInterval: 5000,
+		refetchIntervalInBackground: false,
+		enabled: parsed.sessionType !== "cash_game",
+	});
+
+	const isLoading = cashQuery.isLoading || tournamentQuery.isLoading;
+	const cashItems: CashItem[] =
+		parsed.sessionType === "tournament" ? [] : (cashQuery.data?.items ?? []);
+	const tournamentItems: TournamentItem[] =
+		parsed.sessionType === "cash_game"
+			? []
+			: (tournamentQuery.data?.items ?? []);
+
+	return { isLoading, cashItems, tournamentItems };
+}

--- a/apps/web/src/dashboard/hooks/use-currency-balance-widget.ts
+++ b/apps/web/src/dashboard/hooks/use-currency-balance-widget.ts
@@ -1,0 +1,49 @@
+import { useQuery } from "@tanstack/react-query";
+import { trpc } from "@/utils/trpc";
+
+interface ParsedConfig {
+	currencyId: string | null;
+}
+
+export function parseCurrencyBalanceWidgetConfig(
+	raw: Record<string, unknown>
+): ParsedConfig {
+	const currencyId = typeof raw.currencyId === "string" ? raw.currencyId : null;
+	return { currencyId };
+}
+
+interface CurrencyOption {
+	balance?: number | string | null;
+	id: string;
+	name: string;
+	unit?: string | null;
+}
+
+interface UseCurrencyBalanceWidgetResult {
+	currencies: CurrencyOption[];
+	isLoading: boolean;
+	selected: CurrencyOption | undefined;
+}
+
+export function useCurrencyBalanceWidget(
+	config: Record<string, unknown>
+): UseCurrencyBalanceWidgetResult {
+	const parsed = parseCurrencyBalanceWidgetConfig(config);
+	const query = useQuery(trpc.currency.list.queryOptions());
+	const currencies = (query.data ?? []) as CurrencyOption[];
+	const selected =
+		parsed.currencyId === null
+			? currencies[0]
+			: currencies.find((c) => c.id === parsed.currencyId);
+
+	return {
+		currencies,
+		isLoading: query.isLoading,
+		selected,
+	};
+}
+
+export function useCurrencyBalanceOptions(): CurrencyOption[] {
+	const query = useQuery(trpc.currency.list.queryOptions());
+	return (query.data ?? []) as CurrencyOption[];
+}

--- a/apps/web/src/dashboard/hooks/use-recent-sessions-widget.ts
+++ b/apps/web/src/dashboard/hooks/use-recent-sessions-widget.ts
@@ -1,0 +1,60 @@
+import { useQuery } from "@tanstack/react-query";
+import { trpc } from "@/utils/trpc";
+
+export type RecentSessionsWidgetTypeFilter = "all" | "cash_game" | "tournament";
+
+interface ParsedConfig {
+	limit: number;
+	type: RecentSessionsWidgetTypeFilter;
+}
+
+export function parseRecentSessionsWidgetConfig(
+	raw: Record<string, unknown>
+): ParsedConfig {
+	const limit =
+		typeof raw.limit === "number" && raw.limit > 0 && raw.limit <= 20
+			? Math.floor(raw.limit)
+			: 5;
+	const type =
+		raw.type === "cash_game" || raw.type === "tournament"
+			? (raw.type as RecentSessionsWidgetTypeFilter)
+			: ("all" as RecentSessionsWidgetTypeFilter);
+	return { limit, type };
+}
+
+interface SessionItem {
+	id: string;
+	profitLoss: number | null;
+	ringGameName: string | null;
+	sessionDate: string | Date;
+	tournamentName: string | null;
+	type: string;
+}
+
+interface UseRecentSessionsWidgetResult {
+	isLoading: boolean;
+	items: SessionItem[];
+	limit: number;
+}
+
+export function useRecentSessionsWidget(
+	config: Record<string, unknown>
+): UseRecentSessionsWidgetResult {
+	const parsed = parseRecentSessionsWidgetConfig(config);
+	const query = useQuery(
+		trpc.session.list.queryOptions({
+			type: parsed.type === "all" ? undefined : parsed.type,
+		})
+	);
+
+	const items = ((query.data?.items ?? []) as SessionItem[]).slice(
+		0,
+		parsed.limit
+	);
+
+	return {
+		isLoading: query.isLoading,
+		items,
+		limit: parsed.limit,
+	};
+}

--- a/apps/web/src/dashboard/hooks/use-summary-stats-widget.ts
+++ b/apps/web/src/dashboard/hooks/use-summary-stats-widget.ts
@@ -1,0 +1,95 @@
+import { useQuery } from "@tanstack/react-query";
+import { trpc } from "@/utils/trpc";
+
+export type SummaryStatsWidgetType = "all" | "cash_game" | "tournament";
+
+export type SummaryStatsMetricKey =
+	| "totalSessions"
+	| "totalProfitLoss"
+	| "winRate"
+	| "avgProfitLoss"
+	| "totalEvProfitLoss"
+	| "totalEvDiff";
+
+export const SUMMARY_STATS_ALL_METRICS: Array<{
+	key: SummaryStatsMetricKey;
+	label: string;
+}> = [
+	{ key: "totalSessions", label: "Total Sessions" },
+	{ key: "totalProfitLoss", label: "Total P&L" },
+	{ key: "winRate", label: "Win Rate" },
+	{ key: "avgProfitLoss", label: "Avg P&L" },
+	{ key: "totalEvProfitLoss", label: "Total EV P&L" },
+	{ key: "totalEvDiff", label: "Total EV Diff" },
+];
+
+export const SUMMARY_STATS_DEFAULT_METRICS: SummaryStatsMetricKey[] = [
+	"totalSessions",
+	"totalProfitLoss",
+	"winRate",
+	"avgProfitLoss",
+];
+
+interface ParsedConfig {
+	dateRangeDays: number | null;
+	metrics: SummaryStatsMetricKey[];
+	type: SummaryStatsWidgetType;
+}
+
+export function parseSummaryStatsWidgetConfig(
+	raw: Record<string, unknown>
+): ParsedConfig {
+	const metricsRaw = Array.isArray(raw.metrics) ? raw.metrics : [];
+	const metrics = metricsRaw.filter((m): m is SummaryStatsMetricKey =>
+		SUMMARY_STATS_ALL_METRICS.some((am) => am.key === m)
+	);
+	const type =
+		raw.type === "cash_game" || raw.type === "tournament"
+			? (raw.type as SummaryStatsWidgetType)
+			: ("all" as SummaryStatsWidgetType);
+	const dateRangeDays =
+		typeof raw.dateRangeDays === "number" ? raw.dateRangeDays : null;
+	return {
+		metrics: metrics.length > 0 ? metrics : SUMMARY_STATS_DEFAULT_METRICS,
+		type,
+		dateRangeDays,
+	};
+}
+
+export interface SummaryStatsSummary {
+	avgProfitLoss: number | null;
+	totalEvDiff: number | null;
+	totalEvProfitLoss: number | null;
+	totalProfitLoss: number;
+	totalSessions: number;
+	winRate: number;
+}
+
+interface UseSummaryStatsWidgetResult {
+	isLoading: boolean;
+	metrics: SummaryStatsMetricKey[];
+	summary: SummaryStatsSummary | undefined;
+}
+
+export function useSummaryStatsWidget(
+	config: Record<string, unknown>
+): UseSummaryStatsWidgetResult {
+	const parsed = parseSummaryStatsWidgetConfig(config);
+	const dateFrom =
+		parsed.dateRangeDays === null
+			? undefined
+			: Math.floor(Date.now() / 1000) - parsed.dateRangeDays * 86_400;
+
+	const query = useQuery(
+		trpc.session.list.queryOptions({
+			type: parsed.type === "all" ? undefined : parsed.type,
+			dateFrom,
+		})
+	);
+
+	return {
+		isLoading: query.isLoading,
+		metrics: parsed.metrics,
+		summary: query.data?.summary as SummaryStatsSummary | undefined,
+	};
+}

--- a/apps/web/src/dashboard/widgets/active-session-widget.tsx
+++ b/apps/web/src/dashboard/widgets/active-session-widget.tsx
@@ -1,7 +1,11 @@
 import { IconBolt, IconPokerChip, IconTrophy } from "@tabler/icons-react";
-import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useState } from "react";
+import {
+	type ActiveSessionWidgetSessionType,
+	parseActiveSessionWidgetConfig,
+	useActiveSessionWidget,
+} from "@/dashboard/hooks/use-active-session-widget";
 import type {
 	WidgetEditProps,
 	WidgetRenderProps,
@@ -12,21 +16,6 @@ import { Label } from "@/shared/components/ui/label";
 import { Skeleton } from "@/shared/components/ui/skeleton";
 import { useElapsedTime } from "@/shared/hooks/use-elapsed-time";
 import { formatCompactNumber } from "@/utils/format-number";
-import { trpc } from "@/utils/trpc";
-
-type SessionTypeFilter = "all" | "cash_game" | "tournament";
-
-interface ParsedConfig {
-	sessionType: SessionTypeFilter;
-}
-
-function parseConfig(raw: Record<string, unknown>): ParsedConfig {
-	const sessionType =
-		raw.sessionType === "cash_game" || raw.sessionType === "tournament"
-			? (raw.sessionType as SessionTypeFilter)
-			: ("all" as SessionTypeFilter);
-	return { sessionType };
-}
 
 interface ActiveSessionRowProps {
 	latestStackAmount: number | null;
@@ -77,29 +66,8 @@ function ActiveSessionRow({
 }
 
 export function ActiveSessionWidget({ config }: WidgetRenderProps) {
-	const parsed = parseConfig(config);
-
-	const cashQuery = useQuery({
-		...trpc.liveCashGameSession.list.queryOptions({
-			status: "active",
-			limit: 5,
-		}),
-		refetchInterval: 5000,
-		refetchIntervalInBackground: false,
-		enabled: parsed.sessionType !== "tournament",
-	});
-
-	const tournamentQuery = useQuery({
-		...trpc.liveTournamentSession.list.queryOptions({
-			status: "active",
-			limit: 5,
-		}),
-		refetchInterval: 5000,
-		refetchIntervalInBackground: false,
-		enabled: parsed.sessionType !== "cash_game",
-	});
-
-	const isLoading = cashQuery.isLoading || tournamentQuery.isLoading;
+	const { isLoading, cashItems, tournamentItems } =
+		useActiveSessionWidget(config);
 
 	if (isLoading) {
 		return (
@@ -109,13 +77,6 @@ export function ActiveSessionWidget({ config }: WidgetRenderProps) {
 			</div>
 		);
 	}
-
-	const cashItems =
-		parsed.sessionType === "tournament" ? [] : (cashQuery.data?.items ?? []);
-	const tournamentItems =
-		parsed.sessionType === "cash_game"
-			? []
-			: (tournamentQuery.data?.items ?? []);
 
 	if (cashItems.length === 0 && tournamentItems.length === 0) {
 		return (
@@ -157,10 +118,9 @@ export function ActiveSessionEditForm({
 	onSave,
 	onCancel,
 }: WidgetEditProps) {
-	const parsed = parseConfig(config);
-	const [sessionType, setSessionType] = useState<SessionTypeFilter>(
-		parsed.sessionType
-	);
+	const parsed = parseActiveSessionWidgetConfig(config);
+	const [sessionType, setSessionType] =
+		useState<ActiveSessionWidgetSessionType>(parsed.sessionType);
 	const [isSaving, setIsSaving] = useState(false);
 
 	const handleSave = async () => {
@@ -179,7 +139,9 @@ export function ActiveSessionEditForm({
 				<select
 					className="rounded-md border bg-background px-3 py-2 text-sm"
 					id="active-session-type"
-					onChange={(e) => setSessionType(e.target.value as SessionTypeFilter)}
+					onChange={(e) =>
+						setSessionType(e.target.value as ActiveSessionWidgetSessionType)
+					}
 					value={sessionType}
 				>
 					<option value="all">All</option>

--- a/apps/web/src/dashboard/widgets/currency-balance-widget.tsx
+++ b/apps/web/src/dashboard/widgets/currency-balance-widget.tsx
@@ -1,6 +1,9 @@
 import { IconCoin } from "@tabler/icons-react";
-import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
+import {
+	useCurrencyBalanceOptions,
+	useCurrencyBalanceWidget,
+} from "@/dashboard/hooks/use-currency-balance-widget";
 import type {
 	WidgetEditProps,
 	WidgetRenderProps,
@@ -11,22 +14,11 @@ import { Label } from "@/shared/components/ui/label";
 import { Skeleton } from "@/shared/components/ui/skeleton";
 import { formatCompactNumber } from "@/utils/format-number";
 import { profitLossColorClass } from "@/utils/format-profit-loss";
-import { trpc } from "@/utils/trpc";
-
-interface ParsedConfig {
-	currencyId: string | null;
-}
-
-function parseConfig(raw: Record<string, unknown>): ParsedConfig {
-	const currencyId = typeof raw.currencyId === "string" ? raw.currencyId : null;
-	return { currencyId };
-}
 
 export function CurrencyBalanceWidget({ config }: WidgetRenderProps) {
-	const parsed = parseConfig(config);
-	const query = useQuery(trpc.currency.list.queryOptions());
+	const { isLoading, currencies, selected } = useCurrencyBalanceWidget(config);
 
-	if (query.isLoading) {
+	if (isLoading) {
 		return (
 			<div className="flex h-full items-center p-2">
 				<Skeleton className="h-10 w-full" />
@@ -34,7 +26,6 @@ export function CurrencyBalanceWidget({ config }: WidgetRenderProps) {
 		);
 	}
 
-	const currencies = query.data ?? [];
 	if (currencies.length === 0) {
 		return (
 			<div className="flex h-full items-center justify-center p-4 text-muted-foreground text-sm">
@@ -42,11 +33,6 @@ export function CurrencyBalanceWidget({ config }: WidgetRenderProps) {
 			</div>
 		);
 	}
-
-	const selected =
-		parsed.currencyId === null
-			? currencies[0]
-			: currencies.find((c) => c.id === parsed.currencyId);
 
 	if (!selected) {
 		return (
@@ -82,13 +68,13 @@ export function CurrencyBalanceEditForm({
 	onSave,
 	onCancel,
 }: WidgetEditProps) {
-	const parsed = parseConfig(config);
+	const currencyIdFromConfig =
+		typeof config.currencyId === "string" ? config.currencyId : null;
 	const [currencyId, setCurrencyId] = useState<string | null>(
-		parsed.currencyId
+		currencyIdFromConfig
 	);
 	const [isSaving, setIsSaving] = useState(false);
-	const query = useQuery(trpc.currency.list.queryOptions());
-	const currencies = query.data ?? [];
+	const currencies = useCurrencyBalanceOptions();
 
 	const handleSave = async () => {
 		setIsSaving(true);

--- a/apps/web/src/dashboard/widgets/recent-sessions-widget.tsx
+++ b/apps/web/src/dashboard/widgets/recent-sessions-widget.tsx
@@ -1,7 +1,11 @@
 import { IconPokerChip, IconTrophy } from "@tabler/icons-react";
-import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useState } from "react";
+import {
+	parseRecentSessionsWidgetConfig,
+	type RecentSessionsWidgetTypeFilter,
+	useRecentSessionsWidget,
+} from "@/dashboard/hooks/use-recent-sessions-widget";
 import type {
 	WidgetEditProps,
 	WidgetRenderProps,
@@ -15,46 +19,20 @@ import {
 	formatProfitLoss,
 	profitLossColorClass,
 } from "@/utils/format-profit-loss";
-import { trpc } from "@/utils/trpc";
-
-type TypeFilter = "all" | "cash_game" | "tournament";
-
-interface ParsedConfig {
-	limit: number;
-	type: TypeFilter;
-}
-
-function parseConfig(raw: Record<string, unknown>): ParsedConfig {
-	const limit =
-		typeof raw.limit === "number" && raw.limit > 0 && raw.limit <= 20
-			? Math.floor(raw.limit)
-			: 5;
-	const type =
-		raw.type === "cash_game" || raw.type === "tournament"
-			? (raw.type as TypeFilter)
-			: ("all" as TypeFilter);
-	return { limit, type };
-}
 
 export function RecentSessionsWidget({ config }: WidgetRenderProps) {
-	const parsed = parseConfig(config);
-	const query = useQuery(
-		trpc.session.list.queryOptions({
-			type: parsed.type === "all" ? undefined : parsed.type,
-		})
-	);
+	const { isLoading, items, limit } = useRecentSessionsWidget(config);
 
-	if (query.isLoading) {
+	if (isLoading) {
 		return (
 			<div className="flex flex-col gap-2 p-2">
-				{Array.from({ length: parsed.limit }, (_, i) => i).map((i) => (
+				{Array.from({ length: limit }, (_, i) => i).map((i) => (
 					<Skeleton className="h-10" key={i} />
 				))}
 			</div>
 		);
 	}
 
-	const items = (query.data?.items ?? []).slice(0, parsed.limit);
 	if (items.length === 0) {
 		return (
 			<div className="flex h-full items-center justify-center p-4 text-muted-foreground text-sm">
@@ -112,9 +90,9 @@ export function RecentSessionsEditForm({
 	onSave,
 	onCancel,
 }: WidgetEditProps) {
-	const parsed = parseConfig(config);
+	const parsed = parseRecentSessionsWidgetConfig(config);
 	const [limit, setLimit] = useState<number>(parsed.limit);
-	const [type, setType] = useState<TypeFilter>(parsed.type);
+	const [type, setType] = useState<RecentSessionsWidgetTypeFilter>(parsed.type);
 	const [isSaving, setIsSaving] = useState(false);
 
 	const handleSave = async () => {
@@ -145,7 +123,9 @@ export function RecentSessionsEditForm({
 				<select
 					className="rounded-md border bg-background px-3 py-2 text-sm"
 					id="recent-sessions-type"
-					onChange={(e) => setType(e.target.value as TypeFilter)}
+					onChange={(e) =>
+						setType(e.target.value as RecentSessionsWidgetTypeFilter)
+					}
 					value={type}
 				>
 					<option value="all">All</option>

--- a/apps/web/src/dashboard/widgets/summary-stats-widget.tsx
+++ b/apps/web/src/dashboard/widgets/summary-stats-widget.tsx
@@ -1,5 +1,13 @@
-import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
+import {
+	parseSummaryStatsWidgetConfig,
+	SUMMARY_STATS_ALL_METRICS,
+	SUMMARY_STATS_DEFAULT_METRICS,
+	type SummaryStatsMetricKey,
+	type SummaryStatsSummary,
+	type SummaryStatsWidgetType,
+	useSummaryStatsWidget,
+} from "@/dashboard/hooks/use-summary-stats-widget";
 import type {
 	WidgetEditProps,
 	WidgetRenderProps,
@@ -12,68 +20,10 @@ import {
 	formatProfitLoss,
 	profitLossColorClass,
 } from "@/utils/format-profit-loss";
-import { trpc } from "@/utils/trpc";
-
-type StatsType = "all" | "cash_game" | "tournament";
-
-type MetricKey =
-	| "totalSessions"
-	| "totalProfitLoss"
-	| "winRate"
-	| "avgProfitLoss"
-	| "totalEvProfitLoss"
-	| "totalEvDiff";
-
-const ALL_METRICS: Array<{ key: MetricKey; label: string }> = [
-	{ key: "totalSessions", label: "Total Sessions" },
-	{ key: "totalProfitLoss", label: "Total P&L" },
-	{ key: "winRate", label: "Win Rate" },
-	{ key: "avgProfitLoss", label: "Avg P&L" },
-	{ key: "totalEvProfitLoss", label: "Total EV P&L" },
-	{ key: "totalEvDiff", label: "Total EV Diff" },
-];
-
-const DEFAULT_METRICS: MetricKey[] = [
-	"totalSessions",
-	"totalProfitLoss",
-	"winRate",
-	"avgProfitLoss",
-];
-
-interface ParsedConfig {
-	dateRangeDays: number | null;
-	metrics: MetricKey[];
-	type: StatsType;
-}
-
-function parseConfig(raw: Record<string, unknown>): ParsedConfig {
-	const metricsRaw = Array.isArray(raw.metrics) ? raw.metrics : [];
-	const metrics = metricsRaw.filter((m): m is MetricKey =>
-		ALL_METRICS.some((am) => am.key === m)
-	);
-	const type =
-		raw.type === "cash_game" || raw.type === "tournament"
-			? (raw.type as StatsType)
-			: ("all" as StatsType);
-	const dateRangeDays =
-		typeof raw.dateRangeDays === "number" ? raw.dateRangeDays : null;
-	return {
-		metrics: metrics.length > 0 ? metrics : DEFAULT_METRICS,
-		type,
-		dateRangeDays,
-	};
-}
 
 function formatMetricValue(
-	key: MetricKey,
-	summary: {
-		totalSessions: number;
-		totalProfitLoss: number;
-		winRate: number;
-		avgProfitLoss: number | null;
-		totalEvProfitLoss: number | null;
-		totalEvDiff: number | null;
-	}
+	key: SummaryStatsMetricKey,
+	summary: SummaryStatsSummary
 ): string {
 	switch (key) {
 		case "totalSessions":
@@ -98,13 +48,8 @@ function formatMetricValue(
 }
 
 function metricColor(
-	key: MetricKey,
-	summary: {
-		totalProfitLoss: number;
-		avgProfitLoss: number | null;
-		totalEvProfitLoss: number | null;
-		totalEvDiff: number | null;
-	}
+	key: SummaryStatsMetricKey,
+	summary: SummaryStatsSummary
 ): string {
 	switch (key) {
 		case "totalProfitLoss":
@@ -121,30 +66,18 @@ function metricColor(
 }
 
 export function SummaryStatsWidget({ config }: WidgetRenderProps) {
-	const parsed = parseConfig(config);
-	const dateFrom =
-		parsed.dateRangeDays === null
-			? undefined
-			: Math.floor(Date.now() / 1000) - parsed.dateRangeDays * 86_400;
+	const { isLoading, metrics, summary } = useSummaryStatsWidget(config);
 
-	const query = useQuery(
-		trpc.session.list.queryOptions({
-			type: parsed.type === "all" ? undefined : parsed.type,
-			dateFrom,
-		})
-	);
-
-	if (query.isLoading) {
+	if (isLoading) {
 		return (
 			<div className="grid grid-cols-2 gap-2 p-2 sm:grid-cols-3">
-				{parsed.metrics.map((m) => (
+				{metrics.map((m) => (
 					<Skeleton className="h-14" key={m} />
 				))}
 			</div>
 		);
 	}
 
-	const summary = query.data?.summary;
 	if (!summary || summary.totalSessions === 0) {
 		return (
 			<div className="flex h-full items-center justify-center p-4 text-muted-foreground text-sm">
@@ -155,8 +88,9 @@ export function SummaryStatsWidget({ config }: WidgetRenderProps) {
 
 	return (
 		<div className="grid h-full grid-cols-2 gap-2 overflow-auto p-2 sm:grid-cols-3">
-			{parsed.metrics.map((key) => {
-				const label = ALL_METRICS.find((am) => am.key === key)?.label ?? key;
+			{metrics.map((key) => {
+				const label =
+					SUMMARY_STATS_ALL_METRICS.find((am) => am.key === key)?.label ?? key;
 				const value = formatMetricValue(key, summary);
 				const colorClass = metricColor(key, summary);
 				return (
@@ -180,15 +114,17 @@ export function SummaryStatsEditForm({
 	onSave,
 	onCancel,
 }: WidgetEditProps) {
-	const parsed = parseConfig(config);
-	const [metrics, setMetrics] = useState<MetricKey[]>(parsed.metrics);
-	const [type, setType] = useState<StatsType>(parsed.type);
+	const parsed = parseSummaryStatsWidgetConfig(config);
+	const [metrics, setMetrics] = useState<SummaryStatsMetricKey[]>(
+		parsed.metrics
+	);
+	const [type, setType] = useState<SummaryStatsWidgetType>(parsed.type);
 	const [dateRangeDays, setDateRangeDays] = useState<number | null>(
 		parsed.dateRangeDays
 	);
 	const [isSaving, setIsSaving] = useState(false);
 
-	const toggleMetric = (key: MetricKey) => {
+	const toggleMetric = (key: SummaryStatsMetricKey) => {
 		setMetrics((prev) =>
 			prev.includes(key) ? prev.filter((m) => m !== key) : [...prev, key]
 		);
@@ -198,7 +134,7 @@ export function SummaryStatsEditForm({
 		setIsSaving(true);
 		try {
 			await onSave({
-				metrics: metrics.length > 0 ? metrics : DEFAULT_METRICS,
+				metrics: metrics.length > 0 ? metrics : SUMMARY_STATS_DEFAULT_METRICS,
 				type,
 				dateRangeDays,
 			});
@@ -212,7 +148,7 @@ export function SummaryStatsEditForm({
 			<div className="flex flex-col gap-2">
 				<Label>Metrics</Label>
 				<div className="grid grid-cols-2 gap-2">
-					{ALL_METRICS.map((m) => (
+					{SUMMARY_STATS_ALL_METRICS.map((m) => (
 						<label
 							className="flex cursor-pointer items-center gap-2 text-sm"
 							key={m.key}
@@ -232,7 +168,7 @@ export function SummaryStatsEditForm({
 				<select
 					className="rounded-md border bg-background px-3 py-2 text-sm"
 					id="summary-stats-type"
-					onChange={(e) => setType(e.target.value as StatsType)}
+					onChange={(e) => setType(e.target.value as SummaryStatsWidgetType)}
 					value={type}
 				>
 					<option value="all">All</option>

--- a/apps/web/src/live-sessions/components/assign-ring-game-dialog.tsx
+++ b/apps/web/src/live-sessions/components/assign-ring-game-dialog.tsx
@@ -1,7 +1,4 @@
-import { useForm } from "@tanstack/react-form";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
-import { toast } from "sonner";
+import { useAssignRingGame } from "@/live-sessions/hooks/use-assign-ring-game";
 import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { Field } from "@/shared/components/ui/field";
@@ -15,8 +12,6 @@ import {
 } from "@/shared/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/components/ui/tabs";
 import { RingGameForm } from "@/stores/components/ring-game-form";
-import type { RingGameFormValues } from "@/stores/hooks/use-ring-games";
-import { trpc, trpcClient } from "@/utils/trpc";
 
 interface AssignRingGameDialogProps {
 	onOpenChange: (open: boolean) => void;
@@ -24,8 +19,6 @@ interface AssignRingGameDialogProps {
 	sessionId: string;
 	sessionStoreId: string | null;
 }
-
-type Mode = "existing" | "create";
 
 interface RingGameListItem {
 	id: string;
@@ -125,117 +118,25 @@ export function AssignRingGameDialog({
 	sessionId,
 	sessionStoreId,
 }: AssignRingGameDialogProps) {
-	const [mode, setMode] = useState<Mode>("existing");
-	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(
-		sessionStoreId ?? undefined
-	);
-	const queryClient = useQueryClient();
-
-	const storesQuery = useQuery({
-		...trpc.store.list.queryOptions(),
-		enabled: open,
+	const {
+		mode,
+		setMode,
+		stores,
+		selectedStoreId,
+		setSelectedStoreId,
+		effectiveStoreId,
+		ringGames,
+		selectForm,
+		handleCreate,
+		isAssignPending,
+		isCreatePending,
+		isBusy,
+	} = useAssignRingGame({
+		onClose: () => onOpenChange(false),
+		open,
+		sessionId,
+		sessionStoreId,
 	});
-	const stores = storesQuery.data ?? [];
-
-	const effectiveStoreId = sessionStoreId ?? selectedStoreId;
-
-	const ringGamesQuery = useQuery({
-		...trpc.ringGame.listByStore.queryOptions({
-			storeId: effectiveStoreId ?? "",
-			includeArchived: false,
-		}),
-		enabled: open && !!effectiveStoreId,
-	});
-	const ringGames = (ringGamesQuery.data ?? []) as RingGameListItem[];
-
-	const invalidateSession = async () => {
-		await Promise.all([
-			queryClient.invalidateQueries({
-				queryKey: trpc.liveCashGameSession.getById.queryOptions({
-					id: sessionId,
-				}).queryKey,
-			}),
-			queryClient.invalidateQueries({
-				queryKey: trpc.liveCashGameSession.list.queryOptions({}).queryKey,
-			}),
-			queryClient.invalidateQueries({
-				queryKey: trpc.session.list.queryOptions({}).queryKey,
-			}),
-		]);
-	};
-
-	const assignMutation = useMutation({
-		mutationFn: (ringGameId: string) =>
-			trpcClient.liveCashGameSession.update.mutate({
-				id: sessionId,
-				ringGameId,
-			}),
-		onSuccess: async () => {
-			await invalidateSession();
-			toast.success("Game assigned");
-			onOpenChange(false);
-		},
-		onError: (error) => {
-			toast.error(error.message || "Failed to assign game");
-		},
-	});
-
-	const createAndAssignMutation = useMutation({
-		mutationFn: async ({
-			storeId,
-			values,
-		}: {
-			storeId: string;
-			values: RingGameFormValues;
-		}) => {
-			const created = await trpcClient.ringGame.create.mutate({
-				storeId,
-				...values,
-			});
-			await trpcClient.liveCashGameSession.update.mutate({
-				id: sessionId,
-				ringGameId: created.id,
-			});
-			return created;
-		},
-		onSuccess: async () => {
-			await Promise.all([
-				invalidateSession(),
-				queryClient.invalidateQueries({
-					queryKey: trpc.ringGame.listByStore.queryOptions({
-						storeId: effectiveStoreId ?? "",
-					}).queryKey,
-				}),
-			]);
-			toast.success("Game created and assigned");
-			onOpenChange(false);
-		},
-		onError: (error) => {
-			toast.error(error.message || "Failed to create game");
-		},
-	});
-
-	const selectForm = useForm({
-		defaultValues: { ringGameId: "" },
-		onSubmit: ({ value }) => {
-			if (!value.ringGameId) {
-				return;
-			}
-			assignMutation.mutate(value.ringGameId);
-		},
-	});
-
-	const handleCreate = (values: RingGameFormValues) => {
-		if (!effectiveStoreId) {
-			toast.error("Select a store first");
-			return;
-		}
-		createAndAssignMutation.mutate({ storeId: effectiveStoreId, values });
-	};
-
-	const isAssignPending = assignMutation.isPending;
-	const isCreatePending = createAndAssignMutation.isPending;
-	const isBusy = isAssignPending || isCreatePending;
 
 	const renderExistingTab = () => (
 		<form
@@ -299,7 +200,7 @@ export function AssignRingGameDialog({
 		>
 			<Tabs
 				className="mb-4"
-				onValueChange={(value) => setMode(value as Mode)}
+				onValueChange={(value) => setMode(value as "existing" | "create")}
 				value={mode}
 			>
 				<TabsList className="grid w-full grid-cols-2">

--- a/apps/web/src/live-sessions/hooks/use-assign-ring-game.ts
+++ b/apps/web/src/live-sessions/hooks/use-assign-ring-game.ts
@@ -1,0 +1,152 @@
+import { useForm } from "@tanstack/react-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import type { RingGameFormValues } from "@/stores/hooks/use-ring-games";
+import { invalidateTargets } from "@/utils/optimistic-update";
+import { trpc, trpcClient } from "@/utils/trpc";
+
+type Mode = "existing" | "create";
+
+interface RingGameListItem {
+	id: string;
+	name: string;
+}
+
+interface UseAssignRingGameOptions {
+	onClose: () => void;
+	open: boolean;
+	sessionId: string;
+	sessionStoreId: string | null;
+}
+
+export function useAssignRingGame({
+	onClose,
+	open,
+	sessionId,
+	sessionStoreId,
+}: UseAssignRingGameOptions) {
+	const queryClient = useQueryClient();
+	const [mode, setMode] = useState<Mode>("existing");
+	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(
+		sessionStoreId ?? undefined
+	);
+
+	const storesQuery = useQuery({
+		...trpc.store.list.queryOptions(),
+		enabled: open,
+	});
+	const stores = storesQuery.data ?? [];
+
+	const effectiveStoreId = sessionStoreId ?? selectedStoreId;
+
+	const ringGamesQuery = useQuery({
+		...trpc.ringGame.listByStore.queryOptions({
+			storeId: effectiveStoreId ?? "",
+			includeArchived: false,
+		}),
+		enabled: open && !!effectiveStoreId,
+	});
+	const ringGames = (ringGamesQuery.data ?? []) as RingGameListItem[];
+
+	const invalidateSession = () =>
+		invalidateTargets(queryClient, [
+			{
+				queryKey: trpc.liveCashGameSession.getById.queryOptions({
+					id: sessionId,
+				}).queryKey,
+			},
+			{ queryKey: trpc.liveCashGameSession.list.queryOptions({}).queryKey },
+			{ queryKey: trpc.session.list.queryOptions({}).queryKey },
+		]);
+
+	const assignMutation = useMutation({
+		mutationFn: (ringGameId: string) =>
+			trpcClient.liveCashGameSession.update.mutate({
+				id: sessionId,
+				ringGameId,
+			}),
+		onSuccess: async () => {
+			await invalidateSession();
+			toast.success("Game assigned");
+			onClose();
+		},
+		onError: (error) => {
+			toast.error(error.message || "Failed to assign game");
+		},
+	});
+
+	const createAndAssignMutation = useMutation({
+		mutationFn: async ({
+			storeId,
+			values,
+		}: {
+			storeId: string;
+			values: RingGameFormValues;
+		}) => {
+			const created = await trpcClient.ringGame.create.mutate({
+				storeId,
+				...values,
+			});
+			await trpcClient.liveCashGameSession.update.mutate({
+				id: sessionId,
+				ringGameId: created.id,
+			});
+			return created;
+		},
+		onSuccess: async () => {
+			await Promise.all([
+				invalidateSession(),
+				invalidateTargets(queryClient, [
+					{
+						queryKey: trpc.ringGame.listByStore.queryOptions({
+							storeId: effectiveStoreId ?? "",
+						}).queryKey,
+					},
+				]),
+			]);
+			toast.success("Game created and assigned");
+			onClose();
+		},
+		onError: (error) => {
+			toast.error(error.message || "Failed to create game");
+		},
+	});
+
+	const selectForm = useForm({
+		defaultValues: { ringGameId: "" },
+		onSubmit: ({ value }) => {
+			if (!value.ringGameId) {
+				return;
+			}
+			assignMutation.mutate(value.ringGameId);
+		},
+	});
+
+	const handleCreate = (values: RingGameFormValues) => {
+		if (!effectiveStoreId) {
+			toast.error("Select a store first");
+			return;
+		}
+		createAndAssignMutation.mutate({ storeId: effectiveStoreId, values });
+	};
+
+	const isAssignPending = assignMutation.isPending;
+	const isCreatePending = createAndAssignMutation.isPending;
+	const isBusy = isAssignPending || isCreatePending;
+
+	return {
+		mode,
+		setMode,
+		stores,
+		selectedStoreId,
+		setSelectedStoreId,
+		effectiveStoreId,
+		ringGames,
+		selectForm,
+		handleCreate,
+		isAssignPending,
+		isCreatePending,
+		isBusy,
+	};
+}

--- a/apps/web/src/stores/components/ring-game-form.tsx
+++ b/apps/web/src/stores/components/ring-game-form.tsx
@@ -1,6 +1,3 @@
-import { useForm } from "@tanstack/react-form";
-import { useQuery } from "@tanstack/react-query";
-import { z } from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
@@ -12,8 +9,8 @@ import {
 	SelectValue,
 } from "@/shared/components/ui/select";
 import { Textarea } from "@/shared/components/ui/textarea";
-import { optionalNumericString } from "@/shared/lib/form-fields";
-import { trpc } from "@/utils/trpc";
+import { useRingGameForm } from "@/stores/hooks/use-ring-game-form";
+import type { RingGameFormValues } from "@/stores/hooks/use-ring-games";
 
 const GAME_VARIANTS = {
 	nlh: {
@@ -25,21 +22,6 @@ const GAME_VARIANTS = {
 type Variant = keyof typeof GAME_VARIANTS;
 
 type AnteType = "all" | "bb" | "none";
-
-interface RingGameFormValues {
-	ante?: number;
-	anteType?: AnteType;
-	blind1?: number;
-	blind2?: number;
-	blind3?: number;
-	currencyId?: string;
-	maxBuyIn?: number;
-	memo?: string;
-	minBuyIn?: number;
-	name: string;
-	tableSize?: number;
-	variant: string;
-}
 
 interface RingGameFormProps {
 	defaultValues?: RingGameFormValues;
@@ -55,77 +37,12 @@ const ANTE_TYPES = [
 	{ value: "all", label: "All Ante" },
 ] as const;
 
-const ringGameFormSchema = z.object({
-	name: z.string().min(1, "Game name is required"),
-	variant: z.string().min(1),
-	blind1: optionalNumericString({ integer: true, min: 0 }),
-	blind2: optionalNumericString({ integer: true, min: 0 }),
-	blind3: optionalNumericString({ integer: true, min: 0 }),
-	ante: optionalNumericString({ integer: true, min: 0 }),
-	anteType: z.enum(["all", "bb", "none"]),
-	minBuyIn: optionalNumericString({ integer: true, min: 0 }),
-	maxBuyIn: optionalNumericString({ integer: true, min: 0 }),
-	tableSize: z.string(),
-	currencyId: z.string(),
-	memo: z.string(),
-});
-
-function numStrOrEmpty(value: number | undefined): string {
-	return value === undefined ? "" : String(value);
-}
-
-function parseOptInt(value: string): number | undefined {
-	if (value === "") {
-		return undefined;
-	}
-	const parsed = Number.parseInt(value, 10);
-	return Number.isFinite(parsed) ? parsed : undefined;
-}
-
 export function RingGameForm({
 	onSubmit,
 	defaultValues,
 	isLoading = false,
 }: RingGameFormProps) {
-	const currenciesQuery = useQuery(trpc.currency.list.queryOptions());
-	const currencies = currenciesQuery.data ?? [];
-
-	const form = useForm({
-		defaultValues: {
-			name: defaultValues?.name ?? "",
-			variant: (defaultValues?.variant ?? "nlh") as string,
-			blind1: numStrOrEmpty(defaultValues?.blind1),
-			blind2: numStrOrEmpty(defaultValues?.blind2),
-			blind3: numStrOrEmpty(defaultValues?.blind3),
-			ante: numStrOrEmpty(defaultValues?.ante),
-			anteType: (defaultValues?.anteType ?? "none") as AnteType,
-			minBuyIn: numStrOrEmpty(defaultValues?.minBuyIn),
-			maxBuyIn: numStrOrEmpty(defaultValues?.maxBuyIn),
-			tableSize: defaultValues?.tableSize?.toString() ?? "",
-			currencyId: defaultValues?.currencyId ?? "",
-			memo: defaultValues?.memo ?? "",
-		},
-		onSubmit: ({ value }) => {
-			const isAnteDisabled = value.anteType === "none";
-			onSubmit({
-				name: value.name,
-				variant: value.variant || "nlh",
-				blind1: parseOptInt(value.blind1),
-				blind2: parseOptInt(value.blind2),
-				blind3: parseOptInt(value.blind3),
-				ante: isAnteDisabled ? undefined : parseOptInt(value.ante),
-				anteType: value.anteType,
-				minBuyIn: parseOptInt(value.minBuyIn),
-				maxBuyIn: parseOptInt(value.maxBuyIn),
-				tableSize: parseOptInt(value.tableSize),
-				currencyId: value.currencyId || undefined,
-				memo: value.memo ? value.memo : undefined,
-			});
-		},
-		validators: {
-			onSubmit: ringGameFormSchema,
-		},
-	});
+	const { form, currencies } = useRingGameForm({ defaultValues, onSubmit });
 
 	const variantKey = (defaultValues?.variant ?? "nlh") as Variant;
 	const blindLabels = GAME_VARIANTS[variantKey]?.blindLabels ?? {

--- a/apps/web/src/stores/components/tournament-form.tsx
+++ b/apps/web/src/stores/components/tournament-form.tsx
@@ -1,7 +1,4 @@
 import { IconPlus, IconTrash } from "@tabler/icons-react";
-import { useForm } from "@tanstack/react-form";
-import { useQuery } from "@tanstack/react-query";
-import { z } from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
@@ -14,35 +11,14 @@ import {
 } from "@/shared/components/ui/select";
 import { TagInput } from "@/shared/components/ui/tag-input";
 import { Textarea } from "@/shared/components/ui/textarea";
-import { optionalNumericString } from "@/shared/lib/form-fields";
-import { trpc } from "@/utils/trpc";
+import { useTournamentForm } from "@/stores/hooks/use-tournament-form";
+import type { TournamentFormValues } from "@/stores/hooks/use-tournaments";
 
 const GAME_VARIANTS = {
 	nlh: { label: "NL Hold'em" },
 } as const;
 
 const TABLE_SIZES = [2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
-
-interface ChipPurchaseFormItem {
-	chips: string;
-	cost: string;
-	name: string;
-	uid: string;
-}
-
-export interface TournamentFormValues {
-	bountyAmount?: number;
-	buyIn?: number;
-	chipPurchases: Array<{ name: string; cost: number; chips: number }>;
-	currencyId?: string;
-	entryFee?: number;
-	memo?: string;
-	name: string;
-	startingStack?: number;
-	tableSize?: number;
-	tags?: string[];
-	variant: string;
-}
 
 interface TournamentFormProps {
 	defaultValues?: Omit<TournamentFormValues, "tags" | "chipPurchases"> & {
@@ -53,94 +29,12 @@ interface TournamentFormProps {
 	onSubmit: (values: TournamentFormValues) => void;
 }
 
-function numStrOrEmpty(value: number | undefined): string {
-	return value === undefined ? "" : String(value);
-}
-
-function parseOptInt(value: string): number | undefined {
-	if (value === "") {
-		return undefined;
-	}
-	const parsed = Number.parseInt(value, 10);
-	return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function parseCostInt(value: string): number {
-	const parsed = Number.parseInt(value, 10);
-	return Number.isFinite(parsed) ? parsed : 0;
-}
-
-const chipPurchaseItemSchema = z.object({
-	name: z.string(),
-	cost: z.string(),
-	chips: z.string(),
-	uid: z.string(),
-});
-
-const tournamentFormSchema = z.object({
-	name: z.string().min(1, "Tournament name is required"),
-	variant: z.string(),
-	buyIn: optionalNumericString({ integer: true, min: 0 }),
-	entryFee: optionalNumericString({ integer: true, min: 0 }),
-	startingStack: optionalNumericString({ integer: true, min: 0 }),
-	bountyAmount: optionalNumericString({ integer: true, min: 0 }),
-	tableSize: z.string(),
-	currencyId: z.string(),
-	memo: z.string(),
-	tags: z.array(z.string()),
-	chipPurchases: z.array(chipPurchaseItemSchema),
-});
-
 export function TournamentForm({
 	onSubmit,
 	defaultValues,
 	isLoading = false,
 }: TournamentFormProps) {
-	const currenciesQuery = useQuery(trpc.currency.list.queryOptions());
-	const currencies = currenciesQuery.data ?? [];
-
-	const form = useForm({
-		defaultValues: {
-			name: defaultValues?.name ?? "",
-			variant: defaultValues?.variant ?? "nlh",
-			buyIn: numStrOrEmpty(defaultValues?.buyIn),
-			entryFee: numStrOrEmpty(defaultValues?.entryFee),
-			startingStack: numStrOrEmpty(defaultValues?.startingStack),
-			bountyAmount: numStrOrEmpty(defaultValues?.bountyAmount),
-			tableSize: defaultValues?.tableSize?.toString() ?? "",
-			currencyId: defaultValues?.currencyId ?? "",
-			memo: defaultValues?.memo ?? "",
-			tags: defaultValues?.tags ?? [],
-			chipPurchases: (defaultValues?.chipPurchases ?? []).map((cp) => ({
-				name: cp.name,
-				cost: String(cp.cost),
-				chips: String(cp.chips),
-				uid: crypto.randomUUID(),
-			})) as ChipPurchaseFormItem[],
-		},
-		onSubmit: ({ value }) => {
-			onSubmit({
-				name: value.name,
-				variant: value.variant || "nlh",
-				buyIn: parseOptInt(value.buyIn),
-				entryFee: parseOptInt(value.entryFee),
-				startingStack: parseOptInt(value.startingStack),
-				chipPurchases: value.chipPurchases.map((cp) => ({
-					name: cp.name,
-					cost: parseCostInt(cp.cost),
-					chips: parseCostInt(cp.chips),
-				})),
-				bountyAmount: parseOptInt(value.bountyAmount),
-				tableSize: parseOptInt(value.tableSize),
-				currencyId: value.currencyId || undefined,
-				memo: value.memo ? value.memo : undefined,
-				tags: value.tags,
-			});
-		},
-		validators: {
-			onSubmit: tournamentFormSchema,
-		},
-	});
+	const { form, currencies } = useTournamentForm({ defaultValues, onSubmit });
 
 	return (
 		<form

--- a/apps/web/src/stores/components/tournament-tab.tsx
+++ b/apps/web/src/stores/components/tournament-tab.tsx
@@ -6,7 +6,6 @@ import {
 	IconTrash,
 	IconX,
 } from "@tabler/icons-react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import {
 	ExpandableItem,
@@ -17,19 +16,17 @@ import { ManagementSectionState } from "@/shared/components/management/managemen
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import { TournamentEditDialog } from "@/stores/components/tournament-edit-dialog";
-import type { TournamentPartialFormValues } from "@/stores/components/tournament-modal-content";
 import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
-import type {
-	Tournament,
-	TournamentFormValues,
-} from "@/stores/hooks/use-tournaments";
-import { useTournaments } from "@/stores/hooks/use-tournaments";
+import {
+	useBlindStructureSummary,
+	useTournamentTab,
+} from "@/stores/hooks/use-tournament-tab";
+import type { Tournament } from "@/stores/hooks/use-tournaments";
 import {
 	createGroupFormatter,
 	formatCompactNumber,
 } from "@/utils/format-number";
 import { getTableSizeClassName } from "@/utils/table-size-colors";
-import { trpc, trpcClient } from "@/utils/trpc";
 
 interface TournamentTabProps {
 	expandedGameId: string | null;
@@ -447,12 +444,9 @@ function TournamentActions({
 }
 
 function BlindStructureSummary({ tournamentId }: { tournamentId: string }) {
-	const levelsQuery = useQuery(
-		trpc.blindLevel.listByTournament.queryOptions({ tournamentId })
-	);
-	const levels = (levelsQuery.data ?? []) as BlindLevelRow[];
+	const { levels, isLoading } = useBlindStructureSummary(tournamentId);
 
-	if (levelsQuery.isLoading) {
+	if (isLoading) {
 		return (
 			<p className="py-1 text-center text-muted-foreground text-xs">
 				Loading levels...
@@ -491,7 +485,7 @@ function BlindStructureSummary({ tournamentId }: { tournamentId: string }) {
 					</tr>
 				</thead>
 				<tbody>
-					{levels.map((row) => {
+					{levels.map((row: BlindLevelRow) => {
 						if (row.isBreak) {
 							return (
 								<tr className="bg-muted/30" key={row.id}>
@@ -543,53 +537,11 @@ function BlindStructureSummary({ tournamentId }: { tournamentId: string }) {
 
 // ---- Main tab component ----
 
-function tournamentToInitialFormValues(
-	tournament: Tournament
-): TournamentPartialFormValues {
-	return {
-		name: tournament.name,
-		variant: tournament.variant,
-		buyIn: tournament.buyIn ?? undefined,
-		entryFee: tournament.entryFee ?? undefined,
-		startingStack: tournament.startingStack ?? undefined,
-		chipPurchases: tournament.chipPurchases.map((cp) => ({
-			name: cp.name,
-			cost: cp.cost,
-			chips: cp.chips,
-		})),
-		bountyAmount: tournament.bountyAmount ?? undefined,
-		tableSize: tournament.tableSize ?? undefined,
-		currencyId: tournament.currencyId ?? undefined,
-		memo: tournament.memo ?? undefined,
-		tags: tournament.tags.map((t) => t.name),
-	};
-}
-
-function levelsToPayload(levels: BlindLevelRow[]) {
-	return levels.map((l) => ({
-		isBreak: l.isBreak,
-		blind1: l.blind1,
-		blind2: l.blind2,
-		blind3: l.blind3,
-		ante: l.ante,
-		minutes: l.minutes,
-	}));
-}
-
 export function TournamentTab({
 	storeId,
 	expandedGameId,
 	onToggleGame,
 }: TournamentTabProps) {
-	const queryClient = useQueryClient();
-	const [showArchived, setShowArchived] = useState(false);
-	const [isCreateOpen, setIsCreateOpen] = useState(false);
-	const [editingTournament, setEditingTournament] = useState<Tournament | null>(
-		null
-	);
-	const [isCreateLoading, setIsCreateLoading] = useState(false);
-	const [isUpdateLoading, setIsUpdateLoading] = useState(false);
-
 	const {
 		activeTournaments,
 		archivedTournaments,
@@ -598,104 +550,21 @@ export function TournamentTab({
 		archivedLoading,
 		archive,
 		restore,
-		delete: deleteTournament,
-	} = useTournaments({ storeId, showArchived });
-
-	const editBlindLevelsQuery = useQuery({
-		...trpc.blindLevel.listByTournament.queryOptions({
-			tournamentId: editingTournament?.id ?? "",
-		}),
-		enabled: editingTournament !== null,
-	});
-
-	const invalidateTournamentLists = async () => {
-		await Promise.all([
-			queryClient.invalidateQueries({
-				queryKey: trpc.tournament.listByStore.queryOptions({
-					storeId,
-					includeArchived: false,
-				}).queryKey,
-			}),
-			queryClient.invalidateQueries({
-				queryKey: trpc.tournament.listByStore.queryOptions({
-					storeId,
-					includeArchived: true,
-				}).queryKey,
-			}),
-		]);
-	};
-
-	const handleCreate = async (
-		values: TournamentFormValues,
-		levels: BlindLevelRow[]
-	) => {
-		setIsCreateLoading(true);
-		try {
-			await trpcClient.tournament.createWithLevels.mutate({
-				storeId,
-				name: values.name,
-				variant: values.variant,
-				buyIn: values.buyIn,
-				entryFee: values.entryFee,
-				startingStack: values.startingStack,
-				bountyAmount: values.bountyAmount,
-				tableSize: values.tableSize,
-				currencyId: values.currencyId,
-				memo: values.memo,
-				tags: values.tags,
-				chipPurchases: values.chipPurchases,
-				blindLevels: levelsToPayload(levels),
-			});
-			await invalidateTournamentLists();
-			setIsCreateOpen(false);
-		} finally {
-			setIsCreateLoading(false);
-		}
-	};
-
-	const handleUpdate = async (
-		values: TournamentFormValues,
-		levels: BlindLevelRow[]
-	) => {
-		if (!editingTournament) {
-			return;
-		}
-		setIsUpdateLoading(true);
-		try {
-			await trpcClient.tournament.updateWithLevels.mutate({
-				id: editingTournament.id,
-				name: values.name,
-				variant: values.variant,
-				buyIn: values.buyIn ?? null,
-				entryFee: values.entryFee ?? null,
-				startingStack: values.startingStack ?? null,
-				bountyAmount: values.bountyAmount ?? null,
-				tableSize: values.tableSize ?? null,
-				currencyId: values.currencyId ?? null,
-				memo: values.memo ?? null,
-				tags: values.tags,
-				chipPurchases: values.chipPurchases,
-				blindLevels: levelsToPayload(levels),
-			});
-			await Promise.all([
-				invalidateTournamentLists(),
-				queryClient.invalidateQueries({
-					queryKey: trpc.blindLevel.listByTournament.queryOptions({
-						tournamentId: editingTournament.id,
-					}).queryKey,
-				}),
-			]);
-			setEditingTournament(null);
-		} finally {
-			setIsUpdateLoading(false);
-		}
-	};
-
-	const editInitialFormValues = editingTournament
-		? tournamentToInitialFormValues(editingTournament)
-		: undefined;
-	const editInitialLevels = (editBlindLevelsQuery.data ??
-		[]) as BlindLevelRow[];
+		deleteTournament,
+		showArchived,
+		setShowArchived,
+		isCreateOpen,
+		setIsCreateOpen,
+		editingTournament,
+		setEditingTournament,
+		isCreateLoading,
+		isUpdateLoading,
+		editBlindLevelsLoading,
+		editInitialFormValues,
+		editInitialLevels,
+		handleCreate,
+		handleUpdate,
+	} = useTournamentTab({ storeId });
 
 	return (
 		<div>
@@ -759,7 +628,7 @@ export function TournamentTab({
 				aiMode="edit"
 				initialBlindLevels={editInitialLevels}
 				initialFormValues={editInitialFormValues}
-				isInitializing={editBlindLevelsQuery.isLoading}
+				isInitializing={editBlindLevelsLoading}
 				isLoading={isUpdateLoading}
 				onOpenChange={(open) => {
 					if (!open) {

--- a/apps/web/src/stores/hooks/use-ring-game-form.ts
+++ b/apps/web/src/stores/hooks/use-ring-game-form.ts
@@ -1,0 +1,87 @@
+import { useForm } from "@tanstack/react-form";
+import { useQuery } from "@tanstack/react-query";
+import { z } from "zod";
+import { optionalNumericString } from "@/shared/lib/form-fields";
+import type { RingGameFormValues } from "@/stores/hooks/use-ring-games";
+import { trpc } from "@/utils/trpc";
+
+type RingGameAnteType = "all" | "bb" | "none";
+
+const ringGameFormSchema = z.object({
+	name: z.string().min(1, "Game name is required"),
+	variant: z.string().min(1),
+	blind1: optionalNumericString({ integer: true, min: 0 }),
+	blind2: optionalNumericString({ integer: true, min: 0 }),
+	blind3: optionalNumericString({ integer: true, min: 0 }),
+	ante: optionalNumericString({ integer: true, min: 0 }),
+	anteType: z.enum(["all", "bb", "none"]),
+	minBuyIn: optionalNumericString({ integer: true, min: 0 }),
+	maxBuyIn: optionalNumericString({ integer: true, min: 0 }),
+	tableSize: z.string(),
+	currencyId: z.string(),
+	memo: z.string(),
+});
+
+function numStrOrEmpty(value: number | undefined): string {
+	return value === undefined ? "" : String(value);
+}
+
+function parseOptInt(value: string): number | undefined {
+	if (value === "") {
+		return undefined;
+	}
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+interface UseRingGameFormOptions {
+	defaultValues?: RingGameFormValues;
+	onSubmit: (values: RingGameFormValues) => void;
+}
+
+export function useRingGameForm({
+	defaultValues,
+	onSubmit,
+}: UseRingGameFormOptions) {
+	const currenciesQuery = useQuery(trpc.currency.list.queryOptions());
+	const currencies = currenciesQuery.data ?? [];
+
+	const form = useForm({
+		defaultValues: {
+			name: defaultValues?.name ?? "",
+			variant: (defaultValues?.variant ?? "nlh") as string,
+			blind1: numStrOrEmpty(defaultValues?.blind1),
+			blind2: numStrOrEmpty(defaultValues?.blind2),
+			blind3: numStrOrEmpty(defaultValues?.blind3),
+			ante: numStrOrEmpty(defaultValues?.ante),
+			anteType: (defaultValues?.anteType ?? "none") as RingGameAnteType,
+			minBuyIn: numStrOrEmpty(defaultValues?.minBuyIn),
+			maxBuyIn: numStrOrEmpty(defaultValues?.maxBuyIn),
+			tableSize: defaultValues?.tableSize?.toString() ?? "",
+			currencyId: defaultValues?.currencyId ?? "",
+			memo: defaultValues?.memo ?? "",
+		},
+		onSubmit: ({ value }) => {
+			const isAnteDisabled = value.anteType === "none";
+			onSubmit({
+				name: value.name,
+				variant: value.variant || "nlh",
+				blind1: parseOptInt(value.blind1),
+				blind2: parseOptInt(value.blind2),
+				blind3: parseOptInt(value.blind3),
+				ante: isAnteDisabled ? undefined : parseOptInt(value.ante),
+				anteType: value.anteType,
+				minBuyIn: parseOptInt(value.minBuyIn),
+				maxBuyIn: parseOptInt(value.maxBuyIn),
+				tableSize: parseOptInt(value.tableSize),
+				currencyId: value.currencyId || undefined,
+				memo: value.memo ? value.memo : undefined,
+			});
+		},
+		validators: {
+			onSubmit: ringGameFormSchema,
+		},
+	});
+
+	return { form, currencies };
+}

--- a/apps/web/src/stores/hooks/use-tournament-form.ts
+++ b/apps/web/src/stores/hooks/use-tournament-form.ts
@@ -1,0 +1,112 @@
+import { useForm } from "@tanstack/react-form";
+import { useQuery } from "@tanstack/react-query";
+import { z } from "zod";
+import { optionalNumericString } from "@/shared/lib/form-fields";
+import type { TournamentFormValues } from "@/stores/hooks/use-tournaments";
+import { trpc } from "@/utils/trpc";
+
+interface ChipPurchaseFormItem {
+	chips: string;
+	cost: string;
+	name: string;
+	uid: string;
+}
+
+function numStrOrEmpty(value: number | undefined): string {
+	return value === undefined ? "" : String(value);
+}
+
+function parseOptInt(value: string): number | undefined {
+	if (value === "") {
+		return undefined;
+	}
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseCostInt(value: string): number {
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) ? parsed : 0;
+}
+
+const chipPurchaseItemSchema = z.object({
+	name: z.string(),
+	cost: z.string(),
+	chips: z.string(),
+	uid: z.string(),
+});
+
+const tournamentFormSchema = z.object({
+	name: z.string().min(1, "Tournament name is required"),
+	variant: z.string(),
+	buyIn: optionalNumericString({ integer: true, min: 0 }),
+	entryFee: optionalNumericString({ integer: true, min: 0 }),
+	startingStack: optionalNumericString({ integer: true, min: 0 }),
+	bountyAmount: optionalNumericString({ integer: true, min: 0 }),
+	tableSize: z.string(),
+	currencyId: z.string(),
+	memo: z.string(),
+	tags: z.array(z.string()),
+	chipPurchases: z.array(chipPurchaseItemSchema),
+});
+
+interface UseTournamentFormOptions {
+	defaultValues?: Omit<TournamentFormValues, "tags" | "chipPurchases"> & {
+		chipPurchases?: Array<{ name: string; cost: number; chips: number }>;
+		tags?: string[];
+	};
+	onSubmit: (values: TournamentFormValues) => void;
+}
+
+export function useTournamentForm({
+	defaultValues,
+	onSubmit,
+}: UseTournamentFormOptions) {
+	const currenciesQuery = useQuery(trpc.currency.list.queryOptions());
+	const currencies = currenciesQuery.data ?? [];
+
+	const form = useForm({
+		defaultValues: {
+			name: defaultValues?.name ?? "",
+			variant: defaultValues?.variant ?? "nlh",
+			buyIn: numStrOrEmpty(defaultValues?.buyIn),
+			entryFee: numStrOrEmpty(defaultValues?.entryFee),
+			startingStack: numStrOrEmpty(defaultValues?.startingStack),
+			bountyAmount: numStrOrEmpty(defaultValues?.bountyAmount),
+			tableSize: defaultValues?.tableSize?.toString() ?? "",
+			currencyId: defaultValues?.currencyId ?? "",
+			memo: defaultValues?.memo ?? "",
+			tags: defaultValues?.tags ?? [],
+			chipPurchases: (defaultValues?.chipPurchases ?? []).map((cp) => ({
+				name: cp.name,
+				cost: String(cp.cost),
+				chips: String(cp.chips),
+				uid: crypto.randomUUID(),
+			})) as ChipPurchaseFormItem[],
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				name: value.name,
+				variant: value.variant || "nlh",
+				buyIn: parseOptInt(value.buyIn),
+				entryFee: parseOptInt(value.entryFee),
+				startingStack: parseOptInt(value.startingStack),
+				chipPurchases: value.chipPurchases.map((cp) => ({
+					name: cp.name,
+					cost: parseCostInt(cp.cost),
+					chips: parseCostInt(cp.chips),
+				})),
+				bountyAmount: parseOptInt(value.bountyAmount),
+				tableSize: parseOptInt(value.tableSize),
+				currencyId: value.currencyId || undefined,
+				memo: value.memo ? value.memo : undefined,
+				tags: value.tags,
+			});
+		},
+		validators: {
+			onSubmit: tournamentFormSchema,
+		},
+	});
+
+	return { form, currencies };
+}

--- a/apps/web/src/stores/hooks/use-tournament-tab.ts
+++ b/apps/web/src/stores/hooks/use-tournament-tab.ts
@@ -1,0 +1,201 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import type { TournamentPartialFormValues } from "@/stores/components/tournament-modal-content";
+import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+import type {
+	Tournament,
+	TournamentFormValues,
+} from "@/stores/hooks/use-tournaments";
+import { useTournaments } from "@/stores/hooks/use-tournaments";
+import { invalidateTargets } from "@/utils/optimistic-update";
+import { trpc, trpcClient } from "@/utils/trpc";
+
+function tournamentToInitialFormValues(
+	tournament: Tournament
+): TournamentPartialFormValues {
+	return {
+		name: tournament.name,
+		variant: tournament.variant,
+		buyIn: tournament.buyIn ?? undefined,
+		entryFee: tournament.entryFee ?? undefined,
+		startingStack: tournament.startingStack ?? undefined,
+		chipPurchases: tournament.chipPurchases.map((cp) => ({
+			name: cp.name,
+			cost: cp.cost,
+			chips: cp.chips,
+		})),
+		bountyAmount: tournament.bountyAmount ?? undefined,
+		tableSize: tournament.tableSize ?? undefined,
+		currencyId: tournament.currencyId ?? undefined,
+		memo: tournament.memo ?? undefined,
+		tags: tournament.tags.map((t) => t.name),
+	};
+}
+
+function levelsToPayload(levels: BlindLevelRow[]) {
+	return levels.map((l) => ({
+		isBreak: l.isBreak,
+		blind1: l.blind1,
+		blind2: l.blind2,
+		blind3: l.blind3,
+		ante: l.ante,
+		minutes: l.minutes,
+	}));
+}
+
+interface UseTournamentTabOptions {
+	storeId: string;
+}
+
+export function useTournamentTab({ storeId }: UseTournamentTabOptions) {
+	const queryClient = useQueryClient();
+	const [showArchived, setShowArchived] = useState(false);
+	const [isCreateOpen, setIsCreateOpen] = useState(false);
+	const [editingTournament, setEditingTournament] = useState<Tournament | null>(
+		null
+	);
+	const [isCreateLoading, setIsCreateLoading] = useState(false);
+	const [isUpdateLoading, setIsUpdateLoading] = useState(false);
+
+	const {
+		activeTournaments,
+		archivedTournaments,
+		currencies,
+		activeLoading,
+		archivedLoading,
+		archive,
+		restore,
+		delete: deleteTournament,
+	} = useTournaments({ storeId, showArchived });
+
+	const editBlindLevelsQuery = useQuery({
+		...trpc.blindLevel.listByTournament.queryOptions({
+			tournamentId: editingTournament?.id ?? "",
+		}),
+		enabled: editingTournament !== null,
+	});
+
+	const invalidateTournamentLists = () =>
+		invalidateTargets(queryClient, [
+			{
+				queryKey: trpc.tournament.listByStore.queryOptions({
+					storeId,
+					includeArchived: false,
+				}).queryKey,
+			},
+			{
+				queryKey: trpc.tournament.listByStore.queryOptions({
+					storeId,
+					includeArchived: true,
+				}).queryKey,
+			},
+		]);
+
+	const handleCreate = async (
+		values: TournamentFormValues,
+		levels: BlindLevelRow[]
+	) => {
+		setIsCreateLoading(true);
+		try {
+			await trpcClient.tournament.createWithLevels.mutate({
+				storeId,
+				name: values.name,
+				variant: values.variant,
+				buyIn: values.buyIn,
+				entryFee: values.entryFee,
+				startingStack: values.startingStack,
+				bountyAmount: values.bountyAmount,
+				tableSize: values.tableSize,
+				currencyId: values.currencyId,
+				memo: values.memo,
+				tags: values.tags,
+				chipPurchases: values.chipPurchases,
+				blindLevels: levelsToPayload(levels),
+			});
+			await invalidateTournamentLists();
+			setIsCreateOpen(false);
+		} finally {
+			setIsCreateLoading(false);
+		}
+	};
+
+	const handleUpdate = async (
+		values: TournamentFormValues,
+		levels: BlindLevelRow[]
+	) => {
+		if (!editingTournament) {
+			return;
+		}
+		setIsUpdateLoading(true);
+		try {
+			await trpcClient.tournament.updateWithLevels.mutate({
+				id: editingTournament.id,
+				name: values.name,
+				variant: values.variant,
+				buyIn: values.buyIn ?? null,
+				entryFee: values.entryFee ?? null,
+				startingStack: values.startingStack ?? null,
+				bountyAmount: values.bountyAmount ?? null,
+				tableSize: values.tableSize ?? null,
+				currencyId: values.currencyId ?? null,
+				memo: values.memo ?? null,
+				tags: values.tags,
+				chipPurchases: values.chipPurchases,
+				blindLevels: levelsToPayload(levels),
+			});
+			await Promise.all([
+				invalidateTournamentLists(),
+				invalidateTargets(queryClient, [
+					{
+						queryKey: trpc.blindLevel.listByTournament.queryOptions({
+							tournamentId: editingTournament.id,
+						}).queryKey,
+					},
+				]),
+			]);
+			setEditingTournament(null);
+		} finally {
+			setIsUpdateLoading(false);
+		}
+	};
+
+	const editInitialFormValues = editingTournament
+		? tournamentToInitialFormValues(editingTournament)
+		: undefined;
+	const editInitialLevels = (editBlindLevelsQuery.data ??
+		[]) as BlindLevelRow[];
+
+	return {
+		activeTournaments,
+		archivedTournaments,
+		currencies,
+		activeLoading,
+		archivedLoading,
+		archive,
+		restore,
+		deleteTournament,
+		showArchived,
+		setShowArchived,
+		isCreateOpen,
+		setIsCreateOpen,
+		editingTournament,
+		setEditingTournament,
+		isCreateLoading,
+		isUpdateLoading,
+		editBlindLevelsLoading: editBlindLevelsQuery.isLoading,
+		editInitialFormValues,
+		editInitialLevels,
+		handleCreate,
+		handleUpdate,
+	};
+}
+
+export function useBlindStructureSummary(tournamentId: string) {
+	const levelsQuery = useQuery(
+		trpc.blindLevel.listByTournament.queryOptions({ tournamentId })
+	);
+	return {
+		levels: (levelsQuery.data ?? []) as BlindLevelRow[],
+		isLoading: levelsQuery.isLoading,
+	};
+}

--- a/apps/web/src/update-notes/components/update-notes-sheet.tsx
+++ b/apps/web/src/update-notes/components/update-notes-sheet.tsx
@@ -1,5 +1,3 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
 import {
 	Accordion,
 	AccordionContent,
@@ -10,47 +8,11 @@ import { Badge } from "@/shared/components/ui/badge";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 import { UPDATE_NOTES } from "@/update-notes/constants";
 import { useUpdateNotesSheet } from "@/update-notes/hooks/use-update-notes-sheet";
-import { trpc } from "@/utils/trpc";
+import { useUpdateNotesViewed } from "@/update-notes/hooks/use-update-notes-viewed";
 
 export function UpdateNotesSheet() {
 	const { isOpen, setIsOpen } = useUpdateNotesSheet();
-	const queryClient = useQueryClient();
-	const [optimisticallyViewed, setOptimisticallyViewed] = useState<Set<string>>(
-		new Set()
-	);
-
-	const { data: viewedList } = useQuery(
-		trpc.updateNoteView.list.queryOptions()
-	);
-
-	const serverViewedVersions = new Set(viewedList?.map((v) => v.version));
-	const viewedVersions = new Set([
-		...serverViewedVersions,
-		...optimisticallyViewed,
-	]);
-
-	const markViewedMutation = useMutation(
-		trpc.updateNoteView.markViewed.mutationOptions({
-			onSettled: () => {
-				queryClient.invalidateQueries({
-					queryKey: trpc.updateNoteView.list.queryOptions().queryKey,
-				});
-				queryClient.invalidateQueries({
-					queryKey:
-						trpc.updateNoteView.getLatestViewedVersion.queryOptions().queryKey,
-				});
-			},
-		})
-	);
-
-	const handleAccordionChange = (value: string[]) => {
-		for (const version of value) {
-			if (!viewedVersions.has(version)) {
-				setOptimisticallyViewed((prev) => new Set([...prev, version]));
-				markViewedMutation.mutate({ version });
-			}
-		}
-	};
+	const { viewedVersions, handleAccordionChange } = useUpdateNotesViewed();
 
 	return (
 		<ResponsiveDialog

--- a/apps/web/src/update-notes/hooks/use-update-notes-viewed.ts
+++ b/apps/web/src/update-notes/hooks/use-update-notes-viewed.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { invalidateTargets } from "@/utils/optimistic-update";
+import { trpc } from "@/utils/trpc";
+
+export function useUpdateNotesViewed() {
+	const queryClient = useQueryClient();
+	const [optimisticallyViewed, setOptimisticallyViewed] = useState<Set<string>>(
+		new Set()
+	);
+
+	const { data: viewedList } = useQuery(
+		trpc.updateNoteView.list.queryOptions()
+	);
+
+	const serverViewedVersions = new Set(viewedList?.map((v) => v.version));
+	const viewedVersions = new Set([
+		...serverViewedVersions,
+		...optimisticallyViewed,
+	]);
+
+	const markViewedMutation = useMutation(
+		trpc.updateNoteView.markViewed.mutationOptions({
+			onSettled: () =>
+				invalidateTargets(queryClient, [
+					{ queryKey: trpc.updateNoteView.list.queryOptions().queryKey },
+					{
+						queryKey:
+							trpc.updateNoteView.getLatestViewedVersion.queryOptions()
+								.queryKey,
+					},
+				]),
+		})
+	);
+
+	const handleAccordionChange = (value: string[]) => {
+		for (const version of value) {
+			if (!viewedVersions.has(version)) {
+				setOptimisticallyViewed((prev) => new Set([...prev, version]));
+				markViewedMutation.mutate({ version });
+			}
+		}
+	};
+
+	return { viewedVersions, handleAccordionChange };
+}


### PR DESCRIPTION
## Summary
CLAUDE.md の MANDATORY ルール「UI/Logic Separation」違反（`useQuery` / `useMutation` / `useQueryClient` をコンポーネント内で直接呼んでいる）を 9 ファイルで解消。ロジックを専用 hook に切り出し、コンポーネントは Props / hook 戻り値を描画する View に整理。

## 変更内容

### dashboard widgets (4 ファイル)
- `use-active-session-widget` — cash/tournament queries + ticker (30 秒ごとの再描画)
- `use-currency-balance-widget` + `useCurrencyBalanceOptions`
- `use-recent-sessions-widget`
- `use-summary-stats-widget`

### live-sessions/components/assign-ring-game-dialog
- `use-assign-ring-game` — stores/ringGames queries、assign/create mutations、`invalidateTargets` によるキャッシュ無効化、form 状態を一括管理

### stores/components (3 ファイル)
- `use-ring-game-form` — currencies query + useForm
- `use-tournament-form` — currencies query + useForm
- `use-tournament-tab` — tournaments + edit blind levels + create/update mutations + dialog 状態
- `useBlindStructureSummary` — サブコンポーネント用の薄い hook

### update-notes/components/update-notes-sheet
- `use-update-notes-viewed` — viewed list query + markViewed mutation + optimistic 状態

## #212 との関係
本 PR はスタック型ではなく staging から独立して分岐しており、[PR #212](https://github.com/HIRO15254/sapphire2/pull/212)（フォーマッタ集約）とは**マージ順序に依存しない**。dashboard widgets 4 ファイルは両 PR で触っているため、先に merge された方を base に rebase する必要がある想定。

## Test plan
- [x] `bun run test` — 569 tests passed
- [x] `bunx ultracite check apps/web/src` — no issues
- [x] `bun run --filter web check-types` — 変更ファイルで新規エラーなし（既存エラーは `use-seat-from-screenshot.ts` の 2 件のみ、本 PR と無関係）
- [ ] `/dashboard` — 各 widget が従来通り表示/編集できること（目視）
- [ ] `/sessions` 稼働中セッション → Assign Ring Game ダイアログ（既存選択 + 新規作成の両タブ）が動作すること
- [ ] `/stores` → Tournament タブ（作成 / 編集 / アーカイブ / 復元 / 削除、blind structure 展開）が動作すること
- [ ] Ring Game フォーム / Tournament フォームの通貨ドロップダウンが表示されること
- [ ] Update Notes シートで accordion 展開時に NEW バッジが消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)