### PR TITLE
refactor(web): enforce strict UI/Logic separation across all components and routes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,16 +47,51 @@ TypeScript (strict mode): Follow standard conventions
 - Use helpers from `@/shared/lib/form-fields` (`requiredNumericString`, `optionalNumericString`, `parseOptionalInt`, etc.) to keep numeric validation uniform.
 - Reference implementations: `apps/web/src/shared/hooks/use-sign-in.ts`, `apps/web/src/players/components/player-form.tsx`, `apps/web/src/live-sessions/components/event-editors/update-stack-editor.tsx`.
 
-## UI/Logic Separation (MANDATORY)
+## UI/Logic Separation (STRICT MANDATORY)
 
-**All non-trivial logic in `apps/web` MUST live in a custom hook, so components stay Props-driven presentational views.**
+**All state management and hook usage in `apps/web` components/routes is FORBIDDEN. Components may ONLY call project-defined custom hooks (`useXxx` from `apps/web/src/**/hooks/use-*.ts`).**
 
-- **File layout:** React hooks go in `apps/web/src/<feature>/hooks/use-*.ts` (or `.tsx` when JSX is returned). Pure helpers, constants, and types go in `apps/web/src/<feature>/utils/*.ts`. Never colocate `useQuery`/`useMutation`/complex `useState`+`useEffect` chains inside a component file.
-- **Component responsibility:** Components receive data and handlers from a hook via destructuring and render JSX. Do **not** call `useQueryClient` in a component — keep it inside the hook. Derived values (filters, sorts, aggregates, view-model shaping) belong in the hook, not in JSX.
-- **Hook return shape:** Return `{ data系, is*Pending, on*Handler }`. Reference: [use-players.ts](apps/web/src/players/hooks/use-players.ts) + [routes/players/index.tsx](apps/web/src/routes/players/index.tsx), [use-currencies.ts](apps/web/src/currencies/hooks/use-currencies.ts), [use-cash-game-session.ts](apps/web/src/live-sessions/hooks/use-cash-game-session.ts).
-- **Optimistic updates / invalidation:** Use the shared helpers in [apps/web/src/utils/optimistic-update.ts](apps/web/src/utils/optimistic-update.ts) (`snapshotQuery`, `snapshotQueries`, `restoreSnapshots`, `cancelTargets`, `invalidateTargets`). Do not hand-roll chains of `queryClient.invalidateQueries(...)` / `setQueryData(...)` inside components.
-- **Forms:** The `useForm` call from `@tanstack/react-form` lives in a hook. The component receives `form` and renders `<form.Field>` / `<form.Subscribe>` only. Satisfies the Forms (MANDATORY) rule above.
-- **Acceptable colocation:** Purely presentational subcomponents (`DetailRow`, `XxxCard`, etc.) may stay in the same file. Pure helper functions that are already module-level (not inside the component body) need not be moved to `utils/` unless they grow or become shared.
-- **Reference refactor series (2026-04-21):** PRs [#207](https://github.com/HIRO15254/sapphire2/pull/207) session-form, [#208](https://github.com/HIRO15254/sapphire2/pull/208) seat-from-screenshot, [#209](https://github.com/HIRO15254/sapphire2/pull/209) active-session-game-scene, [#210](https://github.com/HIRO15254/sapphire2/pull/210) misc (sign-in / add-player / assign-tournament / session-events).
+### Forbidden in components (including route page components)
+React builtin hooks: `useState`, `useEffect`, `useMemo`, `useRef`, `useCallback`, `useReducer`, `useDeferredValue`, `useTransition`, `useLayoutEffect`, `useContext`.
+Third-party hooks: `useForm` (`@tanstack/react-form`), `useQuery` / `useMutation` / `useQueryClient` / `useIsMutating` (`@tanstack/react-query`), `useRouter` / `useNavigate` (when used for side-effectful navigation logic — prefer routing via props or hooks).
+
+### Allowed in components
+- Calls to custom hooks: `const { ... } = useXxx(args)`.
+- `Route.useParams()` / `Route.useSearch()` inside route page components for reading params (these are param accessors, not state).
+- Pure JSX rendering from destructured values.
+
+### File layout
+- **Custom hook**: `apps/web/src/<feature>/hooks/use-<name>.ts` (or `.tsx` when returning JSX).
+- **Pure helpers, constants, types**: `apps/web/src/<feature>/utils/*.ts`.
+- **UI primitive hooks**: `apps/web/src/shared/components/ui/hooks/use-*.ts`.
+- **Route page hooks**: `apps/web/src/<feature>/hooks/use-<page>-page.ts`.
+
+### Hook return shape
+`{ data系, is*Pending, on*Handler, state, setState, ... }`. See references below.
+
+### Optimistic updates / invalidation
+Use shared helpers in [apps/web/src/utils/optimistic-update.ts](apps/web/src/utils/optimistic-update.ts) (`snapshotQuery`, `snapshotQueries`, `restoreSnapshots`, `cancelTargets`, `invalidateTargets`). Do not hand-roll `queryClient.invalidateQueries(...)` chains, even inside hooks.
+
+### Forms
+The `useForm` call from `@tanstack/react-form` lives in a hook. The component receives `form` and renders `<form.Field>` / `<form.Subscribe>` only.
+
+### Acceptable colocation
+Purely presentational subcomponents (`DetailRow`, `XxxCard`, etc.) that take **only props** and call **no hooks** may stay in the same file. Pure helper functions already at module level need not be moved to `utils/` unless they grow or become shared.
+
+### Reference implementations
+- Pair: [use-players-page.ts](apps/web/src/players/hooks/use-players-page.ts) + [routes/players/index.tsx](apps/web/src/routes/players/index.tsx)
+- Form: [use-player-form.ts](apps/web/src/players/hooks/use-player-form.ts) + [player-form.tsx](apps/web/src/players/components/player-form.tsx)
+- tRPC: [use-currencies.ts](apps/web/src/currencies/hooks/use-currencies.ts), [use-cash-game-session.ts](apps/web/src/live-sessions/hooks/use-cash-game-session.ts)
+- Auth: [use-sign-in.ts](apps/web/src/shared/hooks/use-sign-in.ts) + [sign-in-form.tsx](apps/web/src/shared/components/sign-in-form.tsx)
+
+### Verification
+Run this check — it MUST return 0 hits (excluding `__tests__/`):
+```sh
+rg '\b(useState|useEffect|useMemo|useRef|useCallback|useForm|useQuery|useMutation|useQueryClient|useReducer|useDeferredValue|useTransition|useLayoutEffect|useIsMutating)\b' apps/web/src/**/components/**/*.tsx apps/web/src/routes/**/*.tsx -g '!**/__tests__/**'
+```
+
+### Reference refactor series (2026-04-21 → 2026-04-22)
+- PRs [#207](https://github.com/HIRO15254/sapphire2/pull/207) session-form, [#208](https://github.com/HIRO15254/sapphire2/pull/208) seat-from-screenshot, [#209](https://github.com/HIRO15254/sapphire2/pull/209) active-session-game-scene, [#210](https://github.com/HIRO15254/sapphire2/pull/210) misc (sign-in / add-player / assign-tournament / session-events), [#212](https://github.com/HIRO15254/sapphire2/pull/212) shared formatters, [#213](https://github.com/HIRO15254/sapphire2/pull/213) widgets / ring-game-form / tournament-form / tournament-tab / update-notes-sheet
+- Full enforcement: `refactor/strict-hooks-extraction` (this PR) — extracted hooks for every remaining violating component + route, covering live-sessions (26), stores (8), players + sessions (6), currencies + dashboard (7), shared + ui primitives (11), routes (8) — ~66 files total.
 
 <!-- MANUAL ADDITIONS END -->

--- a/apps/web/src/currencies/components/currency-form.tsx
+++ b/apps/web/src/currencies/components/currency-form.tsx
@@ -1,14 +1,9 @@
-import { useForm } from "@tanstack/react-form";
-import { z } from "zod";
+import type { CurrencyFormValues } from "@/currencies/hooks/use-currency-form";
+import { useCurrencyForm } from "@/currencies/hooks/use-currency-form";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
-
-interface CurrencyFormValues {
-	name: string;
-	unit?: string;
-}
 
 interface CurrencyFormProps {
 	defaultValues?: CurrencyFormValues;
@@ -16,31 +11,12 @@ interface CurrencyFormProps {
 	onSubmit: (values: CurrencyFormValues) => void;
 }
 
-const currencyFormSchema = z.object({
-	name: z.string().min(1, "Currency name is required"),
-	unit: z.string(),
-});
-
 export function CurrencyForm({
 	onSubmit,
 	defaultValues,
 	isLoading = false,
 }: CurrencyFormProps) {
-	const form = useForm({
-		defaultValues: {
-			name: defaultValues?.name ?? "",
-			unit: defaultValues?.unit ?? "",
-		},
-		onSubmit: ({ value }) => {
-			onSubmit({
-				name: value.name,
-				unit: value.unit ? value.unit : undefined,
-			});
-		},
-		validators: {
-			onSubmit: currencyFormSchema,
-		},
-	});
+	const { form } = useCurrencyForm({ defaultValues, onSubmit });
 
 	return (
 		<form

--- a/apps/web/src/currencies/components/transaction-form.tsx
+++ b/apps/web/src/currencies/components/transaction-form.tsx
@@ -1,7 +1,9 @@
-import { useForm } from "@tanstack/react-form";
-import { useEffect, useRef, useState } from "react";
-import { z } from "zod";
-import { useTransactionTypes } from "@/currencies/hooks/use-transaction-types";
+import {
+	getButtonLabel,
+	type TransactionFormValues,
+	useTransactionForm,
+} from "@/currencies/hooks/use-transaction-form";
+import { useTypeCombobox } from "@/currencies/hooks/use-type-combobox";
 import { Button } from "@/shared/components/ui/button";
 import {
 	Command,
@@ -18,16 +20,6 @@ import {
 	PopoverContent,
 } from "@/shared/components/ui/popover";
 import { Textarea } from "@/shared/components/ui/textarea";
-import { requiredNumericString } from "@/shared/lib/form-fields";
-
-const NEW_TYPE_VALUE = "__new__";
-
-interface TransactionFormValues {
-	amount: number;
-	memo?: string;
-	transactedAt: string;
-	transactionTypeId: string;
-}
 
 interface TransactionFormProps {
 	defaultValues?: TransactionFormValues;
@@ -52,65 +44,33 @@ function TypeCombobox({
 	typeId,
 	types,
 }: TypeComboboxProps) {
-	const initialDisplay =
-		typeId === NEW_TYPE_VALUE
-			? newTypeName
-			: (types.find((t) => t.id === typeId)?.name ?? "");
-
-	const [inputValue, setInputValue] = useState(initialDisplay);
-	const [isFiltering, setIsFiltering] = useState(false);
-	const [isOpen, setIsOpen] = useState(false);
-	const [contentWidth, setContentWidth] = useState<number>();
-	const anchorRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		if (!typeId || typeId === NEW_TYPE_VALUE) {
-			return;
-		}
-		const typeName = types.find((t) => t.id === typeId)?.name;
-		if (typeName) {
-			setInputValue(typeName);
-			setIsFiltering(false);
-		}
-	}, [typeId, types]);
-
-	const normalizedInput = inputValue.trim();
-	const filteredTypes = types.filter(
-		(t) =>
-			!(isFiltering && normalizedInput) ||
-			t.name.toLowerCase().includes(normalizedInput.toLowerCase())
-	);
-	const exactMatch = types.find(
-		(t) => t.name.toLowerCase() === normalizedInput.toLowerCase()
-	);
-	const canCreate = Boolean(normalizedInput && !exactMatch);
-	const shouldShowPopover =
-		isOpen && (types.length > 0 || Boolean(normalizedInput));
-
-	useEffect(() => {
-		if (!(shouldShowPopover && anchorRef.current)) {
-			return;
-		}
-		setContentWidth(anchorRef.current.offsetWidth);
-	}, [shouldShowPopover]);
-
-	const handleSelect = (type: { id: string; name: string }) => {
-		setInputValue(type.name);
-		setIsFiltering(false);
-		onTypeChange(type.id);
-		onNewTypeNameChange("");
-		setIsOpen(false);
-	};
-
-	const handleCreate = () => {
-		setIsFiltering(false);
-		onTypeChange(NEW_TYPE_VALUE);
-		onNewTypeNameChange(normalizedInput);
-		setIsOpen(false);
-	};
+	const {
+		anchorRef,
+		canCreate,
+		contentWidth,
+		filteredTypes,
+		handleCreate,
+		handleInputBlur,
+		handleInputChange,
+		handleInputFocus,
+		handleKeyDown,
+		handleSelect,
+		inputValue,
+		shouldShowPopover,
+	} = useTypeCombobox({
+		newTypeName,
+		onNewTypeNameChange,
+		onTypeChange,
+		typeId,
+		types,
+	});
 
 	return (
-		<Popover modal={false} onOpenChange={setIsOpen} open={shouldShowPopover}>
+		<Popover
+			modal={false}
+			onOpenChange={() => undefined}
+			open={shouldShowPopover}
+		>
 			<PopoverAnchor asChild>
 				<div ref={anchorRef}>
 					<Input
@@ -119,30 +79,17 @@ function TypeCombobox({
 						id={id}
 						onBlur={(e) => {
 							const relatedTarget = e.relatedTarget as HTMLElement | null;
-							if (!relatedTarget?.closest('[data-slot="popover-content"]')) {
-								setIsOpen(false);
-							}
+							handleInputBlur(relatedTarget);
 						}}
 						onChange={(e) => {
-							setInputValue(e.target.value);
-							setIsFiltering(true);
-							setIsOpen(true);
-							onTypeChange("");
-							onNewTypeNameChange("");
+							handleInputChange(e.target.value);
 						}}
-						onFocus={() => setIsOpen(true)}
+						onFocus={handleInputFocus}
 						onKeyDown={(e) => {
 							if (e.key === "Enter") {
 								e.preventDefault();
-								if (exactMatch) {
-									handleSelect(exactMatch);
-								} else if (canCreate) {
-									handleCreate();
-								}
 							}
-							if (e.key === "Escape") {
-								setIsOpen(false);
-							}
+							handleKeyDown(e.key);
 						}}
 						placeholder="Select or create type..."
 						role="combobox"
@@ -177,9 +124,9 @@ function TypeCombobox({
 								<CommandItem
 									onMouseDown={(e) => e.preventDefault()}
 									onSelect={handleCreate}
-									value={`create-${normalizedInput}`}
+									value={`create-${inputValue.trim()}`}
 								>
-									Create &quot;{normalizedInput}&quot;
+									Create &quot;{inputValue.trim()}&quot;
 								</CommandItem>
 							) : null}
 						</CommandList>
@@ -190,77 +137,14 @@ function TypeCombobox({
 	);
 }
 
-function todayISODate() {
-	return new Date().toISOString().slice(0, 10);
-}
-
-function getButtonLabel(isCreatingType: boolean, isLoading: boolean) {
-	if (isCreatingType) {
-		return "Creating type...";
-	}
-	if (isLoading) {
-		return "Saving...";
-	}
-	return "Save";
-}
-
-function buildSchema() {
-	return z
-		.object({
-			amount: requiredNumericString(),
-			transactionTypeId: z.string().min(1, "Type is required"),
-			newTypeName: z.string(),
-			transactedAt: z.string().min(1, "Date is required"),
-			memo: z.string(),
-		})
-		.superRefine((value, ctx) => {
-			if (
-				value.transactionTypeId === NEW_TYPE_VALUE &&
-				value.newTypeName.trim() === ""
-			) {
-				ctx.addIssue({
-					code: "custom",
-					path: ["newTypeName"],
-					message: "New type name is required",
-				});
-			}
-		});
-}
-
 export function TransactionForm({
 	onSubmit,
 	defaultValues,
 	isLoading = false,
 }: TransactionFormProps) {
-	const { types, createType, isCreatingType } = useTransactionTypes();
-
-	const form = useForm({
-		defaultValues: {
-			amount:
-				defaultValues?.amount === undefined ? "" : String(defaultValues.amount),
-			transactionTypeId: defaultValues?.transactionTypeId ?? "",
-			newTypeName: "",
-			transactedAt: defaultValues?.transactedAt
-				? new Date(defaultValues.transactedAt).toISOString().slice(0, 10)
-				: todayISODate(),
-			memo: defaultValues?.memo ?? "",
-		},
-		onSubmit: async ({ value }) => {
-			let transactionTypeId = value.transactionTypeId;
-			if (transactionTypeId === NEW_TYPE_VALUE) {
-				const created = await createType(value.newTypeName.trim());
-				transactionTypeId = created.id;
-			}
-			onSubmit({
-				amount: Number(value.amount),
-				transactionTypeId,
-				transactedAt: value.transactedAt,
-				memo: value.memo ? value.memo : undefined,
-			});
-		},
-		validators: {
-			onSubmit: buildSchema(),
-		},
+	const { form, types, isCreatingType } = useTransactionForm({
+		defaultValues,
+		onSubmit,
 	});
 
 	return (

--- a/apps/web/src/currencies/components/transaction-list.tsx
+++ b/apps/web/src/currencies/components/transaction-list.tsx
@@ -1,12 +1,11 @@
 import { IconEdit, IconTrash, IconX } from "@tabler/icons-react";
-import { useState } from "react";
+import { useTransactionList } from "@/currencies/hooks/use-transaction-list";
 import {
 	ExpandableItem,
 	ExpandableItemList,
 } from "@/shared/components/management/expandable-item-list";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
-import { createGroupFormatter, formatYmdSlash } from "@/utils/format-number";
 
 interface Transaction {
 	amount: number;
@@ -34,10 +33,17 @@ export function TransactionList({
 	isLoadingMore,
 	onLoadMore,
 }: TransactionListProps) {
-	const [expandedId, setExpandedId] = useState<string | null>(null);
-	const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(
-		null
-	);
+	const {
+		confirmingDeleteId,
+		expandedId,
+		getAmountClass,
+		getAmountDisplay,
+		getDateDisplay,
+		onCollapse,
+		onConfirmDelete,
+		onConfirmDeleteCancel,
+		onExpand,
+	} = useTransactionList(transactions);
 
 	if (transactions.length === 0) {
 		return (
@@ -47,18 +53,13 @@ export function TransactionList({
 		);
 	}
 
-	const fmt = createGroupFormatter(transactions.map((tx) => tx.amount));
-
 	return (
 		<div className="flex flex-col">
 			<div className="divide-y">
 				{transactions.map((tx) => {
-					const isPositive = tx.amount >= 0;
-					const amountClass = isPositive ? "text-green-600" : "text-red-600";
-					const amountDisplay = isPositive
-						? `+${fmt(tx.amount)}`
-						: fmt(tx.amount);
-					const dateDisplay = formatYmdSlash(new Date(tx.transactedAt));
+					const amountClass = getAmountClass(tx.amount);
+					const amountDisplay = getAmountDisplay(tx.amount);
+					const dateDisplay = getDateDisplay(tx.transactedAt);
 					const isSessionGenerated = !!tx.sessionId;
 					const isConfirmingDelete = confirmingDeleteId === tx.id;
 
@@ -89,8 +90,11 @@ export function TransactionList({
 						<ExpandableItemList
 							key={tx.id}
 							onValueChange={(id) => {
-								setExpandedId(id);
-								setConfirmingDeleteId(null);
+								if (id) {
+									onExpand(id);
+								} else {
+									onCollapse();
+								}
 							}}
 							value={expandedId === tx.id ? tx.id : null}
 						>
@@ -130,8 +134,8 @@ export function TransactionList({
 												onClick={(e) => {
 													e.stopPropagation();
 													onDelete(tx.id);
-													setConfirmingDeleteId(null);
-													setExpandedId(null);
+													onConfirmDeleteCancel();
+													onCollapse();
 												}}
 												size="icon-xs"
 												variant="ghost"
@@ -142,7 +146,7 @@ export function TransactionList({
 												aria-label="Cancel delete"
 												onClick={(e) => {
 													e.stopPropagation();
-													setConfirmingDeleteId(null);
+													onConfirmDeleteCancel();
 												}}
 												size="icon-xs"
 												variant="ghost"
@@ -170,7 +174,7 @@ export function TransactionList({
 												className="text-destructive hover:text-destructive"
 												onClick={(e) => {
 													e.stopPropagation();
-													setConfirmingDeleteId(tx.id);
+													onConfirmDelete(tx.id);
 												}}
 												size="icon-xs"
 												variant="ghost"

--- a/apps/web/src/currencies/components/transaction-type-manager.tsx
+++ b/apps/web/src/currencies/components/transaction-type-manager.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import { useTransactionTypeManager } from "@/currencies/hooks/use-transaction-type-manager";
+import { useTransactionTypeManagerWithDeleteError } from "@/currencies/hooks/use-transaction-type-manager";
 import { TagManager } from "@/shared/components/management/tag-manager";
 import { TagNameForm } from "@/shared/components/management/tag-name-form";
 
@@ -8,32 +7,12 @@ export function TransactionTypeManager() {
 		types,
 		create,
 		update,
-		delete: deleteType,
+		handleDelete,
+		deleteError,
 		isCreatePending,
 		isUpdatePending,
 		isDeletePending,
-	} = useTransactionTypeManager();
-
-	const [deleteError, setDeleteError] = useState<string | null>(null);
-
-	const handleDelete = async (id: string) => {
-		setDeleteError(null);
-		try {
-			await deleteType(id);
-		} catch (err: unknown) {
-			if (
-				err &&
-				typeof err === "object" &&
-				"message" in err &&
-				typeof err.message === "string"
-			) {
-				setDeleteError(err.message);
-			} else {
-				setDeleteError("Failed to delete");
-			}
-			throw err;
-		}
-	};
+	} = useTransactionTypeManagerWithDeleteError();
 
 	return (
 		<TagManager

--- a/apps/web/src/currencies/hooks/use-currencies-page.ts
+++ b/apps/web/src/currencies/hooks/use-currencies-page.ts
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import type {
+	CurrencyItem,
+	CurrencyValues,
+	Transaction,
+	TransactionValues,
+} from "@/currencies/hooks/use-currencies";
+import { useCurrencies } from "@/currencies/hooks/use-currencies";
+
+export function useCurrenciesPage() {
+	const [isCreateOpen, setIsCreateOpen] = useState(false);
+	const [isTypeManagerOpen, setIsTypeManagerOpen] = useState(false);
+	const [editingCurrency, setEditingCurrency] = useState<CurrencyItem | null>(
+		null
+	);
+	const [expandedCurrencyId, setExpandedCurrencyId] = useState<string | null>(
+		null
+	);
+	const [addTransactionCurrencyId, setAddTransactionCurrencyId] = useState<
+		string | null
+	>(null);
+	const [editingTransaction, setEditingTransaction] =
+		useState<Transaction | null>(null);
+
+	const {
+		currencies,
+		allTransactions,
+		txHasMore,
+		isLoadingMore,
+		isCreatePending,
+		isUpdatePending,
+		isAddTransactionPending,
+		isEditTransactionPending,
+		resetTransactionState,
+		create,
+		update,
+		delete: deleteCurrency,
+		addTransaction,
+		editTransaction,
+		deleteTransaction,
+		handleLoadMore,
+	} = useCurrencies(expandedCurrencyId);
+
+	const handleCreate = (values: CurrencyValues) => {
+		create(values).then(() => {
+			setIsCreateOpen(false);
+		});
+	};
+
+	const handleUpdate = (values: CurrencyValues) => {
+		if (!editingCurrency) {
+			return;
+		}
+		update({ id: editingCurrency.id, ...values }).then(() => {
+			setEditingCurrency(null);
+		});
+	};
+
+	const handleDelete = (id: string) => {
+		deleteCurrency(id).then(() => {
+			if (expandedCurrencyId === id) {
+				setExpandedCurrencyId(null);
+				resetTransactionState();
+			}
+		});
+	};
+
+	const handleAddTransaction = (values: TransactionValues) => {
+		if (!addTransactionCurrencyId) {
+			return;
+		}
+		addTransaction({
+			currencyId: addTransactionCurrencyId,
+			...values,
+		}).then(() => {
+			setAddTransactionCurrencyId(null);
+		});
+	};
+
+	const handleEditTransaction = (values: TransactionValues) => {
+		if (!editingTransaction) {
+			return;
+		}
+		editTransaction({
+			id: editingTransaction.id,
+			transactionTypeId: values.transactionTypeId,
+			amount: values.amount,
+			transactedAt: values.transactedAt,
+			memo: values.memo ?? null,
+		}).then(() => {
+			setEditingTransaction(null);
+		});
+	};
+
+	const handleDeleteTransaction = (id: string) => {
+		deleteTransaction(id);
+	};
+
+	const handleExpandedCurrencyChange = (id: string | null) => {
+		setExpandedCurrencyId((prev) => {
+			if (prev !== id) {
+				resetTransactionState();
+			}
+			return id;
+		});
+	};
+
+	return {
+		currencies,
+		allTransactions,
+		txHasMore,
+		isLoadingMore,
+		isCreatePending,
+		isUpdatePending,
+		isAddTransactionPending,
+		isEditTransactionPending,
+		isCreateOpen,
+		isTypeManagerOpen,
+		editingCurrency,
+		expandedCurrencyId,
+		addTransactionCurrencyId,
+		editingTransaction,
+		setIsCreateOpen,
+		setIsTypeManagerOpen,
+		setEditingCurrency,
+		setAddTransactionCurrencyId,
+		setEditingTransaction,
+		handleCreate,
+		handleUpdate,
+		handleDelete,
+		handleAddTransaction,
+		handleEditTransaction,
+		handleDeleteTransaction,
+		handleExpandedCurrencyChange,
+		handleLoadMore,
+	};
+}

--- a/apps/web/src/currencies/hooks/use-currency-form.ts
+++ b/apps/web/src/currencies/hooks/use-currency-form.ts
@@ -1,0 +1,40 @@
+import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
+
+export interface CurrencyFormValues {
+	name: string;
+	unit?: string;
+}
+
+export interface UseCurrencyFormProps {
+	defaultValues?: CurrencyFormValues;
+	onSubmit: (values: CurrencyFormValues) => void;
+}
+
+export const currencyFormSchema = z.object({
+	name: z.string().min(1, "Currency name is required"),
+	unit: z.string(),
+});
+
+export function useCurrencyForm({
+	defaultValues,
+	onSubmit,
+}: UseCurrencyFormProps) {
+	const form = useForm({
+		defaultValues: {
+			name: defaultValues?.name ?? "",
+			unit: defaultValues?.unit ?? "",
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				name: value.name,
+				unit: value.unit ? value.unit : undefined,
+			});
+		},
+		validators: {
+			onSubmit: currencyFormSchema,
+		},
+	});
+
+	return { form };
+}

--- a/apps/web/src/currencies/hooks/use-transaction-form.ts
+++ b/apps/web/src/currencies/hooks/use-transaction-form.ts
@@ -1,0 +1,93 @@
+import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
+import { useTransactionTypes } from "@/currencies/hooks/use-transaction-types";
+import { requiredNumericString } from "@/shared/lib/form-fields";
+
+export const NEW_TYPE_VALUE = "__new__";
+
+export interface TransactionFormValues {
+	amount: number;
+	memo?: string;
+	transactedAt: string;
+	transactionTypeId: string;
+}
+
+export interface UseTransactionFormProps {
+	defaultValues?: TransactionFormValues;
+	onSubmit: (values: TransactionFormValues) => void;
+}
+
+function todayISODate() {
+	return new Date().toISOString().slice(0, 10);
+}
+
+function buildSchema() {
+	return z
+		.object({
+			amount: requiredNumericString(),
+			transactionTypeId: z.string().min(1, "Type is required"),
+			newTypeName: z.string(),
+			transactedAt: z.string().min(1, "Date is required"),
+			memo: z.string(),
+		})
+		.superRefine((value, ctx) => {
+			if (
+				value.transactionTypeId === NEW_TYPE_VALUE &&
+				value.newTypeName.trim() === ""
+			) {
+				ctx.addIssue({
+					code: "custom",
+					path: ["newTypeName"],
+					message: "New type name is required",
+				});
+			}
+		});
+}
+
+export function getButtonLabel(isCreatingType: boolean, isLoading: boolean) {
+	if (isCreatingType) {
+		return "Creating type...";
+	}
+	if (isLoading) {
+		return "Saving...";
+	}
+	return "Save";
+}
+
+export function useTransactionForm({
+	defaultValues,
+	onSubmit,
+}: UseTransactionFormProps) {
+	const { types, createType, isCreatingType } = useTransactionTypes();
+
+	const form = useForm({
+		defaultValues: {
+			amount:
+				defaultValues?.amount === undefined ? "" : String(defaultValues.amount),
+			transactionTypeId: defaultValues?.transactionTypeId ?? "",
+			newTypeName: "",
+			transactedAt: defaultValues?.transactedAt
+				? new Date(defaultValues.transactedAt).toISOString().slice(0, 10)
+				: todayISODate(),
+			memo: defaultValues?.memo ?? "",
+		},
+		onSubmit: async ({ value }) => {
+			let transactionTypeId = value.transactionTypeId;
+			if (transactionTypeId === NEW_TYPE_VALUE) {
+				const created = await createType(value.newTypeName.trim());
+				transactionTypeId = created.id;
+			}
+			onSubmit({
+				amount: Number(value.amount),
+				transactionTypeId,
+				transactedAt: value.transactedAt,
+				memo: value.memo ? value.memo : undefined,
+			});
+		},
+		validators: {
+			onSubmit: buildSchema(),
+		},
+	});
+
+	return { form, types, isCreatingType };
+}

--- a/apps/web/src/currencies/hooks/use-transaction-list.ts
+++ b/apps/web/src/currencies/hooks/use-transaction-list.ts
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import {
+	buildGroupFormatter,
+	getAmountClass,
+	getAmountDisplay,
+	getDateDisplay,
+	type TransactionDisplayItem,
+} from "@/currencies/utils/transaction-list-helpers";
+
+export interface UseTransactionListResult {
+	confirmingDeleteId: string | null;
+	expandedId: string | null;
+	fmt: (n: number) => string;
+	getAmountClass: (amount: number) => string;
+	getAmountDisplay: (amount: number) => string;
+	getDateDisplay: (transactedAt: Date | string) => string;
+	onCollapse: () => void;
+	onConfirmDelete: (id: string) => void;
+	onConfirmDeleteCancel: () => void;
+	onExpand: (id: string) => void;
+}
+
+export function useTransactionList(
+	transactions: TransactionDisplayItem[]
+): UseTransactionListResult {
+	const [expandedId, setExpandedId] = useState<string | null>(null);
+	const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(
+		null
+	);
+
+	const fmt = buildGroupFormatter(transactions);
+
+	const onExpand = (id: string) => {
+		setExpandedId(id);
+		setConfirmingDeleteId(null);
+	};
+
+	const onCollapse = () => {
+		setExpandedId(null);
+		setConfirmingDeleteId(null);
+	};
+
+	const onConfirmDelete = (id: string) => {
+		setConfirmingDeleteId(id);
+	};
+
+	const onConfirmDeleteCancel = () => {
+		setConfirmingDeleteId(null);
+	};
+
+	return {
+		confirmingDeleteId,
+		expandedId,
+		fmt,
+		getAmountClass,
+		getAmountDisplay: (amount: number) => getAmountDisplay(amount, fmt),
+		getDateDisplay,
+		onCollapse,
+		onConfirmDelete,
+		onConfirmDeleteCancel,
+		onExpand,
+	};
+}

--- a/apps/web/src/currencies/hooks/use-transaction-type-manager.ts
+++ b/apps/web/src/currencies/hooks/use-transaction-type-manager.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 import {
 	cancelTargets,
 	invalidateTargets,
@@ -76,5 +77,35 @@ export function useTransactionTypeManager() {
 		isCreatePending: createMutation.isPending,
 		isUpdatePending: updateMutation.isPending,
 		isDeletePending: deleteMutation.isPending,
+	};
+}
+
+export function useTransactionTypeManagerWithDeleteError() {
+	const manager = useTransactionTypeManager();
+	const [deleteError, setDeleteError] = useState<string | null>(null);
+
+	const handleDelete = async (id: string) => {
+		setDeleteError(null);
+		try {
+			await manager.delete(id);
+		} catch (err: unknown) {
+			if (
+				err &&
+				typeof err === "object" &&
+				"message" in err &&
+				typeof err.message === "string"
+			) {
+				setDeleteError(err.message);
+			} else {
+				setDeleteError("Failed to delete");
+			}
+			throw err;
+		}
+	};
+
+	return {
+		...manager,
+		deleteError,
+		handleDelete,
 	};
 }

--- a/apps/web/src/currencies/hooks/use-type-combobox.ts
+++ b/apps/web/src/currencies/hooks/use-type-combobox.ts
@@ -1,0 +1,121 @@
+import { useEffect, useRef, useState } from "react";
+
+const NEW_TYPE_VALUE = "__new__";
+
+interface UseTypeComboboxProps {
+	newTypeName: string;
+	onNewTypeNameChange: (name: string) => void;
+	onTypeChange: (id: string) => void;
+	typeId: string;
+	types: { id: string; name: string }[];
+}
+
+export function useTypeCombobox({
+	newTypeName,
+	onNewTypeNameChange,
+	onTypeChange,
+	typeId,
+	types,
+}: UseTypeComboboxProps) {
+	const initialDisplay =
+		typeId === NEW_TYPE_VALUE
+			? newTypeName
+			: (types.find((t) => t.id === typeId)?.name ?? "");
+
+	const [inputValue, setInputValue] = useState(initialDisplay);
+	const [isFiltering, setIsFiltering] = useState(false);
+	const [isOpen, setIsOpen] = useState(false);
+	const [contentWidth, setContentWidth] = useState<number>();
+	const anchorRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!typeId || typeId === NEW_TYPE_VALUE) {
+			return;
+		}
+		const typeName = types.find((t) => t.id === typeId)?.name;
+		if (typeName) {
+			setInputValue(typeName);
+			setIsFiltering(false);
+		}
+	}, [typeId, types]);
+
+	const normalizedInput = inputValue.trim();
+	const filteredTypes = types.filter(
+		(t) =>
+			!(isFiltering && normalizedInput) ||
+			t.name.toLowerCase().includes(normalizedInput.toLowerCase())
+	);
+	const exactMatch = types.find(
+		(t) => t.name.toLowerCase() === normalizedInput.toLowerCase()
+	);
+	const canCreate = Boolean(normalizedInput && !exactMatch);
+	const shouldShowPopover =
+		isOpen && (types.length > 0 || Boolean(normalizedInput));
+
+	useEffect(() => {
+		if (!(shouldShowPopover && anchorRef.current)) {
+			return;
+		}
+		setContentWidth(anchorRef.current.offsetWidth);
+	}, [shouldShowPopover]);
+
+	const handleSelect = (type: { id: string; name: string }) => {
+		setInputValue(type.name);
+		setIsFiltering(false);
+		onTypeChange(type.id);
+		onNewTypeNameChange("");
+		setIsOpen(false);
+	};
+
+	const handleCreate = () => {
+		setIsFiltering(false);
+		onTypeChange(NEW_TYPE_VALUE);
+		onNewTypeNameChange(normalizedInput);
+		setIsOpen(false);
+	};
+
+	const handleInputChange = (value: string) => {
+		setInputValue(value);
+		setIsFiltering(true);
+		setIsOpen(true);
+		onTypeChange("");
+		onNewTypeNameChange("");
+	};
+
+	const handleInputFocus = () => setIsOpen(true);
+
+	const handleInputBlur = (relatedTarget: HTMLElement | null) => {
+		if (!relatedTarget?.closest('[data-slot="popover-content"]')) {
+			setIsOpen(false);
+		}
+	};
+
+	const handleKeyDown = (key: string) => {
+		if (key === "Enter") {
+			if (exactMatch) {
+				handleSelect(exactMatch);
+			} else if (canCreate) {
+				handleCreate();
+			}
+		}
+		if (key === "Escape") {
+			setIsOpen(false);
+		}
+	};
+
+	return {
+		anchorRef,
+		canCreate,
+		contentWidth,
+		exactMatch,
+		filteredTypes,
+		handleCreate,
+		handleInputBlur,
+		handleInputChange,
+		handleInputFocus,
+		handleKeyDown,
+		handleSelect,
+		inputValue,
+		shouldShowPopover,
+	};
+}

--- a/apps/web/src/currencies/utils/transaction-list-helpers.ts
+++ b/apps/web/src/currencies/utils/transaction-list-helpers.ts
@@ -1,0 +1,29 @@
+import { createGroupFormatter, formatYmdSlash } from "@/utils/format-number";
+
+export interface TransactionDisplayItem {
+	amount: number;
+	id: string;
+	memo?: string | null;
+	sessionId?: string | null;
+	transactedAt: Date | string;
+	transactionTypeName: string;
+}
+
+export function buildGroupFormatter(transactions: TransactionDisplayItem[]) {
+	return createGroupFormatter(transactions.map((tx) => tx.amount));
+}
+
+export function getAmountClass(amount: number): string {
+	return amount >= 0 ? "text-green-600" : "text-red-600";
+}
+
+export function getAmountDisplay(
+	amount: number,
+	fmt: (n: number) => string
+): string {
+	return amount >= 0 ? `+${fmt(amount)}` : fmt(amount);
+}
+
+export function getDateDisplay(transactedAt: Date | string): string {
+	return formatYmdSlash(new Date(transactedAt));
+}

--- a/apps/web/src/dashboard/components/add-widget-menu.tsx
+++ b/apps/web/src/dashboard/components/add-widget-menu.tsx
@@ -1,7 +1,6 @@
 import { IconPlus } from "@tabler/icons-react";
-import { useState } from "react";
+import { useAddWidgetMenu } from "@/dashboard/hooks/use-add-widget-menu";
 import type { WidgetType } from "@/dashboard/hooks/use-dashboard-widgets";
-import { listWidgetTypes } from "@/dashboard/widgets/registry";
 import { Button } from "@/shared/components/ui/button";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 
@@ -11,19 +10,14 @@ interface AddWidgetMenuProps {
 }
 
 export function AddWidgetMenu({ onSelect, disabled }: AddWidgetMenuProps) {
-	const [open, setOpen] = useState(false);
-	const entries = listWidgetTypes();
-
-	const handleSelect = (type: WidgetType) => {
-		setOpen(false);
-		onSelect(type);
-	};
+	const { entries, handleOpen, handleSelect, open, setOpen } =
+		useAddWidgetMenu(onSelect);
 
 	return (
 		<>
 			<Button
 				disabled={disabled}
-				onClick={() => setOpen(true)}
+				onClick={handleOpen}
 				size="sm"
 				variant="outline"
 			>

--- a/apps/web/src/dashboard/components/dashboard-grid.tsx
+++ b/apps/web/src/dashboard/components/dashboard-grid.tsx
@@ -1,6 +1,5 @@
 import "react-grid-layout/css/styles.css";
 import "./dashboard-grid.css";
-import { useMemo } from "react";
 import GridLayout, { type Layout } from "react-grid-layout";
 import {
 	DashboardWidget,
@@ -8,13 +7,11 @@ import {
 } from "@/dashboard/components/dashboard-widget";
 import { WidgetRenderer } from "@/dashboard/components/widget-renderer";
 import type { Device } from "@/dashboard/hooks/use-current-device";
+import {
+	GRID_COLS,
+	useDashboardGrid,
+} from "@/dashboard/hooks/use-dashboard-grid";
 import type { DashboardWidget as DashboardWidgetRow } from "@/dashboard/hooks/use-dashboard-widgets";
-import { getWidgetEntry } from "@/dashboard/widgets/registry";
-
-const GRID_COLS: Record<Device, number> = {
-	mobile: 4,
-	desktop: 12,
-};
 
 const ROW_HEIGHT = 80;
 
@@ -28,21 +25,6 @@ export interface DashboardGridProps {
 	widgets: DashboardWidgetRow[];
 }
 
-function toLayoutItem(widget: DashboardWidgetRow, device: Device): Layout {
-	const entry = getWidgetEntry(widget.type);
-	const minSize = entry?.minSize ?? { w: 2, h: 1 };
-	return {
-		i: widget.id,
-		x: widget.x,
-		y: widget.y,
-		w: widget.w,
-		h: widget.h,
-		minW: minSize.w,
-		minH: minSize.h,
-		maxW: GRID_COLS[device],
-	};
-}
-
 export function DashboardGrid({
 	device,
 	widgets,
@@ -52,10 +34,7 @@ export function DashboardGrid({
 	onEditWidget,
 	onDeleteWidget,
 }: DashboardGridProps) {
-	const layout = useMemo(
-		() => widgets.map((w) => toLayoutItem(w, device)),
-		[widgets, device]
-	);
+	const { layout } = useDashboardGrid(widgets, device);
 
 	return (
 		<GridLayout

--- a/apps/web/src/dashboard/components/dashboard-page.tsx
+++ b/apps/web/src/dashboard/components/dashboard-page.tsx
@@ -1,21 +1,14 @@
-import { useBlocker } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
 import type { Layout } from "react-grid-layout";
 import { AddWidgetMenu } from "@/dashboard/components/add-widget-menu";
 import { DashboardGrid } from "@/dashboard/components/dashboard-grid";
 import { EditModeToggle } from "@/dashboard/components/edit-mode-toggle";
 import { WidgetEditDialog } from "@/dashboard/components/widget-edit-dialog";
-import { useCurrentDevice } from "@/dashboard/hooks/use-current-device";
-import {
-	type DashboardWidget,
-	useDashboardWidgets,
-	type WidgetType,
+import type { Device } from "@/dashboard/hooks/use-current-device";
+import { useDashboardPage } from "@/dashboard/hooks/use-dashboard-page";
+import type {
+	DashboardWidget,
+	WidgetType,
 } from "@/dashboard/hooks/use-dashboard-widgets";
-import { useEditMode } from "@/dashboard/hooks/use-edit-mode";
-import {
-	type LayoutItem,
-	useLayoutSync,
-} from "@/dashboard/hooks/use-layout-sync";
 import { Alert, AlertDescription } from "@/shared/components/ui/alert";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
@@ -23,38 +16,9 @@ import { EmptyState } from "@/shared/components/ui/empty-state";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 import { Skeleton } from "@/shared/components/ui/skeleton";
 
-function useContainerWidth(): [React.RefObject<HTMLDivElement | null>, number] {
-	const ref = useRef<HTMLDivElement>(null);
-	const [width, setWidth] = useState(0);
-
-	useEffect(() => {
-		const el = ref.current;
-		if (!el) {
-			return;
-		}
-		const update = () => setWidth(el.getBoundingClientRect().width);
-		update();
-		const observer = new ResizeObserver(update);
-		observer.observe(el);
-		return () => observer.disconnect();
-	}, []);
-
-	return [ref, width];
-}
-
-function layoutsToItems(layout: Layout[]): LayoutItem[] {
-	return layout.map((l) => ({
-		id: l.i,
-		x: l.x,
-		y: l.y,
-		w: l.w,
-		h: l.h,
-	}));
-}
-
 interface DashboardContentProps {
 	containerWidth: number;
-	device: ReturnType<typeof useCurrentDevice>;
+	device: Device;
 	isEditing: boolean;
 	isEmpty: boolean;
 	isLoading: boolean;
@@ -98,89 +62,30 @@ function renderContent(props: DashboardContentProps) {
 }
 
 export function DashboardPage() {
-	const device = useCurrentDevice();
 	const {
-		widgets,
-		isLoading,
+		blocker,
+		containerRef,
+		containerWidth,
+		deletingWidget,
+		device,
+		editingWidget,
 		error,
-		createWidget,
-		updateWidget,
-		deleteWidget,
-	} = useDashboardWidgets(device);
-	const { isEditing, setEditing, toggle } = useEditMode();
-	const { enqueue, flush, discard, hasPendingChanges } = useLayoutSync(device);
-	const [containerRef, containerWidth] = useContainerWidth();
-	const [editingWidget, setEditingWidget] = useState<DashboardWidget | null>(
-		null
-	);
-	const [deletingWidget, setDeletingWidget] = useState<DashboardWidget | null>(
-		null
-	);
-
-	const blocker = useBlocker({
-		shouldBlockFn: () => hasPendingChanges,
-		enableBeforeUnload: () => hasPendingChanges,
-		withResolver: true,
-	});
-
-	const handleLayoutChange = useCallback(
-		(layout: Layout[]) => {
-			enqueue(layoutsToItems(layout));
-		},
-		[enqueue]
-	);
-
-	const handleDoneClick = useCallback(async () => {
-		if (isEditing) {
-			await flush();
-			setEditing(false);
-		} else {
-			toggle();
-		}
-	}, [isEditing, flush, setEditing, toggle]);
-
-	const handleAdd = useCallback(
-		async (type: WidgetType) => {
-			await flush();
-			await createWidget({ type });
-		},
-		[createWidget, flush]
-	);
-
-	const handleEditSave = useCallback(
-		async (nextConfig: Record<string, unknown>) => {
-			if (!editingWidget) {
-				return;
-			}
-			await updateWidget({ id: editingWidget.id, config: nextConfig });
-		},
-		[editingWidget, updateWidget]
-	);
-
-	const handleDelete = useCallback(async () => {
-		if (!deletingWidget) {
-			return;
-		}
-		await flush();
-		await deleteWidget(deletingWidget.id);
-		setDeletingWidget(null);
-	}, [deletingWidget, deleteWidget, flush]);
-
-	const handleBlockerSave = useCallback(async () => {
-		if (blocker.status !== "blocked") {
-			return;
-		}
-		await flush();
-		blocker.proceed();
-	}, [blocker, flush]);
-
-	const handleBlockerDiscard = useCallback(() => {
-		if (blocker.status !== "blocked") {
-			return;
-		}
-		discard();
-		blocker.proceed();
-	}, [blocker, discard]);
+		handleAdd,
+		handleBlockerCancel,
+		handleBlockerDiscard,
+		handleBlockerSave,
+		handleDelete,
+		handleDeletingWidgetDialogChange,
+		handleDoneClick,
+		handleEditingWidgetDialogChange,
+		handleEditSave,
+		handleLayoutChange,
+		isEditing,
+		isLoading,
+		setDeletingWidget,
+		setEditingWidget,
+		widgets,
+	} = useDashboardPage();
 
 	return (
 		<div className="p-4 md:p-6">
@@ -218,11 +123,7 @@ export function DashboardPage() {
 			{editingWidget ? (
 				<WidgetEditDialog
 					config={editingWidget.config}
-					onOpenChange={(open) => {
-						if (!open) {
-							setEditingWidget(null);
-						}
-					}}
+					onOpenChange={handleEditingWidgetDialogChange}
 					onSave={handleEditSave}
 					open
 					type={editingWidget.type}
@@ -231,11 +132,7 @@ export function DashboardPage() {
 			) : null}
 
 			<ResponsiveDialog
-				onOpenChange={(open) => {
-					if (!open) {
-						setDeletingWidget(null);
-					}
-				}}
+				onOpenChange={handleDeletingWidgetDialogChange}
 				open={deletingWidget !== null}
 				title="Delete widget"
 			>
@@ -268,18 +165,13 @@ export function DashboardPage() {
 				title="Unsaved changes"
 			>
 				<DialogActionRow>
-					<Button
-						onClick={() =>
-							blocker.status === "blocked" ? blocker.reset() : undefined
-						}
-						variant="outline"
-					>
+					<Button onClick={handleBlockerCancel} variant="outline">
 						Cancel
 					</Button>
 					<Button onClick={handleBlockerDiscard} variant="destructive">
 						Discard
 					</Button>
-					<Button onClick={handleBlockerSave}>Save & continue</Button>
+					<Button onClick={handleBlockerSave}>Save &amp; continue</Button>
 				</DialogActionRow>
 			</ResponsiveDialog>
 		</div>

--- a/apps/web/src/dashboard/hooks/use-add-widget-menu.ts
+++ b/apps/web/src/dashboard/hooks/use-add-widget-menu.ts
@@ -1,0 +1,23 @@
+import { useState } from "react";
+import type { WidgetType } from "@/dashboard/hooks/use-dashboard-widgets";
+import { listWidgetTypes } from "@/dashboard/widgets/registry";
+
+export function useAddWidgetMenu(onSelect: (type: WidgetType) => void) {
+	const [open, setOpen] = useState(false);
+	const entries = listWidgetTypes();
+
+	const handleSelect = (type: WidgetType) => {
+		setOpen(false);
+		onSelect(type);
+	};
+
+	const handleOpen = () => setOpen(true);
+
+	return {
+		entries,
+		handleOpen,
+		handleSelect,
+		open,
+		setOpen,
+	};
+}

--- a/apps/web/src/dashboard/hooks/use-dashboard-grid.ts
+++ b/apps/web/src/dashboard/hooks/use-dashboard-grid.ts
@@ -1,0 +1,34 @@
+import { useMemo } from "react";
+import type { Layout } from "react-grid-layout";
+import type { Device } from "@/dashboard/hooks/use-current-device";
+import type { DashboardWidget } from "@/dashboard/hooks/use-dashboard-widgets";
+import { getWidgetEntry } from "@/dashboard/widgets/registry";
+
+export const GRID_COLS: Record<Device, number> = {
+	mobile: 4,
+	desktop: 12,
+};
+
+export function toLayoutItem(widget: DashboardWidget, device: Device): Layout {
+	const entry = getWidgetEntry(widget.type);
+	const minSize = entry?.minSize ?? { w: 2, h: 1 };
+	return {
+		i: widget.id,
+		x: widget.x,
+		y: widget.y,
+		w: widget.w,
+		h: widget.h,
+		minW: minSize.w,
+		minH: minSize.h,
+		maxW: GRID_COLS[device],
+	};
+}
+
+export function useDashboardGrid(widgets: DashboardWidget[], device: Device) {
+	const layout = useMemo(
+		() => widgets.map((w) => toLayoutItem(w, device)),
+		[widgets, device]
+	);
+
+	return { layout, gridCols: GRID_COLS[device] };
+}

--- a/apps/web/src/dashboard/hooks/use-dashboard-page.ts
+++ b/apps/web/src/dashboard/hooks/use-dashboard-page.ts
@@ -1,0 +1,172 @@
+import { useBlocker } from "@tanstack/react-router";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Layout } from "react-grid-layout";
+import { useCurrentDevice } from "@/dashboard/hooks/use-current-device";
+import {
+	type DashboardWidget,
+	useDashboardWidgets,
+	type WidgetType,
+} from "@/dashboard/hooks/use-dashboard-widgets";
+import { useEditMode } from "@/dashboard/hooks/use-edit-mode";
+import {
+	type LayoutItem,
+	useLayoutSync,
+} from "@/dashboard/hooks/use-layout-sync";
+
+function layoutsToItems(layout: Layout[]): LayoutItem[] {
+	return layout.map((l) => ({
+		id: l.i,
+		x: l.x,
+		y: l.y,
+		w: l.w,
+		h: l.h,
+	}));
+}
+
+function useContainerWidth(): [React.RefObject<HTMLDivElement | null>, number] {
+	const ref = useRef<HTMLDivElement>(null);
+	const [width, setWidth] = useState(0);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) {
+			return;
+		}
+		const update = () => setWidth(el.getBoundingClientRect().width);
+		update();
+		const observer = new ResizeObserver(update);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, []);
+
+	return [ref, width];
+}
+
+export function useDashboardPage() {
+	const device = useCurrentDevice();
+	const {
+		widgets,
+		isLoading,
+		error,
+		createWidget,
+		updateWidget,
+		deleteWidget,
+	} = useDashboardWidgets(device);
+	const { isEditing, setEditing, toggle } = useEditMode();
+	const { enqueue, flush, discard, hasPendingChanges } = useLayoutSync(device);
+	const [containerRef, containerWidth] = useContainerWidth();
+	const [editingWidget, setEditingWidget] = useState<DashboardWidget | null>(
+		null
+	);
+	const [deletingWidget, setDeletingWidget] = useState<DashboardWidget | null>(
+		null
+	);
+
+	const blocker = useBlocker({
+		shouldBlockFn: () => hasPendingChanges,
+		enableBeforeUnload: () => hasPendingChanges,
+		withResolver: true,
+	});
+
+	const handleLayoutChange = useCallback(
+		(layout: Layout[]) => {
+			enqueue(layoutsToItems(layout));
+		},
+		[enqueue]
+	);
+
+	const handleDoneClick = useCallback(async () => {
+		if (isEditing) {
+			await flush();
+			setEditing(false);
+		} else {
+			toggle();
+		}
+	}, [isEditing, flush, setEditing, toggle]);
+
+	const handleAdd = useCallback(
+		async (type: WidgetType) => {
+			await flush();
+			await createWidget({ type });
+		},
+		[createWidget, flush]
+	);
+
+	const handleEditSave = useCallback(
+		async (nextConfig: Record<string, unknown>) => {
+			if (!editingWidget) {
+				return;
+			}
+			await updateWidget({ id: editingWidget.id, config: nextConfig });
+		},
+		[editingWidget, updateWidget]
+	);
+
+	const handleDelete = useCallback(async () => {
+		if (!deletingWidget) {
+			return;
+		}
+		await flush();
+		await deleteWidget(deletingWidget.id);
+		setDeletingWidget(null);
+	}, [deletingWidget, deleteWidget, flush]);
+
+	const handleBlockerSave = useCallback(async () => {
+		if (blocker.status !== "blocked") {
+			return;
+		}
+		await flush();
+		blocker.proceed();
+	}, [blocker, flush]);
+
+	const handleBlockerDiscard = useCallback(() => {
+		if (blocker.status !== "blocked") {
+			return;
+		}
+		discard();
+		blocker.proceed();
+	}, [blocker, discard]);
+
+	const handleBlockerCancel = () => {
+		if (blocker.status === "blocked") {
+			blocker.reset();
+		}
+	};
+
+	const handleDeletingWidgetDialogChange = (open: boolean) => {
+		if (!open) {
+			setDeletingWidget(null);
+		}
+	};
+
+	const handleEditingWidgetDialogChange = (open: boolean) => {
+		if (!open) {
+			setEditingWidget(null);
+		}
+	};
+
+	return {
+		blocker,
+		containerRef,
+		containerWidth,
+		deletingWidget,
+		device,
+		editingWidget,
+		error,
+		handleAdd,
+		handleBlockerCancel,
+		handleBlockerDiscard,
+		handleBlockerSave,
+		handleDelete,
+		handleDeletingWidgetDialogChange,
+		handleDoneClick,
+		handleEditingWidgetDialogChange,
+		handleEditSave,
+		handleLayoutChange,
+		isEditing,
+		isLoading,
+		setDeletingWidget,
+		setEditingWidget,
+		widgets,
+	};
+}

--- a/apps/web/src/live-sessions/components/active-session-game-scene.tsx
+++ b/apps/web/src/live-sessions/components/active-session-game-scene.tsx
@@ -1,8 +1,8 @@
 import { IconEdit } from "@tabler/icons-react";
-import { useState } from "react";
 import { AssignRingGameDialog } from "@/live-sessions/components/assign-ring-game-dialog";
 import { AssignTournamentDialog } from "@/live-sessions/components/assign-tournament-dialog";
 import { useActiveSession } from "@/live-sessions/hooks/use-active-session";
+import { useAssignDialogState } from "@/live-sessions/hooks/use-assign-dialog-state";
 import { useCashGameSession } from "@/live-sessions/hooks/use-cash-game-session";
 import { useRingGameSceneActions } from "@/live-sessions/hooks/use-ring-game-scene-actions";
 import {
@@ -140,7 +140,7 @@ function CashGameNotLinked({
 	sessionId: string;
 	sessionStoreId: string | null;
 }) {
-	const [isAssignOpen, setIsAssignOpen] = useState(false);
+	const { isAssignOpen, setIsAssignOpen } = useAssignDialogState();
 	return (
 		<GameSceneShell title="Cash Game">
 			<EmptyState
@@ -563,7 +563,7 @@ function TournamentNotLinked({
 	sessionId: string;
 	sessionStoreId: string | null;
 }) {
-	const [isAssignOpen, setIsAssignOpen] = useState(false);
+	const { isAssignOpen, setIsAssignOpen } = useAssignDialogState();
 	return (
 		<GameSceneShell title="Tournament">
 			<EmptyState

--- a/apps/web/src/live-sessions/components/active-session-scene.tsx
+++ b/apps/web/src/live-sessions/components/active-session-scene.tsx
@@ -1,6 +1,5 @@
 import { IconAlertTriangle } from "@tabler/icons-react";
 import type { ReactNode } from "react";
-import { useMemo, useState } from "react";
 import { AddPlayerSheet } from "@/live-sessions/components/add-player-sheet";
 import { PlayerDetailSheet } from "@/live-sessions/components/player-detail-sheet";
 import {
@@ -9,6 +8,7 @@ import {
 	type TablePlayer,
 } from "@/live-sessions/components/poker-table";
 import { SeatFromScreenshotSheet } from "@/live-sessions/components/seat-from-screenshot-sheet";
+import { useActiveSessionScene } from "@/live-sessions/hooks/use-active-session-scene";
 import type { PlayerFormValues } from "@/players/components/player-form";
 import type {
 	PlayerDetailData,
@@ -238,18 +238,13 @@ export function ActiveSessionScene({
 	title,
 	topSlot,
 }: ActiveSessionSceneProps) {
-	const [isDiscardOpen, setIsDiscardOpen] = useState(false);
-	const [isScanSheetOpen, setIsScanSheetOpen] = useState(false);
-
-	const occupiedSeatPositions = useMemo(() => {
-		const set = new Set<number>();
-		for (const p of state.players) {
-			if (p.isActive && typeof p.seatPosition === "number") {
-				set.add(p.seatPosition);
-			}
-		}
-		return set;
-	}, [state.players]);
+	const {
+		isDiscardOpen,
+		setIsDiscardOpen,
+		isScanSheetOpen,
+		setIsScanSheetOpen,
+		occupiedSeatPositions,
+	} = useActiveSessionScene({ players: state.players });
 
 	return (
 		<>

--- a/apps/web/src/live-sessions/components/addon-bottom-sheet.tsx
+++ b/apps/web/src/live-sessions/components/addon-bottom-sheet.tsx
@@ -1,11 +1,8 @@
-import { useForm } from "@tanstack/react-form";
-import { useEffect } from "react";
-import { z } from "zod";
 import { AddonFields } from "@/live-sessions/components/event-fields/addon-fields";
+import { useAddonForm } from "@/live-sessions/hooks/use-addon-form";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
-import { requiredNumericString } from "@/shared/lib/form-fields";
 
 interface AddonBottomSheetProps {
 	initialAmount?: number;
@@ -15,10 +12,6 @@ interface AddonBottomSheetProps {
 	open: boolean;
 }
 
-const addonSchema = z.object({
-	amount: requiredNumericString({ integer: true, min: 0 }),
-});
-
 export function AddonBottomSheet({
 	open,
 	onOpenChange,
@@ -26,25 +19,7 @@ export function AddonBottomSheet({
 	onSubmit,
 	onDelete,
 }: AddonBottomSheetProps) {
-	const form = useForm({
-		defaultValues: {
-			amount: initialAmount === undefined ? "0" : String(initialAmount),
-		},
-		onSubmit: ({ value }) => {
-			onSubmit({ amount: Math.round(Number(value.amount)) });
-		},
-		validators: {
-			onSubmit: addonSchema,
-		},
-	});
-
-	useEffect(() => {
-		if (open) {
-			form.reset({
-				amount: initialAmount === undefined ? "0" : String(initialAmount),
-			});
-		}
-	}, [open, initialAmount, form]);
+	const { form } = useAddonForm({ initialAmount, open, onSubmit });
 
 	const isEditMode = initialAmount !== undefined;
 

--- a/apps/web/src/live-sessions/components/all-in-bottom-sheet.tsx
+++ b/apps/web/src/live-sessions/components/all-in-bottom-sheet.tsx
@@ -1,11 +1,8 @@
-import { useForm } from "@tanstack/react-form";
-import { useEffect } from "react";
-import { z } from "zod";
 import { AllInFields } from "@/live-sessions/components/event-fields/all-in-fields";
+import { useAllInForm } from "@/live-sessions/hooks/use-all-in-form";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
-import { requiredNumericString } from "@/shared/lib/form-fields";
 
 interface AllIn {
 	equity: number;
@@ -22,32 +19,6 @@ interface AllInBottomSheetProps {
 	open: boolean;
 }
 
-const DEFAULT_VALUES = {
-	potSize: "0",
-	trials: "1",
-	equity: "0",
-	wins: "0",
-};
-
-const allInSchema = z.object({
-	potSize: requiredNumericString({ min: 0 }),
-	trials: requiredNumericString({ integer: true, min: 1 }),
-	equity: requiredNumericString({ min: 0, max: 100 }),
-	wins: requiredNumericString({ min: 0 }),
-});
-
-function toFormDefaults(initial: AllIn | undefined) {
-	if (!initial) {
-		return DEFAULT_VALUES;
-	}
-	return {
-		potSize: String(initial.potSize),
-		trials: String(initial.trials),
-		equity: String(initial.equity),
-		wins: String(initial.wins),
-	};
-}
-
 export function AllInBottomSheet({
 	open,
 	onOpenChange,
@@ -55,26 +26,7 @@ export function AllInBottomSheet({
 	onSubmit,
 	onDelete,
 }: AllInBottomSheetProps) {
-	const form = useForm({
-		defaultValues: toFormDefaults(initialValues),
-		onSubmit: ({ value }) => {
-			onSubmit({
-				potSize: Number(value.potSize),
-				trials: Number(value.trials),
-				equity: Number(value.equity),
-				wins: Number(value.wins),
-			});
-		},
-		validators: {
-			onSubmit: allInSchema,
-		},
-	});
-
-	useEffect(() => {
-		if (open) {
-			form.reset(toFormDefaults(initialValues));
-		}
-	}, [open, initialValues, form]);
+	const { form } = useAllInForm({ initialValues, open, onSubmit });
 
 	const isEditMode = initialValues !== undefined;
 

--- a/apps/web/src/live-sessions/components/cash-game-complete-form.tsx
+++ b/apps/web/src/live-sessions/components/cash-game-complete-form.tsx
@@ -1,10 +1,8 @@
-import { useForm } from "@tanstack/react-form";
-import { z } from "zod";
+import { useCashGameCompleteForm } from "@/live-sessions/hooks/use-cash-game-complete-form";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
-import { requiredNumericString } from "@/shared/lib/form-fields";
 
 interface CashGameCompleteFormProps {
 	defaultFinalStack?: number;
@@ -12,27 +10,12 @@ interface CashGameCompleteFormProps {
 	onSubmit: (values: { finalStack: number }) => void;
 }
 
-const cashGameCompleteSchema = z.object({
-	finalStack: requiredNumericString({ integer: true, min: 0 }),
-});
-
 export function CashGameCompleteForm({
 	defaultFinalStack,
 	isLoading,
 	onSubmit,
 }: CashGameCompleteFormProps) {
-	const form = useForm({
-		defaultValues: {
-			finalStack:
-				defaultFinalStack === undefined ? "" : String(defaultFinalStack),
-		},
-		onSubmit: ({ value }) => {
-			onSubmit({ finalStack: Number(value.finalStack) });
-		},
-		validators: {
-			onSubmit: cashGameCompleteSchema,
-		},
-	});
+	const { form } = useCashGameCompleteForm({ defaultFinalStack, onSubmit });
 
 	return (
 		<form

--- a/apps/web/src/live-sessions/components/cash-game-stack-form.tsx
+++ b/apps/web/src/live-sessions/components/cash-game-stack-form.tsx
@@ -1,6 +1,3 @@
-import { useForm } from "@tanstack/react-form";
-import { useEffect, useState } from "react";
-import { z } from "zod";
 import { AddonBottomSheet } from "@/live-sessions/components/addon-bottom-sheet";
 import { AllInBottomSheet } from "@/live-sessions/components/all-in-bottom-sheet";
 import { MemoFields } from "@/live-sessions/components/event-fields/memo-fields";
@@ -8,11 +5,10 @@ import {
 	StackNumberField,
 	StackPrimaryRow,
 } from "@/live-sessions/components/stack-ui";
-import { useStackFormContext } from "@/live-sessions/hooks/use-session-form";
+import { useCashGameStackForm } from "@/live-sessions/hooks/use-cash-game-stack-form";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
-import { requiredNumericString } from "@/shared/lib/form-fields";
 
 interface CashGameStackFormProps {
 	isLoading: boolean;
@@ -30,14 +26,6 @@ interface CashGameStackFormProps {
 	onSubmit: (values: { stackAmount: number }) => void;
 }
 
-const stackSchema = z.object({
-	stackAmount: requiredNumericString({ integer: true, min: 0 }),
-});
-
-const memoSchema = z.object({
-	text: z.string().min(1, "Text is required"),
-});
-
 export function CashGameStackForm({
 	isLoading,
 	onAllIn,
@@ -48,41 +36,20 @@ export function CashGameStackForm({
 	onPause,
 	onSubmit,
 }: CashGameStackFormProps) {
-	const { state, setStackAmount } = useStackFormContext();
-	const { stackAmount } = state;
-
-	const stackForm = useForm({
-		defaultValues: { stackAmount },
-		onSubmit: ({ value }) => {
-			onSubmit({ stackAmount: Number(value.stackAmount) });
-		},
-		validators: {
-			onSubmit: stackSchema,
-		},
-	});
-
-	useEffect(() => {
-		if (stackForm.state.values.stackAmount !== stackAmount) {
-			stackForm.setFieldValue("stackAmount", stackAmount);
-		}
-	}, [stackAmount, stackForm]);
-
-	const memoForm = useForm({
-		defaultValues: { text: "" },
-		onSubmit: ({ value }) => {
-			onMemo(value.text);
-			memoForm.reset();
-			setMemoBottomSheetOpen(false);
-		},
-		validators: {
-			onSubmit: memoSchema,
-		},
-	});
-
-	const [allInBottomSheetOpen, setAllInBottomSheetOpen] = useState(false);
-	const [addonBottomSheetOpen, setAddonBottomSheetOpen] = useState(false);
-	const [removeBottomSheetOpen, setRemoveBottomSheetOpen] = useState(false);
-	const [memoBottomSheetOpen, setMemoBottomSheetOpen] = useState(false);
+	const {
+		stackForm,
+		memoForm,
+		stackAmount,
+		setStackAmount,
+		allInBottomSheetOpen,
+		setAllInBottomSheetOpen,
+		addonBottomSheetOpen,
+		setAddonBottomSheetOpen,
+		removeBottomSheetOpen,
+		setRemoveBottomSheetOpen,
+		memoBottomSheetOpen,
+		setMemoBottomSheetOpen,
+	} = useCashGameStackForm({ onMemo, onSubmit });
 
 	const handleAllInSubmit = (values: {
 		potSize: number;

--- a/apps/web/src/live-sessions/components/chip-purchase-sheet.tsx
+++ b/apps/web/src/live-sessions/components/chip-purchase-sheet.tsx
@@ -1,11 +1,8 @@
-import { useForm } from "@tanstack/react-form";
-import { useEffect } from "react";
-import { z } from "zod";
 import { ChipPurchaseFields } from "@/live-sessions/components/event-fields/chip-purchase-fields";
+import { useChipPurchaseForm } from "@/live-sessions/hooks/use-chip-purchase-form";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
-import { requiredNumericString } from "@/shared/lib/form-fields";
 
 interface ChipPurchaseSheetProps {
 	defaultChips?: number;
@@ -20,30 +17,6 @@ interface ChipPurchaseSheetProps {
 	shortcuts?: Array<{ chips: number; cost: number; name: string }>;
 }
 
-const chipPurchaseSchema = z.object({
-	name: z.string().min(1, "Name is required"),
-	cost: requiredNumericString({ integer: true, min: 0 }),
-	chips: requiredNumericString({ integer: true, min: 0 }),
-});
-
-function buildDefaults({
-	initialValues,
-	defaultName,
-	defaultCost,
-	defaultChips,
-}: {
-	defaultChips?: number;
-	defaultCost?: number;
-	defaultName?: string;
-	initialValues?: { name: string; cost: number; chips: number };
-}) {
-	return {
-		name: initialValues?.name ?? defaultName ?? "",
-		cost: String(initialValues?.cost ?? defaultCost ?? 0),
-		chips: String(initialValues?.chips ?? defaultChips ?? 0),
-	};
-}
-
 export function ChipPurchaseSheet({
 	open,
 	onOpenChange,
@@ -56,32 +29,14 @@ export function ChipPurchaseSheet({
 	readOnly = false,
 	shortcuts,
 }: ChipPurchaseSheetProps) {
-	const form = useForm({
-		defaultValues: buildDefaults({
-			defaultChips,
-			defaultCost,
-			defaultName,
-			initialValues,
-		}),
-		onSubmit: ({ value }) => {
-			onSubmit({
-				name: value.name,
-				cost: Math.round(Number(value.cost)),
-				chips: Math.round(Number(value.chips)),
-			});
-		},
-		validators: {
-			onSubmit: chipPurchaseSchema,
-		},
+	const { form } = useChipPurchaseForm({
+		defaultChips,
+		defaultCost,
+		defaultName,
+		initialValues,
+		open,
+		onSubmit,
 	});
-
-	useEffect(() => {
-		if (open) {
-			form.reset(
-				buildDefaults({ defaultChips, defaultCost, defaultName, initialValues })
-			);
-		}
-	}, [open, defaultChips, defaultCost, defaultName, initialValues, form]);
 
 	const isEditMode = initialValues !== undefined;
 

--- a/apps/web/src/live-sessions/components/create-cash-game-session-form.tsx
+++ b/apps/web/src/live-sessions/components/create-cash-game-session-form.tsx
@@ -1,5 +1,4 @@
-import { useForm } from "@tanstack/react-form";
-import { useState } from "react";
+import { useCreateCashGameSessionForm } from "@/live-sessions/hooks/use-create-cash-game-session-form";
 import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { Field } from "@/shared/components/ui/field";
@@ -42,59 +41,17 @@ export function CreateCashGameSessionForm({
 	ringGames,
 	stores,
 }: CreateCashGameSessionFormProps) {
-	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(
-		undefined
-	);
-	const [selectedRingGameId, setSelectedRingGameId] = useState<
-		string | undefined
-	>(undefined);
-	const [selectedCurrencyId, setSelectedCurrencyId] = useState<
-		string | undefined
-	>(undefined);
-
-	const selectedRingGame = selectedRingGameId
-		? ringGames.find((g) => g.id === selectedRingGameId)
-		: null;
-
-	const isCurrencyLocked =
-		selectedRingGame?.currencyId !== null &&
-		selectedRingGame?.currencyId !== undefined;
-
-	const form = useForm({
-		defaultValues: {
-			initialBuyIn: "",
-			memo: "",
-		},
-		onSubmit: ({ value }) => {
-			onSubmit({
-				storeId: selectedStoreId,
-				ringGameId: selectedRingGameId,
-				currencyId: selectedCurrencyId,
-				initialBuyIn: Number(value.initialBuyIn),
-				memo: value.memo || undefined,
-			});
-		},
-	});
-
-	const handleStoreChange = (value: string) => {
-		setSelectedStoreId(value);
-		setSelectedRingGameId(undefined);
-		form.setFieldValue("initialBuyIn", "");
-		onStoreChange?.(value);
-	};
-
-	const handleRingGameChange = (value: string) => {
-		setSelectedRingGameId(value);
-		const ringGame = ringGames.find((g) => g.id === value);
-		if (ringGame) {
-			form.setFieldValue("initialBuyIn", ringGame.maxBuyIn?.toString() ?? "");
-			setSelectedCurrencyId(ringGame.currencyId ?? undefined);
-		}
-	};
-
-	const handleCurrencyChange = (value: string) => {
-		setSelectedCurrencyId(value);
-	};
+	const {
+		form,
+		selectedStoreId,
+		selectedRingGameId,
+		selectedRingGame,
+		selectedCurrencyId,
+		isCurrencyLocked,
+		handleStoreChange,
+		handleRingGameChange,
+		handleCurrencyChange,
+	} = useCreateCashGameSessionForm({ onStoreChange, onSubmit, ringGames });
 
 	const hasRingGames = ringGames.length > 0;
 

--- a/apps/web/src/live-sessions/components/create-session-dialog.tsx
+++ b/apps/web/src/live-sessions/components/create-session-dialog.tsx
@@ -1,11 +1,8 @@
-import { useState } from "react";
 import { CreateCashGameSessionForm } from "@/live-sessions/components/create-cash-game-session-form";
 import { CreateTournamentSessionForm } from "@/live-sessions/components/create-tournament-session-form";
-import { useCreateSession } from "@/live-sessions/hooks/use-create-session";
+import { useCreateSessionDialog } from "@/live-sessions/hooks/use-create-session-dialog";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/components/ui/tabs";
-
-type SessionType = "cash_game" | "tournament";
 
 interface CreateSessionDialogProps {
 	onOpenChange: (open: boolean) => void;
@@ -16,9 +13,9 @@ export function CreateSessionDialog({
 	open,
 	onOpenChange,
 }: CreateSessionDialogProps) {
-	const [sessionType, setSessionType] = useState<SessionType>("cash_game");
-
 	const {
+		sessionType,
+		setSessionType,
 		stores,
 		currencies,
 		ringGames,
@@ -27,12 +24,8 @@ export function CreateSessionDialog({
 		createCash,
 		createTournament,
 		isLoading,
-	} = useCreateSession({ onClose: () => onOpenChange(false) });
-
-	const handleReset = () => {
-		setSelectedStoreId(undefined);
-		setSessionType("cash_game");
-	};
+		handleReset,
+	} = useCreateSessionDialog({ onOpenChange });
 
 	return (
 		<ResponsiveDialog
@@ -48,7 +41,9 @@ export function CreateSessionDialog({
 			{/* Session type selector */}
 			<Tabs
 				className="mb-4"
-				onValueChange={(value) => setSessionType(value as SessionType)}
+				onValueChange={(value) =>
+					setSessionType(value as "cash_game" | "tournament")
+				}
 				value={sessionType}
 			>
 				<TabsList className="grid w-full grid-cols-2">

--- a/apps/web/src/live-sessions/components/create-tournament-session-form.tsx
+++ b/apps/web/src/live-sessions/components/create-tournament-session-form.tsx
@@ -1,6 +1,4 @@
-import { useForm } from "@tanstack/react-form";
-import { useState } from "react";
-import { z } from "zod";
+import { useCreateTournamentSessionForm } from "@/live-sessions/hooks/use-create-tournament-session-form";
 import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
@@ -12,10 +10,6 @@ import {
 	SelectValue,
 } from "@/shared/components/ui/select";
 import { Textarea } from "@/shared/components/ui/textarea";
-import {
-	optionalNumericString,
-	requiredNumericString,
-} from "@/shared/lib/form-fields";
 
 interface CreateTournamentSessionFormProps {
 	currencies: Array<{ id: string; name: string }>;
@@ -42,27 +36,6 @@ interface CreateTournamentSessionFormProps {
 	}>;
 }
 
-const formSchema = z.object({
-	buyIn: requiredNumericString({ integer: true, min: 0 }),
-	entryFee: optionalNumericString({ integer: true, min: 0 }),
-	startingStack: requiredNumericString({ integer: true, min: 0 }),
-	memo: z.string(),
-	timerStartedAt: z.string(),
-});
-
-function parseTimerStartedAt(value: string): number | undefined {
-	const trimmed = value.trim();
-	if (!trimmed) {
-		return;
-	}
-	const parsed = new Date(trimmed);
-	const ms = parsed.getTime();
-	if (Number.isNaN(ms)) {
-		return;
-	}
-	return Math.floor(ms / 1000);
-}
-
 export function CreateTournamentSessionForm({
 	currencies,
 	isLoading,
@@ -71,91 +44,21 @@ export function CreateTournamentSessionForm({
 	stores,
 	tournaments,
 }: CreateTournamentSessionFormProps) {
-	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(
-		undefined
-	);
-	const [selectedTournamentId, setSelectedTournamentId] = useState<
-		string | undefined
-	>(undefined);
-	const [selectedCurrencyId, setSelectedCurrencyId] = useState<
-		string | undefined
-	>(undefined);
-
-	const form = useForm({
-		defaultValues: {
-			buyIn: "",
-			entryFee: "",
-			startingStack: "",
-			memo: "",
-			timerStartedAt: "",
-		},
-		onSubmit: ({ value }) => {
-			onSubmit({
-				storeId: selectedStoreId,
-				tournamentId: selectedTournamentId,
-				currencyId: selectedCurrencyId,
-				buyIn: Number(value.buyIn),
-				entryFee: value.entryFee ? Number(value.entryFee) : undefined,
-				startingStack: Number(value.startingStack),
-				memo: value.memo ? value.memo : undefined,
-				timerStartedAt: parseTimerStartedAt(value.timerStartedAt),
-			});
-		},
-		validators: {
-			onSubmit: formSchema,
-		},
-	});
-
-	const handleStoreChange = (value: string) => {
-		setSelectedStoreId(value);
-		setSelectedTournamentId(undefined);
-		onStoreChange?.(value);
-	};
-
-	const applyTournamentDefaults = (t: (typeof tournaments)[number]) => {
-		if (t.currencyId) {
-			setSelectedCurrencyId(t.currencyId);
-		}
-		if (t.buyIn !== null) {
-			form.setFieldValue("buyIn", String(t.buyIn));
-		}
-		if (t.entryFee !== null) {
-			form.setFieldValue("entryFee", String(t.entryFee));
-		}
-		if (t.startingStack !== null) {
-			form.setFieldValue("startingStack", String(t.startingStack));
-		}
-	};
-
-	const handleTournamentChange = (value: string) => {
-		setSelectedTournamentId(value);
-		const t = tournaments.find((tour) => tour.id === value);
-		if (t) {
-			applyTournamentDefaults(t);
-		}
-	};
-
-	const handleCurrencyChange = (value: string) => {
-		setSelectedCurrencyId(value);
-	};
+	const {
+		form,
+		selectedStoreId,
+		selectedTournamentId,
+		selectedCurrencyId,
+		isBuyInLocked,
+		isEntryFeeLocked,
+		isStartingStackLocked,
+		isCurrencyLocked,
+		handleStoreChange,
+		handleTournamentChange,
+		handleCurrencyChange,
+	} = useCreateTournamentSessionForm({ onStoreChange, onSubmit, tournaments });
 
 	const hasTournaments = tournaments.length > 0;
-
-	const selectedTournament = selectedTournamentId
-		? tournaments.find((t) => t.id === selectedTournamentId)
-		: null;
-	const isBuyInLocked =
-		selectedTournament?.buyIn !== null &&
-		selectedTournament?.buyIn !== undefined;
-	const isEntryFeeLocked =
-		selectedTournament?.entryFee !== null &&
-		selectedTournament?.entryFee !== undefined;
-	const isStartingStackLocked =
-		selectedTournament?.startingStack !== null &&
-		selectedTournament?.startingStack !== undefined;
-	const isCurrencyLocked =
-		selectedTournament?.currencyId !== null &&
-		selectedTournament?.currencyId !== undefined;
 
 	return (
 		<form

--- a/apps/web/src/live-sessions/components/event-editors/all-in-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/all-in-editor.tsx
@@ -1,28 +1,13 @@
-import { useForm } from "@tanstack/react-form";
-import { z } from "zod";
 import { AllInFields } from "@/live-sessions/components/event-fields/all-in-fields";
-import {
-	toOccurredAtTimestamp,
-	toTimeInputValue,
-	validateOccurredAtTime,
-} from "@/live-sessions/components/stack-editor-time";
+import { useAllInEditor } from "@/live-sessions/hooks/event-editors/use-all-in-editor";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
-import { requiredNumericString } from "@/shared/lib/form-fields";
 import { type EditorBaseProps, TimeField } from "./shared";
 
 type Props = Pick<
 	EditorBaseProps,
 	"event" | "isLoading" | "maxTime" | "minTime" | "onSubmit"
 >;
-
-const allInSchema = z.object({
-	time: z.string(),
-	potSize: requiredNumericString({ min: 0 }),
-	trials: requiredNumericString({ integer: true, min: 1 }),
-	equity: requiredNumericString({ min: 0, max: 100 }),
-	wins: requiredNumericString({ min: 0 }),
-});
 
 export function AllInEditor({
 	event,
@@ -31,32 +16,12 @@ export function AllInEditor({
 	minTime,
 	onSubmit,
 }: Props) {
-	const payload = (event.payload ?? {}) as Record<string, unknown>;
-
-	const form = useForm({
-		defaultValues: {
-			time: toTimeInputValue(event.occurredAt),
-			potSize:
-				typeof payload.potSize === "number" ? String(payload.potSize) : "0",
-			trials: typeof payload.trials === "number" ? String(payload.trials) : "1",
-			equity: typeof payload.equity === "number" ? String(payload.equity) : "0",
-			wins: typeof payload.wins === "number" ? String(payload.wins) : "0",
-		},
-		onSubmit: ({ value }) => {
-			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
-			onSubmit(
-				{
-					potSize: Number(value.potSize),
-					trials: Number(value.trials),
-					equity: Number(value.equity),
-					wins: Number(value.wins),
-				},
-				occurredAt
-			);
-		},
-		validators: {
-			onSubmit: allInSchema,
-		},
+	const { form, timeValidator } = useAllInEditor({
+		event,
+		isLoading,
+		maxTime,
+		minTime,
+		onSubmit,
 	});
 
 	return (
@@ -71,9 +36,7 @@ export function AllInEditor({
 			<form.Field
 				name="time"
 				validators={{
-					onChange: ({ value }) =>
-						validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
-						undefined,
+					onChange: ({ value }) => timeValidator(value),
 				}}
 			>
 				{(field) => (

--- a/apps/web/src/live-sessions/components/event-editors/chips-add-remove-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/chips-add-remove-editor.tsx
@@ -1,11 +1,5 @@
-import { useForm } from "@tanstack/react-form";
-import { z } from "zod";
 import { AddonFields } from "@/live-sessions/components/event-fields/addon-fields";
-import {
-	toOccurredAtTimestamp,
-	toTimeInputValue,
-	validateOccurredAtTime,
-} from "@/live-sessions/components/stack-editor-time";
+import { useChipsAddRemoveEditor } from "@/live-sessions/hooks/event-editors/use-chips-add-remove-editor";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
@@ -13,19 +7,12 @@ import {
 	ToggleGroup,
 	ToggleGroupItem,
 } from "@/shared/components/ui/toggle-group";
-import { requiredNumericString } from "@/shared/lib/form-fields";
 import { type EditorBaseProps, TimeField } from "./shared";
 
 type Props = Pick<
 	EditorBaseProps,
 	"event" | "isLoading" | "maxTime" | "minTime" | "onSubmit"
 >;
-
-const chipsAddRemoveSchema = z.object({
-	time: z.string(),
-	amount: requiredNumericString({ integer: true, min: 0 }),
-	type: z.enum(["add", "remove"]),
-});
 
 export function ChipsAddRemoveEditor({
 	event,
@@ -34,24 +21,12 @@ export function ChipsAddRemoveEditor({
 	minTime,
 	onSubmit,
 }: Props) {
-	const payload = (event.payload ?? {}) as Record<string, unknown>;
-
-	const form = useForm({
-		defaultValues: {
-			time: toTimeInputValue(event.occurredAt),
-			amount: typeof payload.amount === "number" ? String(payload.amount) : "0",
-			type: (payload.type === "remove" ? "remove" : "add") as "add" | "remove",
-		},
-		onSubmit: ({ value }) => {
-			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
-			onSubmit(
-				{ amount: Math.round(Number(value.amount)), type: value.type },
-				occurredAt
-			);
-		},
-		validators: {
-			onSubmit: chipsAddRemoveSchema,
-		},
+	const { form, timeValidator } = useChipsAddRemoveEditor({
+		event,
+		isLoading,
+		maxTime,
+		minTime,
+		onSubmit,
 	});
 
 	return (
@@ -66,9 +41,7 @@ export function ChipsAddRemoveEditor({
 			<form.Field
 				name="time"
 				validators={{
-					onChange: ({ value }) =>
-						validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
-						undefined,
+					onChange: ({ value }) => timeValidator(value),
 				}}
 			>
 				{(field) => (

--- a/apps/web/src/live-sessions/components/event-editors/memo-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/memo-editor.tsx
@@ -1,10 +1,5 @@
-import { useForm } from "@tanstack/react-form";
 import { MemoFields } from "@/live-sessions/components/event-fields/memo-fields";
-import {
-	toOccurredAtTimestamp,
-	toTimeInputValue,
-	validateOccurredAtTime,
-} from "@/live-sessions/components/stack-editor-time";
+import { useMemoEditor } from "@/live-sessions/hooks/event-editors/use-memo-editor";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { type EditorBaseProps, TimeField } from "./shared";
@@ -21,17 +16,12 @@ export function MemoEditor({
 	minTime,
 	onSubmit,
 }: Props) {
-	const payload = (event.payload ?? {}) as Record<string, unknown>;
-
-	const form = useForm({
-		defaultValues: {
-			time: toTimeInputValue(event.occurredAt),
-			text: typeof payload.text === "string" ? payload.text : "",
-		},
-		onSubmit: ({ value }) => {
-			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
-			onSubmit({ text: value.text }, occurredAt);
-		},
+	const { form, timeValidator, textValidator } = useMemoEditor({
+		event,
+		isLoading,
+		maxTime,
+		minTime,
+		onSubmit,
 	});
 
 	return (
@@ -46,9 +36,7 @@ export function MemoEditor({
 			<form.Field
 				name="time"
 				validators={{
-					onChange: ({ value }) =>
-						validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
-						undefined,
+					onChange: ({ value }) => timeValidator(value),
 				}}
 			>
 				{(field) => (
@@ -62,8 +50,7 @@ export function MemoEditor({
 			<form.Field
 				name="text"
 				validators={{
-					onChange: ({ value }) =>
-						value.trim().length === 0 ? "Text is required" : undefined,
+					onChange: ({ value }) => textValidator(value),
 				}}
 			>
 				{(field) => (

--- a/apps/web/src/live-sessions/components/event-editors/purchase-chips-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/purchase-chips-editor.tsx
@@ -1,27 +1,13 @@
-import { useForm } from "@tanstack/react-form";
-import { z } from "zod";
 import { ChipPurchaseFields } from "@/live-sessions/components/event-fields/chip-purchase-fields";
-import {
-	toOccurredAtTimestamp,
-	toTimeInputValue,
-	validateOccurredAtTime,
-} from "@/live-sessions/components/stack-editor-time";
+import { usePurchaseChipsEditor } from "@/live-sessions/hooks/event-editors/use-purchase-chips-editor";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
-import { requiredNumericString } from "@/shared/lib/form-fields";
 import { type EditorBaseProps, TimeField } from "./shared";
 
 type Props = Pick<
 	EditorBaseProps,
 	"event" | "isLoading" | "maxTime" | "minTime" | "onSubmit"
 >;
-
-const purchaseChipsSchema = z.object({
-	time: z.string(),
-	name: z.string().min(1, "Name is required"),
-	cost: requiredNumericString({ integer: true, min: 0 }),
-	chips: requiredNumericString({ integer: true, min: 0 }),
-});
 
 export function PurchaseChipsEditor({
 	event,
@@ -30,29 +16,12 @@ export function PurchaseChipsEditor({
 	minTime,
 	onSubmit,
 }: Props) {
-	const payload = (event.payload ?? {}) as Record<string, unknown>;
-
-	const form = useForm({
-		defaultValues: {
-			time: toTimeInputValue(event.occurredAt),
-			name: typeof payload.name === "string" ? payload.name : "",
-			cost: typeof payload.cost === "number" ? String(payload.cost) : "0",
-			chips: typeof payload.chips === "number" ? String(payload.chips) : "0",
-		},
-		onSubmit: ({ value }) => {
-			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
-			onSubmit(
-				{
-					name: value.name,
-					cost: Math.round(Number(value.cost)),
-					chips: Math.round(Number(value.chips)),
-				},
-				occurredAt
-			);
-		},
-		validators: {
-			onSubmit: purchaseChipsSchema,
-		},
+	const { form, timeValidator } = usePurchaseChipsEditor({
+		event,
+		isLoading,
+		maxTime,
+		minTime,
+		onSubmit,
 	});
 
 	return (
@@ -67,9 +36,7 @@ export function PurchaseChipsEditor({
 			<form.Field
 				name="time"
 				validators={{
-					onChange: ({ value }) =>
-						validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
-						undefined,
+					onChange: ({ value }) => timeValidator(value),
 				}}
 			>
 				{(field) => (

--- a/apps/web/src/live-sessions/components/event-editors/session-end-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/session-end-editor.tsx
@@ -1,20 +1,13 @@
-import { useForm } from "@tanstack/react-form";
-import { z } from "zod";
 import {
-	toOccurredAtTimestamp,
-	toTimeInputValue,
-	validateOccurredAtTime,
-} from "@/live-sessions/components/stack-editor-time";
+	useCashGameEndEditor,
+	useTournamentEndEditor,
+} from "@/live-sessions/hooks/event-editors/use-session-end-editor";
 import { Button } from "@/shared/components/ui/button";
 import { Checkbox } from "@/shared/components/ui/checkbox";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
 import { Label } from "@/shared/components/ui/label";
-import {
-	optionalNumericString,
-	requiredNumericString,
-} from "@/shared/lib/form-fields";
 import { type EditorBaseProps, type SessionType, TimeField } from "./shared";
 
 type Props = Pick<
@@ -24,43 +17,6 @@ type Props = Pick<
 	sessionType: SessionType;
 };
 
-const cashGameEndSchema = z.object({
-	time: z.string(),
-	cashOutAmount: requiredNumericString({ integer: true, min: 0 }),
-});
-
-const tournamentEndSchema = z
-	.object({
-		time: z.string(),
-		beforeDeadline: z.boolean(),
-		placement: z.string(),
-		totalEntries: z.string(),
-		prizeMoney: requiredNumericString({ integer: true, min: 0 }),
-		bountyPrizes: optionalNumericString({ integer: true, min: 0 }),
-	})
-	.superRefine((data, ctx) => {
-		if (!data.beforeDeadline) {
-			const placementResult = requiredNumericString({
-				integer: true,
-				min: 1,
-			}).safeParse(data.placement);
-			if (!placementResult.success) {
-				for (const issue of placementResult.error.issues) {
-					ctx.addIssue({ ...issue, path: ["placement"] });
-				}
-			}
-			const totalEntriesResult = requiredNumericString({
-				integer: true,
-				min: 1,
-			}).safeParse(data.totalEntries);
-			if (!totalEntriesResult.success) {
-				for (const issue of totalEntriesResult.error.issues) {
-					ctx.addIssue({ ...issue, path: ["totalEntries"] });
-				}
-			}
-		}
-	});
-
 function CashGameEndEditor({
 	event,
 	isLoading,
@@ -68,23 +24,12 @@ function CashGameEndEditor({
 	minTime,
 	onSubmit,
 }: Props) {
-	const payload = (event.payload ?? {}) as Record<string, unknown>;
-
-	const form = useForm({
-		defaultValues: {
-			time: toTimeInputValue(event.occurredAt),
-			cashOutAmount:
-				typeof payload.cashOutAmount === "number"
-					? String(payload.cashOutAmount)
-					: "0",
-		},
-		onSubmit: ({ value }) => {
-			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
-			onSubmit({ cashOutAmount: Number(value.cashOutAmount) }, occurredAt);
-		},
-		validators: {
-			onSubmit: cashGameEndSchema,
-		},
+	const { form, timeValidator } = useCashGameEndEditor({
+		event,
+		isLoading,
+		maxTime,
+		minTime,
+		onSubmit,
 	});
 
 	return (
@@ -99,9 +44,7 @@ function CashGameEndEditor({
 			<form.Field
 				name="time"
 				validators={{
-					onChange: ({ value }) =>
-						validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
-						undefined,
+					onChange: ({ value }) => timeValidator(value),
 				}}
 			>
 				{(field) => (
@@ -157,54 +100,12 @@ function TournamentEndEditor({
 	minTime,
 	onSubmit,
 }: Props) {
-	const payload = (event.payload ?? {}) as Record<string, unknown>;
-
-	const form = useForm({
-		defaultValues: {
-			time: toTimeInputValue(event.occurredAt),
-			beforeDeadline: payload.beforeDeadline === true,
-			placement:
-				typeof payload.placement === "number" ? String(payload.placement) : "",
-			totalEntries:
-				typeof payload.totalEntries === "number"
-					? String(payload.totalEntries)
-					: "",
-			prizeMoney:
-				typeof payload.prizeMoney === "number"
-					? String(payload.prizeMoney)
-					: "0",
-			bountyPrizes:
-				typeof payload.bountyPrizes === "number" && payload.bountyPrizes > 0
-					? String(payload.bountyPrizes)
-					: "",
-		},
-		onSubmit: ({ value }) => {
-			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
-			if (value.beforeDeadline) {
-				onSubmit(
-					{
-						beforeDeadline: true,
-						prizeMoney: Number(value.prizeMoney),
-						bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
-					},
-					occurredAt
-				);
-			} else {
-				onSubmit(
-					{
-						beforeDeadline: false,
-						placement: Number(value.placement),
-						totalEntries: Number(value.totalEntries),
-						prizeMoney: Number(value.prizeMoney),
-						bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
-					},
-					occurredAt
-				);
-			}
-		},
-		validators: {
-			onSubmit: tournamentEndSchema,
-		},
+	const { form, timeValidator } = useTournamentEndEditor({
+		event,
+		isLoading,
+		maxTime,
+		minTime,
+		onSubmit,
 	});
 
 	return (
@@ -219,9 +120,7 @@ function TournamentEndEditor({
 			<form.Field
 				name="time"
 				validators={{
-					onChange: ({ value }) =>
-						validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
-						undefined,
+					onChange: ({ value }) => timeValidator(value),
 				}}
 			>
 				{(field) => (

--- a/apps/web/src/live-sessions/components/event-editors/session-start-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/session-start-editor.tsx
@@ -1,15 +1,11 @@
-import { useForm } from "@tanstack/react-form";
-import { z } from "zod";
 import {
-	toOccurredAtTimestamp,
-	toTimeInputValue,
-	validateOccurredAtTime,
-} from "@/live-sessions/components/stack-editor-time";
+	useCashGameStartEditor,
+	useTournamentStartEditor,
+} from "@/live-sessions/hooks/event-editors/use-session-start-editor";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
-import { requiredNumericString } from "@/shared/lib/form-fields";
 import { type EditorBaseProps, type SessionType, TimeField } from "./shared";
 
 type Props = Pick<
@@ -19,39 +15,6 @@ type Props = Pick<
 	sessionType: SessionType;
 };
 
-const cashGameStartSchema = z.object({
-	time: z.string(),
-	buyInAmount: requiredNumericString({ integer: true, min: 0 }),
-});
-
-const tournamentStartSchema = z.object({
-	time: z.string(),
-	timerStartedAt: z.string(),
-});
-
-function toDatetimeLocalValue(value: Date | string | number | null): string {
-	if (value === null || value === undefined) {
-		return "";
-	}
-	const date = new Date(value);
-	if (Number.isNaN(date.getTime())) {
-		return "";
-	}
-	const pad = (n: number) => String(n).padStart(2, "0");
-	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
-}
-
-function toTimerSeconds(value: string): number | null {
-	if (!value) {
-		return null;
-	}
-	const ms = new Date(value).getTime();
-	if (Number.isNaN(ms)) {
-		return null;
-	}
-	return Math.floor(ms / 1000);
-}
-
 function CashGameStartEditor({
 	event,
 	isLoading,
@@ -59,23 +22,12 @@ function CashGameStartEditor({
 	minTime,
 	onSubmit,
 }: Props) {
-	const payload = (event.payload ?? {}) as Record<string, unknown>;
-
-	const form = useForm({
-		defaultValues: {
-			time: toTimeInputValue(event.occurredAt),
-			buyInAmount:
-				typeof payload.buyInAmount === "number"
-					? String(payload.buyInAmount)
-					: "0",
-		},
-		onSubmit: ({ value }) => {
-			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
-			onSubmit({ buyInAmount: Number(value.buyInAmount) }, occurredAt);
-		},
-		validators: {
-			onSubmit: cashGameStartSchema,
-		},
+	const { form, timeValidator } = useCashGameStartEditor({
+		event,
+		isLoading,
+		maxTime,
+		minTime,
+		onSubmit,
 	});
 
 	return (
@@ -90,9 +42,7 @@ function CashGameStartEditor({
 			<form.Field
 				name="time"
 				validators={{
-					onChange: ({ value }) =>
-						validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
-						undefined,
+					onChange: ({ value }) => timeValidator(value),
 				}}
 			>
 				{(field) => (
@@ -148,27 +98,12 @@ function TournamentStartEditor({
 	minTime,
 	onSubmit,
 }: Props) {
-	const payload = (event.payload ?? {}) as Record<string, unknown>;
-	const initialTimer =
-		typeof payload.timerStartedAt === "number"
-			? toDatetimeLocalValue(payload.timerStartedAt * 1000)
-			: "";
-
-	const form = useForm({
-		defaultValues: {
-			time: toTimeInputValue(event.occurredAt),
-			timerStartedAt: initialTimer,
-		},
-		onSubmit: ({ value }) => {
-			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
-			onSubmit(
-				{ timerStartedAt: toTimerSeconds(value.timerStartedAt) },
-				occurredAt
-			);
-		},
-		validators: {
-			onSubmit: tournamentStartSchema,
-		},
+	const { form, timeValidator } = useTournamentStartEditor({
+		event,
+		isLoading,
+		maxTime,
+		minTime,
+		onSubmit,
 	});
 
 	return (
@@ -183,9 +118,7 @@ function TournamentStartEditor({
 			<form.Field
 				name="time"
 				validators={{
-					onChange: ({ value }) =>
-						validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
-						undefined,
+					onChange: ({ value }) => timeValidator(value),
 				}}
 			>
 				{(field) => (

--- a/apps/web/src/live-sessions/components/event-editors/time-only-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/time-only-editor.tsx
@@ -1,9 +1,4 @@
-import { useForm } from "@tanstack/react-form";
-import {
-	toOccurredAtTimestamp,
-	toTimeInputValue,
-	validateOccurredAtTime,
-} from "@/live-sessions/components/stack-editor-time";
+import { useTimeOnlyEditor } from "@/live-sessions/hooks/event-editors/use-time-only-editor";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { type EditorBaseProps, TimeField } from "./shared";
@@ -20,14 +15,12 @@ export function TimeOnlyEditor({
 	minTime,
 	onTimeUpdate,
 }: TimeOnlyEditorProps) {
-	const form = useForm({
-		defaultValues: { time: toTimeInputValue(event.occurredAt) },
-		onSubmit: ({ value }) => {
-			const ts = toOccurredAtTimestamp(event.occurredAt, value.time);
-			if (ts !== undefined) {
-				onTimeUpdate(ts);
-			}
-		},
+	const { form, timeValidator } = useTimeOnlyEditor({
+		event,
+		isLoading,
+		maxTime,
+		minTime,
+		onTimeUpdate,
 	});
 
 	return (
@@ -42,9 +35,7 @@ export function TimeOnlyEditor({
 			<form.Field
 				name="time"
 				validators={{
-					onChange: ({ value }) =>
-						validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
-						undefined,
+					onChange: ({ value }) => timeValidator(value),
 				}}
 			>
 				{(field) => (

--- a/apps/web/src/live-sessions/components/event-editors/update-stack-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/update-stack-editor.tsx
@@ -1,25 +1,13 @@
-import { useForm } from "@tanstack/react-form";
-import { z } from "zod";
 import { UpdateStackFields } from "@/live-sessions/components/event-fields/update-stack-fields";
-import {
-	toOccurredAtTimestamp,
-	toTimeInputValue,
-	validateOccurredAtTime,
-} from "@/live-sessions/components/stack-editor-time";
+import { useUpdateStackEditor } from "@/live-sessions/hooks/event-editors/use-update-stack-editor";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
-import { requiredNumericString } from "@/shared/lib/form-fields";
 import { type EditorBaseProps, TimeField } from "./shared";
 
 type Props = Pick<
 	EditorBaseProps,
 	"event" | "isLoading" | "maxTime" | "minTime" | "onSubmit"
 >;
-
-const updateStackSchema = z.object({
-	time: z.string(),
-	stackAmount: requiredNumericString({ integer: true, min: 0 }),
-});
 
 export function UpdateStackEditor({
 	event,
@@ -28,20 +16,12 @@ export function UpdateStackEditor({
 	minTime,
 	onSubmit,
 }: Props) {
-	const payload = (event.payload ?? {}) as Record<string, unknown>;
-
-	const form = useForm({
-		defaultValues: {
-			time: toTimeInputValue(event.occurredAt),
-			stackAmount: String(payload.stackAmount ?? 0),
-		},
-		onSubmit: ({ value }) => {
-			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
-			onSubmit({ stackAmount: Number(value.stackAmount) }, occurredAt);
-		},
-		validators: {
-			onSubmit: updateStackSchema,
-		},
+	const { form, timeValidator } = useUpdateStackEditor({
+		event,
+		isLoading,
+		maxTime,
+		minTime,
+		onSubmit,
 	});
 
 	return (
@@ -56,9 +36,7 @@ export function UpdateStackEditor({
 			<form.Field
 				name="time"
 				validators={{
-					onChange: ({ value }) =>
-						validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
-						undefined,
+					onChange: ({ value }) => timeValidator(value),
 				}}
 			>
 				{(field) => (

--- a/apps/web/src/live-sessions/components/event-editors/update-tournament-info-editor.tsx
+++ b/apps/web/src/live-sessions/components/event-editors/update-tournament-info-editor.tsx
@@ -1,19 +1,8 @@
-import { useForm } from "@tanstack/react-form";
 import { TournamentInfoFields } from "@/live-sessions/components/event-fields/tournament-info-fields";
-import {
-	toOccurredAtTimestamp,
-	toTimeInputValue,
-	validateOccurredAtTime,
-} from "@/live-sessions/components/stack-editor-time";
+import { useUpdateTournamentInfoEditor } from "@/live-sessions/hooks/event-editors/use-update-tournament-info-editor";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { type EditorBaseProps, TimeField } from "./shared";
-
-interface ChipPurchaseCount {
-	chipsPerUnit: number;
-	count: number;
-	name: string;
-}
 
 interface ChipPurchaseType {
 	chips: number;
@@ -36,36 +25,12 @@ export function UpdateTournamentInfoEditor({
 	onSubmit,
 	chipPurchaseTypes,
 }: Props) {
-	const payload = (event.payload ?? {}) as Record<string, unknown>;
-
-	const form = useForm({
-		defaultValues: {
-			time: toTimeInputValue(event.occurredAt),
-			remainingPlayers:
-				typeof payload.remainingPlayers === "number"
-					? String(payload.remainingPlayers)
-					: "",
-			totalEntries:
-				typeof payload.totalEntries === "number"
-					? String(payload.totalEntries)
-					: "",
-			chipPurchaseCounts: Array.isArray(payload.chipPurchaseCounts)
-				? (payload.chipPurchaseCounts as ChipPurchaseCount[])
-				: ([] as ChipPurchaseCount[]),
-		},
-		onSubmit: ({ value }) => {
-			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
-			onSubmit(
-				{
-					remainingPlayers: value.remainingPlayers
-						? Number(value.remainingPlayers)
-						: null,
-					totalEntries: value.totalEntries ? Number(value.totalEntries) : null,
-					chipPurchaseCounts: value.chipPurchaseCounts,
-				},
-				occurredAt
-			);
-		},
+	const { form, timeValidator } = useUpdateTournamentInfoEditor({
+		event,
+		isLoading,
+		maxTime,
+		minTime,
+		onSubmit,
 	});
 
 	return (
@@ -80,9 +45,7 @@ export function UpdateTournamentInfoEditor({
 			<form.Field
 				name="time"
 				validators={{
-					onChange: ({ value }) =>
-						validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
-						undefined,
+					onChange: ({ value }) => timeValidator(value),
 				}}
 			>
 				{(field) => (

--- a/apps/web/src/live-sessions/components/live-stack-form-sheet.tsx
+++ b/apps/web/src/live-sessions/components/live-stack-form-sheet.tsx
@@ -1,20 +1,24 @@
-import { useState } from "react";
 import { CashGameCompleteForm } from "@/live-sessions/components/cash-game-complete-form";
 import { CashGameStackForm } from "@/live-sessions/components/cash-game-stack-form";
 import { TournamentCompleteForm } from "@/live-sessions/components/tournament-complete-form";
 import { TournamentStackForm } from "@/live-sessions/components/tournament-stack-form";
 import { useActiveSession } from "@/live-sessions/hooks/use-active-session";
 import { useCashGameStack } from "@/live-sessions/hooks/use-cash-game-stack";
-import { useStackSheet } from "@/live-sessions/hooks/use-stack-sheet";
+import {
+	useCashGameStackSheet,
+	useTournamentStackSheet,
+} from "@/live-sessions/hooks/use-live-stack-form-sheet";
 import { useTournamentStack } from "@/live-sessions/hooks/use-tournament-stack";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 
 function CashGameStackSheet({ sessionId }: { sessionId: string }) {
-	const stackSheet = useStackSheet();
-	const [isCompleteOpen, setIsCompleteOpen] = useState(false);
-	const [defaultFinalStack, setDefaultFinalStack] = useState<
-		number | undefined
-	>(undefined);
+	const {
+		stackSheet,
+		isCompleteOpen,
+		setIsCompleteOpen,
+		defaultFinalStack,
+		setDefaultFinalStack,
+	} = useCashGameStackSheet();
 
 	const {
 		recordStack,
@@ -76,8 +80,8 @@ function CashGameStackSheet({ sessionId }: { sessionId: string }) {
 }
 
 function TournamentStackSheet({ sessionId }: { sessionId: string }) {
-	const stackSheet = useStackSheet();
-	const [isCompleteOpen, setIsCompleteOpen] = useState(false);
+	const { stackSheet, isCompleteOpen, setIsCompleteOpen } =
+		useTournamentStackSheet();
 
 	const {
 		chipPurchaseTypes,

--- a/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
+++ b/apps/web/src/live-sessions/components/seat-from-screenshot-sheet.tsx
@@ -6,13 +6,9 @@ import {
 	IconPhotoUp,
 	IconSparkles,
 } from "@tabler/icons-react";
-import {
-	type KeyboardEvent as ReactKeyboardEvent,
-	useEffect,
-	useRef,
-	useState,
-} from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { cn } from "@/lib/utils";
+import { useSeatCombobox } from "@/live-sessions/hooks/use-seat-combobox";
 import { useSeatFromScreenshot } from "@/live-sessions/hooks/use-seat-from-screenshot";
 import {
 	type PlayerOption,
@@ -361,9 +357,8 @@ function SeatCombobox({
 	onSelectExisting: (player: PlayerOption) => void;
 	row: ReviewRow;
 }) {
-	const [isOpen, setIsOpen] = useState(false);
-	const [contentWidth, setContentWidth] = useState<number>();
-	const anchorRef = useRef<HTMLDivElement>(null);
+	const { popoverOpen, setPopoverOpen, contentWidth, anchorRef } =
+		useSeatCombobox();
 
 	const displayValue = getSeatDisplayValue(row);
 	const readOnly = row.action === "hero";
@@ -373,40 +368,33 @@ function SeatCombobox({
 		: allPlayers;
 	const trimmedName = row.name.trim();
 
-	useEffect(() => {
-		if (!(isOpen && anchorRef.current)) {
-			return;
-		}
-		setContentWidth(anchorRef.current.offsetWidth);
-	}, [isOpen]);
-
 	const handleSelectExisting = (player: PlayerOption) => {
 		onSelectExisting(player);
-		setIsOpen(false);
+		setPopoverOpen(false);
 	};
 
 	const handlePickHero = () => {
 		onActionChange("hero");
-		setIsOpen(false);
+		setPopoverOpen(false);
 	};
 
 	const handleKeepAsNew = () => {
 		onActionChange("new");
-		setIsOpen(false);
+		setPopoverOpen(false);
 	};
 
 	const handleKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
 		if (e.key === "Escape") {
-			setIsOpen(false);
+			setPopoverOpen(false);
 		}
 	};
 
 	return (
-		<Popover modal={false} onOpenChange={setIsOpen} open={isOpen}>
+		<Popover modal={false} onOpenChange={setPopoverOpen} open={popoverOpen}>
 			<PopoverAnchor asChild>
 				<div className="relative flex-1" ref={anchorRef}>
 					<Input
-						aria-expanded={isOpen}
+						aria-expanded={popoverOpen}
 						autoComplete="off"
 						className={cn(
 							"h-8 pr-7",
@@ -418,11 +406,11 @@ function SeatCombobox({
 								return;
 							}
 							onNameChange(e.target.value);
-							setIsOpen(true);
+							setPopoverOpen(true);
 						}}
 						onFocus={() => {
 							if (!disabled) {
-								setIsOpen(true);
+								setPopoverOpen(true);
 							}
 						}}
 						onKeyDown={handleKeyDown}
@@ -437,7 +425,7 @@ function SeatCombobox({
 					/>
 				</div>
 			</PopoverAnchor>
-			{isOpen ? (
+			{popoverOpen ? (
 				<PopoverContent
 					align="start"
 					className="p-0"

--- a/apps/web/src/live-sessions/components/session-events-scene.tsx
+++ b/apps/web/src/live-sessions/components/session-events-scene.tsx
@@ -1,16 +1,11 @@
 import { IconPencil, IconTrash, IconX } from "@tabler/icons-react";
-import { useMemo, useState } from "react";
 import { EventEditor } from "@/live-sessions/components/event-editors/event-editor";
 import { toTimeInputValue } from "@/live-sessions/components/stack-editor-time";
-import {
-	type SessionEvent,
-	useSessionEvents,
-} from "@/live-sessions/hooks/use-session-events";
+import type { SessionEvent } from "@/live-sessions/hooks/use-session-events";
+import { useSessionEventsScene } from "@/live-sessions/hooks/use-session-events-scene";
 import {
 	formatEventLabel,
 	formatPayloadSummary,
-	getTimeBounds,
-	groupEventsForDisplay,
 	LIFECYCLE_EVENTS,
 } from "@/live-sessions/utils/session-events-formatters";
 import {
@@ -41,23 +36,18 @@ export function SessionEventsScene({
 	sessionLoading = false,
 	sessionType,
 }: SessionEventsSceneProps) {
-	const [editEvent, setEditEvent] = useState<SessionEvent | null>(null);
-	const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(
-		null
-	);
-
 	const {
+		editEvent,
+		setEditEvent,
+		confirmingDeleteId,
+		setConfirmingDeleteId,
 		events,
 		update,
-		delete: deleteEvent,
+		deleteEvent,
 		isUpdatePending,
-	} = useSessionEvents({
-		sessionId,
-		sessionType,
-		refetchInterval,
-	});
-
-	const groups = useMemo(() => groupEventsForDisplay(events), [events]);
+		groups,
+		timeBounds,
+	} = useSessionEventsScene({ sessionId, sessionType, refetchInterval });
 
 	if (sessionLoading) {
 		return (
@@ -73,10 +63,6 @@ export function SessionEventsScene({
 			</div>
 		);
 	}
-	const timeBounds = editEvent
-		? getTimeBounds(events, editEvent.id)
-		: { minTime: null, maxTime: null };
-
 	function renderEventRow(event: SessionEvent) {
 		const payloadSummary = formatPayloadSummary(event.eventType, event.payload);
 		const isLifecycle = LIFECYCLE_EVENTS.has(event.eventType);

--- a/apps/web/src/live-sessions/components/stack-record-editor.tsx
+++ b/apps/web/src/live-sessions/components/stack-record-editor.tsx
@@ -1,11 +1,5 @@
-import { useState } from "react";
 import { AllInBottomSheet } from "@/live-sessions/components/all-in-bottom-sheet";
 import { EventBadge } from "@/live-sessions/components/event-badge";
-import {
-	toOccurredAtTimestamp,
-	toTimeInputValue,
-	validateOccurredAtTime,
-} from "@/live-sessions/components/stack-editor-time";
 import {
 	StackBadgeRow,
 	StackEditorActionRow,
@@ -13,15 +7,8 @@ import {
 	StackSectionHeader,
 	StackTimeField,
 } from "@/live-sessions/components/stack-ui";
+import { useStackRecordEditor } from "@/live-sessions/hooks/use-stack-record-editor";
 import { Button } from "@/shared/components/ui/button";
-
-interface AllIn {
-	equity: number;
-	id: number;
-	potSize: number;
-	trials: number;
-	wins: number;
-}
 
 interface StackRecordPayload {
 	allIns: Array<{
@@ -50,67 +37,27 @@ export function StackRecordEditor({
 	minTime,
 	onSubmit,
 }: StackRecordEditorProps) {
-	const [stackAmount, setStackAmount] = useState(
-		String(initialPayload.stackAmount)
-	);
-	const [allIns, setAllIns] = useState<AllIn[]>(() =>
-		(initialPayload.allIns ?? []).map((ai, i) => ({ ...ai, id: i + 1 }))
-	);
-	const [time, setTime] = useState(
-		initialOccurredAt ? toTimeInputValue(initialOccurredAt) : ""
-	);
-
-	const [allInSheetOpen, setAllInSheetOpen] = useState(false);
-	const [editingAllIn, setEditingAllIn] = useState<AllIn | null>(null);
-
-	let nextId = allIns.length > 0 ? Math.max(...allIns.map((a) => a.id)) : 0;
-
-	const handleAllInSubmit = (values: {
-		potSize: number;
-		trials: number;
-		equity: number;
-		wins: number;
-	}) => {
-		if (editingAllIn === null) {
-			nextId += 1;
-			setAllIns((prev) => [...prev, { ...values, id: nextId }]);
-		} else {
-			setAllIns((prev) =>
-				prev.map((item) =>
-					item.id === editingAllIn.id ? { ...values, id: item.id } : item
-				)
-			);
-		}
-		setAllInSheetOpen(false);
-		setEditingAllIn(null);
-	};
-
-	const handleAllInDelete = () => {
-		if (editingAllIn !== null) {
-			setAllIns((prev) => prev.filter((item) => item.id !== editingAllIn.id));
-		}
-		setAllInSheetOpen(false);
-		setEditingAllIn(null);
-	};
-
-	const handleSave = () => {
-		const payload: StackRecordPayload = {
-			stackAmount: Number(stackAmount),
-			allIns: allIns.map(({ potSize, trials, equity, wins }) => ({
-				potSize,
-				trials,
-				equity,
-				wins,
-			})),
-		};
-		const occurredAt = toOccurredAtTimestamp(initialOccurredAt, time);
-		onSubmit(payload, occurredAt);
-	};
-
-	const timeError =
-		initialOccurredAt && time
-			? validateOccurredAtTime(time, initialOccurredAt, minTime, maxTime)
-			: null;
+	const {
+		stackAmount,
+		setStackAmount,
+		allIns,
+		time,
+		setTime,
+		allInSheetOpen,
+		setAllInSheetOpen,
+		editingAllIn,
+		setEditingAllIn,
+		handleAllInSubmit,
+		handleAllInDelete,
+		handleSave,
+		timeError,
+	} = useStackRecordEditor({
+		initialOccurredAt,
+		initialPayload,
+		maxTime,
+		minTime,
+		onSubmit,
+	});
 
 	return (
 		<div className="flex flex-col gap-4">

--- a/apps/web/src/live-sessions/components/tournament-complete-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-complete-form.tsx
@@ -1,15 +1,10 @@
-import { useForm } from "@tanstack/react-form";
-import { z } from "zod";
+import { useTournamentCompleteForm } from "@/live-sessions/hooks/use-tournament-complete-form";
 import { Button } from "@/shared/components/ui/button";
 import { Checkbox } from "@/shared/components/ui/checkbox";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
 import { Label } from "@/shared/components/ui/label";
-import {
-	optionalNumericString,
-	requiredNumericString,
-} from "@/shared/lib/form-fields";
 
 interface TournamentCompleteFormProps {
 	isLoading: boolean;
@@ -30,70 +25,11 @@ interface TournamentCompleteFormProps {
 	) => void;
 }
 
-const tournamentCompleteSchema = z
-	.object({
-		beforeDeadline: z.boolean(),
-		placement: z.string(),
-		totalEntries: z.string(),
-		prizeMoney: requiredNumericString({ integer: true, min: 0 }),
-		bountyPrizes: optionalNumericString({ integer: true, min: 0 }),
-	})
-	.superRefine((data, ctx) => {
-		if (!data.beforeDeadline) {
-			const placementResult = requiredNumericString({
-				integer: true,
-				min: 1,
-			}).safeParse(data.placement);
-			if (!placementResult.success) {
-				for (const issue of placementResult.error.issues) {
-					ctx.addIssue({ ...issue, path: ["placement"] });
-				}
-			}
-			const totalEntriesResult = requiredNumericString({
-				integer: true,
-				min: 1,
-			}).safeParse(data.totalEntries);
-			if (!totalEntriesResult.success) {
-				for (const issue of totalEntriesResult.error.issues) {
-					ctx.addIssue({ ...issue, path: ["totalEntries"] });
-				}
-			}
-		}
-	});
-
 export function TournamentCompleteForm({
 	isLoading,
 	onSubmit,
 }: TournamentCompleteFormProps) {
-	const form = useForm({
-		defaultValues: {
-			beforeDeadline: false,
-			placement: "",
-			totalEntries: "",
-			prizeMoney: "0",
-			bountyPrizes: "",
-		},
-		onSubmit: ({ value }) => {
-			if (value.beforeDeadline) {
-				onSubmit({
-					beforeDeadline: true,
-					prizeMoney: Number(value.prizeMoney),
-					bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
-				});
-			} else {
-				onSubmit({
-					beforeDeadline: false,
-					placement: Number(value.placement),
-					totalEntries: Number(value.totalEntries),
-					prizeMoney: Number(value.prizeMoney),
-					bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
-				});
-			}
-		},
-		validators: {
-			onSubmit: tournamentCompleteSchema,
-		},
-	});
+	const { form } = useTournamentCompleteForm({ onSubmit });
 
 	return (
 		<form

--- a/apps/web/src/live-sessions/components/tournament-stack-form.tsx
+++ b/apps/web/src/live-sessions/components/tournament-stack-form.tsx
@@ -1,19 +1,12 @@
-import { useForm } from "@tanstack/react-form";
-import { useEffect, useState } from "react";
-import { z } from "zod";
 import { ChipPurchaseSheet } from "@/live-sessions/components/chip-purchase-sheet";
 import { MemoFields } from "@/live-sessions/components/event-fields/memo-fields";
 import { StackNumberField } from "@/live-sessions/components/stack-ui";
-import { useTournamentFormContext } from "@/live-sessions/hooks/use-session-form";
+import { useTournamentStackForm } from "@/live-sessions/hooks/use-tournament-stack-form";
 import { Button } from "@/shared/components/ui/button";
 import { Checkbox } from "@/shared/components/ui/checkbox";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Label } from "@/shared/components/ui/label";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
-import {
-	optionalNumericString,
-	requiredNumericString,
-} from "@/shared/lib/form-fields";
 
 interface ChipPurchaseType {
 	chips: number;
@@ -47,16 +40,6 @@ interface TournamentStackFormProps {
 	onSubmit: (values: TournamentStackFormSubmitValues) => void;
 }
 
-const updateSchema = z.object({
-	stackAmount: requiredNumericString({ integer: true, min: 0 }),
-	remainingPlayers: optionalNumericString({ integer: true, min: 1 }),
-	totalEntries: optionalNumericString({ integer: true, min: 1 }),
-});
-
-const memoSchema = z.object({
-	text: z.string().min(1, "Text is required"),
-});
-
 export function TournamentStackForm({
 	chipPurchaseTypes = [],
 	isLoading,
@@ -67,64 +50,20 @@ export function TournamentStackForm({
 	onSubmit,
 }: TournamentStackFormProps) {
 	const {
-		state,
+		form,
+		memoForm,
 		setStackAmount,
 		setRemainingPlayers,
 		setTotalEntries,
+		chipPurchaseCounts,
 		setChipPurchaseCounts,
-	} = useTournamentFormContext();
-	const { stackAmount, remainingPlayers, totalEntries, chipPurchaseCounts } =
-		state;
-
-	const form = useForm({
-		defaultValues: {
-			stackAmount,
-			remainingPlayers,
-			totalEntries,
-		},
-		onSubmit: ({ value }) => {
-			onSubmit({
-				stackAmount: Number(value.stackAmount),
-				recordTournamentInfo,
-				remainingPlayers: value.remainingPlayers
-					? Number(value.remainingPlayers)
-					: null,
-				totalEntries: value.totalEntries ? Number(value.totalEntries) : null,
-				chipPurchaseCounts,
-			});
-		},
-		validators: {
-			onSubmit: updateSchema,
-		},
-	});
-
-	useEffect(() => {
-		if (form.state.values.stackAmount !== stackAmount) {
-			form.setFieldValue("stackAmount", stackAmount);
-		}
-		if (form.state.values.remainingPlayers !== remainingPlayers) {
-			form.setFieldValue("remainingPlayers", remainingPlayers);
-		}
-		if (form.state.values.totalEntries !== totalEntries) {
-			form.setFieldValue("totalEntries", totalEntries);
-		}
-	}, [stackAmount, remainingPlayers, totalEntries, form]);
-
-	const memoForm = useForm({
-		defaultValues: { text: "" },
-		onSubmit: ({ value }) => {
-			onMemo(value.text);
-			memoForm.reset();
-			setMemoSheetOpen(false);
-		},
-		validators: {
-			onSubmit: memoSchema,
-		},
-	});
-
-	const [recordTournamentInfo, setRecordTournamentInfo] = useState(true);
-	const [chipPurchaseSheetOpen, setChipPurchaseSheetOpen] = useState(false);
-	const [memoSheetOpen, setMemoSheetOpen] = useState(false);
+		recordTournamentInfo,
+		setRecordTournamentInfo,
+		chipPurchaseSheetOpen,
+		setChipPurchaseSheetOpen,
+		memoSheetOpen,
+		setMemoSheetOpen,
+	} = useTournamentStackForm({ onMemo, onSubmit });
 
 	const handleChipPurchaseSubmit = (values: {
 		chips: number;

--- a/apps/web/src/live-sessions/components/tournament-stack-record-editor.tsx
+++ b/apps/web/src/live-sessions/components/tournament-stack-record-editor.tsx
@@ -1,11 +1,5 @@
-import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { ChipPurchaseSheet } from "@/live-sessions/components/chip-purchase-sheet";
-import {
-	toOccurredAtTimestamp,
-	toTimeInputValue,
-	validateOccurredAtTime,
-} from "@/live-sessions/components/stack-editor-time";
 import {
 	StackBadgeRow,
 	StackEditorActionRow,
@@ -13,6 +7,7 @@ import {
 	StackSectionHeader,
 	StackTimeField,
 } from "@/live-sessions/components/stack-ui";
+import { useTournamentStackRecordEditor } from "@/live-sessions/hooks/use-tournament-stack-record-editor";
 import { Button } from "@/shared/components/ui/button";
 
 interface TournamentStackRecordPayload {
@@ -37,13 +32,6 @@ interface TournamentStackRecordEditorProps {
 		payload: TournamentStackRecordPayload,
 		occurredAt?: number
 	) => void;
-}
-
-interface EditingPurchase {
-	chips: number;
-	cost: number;
-	index: number;
-	name: string;
 }
 
 function ChipPurchaseList({
@@ -123,87 +111,33 @@ export function TournamentStackRecordEditor({
 	minTime,
 	onSubmit,
 }: TournamentStackRecordEditorProps) {
-	const [stackAmount, setStackAmount] = useState(
-		String(initialPayload.stackAmount)
-	);
-	const [remainingPlayers, setRemainingPlayers] = useState(
-		initialPayload.remainingPlayers === null
-			? ""
-			: String(initialPayload.remainingPlayers)
-	);
-	const [totalEntries, setTotalEntries] = useState(
-		initialPayload.totalEntries === null
-			? ""
-			: String(initialPayload.totalEntries)
-	);
-	const [chipPurchases, setChipPurchases] = useState<
-		Array<{ name: string; cost: number; chips: number }>
-	>(initialPayload.chipPurchases);
-	const [time, setTime] = useState(
-		initialOccurredAt ? toTimeInputValue(initialOccurredAt) : ""
-	);
-
-	const [sheetOpen, setSheetOpen] = useState(false);
-	const [editingPurchase, setEditingPurchase] =
-		useState<EditingPurchase | null>(null);
-
-	const openAddSheet = () => {
-		setEditingPurchase(null);
-		setSheetOpen(true);
-	};
-
-	const openEditSheet = (index: number) => {
-		const p = chipPurchases[index];
-		if (p) {
-			setEditingPurchase({ index, name: p.name, cost: p.cost, chips: p.chips });
-			setSheetOpen(true);
-		}
-	};
-
-	const handleSheetSubmit = (purchase: {
-		name: string;
-		cost: number;
-		chips: number;
-	}) => {
-		if (editingPurchase === null) {
-			setChipPurchases((prev) => [...prev, purchase]);
-		} else {
-			setChipPurchases((prev) =>
-				prev.map((p, i) => (i === editingPurchase.index ? purchase : p))
-			);
-		}
-		setSheetOpen(false);
-	};
-
-	const handleSheetDelete = () => {
-		if (editingPurchase !== null) {
-			setChipPurchases((prev) =>
-				prev.filter((_, i) => i !== editingPurchase.index)
-			);
-		}
-		setSheetOpen(false);
-	};
-
-	const handleRemove = (index: number) => {
-		setChipPurchases((prev) => prev.filter((_, i) => i !== index));
-	};
-
-	const handleSave = () => {
-		const payload: TournamentStackRecordPayload = {
-			stackAmount: Number(stackAmount),
-			remainingPlayers: remainingPlayers ? Number(remainingPlayers) : null,
-			totalEntries: totalEntries ? Number(totalEntries) : null,
-			chipPurchases,
-			chipPurchaseCounts: initialPayload.chipPurchaseCounts,
-		};
-		const occurredAt = toOccurredAtTimestamp(initialOccurredAt, time);
-		onSubmit(payload, occurredAt);
-	};
-
-	const timeError =
-		initialOccurredAt && time
-			? validateOccurredAtTime(time, initialOccurredAt, minTime, maxTime)
-			: null;
+	const {
+		stackAmount,
+		setStackAmount,
+		remainingPlayers,
+		setRemainingPlayers,
+		totalEntries,
+		setTotalEntries,
+		chipPurchases,
+		time,
+		setTime,
+		sheetOpen,
+		setSheetOpen,
+		editingPurchase,
+		openAddSheet,
+		openEditSheet,
+		handleSheetSubmit,
+		handleSheetDelete,
+		handleRemove,
+		handleSave,
+		timeError,
+	} = useTournamentStackRecordEditor({
+		initialOccurredAt,
+		initialPayload,
+		maxTime,
+		minTime,
+		onSubmit,
+	});
 
 	return (
 		<div className="flex flex-col gap-4">

--- a/apps/web/src/live-sessions/components/tournament-timer-dialog.tsx
+++ b/apps/web/src/live-sessions/components/tournament-timer-dialog.tsx
@@ -1,6 +1,4 @@
-import { useForm } from "@tanstack/react-form";
-import { useEffect } from "react";
-import { z } from "zod";
+import { useTournamentTimerDialog } from "@/live-sessions/hooks/use-tournament-timer-dialog";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
@@ -16,16 +14,6 @@ interface TournamentTimerDialogProps {
 	timerStartedAt: Date | string | number | null;
 }
 
-function toDatetimeLocalValue(value: Date | string | number | null): string {
-	const date = value ? new Date(value) : new Date();
-	const pad = (n: number) => String(n).padStart(2, "0");
-	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
-}
-
-const schema = z.object({
-	timerStartedAt: z.string().min(1, "Required"),
-});
-
 export function TournamentTimerDialog({
 	isLoading = false,
 	onClear,
@@ -34,29 +22,7 @@ export function TournamentTimerDialog({
 	open,
 	timerStartedAt,
 }: TournamentTimerDialogProps) {
-	const form = useForm({
-		defaultValues: {
-			timerStartedAt: toDatetimeLocalValue(timerStartedAt),
-		},
-		onSubmit: ({ value }) => {
-			const parsed = new Date(value.timerStartedAt);
-			if (!Number.isNaN(parsed.getTime())) {
-				onSubmit(parsed);
-			}
-		},
-		validators: {
-			onSubmit: schema,
-		},
-	});
-
-	useEffect(() => {
-		if (open) {
-			form.setFieldValue(
-				"timerStartedAt",
-				toDatetimeLocalValue(timerStartedAt)
-			);
-		}
-	}, [open, timerStartedAt, form]);
+	const { form } = useTournamentTimerDialog({ open, timerStartedAt, onSubmit });
 
 	return (
 		<ResponsiveDialog

--- a/apps/web/src/live-sessions/components/tournament-timer.tsx
+++ b/apps/web/src/live-sessions/components/tournament-timer.tsx
@@ -1,6 +1,6 @@
 import { IconClock } from "@tabler/icons-react";
-import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
+import { useNowTick } from "@/live-sessions/hooks/use-tournament-timer-scene";
 import {
 	computeTournamentTimerState,
 	formatBlindLevelLabel,
@@ -16,15 +16,6 @@ interface TournamentTimerProps {
 	blindLevels: readonly TournamentBlindLevel[];
 	onEditTimer: () => void;
 	timerStartedAt: Date | string | number | null;
-}
-
-function useNowTick(intervalMs: number): number {
-	const [now, setNow] = useState(() => Date.now());
-	useEffect(() => {
-		const id = setInterval(() => setNow(Date.now()), intervalMs);
-		return () => clearInterval(id);
-	}, [intervalMs]);
-	return now;
 }
 
 function TimerNotStarted({ onEditTimer }: { onEditTimer: () => void }) {

--- a/apps/web/src/live-sessions/hooks/event-editors/use-all-in-editor.ts
+++ b/apps/web/src/live-sessions/hooks/event-editors/use-all-in-editor.ts
@@ -1,0 +1,66 @@
+import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
+import {
+	toOccurredAtTimestamp,
+	toTimeInputValue,
+	validateOccurredAtTime,
+} from "@/live-sessions/components/stack-editor-time";
+import type { SessionEvent } from "@/live-sessions/hooks/use-session-events";
+import { requiredNumericString } from "@/shared/lib/form-fields";
+
+const allInSchema = z.object({
+	time: z.string(),
+	potSize: requiredNumericString({ min: 0 }),
+	trials: requiredNumericString({ integer: true, min: 1 }),
+	equity: requiredNumericString({ min: 0, max: 100 }),
+	wins: requiredNumericString({ min: 0 }),
+});
+
+interface UseAllInEditorOptions {
+	event: SessionEvent;
+	isLoading: boolean;
+	maxTime: Date | null;
+	minTime: Date | null;
+	onSubmit: (payload: unknown, occurredAt?: number) => void;
+}
+
+export function useAllInEditor({
+	event,
+	maxTime,
+	minTime,
+	onSubmit,
+}: UseAllInEditorOptions) {
+	const payload = (event.payload ?? {}) as Record<string, unknown>;
+
+	const form = useForm({
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			potSize:
+				typeof payload.potSize === "number" ? String(payload.potSize) : "0",
+			trials: typeof payload.trials === "number" ? String(payload.trials) : "1",
+			equity: typeof payload.equity === "number" ? String(payload.equity) : "0",
+			wins: typeof payload.wins === "number" ? String(payload.wins) : "0",
+		},
+		onSubmit: ({ value }) => {
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			onSubmit(
+				{
+					potSize: Number(value.potSize),
+					trials: Number(value.trials),
+					equity: Number(value.equity),
+					wins: Number(value.wins),
+				},
+				occurredAt
+			);
+		},
+		validators: {
+			onSubmit: allInSchema,
+		},
+	});
+
+	const timeValidator = (value: string) =>
+		validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
+		undefined;
+
+	return { form, timeValidator };
+}

--- a/apps/web/src/live-sessions/hooks/event-editors/use-chips-add-remove-editor.ts
+++ b/apps/web/src/live-sessions/hooks/event-editors/use-chips-add-remove-editor.ts
@@ -1,0 +1,56 @@
+import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
+import {
+	toOccurredAtTimestamp,
+	toTimeInputValue,
+	validateOccurredAtTime,
+} from "@/live-sessions/components/stack-editor-time";
+import type { SessionEvent } from "@/live-sessions/hooks/use-session-events";
+import { requiredNumericString } from "@/shared/lib/form-fields";
+
+const chipsAddRemoveSchema = z.object({
+	time: z.string(),
+	amount: requiredNumericString({ integer: true, min: 0 }),
+	type: z.enum(["add", "remove"]),
+});
+
+interface UseChipsAddRemoveEditorOptions {
+	event: SessionEvent;
+	isLoading: boolean;
+	maxTime: Date | null;
+	minTime: Date | null;
+	onSubmit: (payload: unknown, occurredAt?: number) => void;
+}
+
+export function useChipsAddRemoveEditor({
+	event,
+	maxTime,
+	minTime,
+	onSubmit,
+}: UseChipsAddRemoveEditorOptions) {
+	const payload = (event.payload ?? {}) as Record<string, unknown>;
+
+	const form = useForm({
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			amount: typeof payload.amount === "number" ? String(payload.amount) : "0",
+			type: (payload.type === "remove" ? "remove" : "add") as "add" | "remove",
+		},
+		onSubmit: ({ value }) => {
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			onSubmit(
+				{ amount: Math.round(Number(value.amount)), type: value.type },
+				occurredAt
+			);
+		},
+		validators: {
+			onSubmit: chipsAddRemoveSchema,
+		},
+	});
+
+	const timeValidator = (value: string) =>
+		validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
+		undefined;
+
+	return { form, timeValidator };
+}

--- a/apps/web/src/live-sessions/hooks/event-editors/use-memo-editor.ts
+++ b/apps/web/src/live-sessions/hooks/event-editors/use-memo-editor.ts
@@ -1,0 +1,44 @@
+import { useForm } from "@tanstack/react-form";
+import {
+	toOccurredAtTimestamp,
+	toTimeInputValue,
+	validateOccurredAtTime,
+} from "@/live-sessions/components/stack-editor-time";
+import type { SessionEvent } from "@/live-sessions/hooks/use-session-events";
+
+interface UseMemoEditorOptions {
+	event: SessionEvent;
+	isLoading: boolean;
+	maxTime: Date | null;
+	minTime: Date | null;
+	onSubmit: (payload: unknown, occurredAt?: number) => void;
+}
+
+export function useMemoEditor({
+	event,
+	maxTime,
+	minTime,
+	onSubmit,
+}: UseMemoEditorOptions) {
+	const payload = (event.payload ?? {}) as Record<string, unknown>;
+
+	const form = useForm({
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			text: typeof payload.text === "string" ? payload.text : "",
+		},
+		onSubmit: ({ value }) => {
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			onSubmit({ text: value.text }, occurredAt);
+		},
+	});
+
+	const timeValidator = (value: string) =>
+		validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
+		undefined;
+
+	const textValidator = (value: string) =>
+		value.trim().length === 0 ? "Text is required" : undefined;
+
+	return { form, timeValidator, textValidator };
+}

--- a/apps/web/src/live-sessions/hooks/event-editors/use-purchase-chips-editor.ts
+++ b/apps/web/src/live-sessions/hooks/event-editors/use-purchase-chips-editor.ts
@@ -1,0 +1,62 @@
+import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
+import {
+	toOccurredAtTimestamp,
+	toTimeInputValue,
+	validateOccurredAtTime,
+} from "@/live-sessions/components/stack-editor-time";
+import type { SessionEvent } from "@/live-sessions/hooks/use-session-events";
+import { requiredNumericString } from "@/shared/lib/form-fields";
+
+const purchaseChipsSchema = z.object({
+	time: z.string(),
+	name: z.string().min(1, "Name is required"),
+	cost: requiredNumericString({ integer: true, min: 0 }),
+	chips: requiredNumericString({ integer: true, min: 0 }),
+});
+
+interface UsePurchaseChipsEditorOptions {
+	event: SessionEvent;
+	isLoading: boolean;
+	maxTime: Date | null;
+	minTime: Date | null;
+	onSubmit: (payload: unknown, occurredAt?: number) => void;
+}
+
+export function usePurchaseChipsEditor({
+	event,
+	maxTime,
+	minTime,
+	onSubmit,
+}: UsePurchaseChipsEditorOptions) {
+	const payload = (event.payload ?? {}) as Record<string, unknown>;
+
+	const form = useForm({
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			name: typeof payload.name === "string" ? payload.name : "",
+			cost: typeof payload.cost === "number" ? String(payload.cost) : "0",
+			chips: typeof payload.chips === "number" ? String(payload.chips) : "0",
+		},
+		onSubmit: ({ value }) => {
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			onSubmit(
+				{
+					name: value.name,
+					cost: Math.round(Number(value.cost)),
+					chips: Math.round(Number(value.chips)),
+				},
+				occurredAt
+			);
+		},
+		validators: {
+			onSubmit: purchaseChipsSchema,
+		},
+	});
+
+	const timeValidator = (value: string) =>
+		validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
+		undefined;
+
+	return { form, timeValidator };
+}

--- a/apps/web/src/live-sessions/hooks/event-editors/use-session-end-editor.ts
+++ b/apps/web/src/live-sessions/hooks/event-editors/use-session-end-editor.ts
@@ -1,0 +1,152 @@
+import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
+import {
+	toOccurredAtTimestamp,
+	toTimeInputValue,
+	validateOccurredAtTime,
+} from "@/live-sessions/components/stack-editor-time";
+import type { SessionEvent } from "@/live-sessions/hooks/use-session-events";
+import {
+	optionalNumericString,
+	requiredNumericString,
+} from "@/shared/lib/form-fields";
+
+const cashGameEndSchema = z.object({
+	time: z.string(),
+	cashOutAmount: requiredNumericString({ integer: true, min: 0 }),
+});
+
+const tournamentEndSchema = z
+	.object({
+		time: z.string(),
+		beforeDeadline: z.boolean(),
+		placement: z.string(),
+		totalEntries: z.string(),
+		prizeMoney: requiredNumericString({ integer: true, min: 0 }),
+		bountyPrizes: optionalNumericString({ integer: true, min: 0 }),
+	})
+	.superRefine((data, ctx) => {
+		if (!data.beforeDeadline) {
+			const placementResult = requiredNumericString({
+				integer: true,
+				min: 1,
+			}).safeParse(data.placement);
+			if (!placementResult.success) {
+				for (const issue of placementResult.error.issues) {
+					ctx.addIssue({ ...issue, path: ["placement"] });
+				}
+			}
+			const totalEntriesResult = requiredNumericString({
+				integer: true,
+				min: 1,
+			}).safeParse(data.totalEntries);
+			if (!totalEntriesResult.success) {
+				for (const issue of totalEntriesResult.error.issues) {
+					ctx.addIssue({ ...issue, path: ["totalEntries"] });
+				}
+			}
+		}
+	});
+
+interface UseSessionEndEditorOptions {
+	event: SessionEvent;
+	isLoading: boolean;
+	maxTime: Date | null;
+	minTime: Date | null;
+	onSubmit: (payload: unknown, occurredAt?: number) => void;
+}
+
+export function useCashGameEndEditor({
+	event,
+	maxTime,
+	minTime,
+	onSubmit,
+}: UseSessionEndEditorOptions) {
+	const payload = (event.payload ?? {}) as Record<string, unknown>;
+
+	const form = useForm({
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			cashOutAmount:
+				typeof payload.cashOutAmount === "number"
+					? String(payload.cashOutAmount)
+					: "0",
+		},
+		onSubmit: ({ value }) => {
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			onSubmit({ cashOutAmount: Number(value.cashOutAmount) }, occurredAt);
+		},
+		validators: {
+			onSubmit: cashGameEndSchema,
+		},
+	});
+
+	const timeValidator = (value: string) =>
+		validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
+		undefined;
+
+	return { form, timeValidator };
+}
+
+export function useTournamentEndEditor({
+	event,
+	maxTime,
+	minTime,
+	onSubmit,
+}: UseSessionEndEditorOptions) {
+	const payload = (event.payload ?? {}) as Record<string, unknown>;
+
+	const form = useForm({
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			beforeDeadline: payload.beforeDeadline === true,
+			placement:
+				typeof payload.placement === "number" ? String(payload.placement) : "",
+			totalEntries:
+				typeof payload.totalEntries === "number"
+					? String(payload.totalEntries)
+					: "",
+			prizeMoney:
+				typeof payload.prizeMoney === "number"
+					? String(payload.prizeMoney)
+					: "0",
+			bountyPrizes:
+				typeof payload.bountyPrizes === "number" && payload.bountyPrizes > 0
+					? String(payload.bountyPrizes)
+					: "",
+		},
+		onSubmit: ({ value }) => {
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			if (value.beforeDeadline) {
+				onSubmit(
+					{
+						beforeDeadline: true,
+						prizeMoney: Number(value.prizeMoney),
+						bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
+					},
+					occurredAt
+				);
+			} else {
+				onSubmit(
+					{
+						beforeDeadline: false,
+						placement: Number(value.placement),
+						totalEntries: Number(value.totalEntries),
+						prizeMoney: Number(value.prizeMoney),
+						bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
+					},
+					occurredAt
+				);
+			}
+		},
+		validators: {
+			onSubmit: tournamentEndSchema,
+		},
+	});
+
+	const timeValidator = (value: string) =>
+		validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
+		undefined;
+
+	return { form, timeValidator };
+}

--- a/apps/web/src/live-sessions/hooks/event-editors/use-session-start-editor.ts
+++ b/apps/web/src/live-sessions/hooks/event-editors/use-session-start-editor.ts
@@ -1,0 +1,118 @@
+import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
+import {
+	toOccurredAtTimestamp,
+	toTimeInputValue,
+	validateOccurredAtTime,
+} from "@/live-sessions/components/stack-editor-time";
+import type { SessionEvent } from "@/live-sessions/hooks/use-session-events";
+import { requiredNumericString } from "@/shared/lib/form-fields";
+
+const cashGameStartSchema = z.object({
+	time: z.string(),
+	buyInAmount: requiredNumericString({ integer: true, min: 0 }),
+});
+
+const tournamentStartSchema = z.object({
+	time: z.string(),
+	timerStartedAt: z.string(),
+});
+
+function toDatetimeLocalValue(value: Date | string | number | null): string {
+	if (value === null || value === undefined) {
+		return "";
+	}
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		return "";
+	}
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function toTimerSeconds(value: string): number | null {
+	if (!value) {
+		return null;
+	}
+	const ms = new Date(value).getTime();
+	if (Number.isNaN(ms)) {
+		return null;
+	}
+	return Math.floor(ms / 1000);
+}
+
+interface UseSessionStartEditorOptions {
+	event: SessionEvent;
+	isLoading: boolean;
+	maxTime: Date | null;
+	minTime: Date | null;
+	onSubmit: (payload: unknown, occurredAt?: number) => void;
+}
+
+export function useCashGameStartEditor({
+	event,
+	maxTime,
+	minTime,
+	onSubmit,
+}: UseSessionStartEditorOptions) {
+	const payload = (event.payload ?? {}) as Record<string, unknown>;
+
+	const form = useForm({
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			buyInAmount:
+				typeof payload.buyInAmount === "number"
+					? String(payload.buyInAmount)
+					: "0",
+		},
+		onSubmit: ({ value }) => {
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			onSubmit({ buyInAmount: Number(value.buyInAmount) }, occurredAt);
+		},
+		validators: {
+			onSubmit: cashGameStartSchema,
+		},
+	});
+
+	const timeValidator = (value: string) =>
+		validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
+		undefined;
+
+	return { form, timeValidator };
+}
+
+export function useTournamentStartEditor({
+	event,
+	maxTime,
+	minTime,
+	onSubmit,
+}: UseSessionStartEditorOptions) {
+	const payload = (event.payload ?? {}) as Record<string, unknown>;
+	const initialTimer =
+		typeof payload.timerStartedAt === "number"
+			? toDatetimeLocalValue(payload.timerStartedAt * 1000)
+			: "";
+
+	const form = useForm({
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			timerStartedAt: initialTimer,
+		},
+		onSubmit: ({ value }) => {
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			onSubmit(
+				{ timerStartedAt: toTimerSeconds(value.timerStartedAt) },
+				occurredAt
+			);
+		},
+		validators: {
+			onSubmit: tournamentStartSchema,
+		},
+	});
+
+	const timeValidator = (value: string) =>
+		validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
+		undefined;
+
+	return { form, timeValidator };
+}

--- a/apps/web/src/live-sessions/hooks/event-editors/use-time-only-editor.ts
+++ b/apps/web/src/live-sessions/hooks/event-editors/use-time-only-editor.ts
@@ -1,0 +1,38 @@
+import { useForm } from "@tanstack/react-form";
+import {
+	toOccurredAtTimestamp,
+	toTimeInputValue,
+	validateOccurredAtTime,
+} from "@/live-sessions/components/stack-editor-time";
+import type { SessionEvent } from "@/live-sessions/hooks/use-session-events";
+
+interface UseTimeOnlyEditorOptions {
+	event: SessionEvent;
+	isLoading: boolean;
+	maxTime: Date | null;
+	minTime: Date | null;
+	onTimeUpdate: (occurredAt: number) => void;
+}
+
+export function useTimeOnlyEditor({
+	event,
+	maxTime,
+	minTime,
+	onTimeUpdate,
+}: UseTimeOnlyEditorOptions) {
+	const form = useForm({
+		defaultValues: { time: toTimeInputValue(event.occurredAt) },
+		onSubmit: ({ value }) => {
+			const ts = toOccurredAtTimestamp(event.occurredAt, value.time);
+			if (ts !== undefined) {
+				onTimeUpdate(ts);
+			}
+		},
+	});
+
+	const timeValidator = (value: string) =>
+		validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
+		undefined;
+
+	return { form, timeValidator };
+}

--- a/apps/web/src/live-sessions/hooks/event-editors/use-update-stack-editor.ts
+++ b/apps/web/src/live-sessions/hooks/event-editors/use-update-stack-editor.ts
@@ -1,0 +1,51 @@
+import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
+import {
+	toOccurredAtTimestamp,
+	toTimeInputValue,
+	validateOccurredAtTime,
+} from "@/live-sessions/components/stack-editor-time";
+import type { SessionEvent } from "@/live-sessions/hooks/use-session-events";
+import { requiredNumericString } from "@/shared/lib/form-fields";
+
+const updateStackSchema = z.object({
+	time: z.string(),
+	stackAmount: requiredNumericString({ integer: true, min: 0 }),
+});
+
+interface UseUpdateStackEditorOptions {
+	event: SessionEvent;
+	isLoading: boolean;
+	maxTime: Date | null;
+	minTime: Date | null;
+	onSubmit: (payload: unknown, occurredAt?: number) => void;
+}
+
+export function useUpdateStackEditor({
+	event,
+	maxTime,
+	minTime,
+	onSubmit,
+}: UseUpdateStackEditorOptions) {
+	const payload = (event.payload ?? {}) as Record<string, unknown>;
+
+	const form = useForm({
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			stackAmount: String(payload.stackAmount ?? 0),
+		},
+		onSubmit: ({ value }) => {
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			onSubmit({ stackAmount: Number(value.stackAmount) }, occurredAt);
+		},
+		validators: {
+			onSubmit: updateStackSchema,
+		},
+	});
+
+	const timeValidator = (value: string) =>
+		validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
+		undefined;
+
+	return { form, timeValidator };
+}

--- a/apps/web/src/live-sessions/hooks/event-editors/use-update-tournament-info-editor.ts
+++ b/apps/web/src/live-sessions/hooks/event-editors/use-update-tournament-info-editor.ts
@@ -1,0 +1,66 @@
+import { useForm } from "@tanstack/react-form";
+import {
+	toOccurredAtTimestamp,
+	toTimeInputValue,
+	validateOccurredAtTime,
+} from "@/live-sessions/components/stack-editor-time";
+import type { SessionEvent } from "@/live-sessions/hooks/use-session-events";
+
+interface ChipPurchaseCount {
+	chipsPerUnit: number;
+	count: number;
+	name: string;
+}
+
+interface UseUpdateTournamentInfoEditorOptions {
+	event: SessionEvent;
+	isLoading: boolean;
+	maxTime: Date | null;
+	minTime: Date | null;
+	onSubmit: (payload: unknown, occurredAt?: number) => void;
+}
+
+export function useUpdateTournamentInfoEditor({
+	event,
+	maxTime,
+	minTime,
+	onSubmit,
+}: UseUpdateTournamentInfoEditorOptions) {
+	const payload = (event.payload ?? {}) as Record<string, unknown>;
+
+	const form = useForm({
+		defaultValues: {
+			time: toTimeInputValue(event.occurredAt),
+			remainingPlayers:
+				typeof payload.remainingPlayers === "number"
+					? String(payload.remainingPlayers)
+					: "",
+			totalEntries:
+				typeof payload.totalEntries === "number"
+					? String(payload.totalEntries)
+					: "",
+			chipPurchaseCounts: Array.isArray(payload.chipPurchaseCounts)
+				? (payload.chipPurchaseCounts as ChipPurchaseCount[])
+				: ([] as ChipPurchaseCount[]),
+		},
+		onSubmit: ({ value }) => {
+			const occurredAt = toOccurredAtTimestamp(event.occurredAt, value.time);
+			onSubmit(
+				{
+					remainingPlayers: value.remainingPlayers
+						? Number(value.remainingPlayers)
+						: null,
+					totalEntries: value.totalEntries ? Number(value.totalEntries) : null,
+					chipPurchaseCounts: value.chipPurchaseCounts,
+				},
+				occurredAt
+			);
+		},
+	});
+
+	const timeValidator = (value: string) =>
+		validateOccurredAtTime(value, event.occurredAt, minTime, maxTime) ??
+		undefined;
+
+	return { form, timeValidator };
+}

--- a/apps/web/src/live-sessions/hooks/use-active-session-page.ts
+++ b/apps/web/src/live-sessions/hooks/use-active-session-page.ts
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import { useTournamentSession } from "@/live-sessions/hooks/use-tournament-session";
+
+export function useTournamentSessionPage(sessionId: string) {
+	const tournamentSession = useTournamentSession(sessionId);
+	const [isTimerDialogOpen, setIsTimerDialogOpen] = useState(false);
+
+	const handleOpenTimerDialog = () => {
+		setIsTimerDialogOpen(true);
+	};
+
+	const handleClearTimer = () => {
+		tournamentSession.updateTimerStartedAt(null);
+		setIsTimerDialogOpen(false);
+	};
+
+	const handleSubmitTimer = (value: Date) => {
+		tournamentSession.updateTimerStartedAt(value);
+		setIsTimerDialogOpen(false);
+	};
+
+	return {
+		...tournamentSession,
+		isTimerDialogOpen,
+		setIsTimerDialogOpen,
+		handleOpenTimerDialog,
+		handleClearTimer,
+		handleSubmitTimer,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-active-session-scene.ts
+++ b/apps/web/src/live-sessions/hooks/use-active-session-scene.ts
@@ -1,0 +1,31 @@
+import { useMemo, useState } from "react";
+import type { TablePlayer } from "@/live-sessions/components/poker-table";
+
+interface UseActiveSessionSceneOptions {
+	players: TablePlayer[];
+}
+
+export function useActiveSessionScene({
+	players,
+}: UseActiveSessionSceneOptions) {
+	const [isDiscardOpen, setIsDiscardOpen] = useState(false);
+	const [isScanSheetOpen, setIsScanSheetOpen] = useState(false);
+
+	const occupiedSeatPositions = useMemo(() => {
+		const set = new Set<number>();
+		for (const p of players) {
+			if (p.isActive && typeof p.seatPosition === "number") {
+				set.add(p.seatPosition);
+			}
+		}
+		return set;
+	}, [players]);
+
+	return {
+		isDiscardOpen,
+		setIsDiscardOpen,
+		isScanSheetOpen,
+		setIsScanSheetOpen,
+		occupiedSeatPositions,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-addon-form.ts
+++ b/apps/web/src/live-sessions/hooks/use-addon-form.ts
@@ -1,0 +1,42 @@
+import { useForm } from "@tanstack/react-form";
+import { useEffect } from "react";
+import { z } from "zod";
+import { requiredNumericString } from "@/shared/lib/form-fields";
+
+const addonSchema = z.object({
+	amount: requiredNumericString({ integer: true, min: 0 }),
+});
+
+interface UseAddonFormOptions {
+	initialAmount?: number;
+	onSubmit: (addon: { amount: number }) => void;
+	open: boolean;
+}
+
+export function useAddonForm({
+	initialAmount,
+	open,
+	onSubmit,
+}: UseAddonFormOptions) {
+	const form = useForm({
+		defaultValues: {
+			amount: initialAmount === undefined ? "0" : String(initialAmount),
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({ amount: Math.round(Number(value.amount)) });
+		},
+		validators: {
+			onSubmit: addonSchema,
+		},
+	});
+
+	useEffect(() => {
+		if (open) {
+			form.reset({
+				amount: initialAmount === undefined ? "0" : String(initialAmount),
+			});
+		}
+	}, [open, initialAmount, form]);
+
+	return { form };
+}

--- a/apps/web/src/live-sessions/hooks/use-all-in-form.ts
+++ b/apps/web/src/live-sessions/hooks/use-all-in-form.ts
@@ -1,0 +1,72 @@
+import { useForm } from "@tanstack/react-form";
+import { useEffect } from "react";
+import { z } from "zod";
+import { requiredNumericString } from "@/shared/lib/form-fields";
+
+interface AllIn {
+	equity: number;
+	potSize: number;
+	trials: number;
+	wins: number;
+}
+
+const DEFAULT_VALUES = {
+	potSize: "0",
+	trials: "1",
+	equity: "0",
+	wins: "0",
+};
+
+const allInSchema = z.object({
+	potSize: requiredNumericString({ min: 0 }),
+	trials: requiredNumericString({ integer: true, min: 1 }),
+	equity: requiredNumericString({ min: 0, max: 100 }),
+	wins: requiredNumericString({ min: 0 }),
+});
+
+function toFormDefaults(initial: AllIn | undefined) {
+	if (!initial) {
+		return DEFAULT_VALUES;
+	}
+	return {
+		potSize: String(initial.potSize),
+		trials: String(initial.trials),
+		equity: String(initial.equity),
+		wins: String(initial.wins),
+	};
+}
+
+interface UseAllInFormOptions {
+	initialValues?: AllIn;
+	onSubmit: (allIn: AllIn) => void;
+	open: boolean;
+}
+
+export function useAllInForm({
+	initialValues,
+	open,
+	onSubmit,
+}: UseAllInFormOptions) {
+	const form = useForm({
+		defaultValues: toFormDefaults(initialValues),
+		onSubmit: ({ value }) => {
+			onSubmit({
+				potSize: Number(value.potSize),
+				trials: Number(value.trials),
+				equity: Number(value.equity),
+				wins: Number(value.wins),
+			});
+		},
+		validators: {
+			onSubmit: allInSchema,
+		},
+	});
+
+	useEffect(() => {
+		if (open) {
+			form.reset(toFormDefaults(initialValues));
+		}
+	}, [open, initialValues, form]);
+
+	return { form };
+}

--- a/apps/web/src/live-sessions/hooks/use-assign-dialog-state.ts
+++ b/apps/web/src/live-sessions/hooks/use-assign-dialog-state.ts
@@ -1,0 +1,6 @@
+import { useState } from "react";
+
+export function useAssignDialogState() {
+	const [isAssignOpen, setIsAssignOpen] = useState(false);
+	return { isAssignOpen, setIsAssignOpen };
+}

--- a/apps/web/src/live-sessions/hooks/use-cash-game-compact-summary.ts
+++ b/apps/web/src/live-sessions/hooks/use-cash-game-compact-summary.ts
@@ -1,0 +1,55 @@
+import { useElapsedTime } from "@/shared/hooks/use-elapsed-time";
+import { formatCompactNumber } from "@/utils/format-number";
+import {
+	formatProfitLoss,
+	profitLossColorClass,
+} from "@/utils/format-profit-loss";
+
+interface CashGameCompactSummaryInput {
+	currentStack: number | null;
+	evDiff: number;
+	startedAt: Date | string | number;
+	totalBuyIn: number;
+}
+
+export interface CashGameCompactSummaryViewModel {
+	displayPL: number | null;
+	displayPLColorClass: string;
+	displayPLFormatted: string;
+	duration: string;
+	evPL: number | null;
+	evPLColorClass: string;
+	evPLFormatted: string;
+	showEvPL: boolean;
+	totalBuyInFormatted: string;
+}
+
+export function useCashGameCompactSummary(
+	summary: CashGameCompactSummaryInput
+): CashGameCompactSummaryViewModel {
+	const duration = useElapsedTime(summary.startedAt);
+
+	const displayPL =
+		summary.currentStack === null
+			? null
+			: summary.currentStack - summary.totalBuyIn;
+
+	const evPL =
+		summary.currentStack !== null && summary.evDiff !== 0
+			? summary.currentStack + summary.evDiff - summary.totalBuyIn
+			: null;
+	const showEvPL = evPL !== null && evPL !== displayPL;
+
+	return {
+		duration,
+		totalBuyInFormatted: formatCompactNumber(summary.totalBuyIn),
+		displayPL,
+		displayPLFormatted: displayPL === null ? "-" : formatProfitLoss(displayPL),
+		displayPLColorClass:
+			displayPL === null ? "" : profitLossColorClass(displayPL),
+		evPL,
+		showEvPL,
+		evPLFormatted: evPL === null ? "" : formatProfitLoss(evPL),
+		evPLColorClass: evPL === null ? "" : profitLossColorClass(evPL),
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-cash-game-complete-form.ts
+++ b/apps/web/src/live-sessions/hooks/use-cash-game-complete-form.ts
@@ -1,0 +1,32 @@
+import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
+import { requiredNumericString } from "@/shared/lib/form-fields";
+
+const cashGameCompleteSchema = z.object({
+	finalStack: requiredNumericString({ integer: true, min: 0 }),
+});
+
+interface UseCashGameCompleteFormOptions {
+	defaultFinalStack?: number;
+	onSubmit: (values: { finalStack: number }) => void;
+}
+
+export function useCashGameCompleteForm({
+	defaultFinalStack,
+	onSubmit,
+}: UseCashGameCompleteFormOptions) {
+	const form = useForm({
+		defaultValues: {
+			finalStack:
+				defaultFinalStack === undefined ? "" : String(defaultFinalStack),
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({ finalStack: Number(value.finalStack) });
+		},
+		validators: {
+			onSubmit: cashGameCompleteSchema,
+		},
+	});
+
+	return { form };
+}

--- a/apps/web/src/live-sessions/hooks/use-cash-game-stack-form.ts
+++ b/apps/web/src/live-sessions/hooks/use-cash-game-stack-form.ts
@@ -1,0 +1,74 @@
+import { useForm } from "@tanstack/react-form";
+import { useEffect, useState } from "react";
+import { z } from "zod";
+import { useStackFormContext } from "@/live-sessions/hooks/use-session-form";
+import { requiredNumericString } from "@/shared/lib/form-fields";
+
+const stackSchema = z.object({
+	stackAmount: requiredNumericString({ integer: true, min: 0 }),
+});
+
+const memoSchema = z.object({
+	text: z.string().min(1, "Text is required"),
+});
+
+interface UseCashGameStackFormOptions {
+	onMemo: (text: string) => void;
+	onSubmit: (values: { stackAmount: number }) => void;
+}
+
+export function useCashGameStackForm({
+	onMemo,
+	onSubmit,
+}: UseCashGameStackFormOptions) {
+	const { state, setStackAmount } = useStackFormContext();
+	const { stackAmount } = state;
+
+	const stackForm = useForm({
+		defaultValues: { stackAmount },
+		onSubmit: ({ value }) => {
+			onSubmit({ stackAmount: Number(value.stackAmount) });
+		},
+		validators: {
+			onSubmit: stackSchema,
+		},
+	});
+
+	useEffect(() => {
+		if (stackForm.state.values.stackAmount !== stackAmount) {
+			stackForm.setFieldValue("stackAmount", stackAmount);
+		}
+	}, [stackAmount, stackForm]);
+
+	const [allInBottomSheetOpen, setAllInBottomSheetOpen] = useState(false);
+	const [addonBottomSheetOpen, setAddonBottomSheetOpen] = useState(false);
+	const [removeBottomSheetOpen, setRemoveBottomSheetOpen] = useState(false);
+	const [memoBottomSheetOpen, setMemoBottomSheetOpen] = useState(false);
+
+	const memoForm = useForm({
+		defaultValues: { text: "" },
+		onSubmit: ({ value }) => {
+			onMemo(value.text);
+			memoForm.reset();
+			setMemoBottomSheetOpen(false);
+		},
+		validators: {
+			onSubmit: memoSchema,
+		},
+	});
+
+	return {
+		stackForm,
+		memoForm,
+		stackAmount,
+		setStackAmount,
+		allInBottomSheetOpen,
+		setAllInBottomSheetOpen,
+		addonBottomSheetOpen,
+		setAddonBottomSheetOpen,
+		removeBottomSheetOpen,
+		setRemoveBottomSheetOpen,
+		memoBottomSheetOpen,
+		setMemoBottomSheetOpen,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-chip-purchase-form.ts
+++ b/apps/web/src/live-sessions/hooks/use-chip-purchase-form.ts
@@ -1,0 +1,75 @@
+import { useForm } from "@tanstack/react-form";
+import { useEffect } from "react";
+import { z } from "zod";
+import { requiredNumericString } from "@/shared/lib/form-fields";
+
+const chipPurchaseSchema = z.object({
+	name: z.string().min(1, "Name is required"),
+	cost: requiredNumericString({ integer: true, min: 0 }),
+	chips: requiredNumericString({ integer: true, min: 0 }),
+});
+
+function buildDefaults({
+	initialValues,
+	defaultName,
+	defaultCost,
+	defaultChips,
+}: {
+	defaultChips?: number;
+	defaultCost?: number;
+	defaultName?: string;
+	initialValues?: { name: string; cost: number; chips: number };
+}) {
+	return {
+		name: initialValues?.name ?? defaultName ?? "",
+		cost: String(initialValues?.cost ?? defaultCost ?? 0),
+		chips: String(initialValues?.chips ?? defaultChips ?? 0),
+	};
+}
+
+interface UseChipPurchaseFormOptions {
+	defaultChips?: number;
+	defaultCost?: number;
+	defaultName?: string;
+	initialValues?: { name: string; cost: number; chips: number };
+	onSubmit: (purchase: { name: string; cost: number; chips: number }) => void;
+	open: boolean;
+}
+
+export function useChipPurchaseForm({
+	defaultChips,
+	defaultCost,
+	defaultName,
+	initialValues,
+	open,
+	onSubmit,
+}: UseChipPurchaseFormOptions) {
+	const form = useForm({
+		defaultValues: buildDefaults({
+			defaultChips,
+			defaultCost,
+			defaultName,
+			initialValues,
+		}),
+		onSubmit: ({ value }) => {
+			onSubmit({
+				name: value.name,
+				cost: Math.round(Number(value.cost)),
+				chips: Math.round(Number(value.chips)),
+			});
+		},
+		validators: {
+			onSubmit: chipPurchaseSchema,
+		},
+	});
+
+	useEffect(() => {
+		if (open) {
+			form.reset(
+				buildDefaults({ defaultChips, defaultCost, defaultName, initialValues })
+			);
+		}
+	}, [open, defaultChips, defaultCost, defaultName, initialValues, form]);
+
+	return { form };
+}

--- a/apps/web/src/live-sessions/hooks/use-create-cash-game-session-form.ts
+++ b/apps/web/src/live-sessions/hooks/use-create-cash-game-session-form.ts
@@ -1,0 +1,94 @@
+import { useForm } from "@tanstack/react-form";
+import { useState } from "react";
+
+interface RingGame {
+	currencyId: string | null;
+	id: string;
+	maxBuyIn: number | null;
+	minBuyIn: number | null;
+	name: string;
+}
+
+interface UseCreateCashGameSessionFormOptions {
+	onStoreChange?: (storeId?: string) => void;
+	onSubmit: (values: {
+		currencyId?: string;
+		initialBuyIn: number;
+		memo?: string;
+		ringGameId?: string;
+		storeId?: string;
+	}) => void;
+	ringGames: RingGame[];
+}
+
+export function useCreateCashGameSessionForm({
+	onStoreChange,
+	onSubmit,
+	ringGames,
+}: UseCreateCashGameSessionFormOptions) {
+	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(
+		undefined
+	);
+	const [selectedRingGameId, setSelectedRingGameId] = useState<
+		string | undefined
+	>(undefined);
+	const [selectedCurrencyId, setSelectedCurrencyId] = useState<
+		string | undefined
+	>(undefined);
+
+	const selectedRingGame = selectedRingGameId
+		? ringGames.find((g) => g.id === selectedRingGameId)
+		: null;
+
+	const isCurrencyLocked =
+		selectedRingGame?.currencyId !== null &&
+		selectedRingGame?.currencyId !== undefined;
+
+	const form = useForm({
+		defaultValues: {
+			initialBuyIn: "",
+			memo: "",
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				storeId: selectedStoreId,
+				ringGameId: selectedRingGameId,
+				currencyId: selectedCurrencyId,
+				initialBuyIn: Number(value.initialBuyIn),
+				memo: value.memo || undefined,
+			});
+		},
+	});
+
+	const handleStoreChange = (value: string) => {
+		setSelectedStoreId(value);
+		setSelectedRingGameId(undefined);
+		form.setFieldValue("initialBuyIn", "");
+		onStoreChange?.(value);
+	};
+
+	const handleRingGameChange = (value: string) => {
+		setSelectedRingGameId(value);
+		const ringGame = ringGames.find((g) => g.id === value);
+		if (ringGame) {
+			form.setFieldValue("initialBuyIn", ringGame.maxBuyIn?.toString() ?? "");
+			setSelectedCurrencyId(ringGame.currencyId ?? undefined);
+		}
+	};
+
+	const handleCurrencyChange = (value: string) => {
+		setSelectedCurrencyId(value);
+	};
+
+	return {
+		form,
+		selectedStoreId,
+		selectedRingGameId,
+		selectedRingGame,
+		selectedCurrencyId,
+		isCurrencyLocked,
+		handleStoreChange,
+		handleRingGameChange,
+		handleCurrencyChange,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-create-session-dialog.ts
+++ b/apps/web/src/live-sessions/hooks/use-create-session-dialog.ts
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { useCreateSession } from "@/live-sessions/hooks/use-create-session";
+
+type SessionType = "cash_game" | "tournament";
+
+interface UseCreateSessionDialogOptions {
+	onOpenChange: (open: boolean) => void;
+}
+
+export function useCreateSessionDialog({
+	onOpenChange,
+}: UseCreateSessionDialogOptions) {
+	const [sessionType, setSessionType] = useState<SessionType>("cash_game");
+
+	const {
+		stores,
+		currencies,
+		ringGames,
+		tournaments,
+		setSelectedStoreId,
+		createCash,
+		createTournament,
+		isLoading,
+	} = useCreateSession({ onClose: () => onOpenChange(false) });
+
+	const handleReset = () => {
+		setSelectedStoreId(undefined);
+		setSessionType("cash_game");
+	};
+
+	return {
+		sessionType,
+		setSessionType,
+		stores,
+		currencies,
+		ringGames,
+		tournaments,
+		setSelectedStoreId,
+		createCash,
+		createTournament,
+		isLoading,
+		handleReset,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-create-tournament-session-form.ts
+++ b/apps/web/src/live-sessions/hooks/use-create-tournament-session-form.ts
@@ -1,0 +1,135 @@
+import { useForm } from "@tanstack/react-form";
+import { useState } from "react";
+import {
+	createTournamentSessionFormSchema,
+	parseTimerStartedAt,
+} from "@/live-sessions/utils/create-tournament-session-form-helpers";
+
+interface Tournament {
+	buyIn: number | null;
+	currencyId: string | null;
+	entryFee: number | null;
+	id: string;
+	name: string;
+	startingStack: number | null;
+}
+
+interface UseCreateTournamentSessionFormOptions {
+	onStoreChange?: (storeId?: string) => void;
+	onSubmit: (values: {
+		buyIn: number;
+		currencyId?: string;
+		entryFee?: number;
+		memo?: string;
+		startingStack: number;
+		storeId?: string;
+		timerStartedAt?: number;
+		tournamentId?: string;
+	}) => void;
+	tournaments: Tournament[];
+}
+
+export function useCreateTournamentSessionForm({
+	onStoreChange,
+	onSubmit,
+	tournaments,
+}: UseCreateTournamentSessionFormOptions) {
+	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>(
+		undefined
+	);
+	const [selectedTournamentId, setSelectedTournamentId] = useState<
+		string | undefined
+	>(undefined);
+	const [selectedCurrencyId, setSelectedCurrencyId] = useState<
+		string | undefined
+	>(undefined);
+
+	const form = useForm({
+		defaultValues: {
+			buyIn: "",
+			entryFee: "",
+			startingStack: "",
+			memo: "",
+			timerStartedAt: "",
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				storeId: selectedStoreId,
+				tournamentId: selectedTournamentId,
+				currencyId: selectedCurrencyId,
+				buyIn: Number(value.buyIn),
+				entryFee: value.entryFee ? Number(value.entryFee) : undefined,
+				startingStack: Number(value.startingStack),
+				memo: value.memo ? value.memo : undefined,
+				timerStartedAt: parseTimerStartedAt(value.timerStartedAt),
+			});
+		},
+		validators: {
+			onSubmit: createTournamentSessionFormSchema,
+		},
+	});
+
+	const handleStoreChange = (value: string) => {
+		setSelectedStoreId(value);
+		setSelectedTournamentId(undefined);
+		onStoreChange?.(value);
+	};
+
+	const applyTournamentDefaults = (t: Tournament) => {
+		if (t.currencyId) {
+			setSelectedCurrencyId(t.currencyId);
+		}
+		if (t.buyIn !== null) {
+			form.setFieldValue("buyIn", String(t.buyIn));
+		}
+		if (t.entryFee !== null) {
+			form.setFieldValue("entryFee", String(t.entryFee));
+		}
+		if (t.startingStack !== null) {
+			form.setFieldValue("startingStack", String(t.startingStack));
+		}
+	};
+
+	const handleTournamentChange = (value: string) => {
+		setSelectedTournamentId(value);
+		const t = tournaments.find((tour) => tour.id === value);
+		if (t) {
+			applyTournamentDefaults(t);
+		}
+	};
+
+	const handleCurrencyChange = (value: string) => {
+		setSelectedCurrencyId(value);
+	};
+
+	const selectedTournament = selectedTournamentId
+		? tournaments.find((t) => t.id === selectedTournamentId)
+		: null;
+
+	const isBuyInLocked =
+		selectedTournament?.buyIn !== null &&
+		selectedTournament?.buyIn !== undefined;
+	const isEntryFeeLocked =
+		selectedTournament?.entryFee !== null &&
+		selectedTournament?.entryFee !== undefined;
+	const isStartingStackLocked =
+		selectedTournament?.startingStack !== null &&
+		selectedTournament?.startingStack !== undefined;
+	const isCurrencyLocked =
+		selectedTournament?.currencyId !== null &&
+		selectedTournament?.currencyId !== undefined;
+
+	return {
+		form,
+		selectedStoreId,
+		selectedTournamentId,
+		selectedCurrencyId,
+		isBuyInLocked,
+		isEntryFeeLocked,
+		isStartingStackLocked,
+		isCurrencyLocked,
+		handleStoreChange,
+		handleTournamentChange,
+		handleCurrencyChange,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-live-stack-form-sheet.ts
+++ b/apps/web/src/live-sessions/hooks/use-live-stack-form-sheet.ts
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { useStackSheet } from "@/live-sessions/hooks/use-stack-sheet";
+
+export function useCashGameStackSheet() {
+	const stackSheet = useStackSheet();
+	const [isCompleteOpen, setIsCompleteOpen] = useState(false);
+	const [defaultFinalStack, setDefaultFinalStack] = useState<
+		number | undefined
+	>(undefined);
+
+	return {
+		stackSheet,
+		isCompleteOpen,
+		setIsCompleteOpen,
+		defaultFinalStack,
+		setDefaultFinalStack,
+	};
+}
+
+export function useTournamentStackSheet() {
+	const stackSheet = useStackSheet();
+	const [isCompleteOpen, setIsCompleteOpen] = useState(false);
+
+	return {
+		stackSheet,
+		isCompleteOpen,
+		setIsCompleteOpen,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-seat-combobox.ts
+++ b/apps/web/src/live-sessions/hooks/use-seat-combobox.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef, useState } from "react";
+
+export function useSeatCombobox() {
+	const [popoverOpen, setPopoverOpen] = useState(false);
+	const [contentWidth, setContentWidth] = useState<number>();
+	const anchorRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!(popoverOpen && anchorRef.current)) {
+			return;
+		}
+		setContentWidth(anchorRef.current.offsetWidth);
+	}, [popoverOpen]);
+
+	return {
+		popoverOpen,
+		setPopoverOpen,
+		contentWidth,
+		anchorRef,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-session-events-scene.ts
+++ b/apps/web/src/live-sessions/hooks/use-session-events-scene.ts
@@ -1,0 +1,58 @@
+import { useMemo, useState } from "react";
+import {
+	type SessionEvent,
+	useSessionEvents,
+} from "@/live-sessions/hooks/use-session-events";
+import {
+	getTimeBounds,
+	groupEventsForDisplay,
+} from "@/live-sessions/utils/session-events-formatters";
+
+type SessionType = "cash_game" | "tournament";
+
+interface UseSessionEventsSceneOptions {
+	refetchInterval?: number;
+	sessionId: string;
+	sessionType: SessionType;
+}
+
+export function useSessionEventsScene({
+	refetchInterval,
+	sessionId,
+	sessionType,
+}: UseSessionEventsSceneOptions) {
+	const [editEvent, setEditEvent] = useState<SessionEvent | null>(null);
+	const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(
+		null
+	);
+
+	const {
+		events,
+		update,
+		delete: deleteEvent,
+		isUpdatePending,
+	} = useSessionEvents({
+		sessionId,
+		sessionType,
+		refetchInterval,
+	});
+
+	const groups = useMemo(() => groupEventsForDisplay(events), [events]);
+
+	const timeBounds = editEvent
+		? getTimeBounds(events, editEvent.id)
+		: { minTime: null, maxTime: null };
+
+	return {
+		editEvent,
+		setEditEvent,
+		confirmingDeleteId,
+		setConfirmingDeleteId,
+		events,
+		update,
+		deleteEvent,
+		isUpdatePending,
+		groups,
+		timeBounds,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-stack-record-editor.ts
+++ b/apps/web/src/live-sessions/hooks/use-stack-record-editor.ts
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import {
+	toOccurredAtTimestamp,
+	toTimeInputValue,
+	validateOccurredAtTime,
+} from "@/live-sessions/components/stack-editor-time";
+
+interface AllIn {
+	equity: number;
+	id: number;
+	potSize: number;
+	trials: number;
+	wins: number;
+}
+
+interface StackRecordPayload {
+	allIns: Array<{
+		equity: number;
+		potSize: number;
+		trials: number;
+		wins: number;
+	}>;
+	stackAmount: number;
+}
+
+interface UseStackRecordEditorOptions {
+	initialOccurredAt?: string | Date;
+	initialPayload: StackRecordPayload;
+	maxTime?: Date | null;
+	minTime?: Date | null;
+	onSubmit: (payload: StackRecordPayload, occurredAt?: number) => void;
+}
+
+export function useStackRecordEditor({
+	initialOccurredAt,
+	initialPayload,
+	maxTime,
+	minTime,
+	onSubmit,
+}: UseStackRecordEditorOptions) {
+	const [stackAmount, setStackAmount] = useState(
+		String(initialPayload.stackAmount)
+	);
+	const [allIns, setAllIns] = useState<AllIn[]>(() =>
+		(initialPayload.allIns ?? []).map((ai, i) => ({ ...ai, id: i + 1 }))
+	);
+	const [time, setTime] = useState(
+		initialOccurredAt ? toTimeInputValue(initialOccurredAt) : ""
+	);
+	const [allInSheetOpen, setAllInSheetOpen] = useState(false);
+	const [editingAllIn, setEditingAllIn] = useState<AllIn | null>(null);
+
+	let nextId = allIns.length > 0 ? Math.max(...allIns.map((a) => a.id)) : 0;
+
+	const handleAllInSubmit = (values: {
+		potSize: number;
+		trials: number;
+		equity: number;
+		wins: number;
+	}) => {
+		if (editingAllIn === null) {
+			nextId += 1;
+			setAllIns((prev) => [...prev, { ...values, id: nextId }]);
+		} else {
+			setAllIns((prev) =>
+				prev.map((item) =>
+					item.id === editingAllIn.id ? { ...values, id: item.id } : item
+				)
+			);
+		}
+		setAllInSheetOpen(false);
+		setEditingAllIn(null);
+	};
+
+	const handleAllInDelete = () => {
+		if (editingAllIn !== null) {
+			setAllIns((prev) => prev.filter((item) => item.id !== editingAllIn.id));
+		}
+		setAllInSheetOpen(false);
+		setEditingAllIn(null);
+	};
+
+	const handleSave = () => {
+		const payload: StackRecordPayload = {
+			stackAmount: Number(stackAmount),
+			allIns: allIns.map(({ potSize, trials, equity, wins }) => ({
+				potSize,
+				trials,
+				equity,
+				wins,
+			})),
+		};
+		const occurredAt = toOccurredAtTimestamp(initialOccurredAt, time);
+		onSubmit(payload, occurredAt);
+	};
+
+	const timeError =
+		initialOccurredAt && time
+			? validateOccurredAtTime(time, initialOccurredAt, minTime, maxTime)
+			: null;
+
+	return {
+		stackAmount,
+		setStackAmount,
+		allIns,
+		time,
+		setTime,
+		allInSheetOpen,
+		setAllInSheetOpen,
+		editingAllIn,
+		setEditingAllIn,
+		handleAllInSubmit,
+		handleAllInDelete,
+		handleSave,
+		timeError,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-tournament-compact-summary.ts
+++ b/apps/web/src/live-sessions/hooks/use-tournament-compact-summary.ts
@@ -1,0 +1,37 @@
+import { useElapsedTime } from "@/shared/hooks/use-elapsed-time";
+import { formatCompactNumber } from "@/utils/format-number";
+
+interface TournamentCompactSummaryInput {
+	averageStack: number | null;
+	remainingPlayers: number | null;
+	startedAt: Date | string | number;
+	totalEntries: number | null;
+}
+
+export interface TournamentCompactSummaryViewModel {
+	averageStackFormatted: string;
+	duration: string;
+	fieldEntry: string;
+}
+
+export function useTournamentCompactSummary(
+	summary: TournamentCompactSummaryInput
+): TournamentCompactSummaryViewModel {
+	const duration = useElapsedTime(summary.startedAt);
+
+	const fieldEntry =
+		summary.remainingPlayers === null && summary.totalEntries === null
+			? "-"
+			: `${summary.remainingPlayers ?? "-"}/${summary.totalEntries ?? "-"}`;
+
+	const averageStackFormatted =
+		summary.averageStack === null
+			? "-"
+			: formatCompactNumber(summary.averageStack);
+
+	return {
+		duration,
+		fieldEntry,
+		averageStackFormatted,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-tournament-complete-form.ts
+++ b/apps/web/src/live-sessions/hooks/use-tournament-complete-form.ts
@@ -1,0 +1,91 @@
+import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
+import {
+	optionalNumericString,
+	requiredNumericString,
+} from "@/shared/lib/form-fields";
+
+type TournamentCompleteSubmitValues =
+	| {
+			beforeDeadline: false;
+			bountyPrizes: number;
+			placement: number;
+			prizeMoney: number;
+			totalEntries: number;
+	  }
+	| {
+			beforeDeadline: true;
+			bountyPrizes: number;
+			prizeMoney: number;
+	  };
+
+const tournamentCompleteSchema = z
+	.object({
+		beforeDeadline: z.boolean(),
+		placement: z.string(),
+		totalEntries: z.string(),
+		prizeMoney: requiredNumericString({ integer: true, min: 0 }),
+		bountyPrizes: optionalNumericString({ integer: true, min: 0 }),
+	})
+	.superRefine((data, ctx) => {
+		if (!data.beforeDeadline) {
+			const placementResult = requiredNumericString({
+				integer: true,
+				min: 1,
+			}).safeParse(data.placement);
+			if (!placementResult.success) {
+				for (const issue of placementResult.error.issues) {
+					ctx.addIssue({ ...issue, path: ["placement"] });
+				}
+			}
+			const totalEntriesResult = requiredNumericString({
+				integer: true,
+				min: 1,
+			}).safeParse(data.totalEntries);
+			if (!totalEntriesResult.success) {
+				for (const issue of totalEntriesResult.error.issues) {
+					ctx.addIssue({ ...issue, path: ["totalEntries"] });
+				}
+			}
+		}
+	});
+
+interface UseTournamentCompleteFormOptions {
+	onSubmit: (values: TournamentCompleteSubmitValues) => void;
+}
+
+export function useTournamentCompleteForm({
+	onSubmit,
+}: UseTournamentCompleteFormOptions) {
+	const form = useForm({
+		defaultValues: {
+			beforeDeadline: false,
+			placement: "",
+			totalEntries: "",
+			prizeMoney: "0",
+			bountyPrizes: "",
+		},
+		onSubmit: ({ value }) => {
+			if (value.beforeDeadline) {
+				onSubmit({
+					beforeDeadline: true,
+					prizeMoney: Number(value.prizeMoney),
+					bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
+				});
+			} else {
+				onSubmit({
+					beforeDeadline: false,
+					placement: Number(value.placement),
+					totalEntries: Number(value.totalEntries),
+					prizeMoney: Number(value.prizeMoney),
+					bountyPrizes: value.bountyPrizes ? Number(value.bountyPrizes) : 0,
+				});
+			}
+		},
+		validators: {
+			onSubmit: tournamentCompleteSchema,
+		},
+	});
+
+	return { form };
+}

--- a/apps/web/src/live-sessions/hooks/use-tournament-stack-form.ts
+++ b/apps/web/src/live-sessions/hooks/use-tournament-stack-form.ts
@@ -1,0 +1,117 @@
+import { useForm } from "@tanstack/react-form";
+import { useEffect, useState } from "react";
+import { z } from "zod";
+import { useTournamentFormContext } from "@/live-sessions/hooks/use-session-form";
+import {
+	optionalNumericString,
+	requiredNumericString,
+} from "@/shared/lib/form-fields";
+
+const updateSchema = z.object({
+	stackAmount: requiredNumericString({ integer: true, min: 0 }),
+	remainingPlayers: optionalNumericString({ integer: true, min: 1 }),
+	totalEntries: optionalNumericString({ integer: true, min: 1 }),
+});
+
+const memoSchema = z.object({
+	text: z.string().min(1, "Text is required"),
+});
+
+interface TournamentStackFormSubmitValues {
+	chipPurchaseCounts: Array<{
+		chipsPerUnit: number;
+		count: number;
+		name: string;
+	}>;
+	recordTournamentInfo: boolean;
+	remainingPlayers: number | null;
+	stackAmount: number;
+	totalEntries: number | null;
+}
+
+interface UseTournamentStackFormOptions {
+	onMemo: (text: string) => void;
+	onSubmit: (values: TournamentStackFormSubmitValues) => void;
+}
+
+export function useTournamentStackForm({
+	onMemo,
+	onSubmit,
+}: UseTournamentStackFormOptions) {
+	const {
+		state,
+		setStackAmount,
+		setRemainingPlayers,
+		setTotalEntries,
+		setChipPurchaseCounts,
+	} = useTournamentFormContext();
+	const { stackAmount, remainingPlayers, totalEntries, chipPurchaseCounts } =
+		state;
+
+	const [recordTournamentInfo, setRecordTournamentInfo] = useState(true);
+	const [chipPurchaseSheetOpen, setChipPurchaseSheetOpen] = useState(false);
+	const [memoSheetOpen, setMemoSheetOpen] = useState(false);
+
+	const form = useForm({
+		defaultValues: {
+			stackAmount,
+			remainingPlayers,
+			totalEntries,
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				stackAmount: Number(value.stackAmount),
+				recordTournamentInfo,
+				remainingPlayers: value.remainingPlayers
+					? Number(value.remainingPlayers)
+					: null,
+				totalEntries: value.totalEntries ? Number(value.totalEntries) : null,
+				chipPurchaseCounts,
+			});
+		},
+		validators: {
+			onSubmit: updateSchema,
+		},
+	});
+
+	useEffect(() => {
+		if (form.state.values.stackAmount !== stackAmount) {
+			form.setFieldValue("stackAmount", stackAmount);
+		}
+		if (form.state.values.remainingPlayers !== remainingPlayers) {
+			form.setFieldValue("remainingPlayers", remainingPlayers);
+		}
+		if (form.state.values.totalEntries !== totalEntries) {
+			form.setFieldValue("totalEntries", totalEntries);
+		}
+	}, [stackAmount, remainingPlayers, totalEntries, form]);
+
+	const memoForm = useForm({
+		defaultValues: { text: "" },
+		onSubmit: ({ value }) => {
+			onMemo(value.text);
+			memoForm.reset();
+			setMemoSheetOpen(false);
+		},
+		validators: {
+			onSubmit: memoSchema,
+		},
+	});
+
+	return {
+		form,
+		memoForm,
+		stackAmount,
+		setStackAmount,
+		setRemainingPlayers,
+		setTotalEntries,
+		chipPurchaseCounts,
+		setChipPurchaseCounts,
+		recordTournamentInfo,
+		setRecordTournamentInfo,
+		chipPurchaseSheetOpen,
+		setChipPurchaseSheetOpen,
+		memoSheetOpen,
+		setMemoSheetOpen,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-tournament-stack-record-editor.ts
+++ b/apps/web/src/live-sessions/hooks/use-tournament-stack-record-editor.ts
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import {
+	toOccurredAtTimestamp,
+	toTimeInputValue,
+	validateOccurredAtTime,
+} from "@/live-sessions/components/stack-editor-time";
+
+interface TournamentStackRecordPayload {
+	chipPurchaseCounts: Array<{
+		name: string;
+		count: number;
+		chipsPerUnit: number;
+	}>;
+	chipPurchases: Array<{ name: string; cost: number; chips: number }>;
+	remainingPlayers: number | null;
+	stackAmount: number;
+	totalEntries: number | null;
+}
+
+interface EditingPurchase {
+	chips: number;
+	cost: number;
+	index: number;
+	name: string;
+}
+
+interface UseTournamentStackRecordEditorOptions {
+	initialOccurredAt?: string | Date;
+	initialPayload: TournamentStackRecordPayload;
+	maxTime?: Date | null;
+	minTime?: Date | null;
+	onSubmit: (
+		payload: TournamentStackRecordPayload,
+		occurredAt?: number
+	) => void;
+}
+
+export function useTournamentStackRecordEditor({
+	initialOccurredAt,
+	initialPayload,
+	maxTime,
+	minTime,
+	onSubmit,
+}: UseTournamentStackRecordEditorOptions) {
+	const [stackAmount, setStackAmount] = useState(
+		String(initialPayload.stackAmount)
+	);
+	const [remainingPlayers, setRemainingPlayers] = useState(
+		initialPayload.remainingPlayers === null
+			? ""
+			: String(initialPayload.remainingPlayers)
+	);
+	const [totalEntries, setTotalEntries] = useState(
+		initialPayload.totalEntries === null
+			? ""
+			: String(initialPayload.totalEntries)
+	);
+	const [chipPurchases, setChipPurchases] = useState<
+		Array<{ name: string; cost: number; chips: number }>
+	>(initialPayload.chipPurchases);
+	const [time, setTime] = useState(
+		initialOccurredAt ? toTimeInputValue(initialOccurredAt) : ""
+	);
+	const [sheetOpen, setSheetOpen] = useState(false);
+	const [editingPurchase, setEditingPurchase] =
+		useState<EditingPurchase | null>(null);
+
+	const openAddSheet = () => {
+		setEditingPurchase(null);
+		setSheetOpen(true);
+	};
+
+	const openEditSheet = (index: number) => {
+		const p = chipPurchases[index];
+		if (p) {
+			setEditingPurchase({ index, name: p.name, cost: p.cost, chips: p.chips });
+			setSheetOpen(true);
+		}
+	};
+
+	const handleSheetSubmit = (purchase: {
+		name: string;
+		cost: number;
+		chips: number;
+	}) => {
+		if (editingPurchase === null) {
+			setChipPurchases((prev) => [...prev, purchase]);
+		} else {
+			setChipPurchases((prev) =>
+				prev.map((p, i) => (i === editingPurchase.index ? purchase : p))
+			);
+		}
+		setSheetOpen(false);
+	};
+
+	const handleSheetDelete = () => {
+		if (editingPurchase !== null) {
+			setChipPurchases((prev) =>
+				prev.filter((_, i) => i !== editingPurchase.index)
+			);
+		}
+		setSheetOpen(false);
+	};
+
+	const handleRemove = (index: number) => {
+		setChipPurchases((prev) => prev.filter((_, i) => i !== index));
+	};
+
+	const handleSave = () => {
+		const payload: TournamentStackRecordPayload = {
+			stackAmount: Number(stackAmount),
+			remainingPlayers: remainingPlayers ? Number(remainingPlayers) : null,
+			totalEntries: totalEntries ? Number(totalEntries) : null,
+			chipPurchases,
+			chipPurchaseCounts: initialPayload.chipPurchaseCounts,
+		};
+		const occurredAt = toOccurredAtTimestamp(initialOccurredAt, time);
+		onSubmit(payload, occurredAt);
+	};
+
+	const timeError =
+		initialOccurredAt && time
+			? validateOccurredAtTime(time, initialOccurredAt, minTime, maxTime)
+			: null;
+
+	return {
+		stackAmount,
+		setStackAmount,
+		remainingPlayers,
+		setRemainingPlayers,
+		totalEntries,
+		setTotalEntries,
+		chipPurchases,
+		time,
+		setTime,
+		sheetOpen,
+		setSheetOpen,
+		editingPurchase,
+		openAddSheet,
+		openEditSheet,
+		handleSheetSubmit,
+		handleSheetDelete,
+		handleRemove,
+		handleSave,
+		timeError,
+	};
+}

--- a/apps/web/src/live-sessions/hooks/use-tournament-timer-dialog.ts
+++ b/apps/web/src/live-sessions/hooks/use-tournament-timer-dialog.ts
@@ -1,0 +1,51 @@
+import { useForm } from "@tanstack/react-form";
+import { useEffect } from "react";
+import { z } from "zod";
+
+const schema = z.object({
+	timerStartedAt: z.string().min(1, "Required"),
+});
+
+function toDatetimeLocalValue(value: Date | string | number | null): string {
+	const date = value ? new Date(value) : new Date();
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+interface UseTournamentTimerDialogOptions {
+	onSubmit: (timerStartedAt: Date) => void;
+	open: boolean;
+	timerStartedAt: Date | string | number | null;
+}
+
+export function useTournamentTimerDialog({
+	open,
+	timerStartedAt,
+	onSubmit,
+}: UseTournamentTimerDialogOptions) {
+	const form = useForm({
+		defaultValues: {
+			timerStartedAt: toDatetimeLocalValue(timerStartedAt),
+		},
+		onSubmit: ({ value }) => {
+			const parsed = new Date(value.timerStartedAt);
+			if (!Number.isNaN(parsed.getTime())) {
+				onSubmit(parsed);
+			}
+		},
+		validators: {
+			onSubmit: schema,
+		},
+	});
+
+	useEffect(() => {
+		if (open) {
+			form.setFieldValue(
+				"timerStartedAt",
+				toDatetimeLocalValue(timerStartedAt)
+			);
+		}
+	}, [open, timerStartedAt, form]);
+
+	return { form };
+}

--- a/apps/web/src/live-sessions/hooks/use-tournament-timer-scene.ts
+++ b/apps/web/src/live-sessions/hooks/use-tournament-timer-scene.ts
@@ -1,0 +1,10 @@
+import { useEffect, useState } from "react";
+
+export function useNowTick(intervalMs: number): number {
+	const [now, setNow] = useState(() => Date.now());
+	useEffect(() => {
+		const id = setInterval(() => setNow(Date.now()), intervalMs);
+		return () => clearInterval(id);
+	}, [intervalMs]);
+	return now;
+}

--- a/apps/web/src/live-sessions/utils/create-tournament-session-form-helpers.ts
+++ b/apps/web/src/live-sessions/utils/create-tournament-session-form-helpers.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import {
+	optionalNumericString,
+	requiredNumericString,
+} from "@/shared/lib/form-fields";
+
+export const createTournamentSessionFormSchema = z.object({
+	buyIn: requiredNumericString({ integer: true, min: 0 }),
+	entryFee: optionalNumericString({ integer: true, min: 0 }),
+	startingStack: requiredNumericString({ integer: true, min: 0 }),
+	memo: z.string(),
+	timerStartedAt: z.string(),
+});
+
+export function parseTimerStartedAt(value: string): number | undefined {
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return;
+	}
+	const parsed = new Date(trimmed);
+	const ms = parsed.getTime();
+	if (Number.isNaN(ms)) {
+		return;
+	}
+	return Math.floor(ms / 1000);
+}

--- a/apps/web/src/players/components/player-card.tsx
+++ b/apps/web/src/players/components/player-card.tsx
@@ -1,62 +1,10 @@
 import { IconNote } from "@tabler/icons-react";
-import { useEffect, useRef } from "react";
 import { ColorBadge } from "@/players/components/color-badge";
+import { useSafeHtml } from "@/players/hooks/use-player-card";
 import { EntityListItem } from "@/shared/components/management/entity-list-item";
 
-const ALLOWED_TAGS = new Set([
-	"P",
-	"H2",
-	"H3",
-	"UL",
-	"OL",
-	"LI",
-	"STRONG",
-	"EM",
-	"A",
-	"BR",
-	"BLOCKQUOTE",
-]);
-
-function sanitizeHtml(html: string): string {
-	const doc = new DOMParser().parseFromString(html, "text/html");
-	const clean = (node: Node): void => {
-		const children = Array.from(node.childNodes);
-		for (const child of children) {
-			if (child.nodeType === Node.ELEMENT_NODE) {
-				const el = child as Element;
-				if (!ALLOWED_TAGS.has(el.tagName)) {
-					el.replaceWith(...Array.from(el.childNodes));
-					continue;
-				}
-				const attrs = Array.from(el.attributes);
-				for (const attr of attrs) {
-					if (
-						el.tagName === "A" &&
-						(attr.name === "href" ||
-							attr.name === "rel" ||
-							attr.name === "target")
-					) {
-						continue;
-					}
-					el.removeAttribute(attr.name);
-				}
-				clean(el);
-			}
-		}
-	};
-	clean(doc.body);
-	return doc.body.innerHTML;
-}
-
 function SafeHtml({ className, html }: { className?: string; html: string }) {
-	const ref = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		if (ref.current) {
-			ref.current.innerHTML = sanitizeHtml(html);
-		}
-	}, [html]);
-
+	const { ref } = useSafeHtml(html);
 	return <div className={className} ref={ref} />;
 }
 

--- a/apps/web/src/players/components/player-filters.tsx
+++ b/apps/web/src/players/components/player-filters.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
 import { PlayerTagInput } from "@/players/components/player-tag-input";
+import { usePlayerFilters } from "@/players/hooks/use-player-filters";
 import { FilterDialogShell } from "@/shared/components/filter-dialog-shell";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { Field } from "@/shared/components/ui/field";
@@ -21,44 +21,16 @@ export function PlayerFilters({
 	onTagIdsChange,
 	selectedTagIds,
 }: PlayerFiltersProps) {
-	const [isOpen, setIsOpen] = useState(false);
-	const [draft, setDraft] = useState<string[]>(selectedTagIds);
-
-	const handleOpen = () => {
-		setDraft(selectedTagIds);
-		setIsOpen(true);
-	};
-
-	const toggleTag = (tagId: string) => {
-		setDraft((prev) =>
-			prev.includes(tagId)
-				? prev.filter((id) => id !== tagId)
-				: [...prev, tagId]
-		);
-	};
-
-	const handleApply = () => {
-		onTagIdsChange(draft);
-		setIsOpen(false);
-	};
-
-	const handleReset = () => {
-		setDraft([]);
-		onTagIdsChange([]);
-		setIsOpen(false);
-	};
+	const { draft, isOpen, onApply, onOpen, onOpenChange, onReset, toggleTag } =
+		usePlayerFilters({ onTagIdsChange, selectedTagIds });
 
 	return (
 		<FilterDialogShell
 			activeCount={selectedTagIds.length}
-			onApply={handleApply}
-			onOpen={handleOpen}
-			onOpenChange={(open) => {
-				if (!open) {
-					setIsOpen(false);
-				}
-			}}
-			onReset={handleReset}
+			onApply={onApply}
+			onOpen={onOpen}
+			onOpenChange={onOpenChange}
+			onReset={onReset}
 			open={isOpen}
 			title="Filter by Tags"
 		>

--- a/apps/web/src/players/components/player-form.tsx
+++ b/apps/web/src/players/components/player-form.tsx
@@ -1,7 +1,6 @@
-import { useForm } from "@tanstack/react-form";
 import type { ReactNode } from "react";
-import z from "zod";
 import { PlayerTagInput } from "@/players/components/player-tag-input";
+import { usePlayerForm } from "@/players/hooks/use-player-form";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
@@ -31,17 +30,6 @@ interface PlayerFormProps {
 	onSubmit: (values: PlayerFormValues) => void;
 }
 
-const playerFormSchema = z.object({
-	memo: z.string().max(50_000).nullable(),
-	name: z
-		.string()
-		.min(1, "Name is required")
-		.max(100, "Name must be 100 characters or less"),
-	tags: z.array(
-		z.object({ color: z.string(), id: z.string(), name: z.string() })
-	),
-});
-
 export function PlayerForm({
 	availableTags,
 	defaultMemo,
@@ -52,22 +40,11 @@ export function PlayerForm({
 	onCreateTag,
 	onSubmit,
 }: PlayerFormProps) {
-	const form = useForm({
-		defaultValues: {
-			memo: defaultMemo ?? (null as string | null),
-			name: defaultValues?.name ?? "",
-			tags: defaultTags ?? ([] as TagWithColor[]),
-		},
-		onSubmit: ({ value }) => {
-			onSubmit({
-				memo: value.memo,
-				name: value.name,
-				tagIds: value.tags.length > 0 ? value.tags.map((t) => t.id) : undefined,
-			});
-		},
-		validators: {
-			onSubmit: playerFormSchema,
-		},
+	const { form } = usePlayerForm({
+		defaultMemo,
+		defaultTags,
+		defaultValues,
+		onSubmit,
 	});
 
 	return (

--- a/apps/web/src/players/components/player-tag-manager.tsx
+++ b/apps/web/src/players/components/player-tag-manager.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
 import { ColorBadge } from "@/players/components/color-badge";
 import { TagColorPicker } from "@/players/components/tag-color-picker";
 import type { TagColor } from "@/players/constants/player-tag-colors";
+import { useTagForm } from "@/players/hooks/use-player-tag-manager";
 import {
 	type TagFormValues,
 	type TagItem,
@@ -20,9 +20,7 @@ function TagForm({
 	isLoading?: boolean;
 	onSubmit: (values: TagFormValues) => void;
 }) {
-	const [selectedColor, setSelectedColor] = useState<TagColor>(
-		defaultValues?.color ?? "gray"
-	);
+	const { selectedColor, onColorChange } = useTagForm({ defaultValues });
 
 	return (
 		<TagNameForm
@@ -31,7 +29,7 @@ function TagForm({
 			onSubmit={(name) => onSubmit({ name, color: selectedColor })}
 		>
 			<Field label="Color">
-				<TagColorPicker onChange={setSelectedColor} value={selectedColor} />
+				<TagColorPicker onChange={onColorChange} value={selectedColor} />
 			</Field>
 		</TagNameForm>
 	);

--- a/apps/web/src/players/hooks/use-player-card.ts
+++ b/apps/web/src/players/hooks/use-player-card.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from "react";
+
+const ALLOWED_TAGS = new Set([
+	"P",
+	"H2",
+	"H3",
+	"UL",
+	"OL",
+	"LI",
+	"STRONG",
+	"EM",
+	"A",
+	"BR",
+	"BLOCKQUOTE",
+]);
+
+function sanitizeHtml(html: string): string {
+	const doc = new DOMParser().parseFromString(html, "text/html");
+	const clean = (node: Node): void => {
+		const children = Array.from(node.childNodes);
+		for (const child of children) {
+			if (child.nodeType === Node.ELEMENT_NODE) {
+				const el = child as Element;
+				if (!ALLOWED_TAGS.has(el.tagName)) {
+					el.replaceWith(...Array.from(el.childNodes));
+					continue;
+				}
+				const attrs = Array.from(el.attributes);
+				for (const attr of attrs) {
+					if (
+						el.tagName === "A" &&
+						(attr.name === "href" ||
+							attr.name === "rel" ||
+							attr.name === "target")
+					) {
+						continue;
+					}
+					el.removeAttribute(attr.name);
+				}
+				clean(el);
+			}
+		}
+	};
+	clean(doc.body);
+	return doc.body.innerHTML;
+}
+
+export function useSafeHtml(html: string) {
+	const ref = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (ref.current) {
+			ref.current.innerHTML = sanitizeHtml(html);
+		}
+	}, [html]);
+
+	return { ref };
+}

--- a/apps/web/src/players/hooks/use-player-filters.ts
+++ b/apps/web/src/players/hooks/use-player-filters.ts
@@ -1,0 +1,54 @@
+import { useState } from "react";
+
+interface UsePlayerFiltersProps {
+	onTagIdsChange: (tagIds: string[]) => void;
+	selectedTagIds: string[];
+}
+
+export function usePlayerFilters({
+	onTagIdsChange,
+	selectedTagIds,
+}: UsePlayerFiltersProps) {
+	const [isOpen, setIsOpen] = useState(false);
+	const [draft, setDraft] = useState<string[]>(selectedTagIds);
+
+	const handleOpen = () => {
+		setDraft(selectedTagIds);
+		setIsOpen(true);
+	};
+
+	const toggleTag = (tagId: string) => {
+		setDraft((prev) =>
+			prev.includes(tagId)
+				? prev.filter((id) => id !== tagId)
+				: [...prev, tagId]
+		);
+	};
+
+	const handleApply = () => {
+		onTagIdsChange(draft);
+		setIsOpen(false);
+	};
+
+	const handleReset = () => {
+		setDraft([]);
+		onTagIdsChange([]);
+		setIsOpen(false);
+	};
+
+	const handleOpenChange = (open: boolean) => {
+		if (!open) {
+			setIsOpen(false);
+		}
+	};
+
+	return {
+		draft,
+		isOpen,
+		onApply: handleApply,
+		onOpen: handleOpen,
+		onOpenChange: handleOpenChange,
+		onReset: handleReset,
+		toggleTag,
+	};
+}

--- a/apps/web/src/players/hooks/use-player-form.ts
+++ b/apps/web/src/players/hooks/use-player-form.ts
@@ -1,0 +1,54 @@
+import { useForm } from "@tanstack/react-form";
+import z from "zod";
+import type { PlayerFormValues } from "@/players/components/player-form";
+
+interface TagWithColor {
+	color: string;
+	id: string;
+	name: string;
+}
+
+interface UsePlayerFormProps {
+	defaultMemo?: string | null;
+	defaultTags?: TagWithColor[];
+	defaultValues?: { name: string };
+	onSubmit: (values: PlayerFormValues) => void;
+}
+
+export const playerFormSchema = z.object({
+	memo: z.string().max(50_000).nullable(),
+	name: z
+		.string()
+		.min(1, "Name is required")
+		.max(100, "Name must be 100 characters or less"),
+	tags: z.array(
+		z.object({ color: z.string(), id: z.string(), name: z.string() })
+	),
+});
+
+export function usePlayerForm({
+	defaultMemo,
+	defaultTags,
+	defaultValues,
+	onSubmit,
+}: UsePlayerFormProps) {
+	const form = useForm({
+		defaultValues: {
+			memo: defaultMemo ?? (null as string | null),
+			name: defaultValues?.name ?? "",
+			tags: defaultTags ?? ([] as TagWithColor[]),
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				memo: value.memo,
+				name: value.name,
+				tagIds: value.tags.length > 0 ? value.tags.map((t) => t.id) : undefined,
+			});
+		},
+		validators: {
+			onSubmit: playerFormSchema,
+		},
+	});
+
+	return { form };
+}

--- a/apps/web/src/players/hooks/use-player-tag-manager.ts
+++ b/apps/web/src/players/hooks/use-player-tag-manager.ts
@@ -1,0 +1,18 @@
+import { useState } from "react";
+import type { TagColor } from "@/players/constants/player-tag-colors";
+import type { TagFormValues } from "@/players/hooks/use-player-tags";
+
+interface UseTagFormProps {
+	defaultValues?: TagFormValues;
+}
+
+export function useTagForm({ defaultValues }: UseTagFormProps) {
+	const [selectedColor, setSelectedColor] = useState<TagColor>(
+		defaultValues?.color ?? "gray"
+	);
+
+	return {
+		onColorChange: setSelectedColor,
+		selectedColor,
+	};
+}

--- a/apps/web/src/players/hooks/use-players-page.ts
+++ b/apps/web/src/players/hooks/use-players-page.ts
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import type { PlayerFormValues } from "@/players/components/player-form";
+import type { PlayerItem } from "@/players/hooks/use-players";
+import { usePlayers } from "@/players/hooks/use-players";
+
+export function usePlayersPage() {
+	const [isCreateOpen, setIsCreateOpen] = useState(false);
+	const [editingPlayer, setEditingPlayer] = useState<PlayerItem | null>(null);
+	const [isTagManagerOpen, setIsTagManagerOpen] = useState(false);
+	const [filterTagIds, setFilterTagIds] = useState<string[]>([]);
+
+	const {
+		players,
+		availableTags,
+		isCreatePending,
+		isUpdatePending,
+		create,
+		update,
+		delete: deletePlayer,
+		createTag,
+	} = usePlayers(filterTagIds);
+
+	const handleCreate = (values: PlayerFormValues) => {
+		create(values).then(() => {
+			setIsCreateOpen(false);
+		});
+	};
+
+	const handleUpdate = (values: PlayerFormValues) => {
+		if (!editingPlayer) {
+			return;
+		}
+		update({ id: editingPlayer.id, ...values }).then(() => {
+			setEditingPlayer(null);
+		});
+	};
+
+	const handleDelete = (id: string) => {
+		deletePlayer(id);
+	};
+
+	const handleOpenEdit = (player: PlayerItem) => {
+		setEditingPlayer({ ...player, isTemporary: false });
+	};
+
+	const handleCloseEdit = () => {
+		setEditingPlayer(null);
+	};
+
+	return {
+		players,
+		availableTags,
+		isCreatePending,
+		isUpdatePending,
+		isCreateOpen,
+		editingPlayer,
+		isTagManagerOpen,
+		filterTagIds,
+		setIsCreateOpen,
+		setIsTagManagerOpen,
+		setFilterTagIds,
+		handleCreate,
+		handleUpdate,
+		handleDelete,
+		handleOpenEdit,
+		handleCloseEdit,
+		createTag,
+	};
+}

--- a/apps/web/src/routes/active-session/index.tsx
+++ b/apps/web/src/routes/active-session/index.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
 import { cn } from "@/lib/utils";
 import {
 	ActiveSessionScene,
@@ -9,16 +8,13 @@ import type { TableGameInfo } from "@/live-sessions/components/poker-table";
 import { TournamentTimer } from "@/live-sessions/components/tournament-timer";
 import { TournamentTimerDialog } from "@/live-sessions/components/tournament-timer-dialog";
 import { useActiveSession } from "@/live-sessions/hooks/use-active-session";
+import { useTournamentSessionPage } from "@/live-sessions/hooks/use-active-session-page";
+import { useCashGameCompactSummary } from "@/live-sessions/hooks/use-cash-game-compact-summary";
 import { useCashGameSession } from "@/live-sessions/hooks/use-cash-game-session";
-import { useTournamentSession } from "@/live-sessions/hooks/use-tournament-session";
+import { useTournamentCompactSummary } from "@/live-sessions/hooks/use-tournament-compact-summary";
 import type { TournamentBlindLevel } from "@/live-sessions/utils/tournament-timer";
 import { EmptyState } from "@/shared/components/ui/empty-state";
-import { useElapsedTime } from "@/shared/hooks/use-elapsed-time";
 import { formatCompactNumber } from "@/utils/format-number";
-import {
-	formatProfitLoss,
-	profitLossColorClass,
-} from "@/utils/format-profit-loss";
 
 export const Route = createFileRoute("/active-session/")({
 	component: ActiveSessionPage,
@@ -34,47 +30,26 @@ function CashGameCompactSummary({
 		totalBuyIn: number;
 	};
 }) {
-	const duration = useElapsedTime(summary.startedAt);
-
-	// Use currentStack-based running P&L during the active session.
-	// profitLoss (from cashOut) is only available at session end.
-	const displayPL =
-		summary.currentStack === null
-			? null
-			: summary.currentStack - summary.totalBuyIn;
-
-	// Running EV P&L = (currentStack + evDiff) - totalBuyIn
-	const evPL =
-		summary.currentStack !== null && summary.evDiff !== 0
-			? summary.currentStack + summary.evDiff - summary.totalBuyIn
-			: null;
-	const showEvPL = evPL !== null && evPL !== displayPL;
+	const vm = useCashGameCompactSummary(summary);
 
 	return (
 		<div className="flex rounded-md border">
 			<div className="flex flex-1 flex-col gap-0.5 px-3 py-2">
 				<span className="text-muted-foreground text-xs">Time</span>
-				<p className="font-semibold">{duration}</p>
+				<p className="font-semibold">{vm.duration}</p>
 			</div>
 			<div className="flex flex-1 flex-col gap-0.5 border-l px-3 py-2">
 				<span className="text-muted-foreground text-xs">Total Buy-in</span>
-				<p className="font-semibold">
-					{formatCompactNumber(summary.totalBuyIn)}
-				</p>
+				<p className="font-semibold">{vm.totalBuyInFormatted}</p>
 			</div>
 			<div className="flex flex-1 flex-col gap-0.5 border-l px-3 py-2">
 				<span className="text-muted-foreground text-xs">P&L</span>
-				<p
-					className={cn(
-						"font-semibold",
-						displayPL === null ? undefined : profitLossColorClass(displayPL)
-					)}
-				>
-					{displayPL === null ? "-" : formatProfitLoss(displayPL)}
+				<p className={cn("font-semibold", vm.displayPLColorClass || undefined)}>
+					{vm.displayPLFormatted}
 				</p>
-				{showEvPL ? (
-					<p className={cn("text-xs", profitLossColorClass(evPL))}>
-						EV: {formatProfitLoss(evPL)}
+				{vm.showEvPL ? (
+					<p className={cn("text-xs", vm.evPLColorClass)}>
+						EV: {vm.evPLFormatted}
 					</p>
 				) : null}
 			</div>
@@ -92,29 +67,21 @@ function TournamentCompactSummary({
 		totalEntries: number | null;
 	};
 }) {
-	const duration = useElapsedTime(summary.startedAt);
-	const fieldEntry =
-		summary.remainingPlayers === null && summary.totalEntries === null
-			? "-"
-			: `${summary.remainingPlayers ?? "-"}/${summary.totalEntries ?? "-"}`;
+	const vm = useTournamentCompactSummary(summary);
 
 	return (
 		<div className="flex rounded-md border">
 			<div className="flex flex-1 flex-col gap-0.5 px-3 py-2">
 				<span className="text-muted-foreground text-xs">Time</span>
-				<p className="font-semibold">{duration}</p>
+				<p className="font-semibold">{vm.duration}</p>
 			</div>
 			<div className="flex flex-1 flex-col gap-0.5 border-l px-3 py-2">
 				<span className="text-muted-foreground text-xs">Field/Entry</span>
-				<p className="font-semibold">{fieldEntry}</p>
+				<p className="font-semibold">{vm.fieldEntry}</p>
 			</div>
 			<div className="flex flex-1 flex-col gap-0.5 border-l px-3 py-2">
 				<span className="text-muted-foreground text-xs">Avg Stack</span>
-				<p className="font-semibold">
-					{summary.averageStack === null
-						? "-"
-						: formatCompactNumber(summary.averageStack)}
-				</p>
+				<p className="font-semibold">{vm.averageStackFormatted}</p>
 			</div>
 		</div>
 	);
@@ -206,9 +173,12 @@ function TournamentSession({ sessionId }: { sessionId: string }) {
 		isDiscardPending,
 		discard,
 		isUpdatingTimer,
-		updateTimerStartedAt,
-	} = useTournamentSession(sessionId);
-	const [isTimerDialogOpen, setIsTimerDialogOpen] = useState(false);
+		isTimerDialogOpen,
+		setIsTimerDialogOpen,
+		handleOpenTimerDialog,
+		handleClearTimer,
+		handleSubmitTimer,
+	} = useTournamentSessionPage(sessionId);
 
 	const rawHeroSeat = session?.heroSeatPosition;
 	const heroSeatPosition =
@@ -222,6 +192,7 @@ function TournamentSession({ sessionId }: { sessionId: string }) {
 	if (!session) {
 		return null;
 	}
+
 	const tournamentSummary = buildTournamentSummary(
 		session as { summary: Record<string, unknown> }
 	);
@@ -257,7 +228,7 @@ function TournamentSession({ sessionId }: { sessionId: string }) {
 					hasStructure ? (
 						<TournamentTimer
 							blindLevels={blindLevels}
-							onEditTimer={() => setIsTimerDialogOpen(true)}
+							onEditTimer={handleOpenTimerDialog}
 							timerStartedAt={timerStartedAt}
 						/>
 					) : undefined
@@ -266,15 +237,9 @@ function TournamentSession({ sessionId }: { sessionId: string }) {
 			{hasStructure ? (
 				<TournamentTimerDialog
 					isLoading={isUpdatingTimer}
-					onClear={() => {
-						updateTimerStartedAt(null);
-						setIsTimerDialogOpen(false);
-					}}
+					onClear={handleClearTimer}
 					onOpenChange={setIsTimerDialogOpen}
-					onSubmit={(value) => {
-						updateTimerStartedAt(value);
-						setIsTimerDialogOpen(false);
-					}}
+					onSubmit={handleSubmitTimer}
 					open={isTimerDialogOpen}
 					timerStartedAt={timerStartedAt}
 				/>

--- a/apps/web/src/routes/currencies/index.tsx
+++ b/apps/web/src/routes/currencies/index.tsx
@@ -1,17 +1,10 @@
 import { IconCoins, IconPlus, IconTags } from "@tabler/icons-react";
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
 import { CurrencyCard } from "@/currencies/components/currency-card";
 import { CurrencyForm } from "@/currencies/components/currency-form";
 import { TransactionForm } from "@/currencies/components/transaction-form";
 import { TransactionTypeManager } from "@/currencies/components/transaction-type-manager";
-import type {
-	CurrencyItem,
-	CurrencyValues,
-	Transaction,
-	TransactionValues,
-} from "@/currencies/hooks/use-currencies";
-import { useCurrencies } from "@/currencies/hooks/use-currencies";
+import { useCurrenciesPage } from "@/currencies/hooks/use-currencies-page";
 import { PageHeader } from "@/shared/components/page-header";
 import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
@@ -22,20 +15,6 @@ export const Route = createFileRoute("/currencies/")({
 });
 
 function CurrenciesPage() {
-	const [isCreateOpen, setIsCreateOpen] = useState(false);
-	const [isTypeManagerOpen, setIsTypeManagerOpen] = useState(false);
-	const [editingCurrency, setEditingCurrency] = useState<CurrencyItem | null>(
-		null
-	);
-	const [expandedCurrencyId, setExpandedCurrencyId] = useState<string | null>(
-		null
-	);
-	const [addTransactionCurrencyId, setAddTransactionCurrencyId] = useState<
-		string | null
-	>(null);
-	const [editingTransaction, setEditingTransaction] =
-		useState<Transaction | null>(null);
-
 	const {
 		currencies,
 		allTransactions,
@@ -45,79 +24,26 @@ function CurrenciesPage() {
 		isUpdatePending,
 		isAddTransactionPending,
 		isEditTransactionPending,
-		resetTransactionState,
-		create,
-		update,
-		delete: deleteCurrency,
-		addTransaction,
-		editTransaction,
-		deleteTransaction,
+		isCreateOpen,
+		isTypeManagerOpen,
+		editingCurrency,
+		expandedCurrencyId,
+		addTransactionCurrencyId,
+		editingTransaction,
+		setIsCreateOpen,
+		setIsTypeManagerOpen,
+		setEditingCurrency,
+		setAddTransactionCurrencyId,
+		setEditingTransaction,
+		handleCreate,
+		handleUpdate,
+		handleDelete,
+		handleAddTransaction,
+		handleEditTransaction,
+		handleDeleteTransaction,
+		handleExpandedCurrencyChange,
 		handleLoadMore,
-	} = useCurrencies(expandedCurrencyId);
-
-	const handleCreate = (values: CurrencyValues) => {
-		create(values).then(() => {
-			setIsCreateOpen(false);
-		});
-	};
-
-	const handleUpdate = (values: CurrencyValues) => {
-		if (!editingCurrency) {
-			return;
-		}
-		update({ id: editingCurrency.id, ...values }).then(() => {
-			setEditingCurrency(null);
-		});
-	};
-
-	const handleDelete = (id: string) => {
-		deleteCurrency(id).then(() => {
-			if (expandedCurrencyId === id) {
-				setExpandedCurrencyId(null);
-				resetTransactionState();
-			}
-		});
-	};
-
-	const handleAddTransaction = (values: TransactionValues) => {
-		if (!addTransactionCurrencyId) {
-			return;
-		}
-		addTransaction({
-			currencyId: addTransactionCurrencyId,
-			...values,
-		}).then(() => {
-			setAddTransactionCurrencyId(null);
-		});
-	};
-
-	const handleEditTransaction = (values: TransactionValues) => {
-		if (!editingTransaction) {
-			return;
-		}
-		editTransaction({
-			id: editingTransaction.id,
-			transactionTypeId: values.transactionTypeId,
-			amount: values.amount,
-			transactedAt: values.transactedAt,
-			memo: values.memo ?? null,
-		}).then(() => {
-			setEditingTransaction(null);
-		});
-	};
-
-	const handleDeleteTransaction = (id: string) => {
-		deleteTransaction(id);
-	};
-
-	const handleExpandedCurrencyChange = (id: string | null) => {
-		setExpandedCurrencyId((prev) => {
-			if (prev !== id) {
-				resetTransactionState();
-			}
-			return id;
-		});
-	};
+	} = useCurrenciesPage();
 
 	return (
 		<div className="p-4 md:p-6">

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,23 +1,18 @@
-import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { authClient } from "@/lib/auth-client";
 import { PageSection } from "@/shared/components/page-section";
 import { PublicPageShell } from "@/shared/components/public-page-shell";
 import { Button } from "@/shared/components/ui/button";
-import { trpc } from "@/utils/trpc";
+import { useHomePage } from "@/shared/hooks/use-home-page";
 
 export const Route = createFileRoute("/")({
 	component: HomeComponent,
 });
 
-function getStatusText(isLoading: boolean, data: unknown) {
+function getStatusText(isLoading: boolean, isConnected: boolean) {
 	if (isLoading) {
 		return "Checking...";
 	}
-	if (data) {
-		return "Connected";
-	}
-	return "Disconnected";
+	return isConnected ? "Connected" : "Disconnected";
 }
 
 function getStatusDescription(isLoading: boolean, isConnected: boolean) {
@@ -31,14 +26,8 @@ function getStatusDescription(isLoading: boolean, isConnected: boolean) {
 }
 
 function HomeComponent() {
-	const healthCheck = useQuery(trpc.healthCheck.queryOptions());
-	const { data: session } = authClient.useSession();
-	const isConnected = Boolean(healthCheck.data);
-	const isSignedIn = Boolean(session);
-	const healthStatusDescription = getStatusDescription(
-		healthCheck.isLoading,
-		isConnected
-	);
+	const { isConnected, isSignedIn, isLoading, userName } = useHomePage();
+	const healthStatusDescription = getStatusDescription(isLoading, isConnected);
 
 	return (
 		<PublicPageShell
@@ -83,7 +72,7 @@ function HomeComponent() {
 						/>
 						<div className="space-y-1">
 							<p className="font-medium">
-								API: {getStatusText(healthCheck.isLoading, healthCheck.data)}
+								API: {getStatusText(isLoading, isConnected)}
 							</p>
 							<p className="text-muted-foreground text-sm">
 								{healthStatusDescription}
@@ -94,7 +83,7 @@ function HomeComponent() {
 				<PageSection
 					description={
 						isSignedIn
-							? `Signed in as ${session?.user.name ?? "your account"}. Continue where you left off.`
+							? `Signed in as ${userName ?? "your account"}. Continue where you left off.`
 							: "Sign in to access dashboard, settings, sessions, and live tools."
 					}
 					heading={isSignedIn ? "Ready to continue" : "Start with your account"}

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { useState } from "react";
 import { authClient } from "@/lib/auth-client";
 import { PageSection } from "@/shared/components/page-section";
 import { PreviewAutoLogin } from "@/shared/components/preview-auto-login";
 import { PublicPageShell } from "@/shared/components/public-page-shell";
 import SignInForm from "@/shared/components/sign-in-form";
 import SignUpForm from "@/shared/components/sign-up-form";
+import { useLoginPage } from "@/shared/hooks/use-login-page";
 
 export const Route = createFileRoute("/login")({
 	beforeLoad: async () => {
@@ -18,7 +18,7 @@ export const Route = createFileRoute("/login")({
 });
 
 function RouteComponent() {
-	const [showSignIn, setShowSignIn] = useState(false);
+	const { showSignIn, onSwitchToSignIn, onSwitchToSignUp } = useLoginPage();
 
 	return (
 		<PublicPageShell
@@ -42,9 +42,9 @@ function RouteComponent() {
 		>
 			<PreviewAutoLogin />
 			{showSignIn ? (
-				<SignInForm onSwitchToSignUp={() => setShowSignIn(false)} />
+				<SignInForm onSwitchToSignUp={onSwitchToSignUp} />
 			) : (
-				<SignUpForm onSwitchToSignIn={() => setShowSignIn(true)} />
+				<SignUpForm onSwitchToSignIn={onSwitchToSignIn} />
 			)}
 		</PublicPageShell>
 	);

--- a/apps/web/src/routes/players/index.tsx
+++ b/apps/web/src/routes/players/index.tsx
@@ -1,13 +1,10 @@
 import { IconPlus, IconTags, IconUsers } from "@tabler/icons-react";
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
 import { PlayerCard } from "@/players/components/player-card";
 import { PlayerFilters } from "@/players/components/player-filters";
-import type { PlayerFormValues } from "@/players/components/player-form";
 import { PlayerForm } from "@/players/components/player-form";
 import { PlayerTagManager } from "@/players/components/player-tag-manager";
-import type { PlayerItem } from "@/players/hooks/use-players";
-import { usePlayers } from "@/players/hooks/use-players";
+import { usePlayersPage } from "@/players/hooks/use-players-page";
 import { PageHeader } from "@/shared/components/page-header";
 import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
@@ -18,40 +15,25 @@ export const Route = createFileRoute("/players/")({
 });
 
 function PlayersPage() {
-	const [isCreateOpen, setIsCreateOpen] = useState(false);
-	const [editingPlayer, setEditingPlayer] = useState<PlayerItem | null>(null);
-	const [isTagManagerOpen, setIsTagManagerOpen] = useState(false);
-	const [filterTagIds, setFilterTagIds] = useState<string[]>([]);
-
 	const {
 		players,
 		availableTags,
 		isCreatePending,
 		isUpdatePending,
-		create,
-		update,
-		delete: deletePlayer,
+		isCreateOpen,
+		editingPlayer,
+		isTagManagerOpen,
+		filterTagIds,
+		setIsCreateOpen,
+		setIsTagManagerOpen,
+		setFilterTagIds,
+		handleCreate,
+		handleUpdate,
+		handleDelete,
+		handleOpenEdit,
+		handleCloseEdit,
 		createTag,
-	} = usePlayers(filterTagIds);
-
-	const handleCreate = (values: PlayerFormValues) => {
-		create(values).then(() => {
-			setIsCreateOpen(false);
-		});
-	};
-
-	const handleUpdate = (values: PlayerFormValues) => {
-		if (!editingPlayer) {
-			return;
-		}
-		update({ id: editingPlayer.id, ...values }).then(() => {
-			setEditingPlayer(null);
-		});
-	};
-
-	const handleDelete = (id: string) => {
-		deletePlayer(id);
-	};
+	} = usePlayersPage();
 
 	return (
 		<div className="p-4 md:p-6">
@@ -113,9 +95,7 @@ function PlayersPage() {
 						<PlayerCard
 							key={player.id}
 							onDelete={handleDelete}
-							onEdit={(player) =>
-								setEditingPlayer({ ...player, isTemporary: false })
-							}
+							onEdit={handleOpenEdit}
 							player={player}
 						/>
 					))}
@@ -138,7 +118,7 @@ function PlayersPage() {
 			<ResponsiveDialog
 				onOpenChange={(open) => {
 					if (!open) {
-						setEditingPlayer(null);
+						handleCloseEdit();
 					}
 				}}
 				open={editingPlayer !== null}

--- a/apps/web/src/routes/sessions/index.tsx
+++ b/apps/web/src/routes/sessions/index.tsx
@@ -1,83 +1,52 @@
 import { IconCards, IconPlus, IconTags } from "@tabler/icons-react";
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
 import { SessionCard } from "@/sessions/components/session-card";
-import {
-	SessionFilters,
-	type SessionFilterValues,
-} from "@/sessions/components/session-filters";
+import { SessionFilters } from "@/sessions/components/session-filters";
 import { SessionForm } from "@/sessions/components/session-form";
 import { SessionTagManager } from "@/sessions/components/session-tag-manager";
-import {
-	buildEditDefaults,
-	type SessionFormValues,
-	type SessionItem,
-	useSessions,
-} from "@/sessions/hooks/use-sessions";
+import { buildEditDefaults } from "@/sessions/hooks/use-sessions";
+import { useSessionsPage } from "@/sessions/hooks/use-sessions-page";
 import { PageHeader } from "@/shared/components/page-header";
 import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { Label } from "@/shared/components/ui/label";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 import { Switch } from "@/shared/components/ui/switch";
-import { useEntityLists, useStoreGames } from "@/stores/hooks/use-store-games";
 
 export const Route = createFileRoute("/sessions/")({
 	component: SessionsPage,
 });
 
 function SessionsPage() {
-	const [isCreateOpen, setIsCreateOpen] = useState(false);
-	const [isTagManagerOpen, setIsTagManagerOpen] = useState(false);
-	const [editingSession, setEditingSession] = useState<SessionItem | null>(
-		null
-	);
-	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>();
-	const [editStoreId, setEditStoreId] = useState<string | undefined>();
-	const [filters, setFilters] = useState<SessionFilterValues>({});
-	const [bbBiMode, setBbBiMode] = useState(false);
-
 	const {
 		sessions,
 		availableTags,
 		isCreatePending,
 		isUpdatePending,
-		create,
-		update,
-		delete: deleteSession,
-		reopen,
+		isCreateOpen,
+		isTagManagerOpen,
+		editingSession,
+		filters,
+		bbBiMode,
+		stores,
+		currencies,
+		createGames,
+		editGames,
+		isEditLiveLinked,
+		setIsTagManagerOpen,
+		setFilters,
+		setBbBiMode,
+		setSelectedStoreId,
+		setEditStoreId,
+		handleCreate,
+		handleUpdate,
+		handleDelete,
+		handleReopen,
+		handleOpenEdit,
+		handleCloseEdit,
+		handleCreateDialogOpenChange,
 		createTag,
-	} = useSessions(filters);
-
-	const { stores, currencies } = useEntityLists();
-	const createGames = useStoreGames(selectedStoreId);
-	const editGames = useStoreGames(editStoreId);
-
-	const handleCreate = (values: SessionFormValues) => {
-		create(values).then(() => {
-			setIsCreateOpen(false);
-		});
-	};
-
-	const handleUpdate = (values: SessionFormValues) => {
-		if (!editingSession) {
-			return;
-		}
-		const isLiveLinked =
-			editingSession.liveCashGameSessionId !== null ||
-			editingSession.liveTournamentSessionId !== null;
-		update({ id: editingSession.id, isLiveLinked, ...values }).then(() => {
-			setEditingSession(null);
-		});
-	};
-
-	const handleDelete = (id: string) => {
-		deleteSession(id);
-	};
-
-	const handleReopen = (liveCashGameSessionId: string) => {
-		reopen(liveCashGameSessionId);
-	};
+	} = useSessionsPage();
 
 	return (
 		<div className="p-4 md:p-6">
@@ -108,7 +77,7 @@ function SessionsPage() {
 								onCheckedChange={setBbBiMode}
 							/>
 						</div>
-						<Button onClick={() => setIsCreateOpen(true)}>
+						<Button onClick={() => handleCreateDialogOpenChange(true)}>
 							<IconPlus size={16} />
 							New Session
 						</Button>
@@ -120,7 +89,10 @@ function SessionsPage() {
 			{sessions.length === 0 ? (
 				<EmptyState
 					action={
-						<Button onClick={() => setIsCreateOpen(true)} variant="outline">
+						<Button
+							onClick={() => handleCreateDialogOpenChange(true)}
+							variant="outline"
+						>
 							<IconPlus size={16} />
 							New Session
 						</Button>
@@ -136,10 +108,7 @@ function SessionsPage() {
 							bbBiMode={bbBiMode}
 							key={s.id}
 							onDelete={handleDelete}
-							onEdit={(session) => {
-								setEditingSession(session);
-								setEditStoreId(session.storeId ?? undefined);
-							}}
+							onEdit={handleOpenEdit}
 							onReopen={handleReopen}
 							session={s}
 						/>
@@ -148,12 +117,7 @@ function SessionsPage() {
 			)}
 
 			<ResponsiveDialog
-				onOpenChange={(open) => {
-					setIsCreateOpen(open);
-					if (!open) {
-						setSelectedStoreId(undefined);
-					}
-				}}
+				onOpenChange={handleCreateDialogOpenChange}
 				open={isCreateOpen}
 				title="New Session"
 			>
@@ -173,8 +137,7 @@ function SessionsPage() {
 			<ResponsiveDialog
 				onOpenChange={(open) => {
 					if (!open) {
-						setEditingSession(null);
-						setEditStoreId(undefined);
+						handleCloseEdit();
 					}
 				}}
 				open={editingSession !== null}
@@ -184,10 +147,7 @@ function SessionsPage() {
 					<SessionForm
 						currencies={currencies}
 						defaultValues={buildEditDefaults(editingSession)}
-						isLiveLinked={
-							editingSession.liveCashGameSessionId !== null ||
-							editingSession.liveTournamentSessionId !== null
-						}
+						isLiveLinked={isEditLiveLinked}
 						isLoading={isUpdatePending}
 						onCreateTag={createTag}
 						onStoreChange={setEditStoreId}

--- a/apps/web/src/routes/stores/$storeId.tsx
+++ b/apps/web/src/routes/stores/$storeId.tsx
@@ -1,7 +1,5 @@
 import { IconArrowLeft } from "@tabler/icons-react";
-import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useState } from "react";
 import { PageHeader } from "@/shared/components/page-header";
 import { Button } from "@/shared/components/ui/button";
 import {
@@ -12,7 +10,7 @@ import {
 } from "@/shared/components/ui/tabs";
 import { RingGameTab } from "@/stores/components/ring-game-tab";
 import { TournamentTab } from "@/stores/components/tournament-tab";
-import { trpc } from "@/utils/trpc";
+import { useStoreDetailPage } from "@/stores/hooks/use-store-detail-page";
 
 export const Route = createFileRoute("/stores/$storeId")({
 	component: StoreDetailPage,
@@ -20,16 +18,10 @@ export const Route = createFileRoute("/stores/$storeId")({
 
 function StoreDetailPage() {
 	const { storeId } = Route.useParams();
-	const storeQuery = useQuery(trpc.store.getById.queryOptions({ id: storeId }));
-	const [expandedGameId, setExpandedGameId] = useState<string | null>(null);
+	const { store, isLoading, expandedGameId, handleToggleGame } =
+		useStoreDetailPage(storeId);
 
-	const handleToggleGame = (id: string | null) => {
-		setExpandedGameId(id);
-	};
-
-	const store = storeQuery.data;
-
-	if (storeQuery.isLoading) {
+	if (isLoading) {
 		return (
 			<div className="p-4 md:p-6">
 				<div className="flex items-center justify-center py-16">

--- a/apps/web/src/routes/stores/index.tsx
+++ b/apps/web/src/routes/stores/index.tsx
@@ -1,50 +1,31 @@
 import { IconBuildingStore, IconPlus } from "@tabler/icons-react";
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
 import { PageHeader } from "@/shared/components/page-header";
 import { Button } from "@/shared/components/ui/button";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 import { StoreCard } from "@/stores/components/store-card";
 import { StoreForm } from "@/stores/components/store-form";
-import type { StoreItem, StoreValues } from "@/stores/hooks/use-stores";
-import { useStores } from "@/stores/hooks/use-stores";
+import { useStoresPage } from "@/stores/hooks/use-stores-page";
 
 export const Route = createFileRoute("/stores/")({
 	component: StoresPage,
 });
 
 function StoresPage() {
-	const [isCreateOpen, setIsCreateOpen] = useState(false);
-	const [editingStore, setEditingStore] = useState<StoreItem | null>(null);
-
 	const {
 		stores,
 		isCreatePending,
 		isUpdatePending,
-		create,
-		update,
-		delete: deleteStore,
-	} = useStores();
-
-	const handleCreate = (values: StoreValues) => {
-		create(values).then(() => {
-			setIsCreateOpen(false);
-		});
-	};
-
-	const handleUpdate = (values: StoreValues) => {
-		if (!editingStore) {
-			return;
-		}
-		update({ id: editingStore.id, ...values }).then(() => {
-			setEditingStore(null);
-		});
-	};
-
-	const handleDelete = (id: string) => {
-		deleteStore(id);
-	};
+		isCreateOpen,
+		editingStore,
+		setIsCreateOpen,
+		setEditingStore,
+		handleCreate,
+		handleUpdate,
+		handleDelete,
+		handleCloseEdit,
+	} = useStoresPage();
 
 	return (
 		<div className="p-4 md:p-6">
@@ -94,7 +75,7 @@ function StoresPage() {
 			<ResponsiveDialog
 				onOpenChange={(open) => {
 					if (!open) {
-						setEditingStore(null);
+						handleCloseEdit();
 					}
 				}}
 				open={editingStore !== null}

--- a/apps/web/src/sessions/components/session-card.tsx
+++ b/apps/web/src/sessions/components/session-card.tsx
@@ -10,8 +10,7 @@ import {
 	IconTrophy,
 } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
-import { useState } from "react";
-import { shareSession } from "@/sessions/utils/share-session";
+import { useSessionCard } from "@/sessions/hooks/use-session-card";
 import { EntityListItem } from "@/shared/components/management/entity-list-item";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
@@ -430,26 +429,17 @@ export function SessionCard({
 	onDelete,
 	onReopen,
 }: SessionCardProps) {
-	const [isSharing, setIsSharing] = useState(false);
+	const { isSharing, onShare } = useSessionCard(session);
 	const isTournament = session.type === "tournament";
 	const liveSessionId =
 		session.liveCashGameSessionId ?? session.liveTournamentSessionId;
-
-	const handleShare = async () => {
-		setIsSharing(true);
-		try {
-			await shareSession(session);
-		} finally {
-			setIsSharing(false);
-		}
-	};
 
 	return (
 		<EntityListItem
 			actions={
 				<Button
 					disabled={isSharing}
-					onClick={handleShare}
+					onClick={onShare}
 					size="xs"
 					type="button"
 					variant="ghost"

--- a/apps/web/src/sessions/components/session-filters.tsx
+++ b/apps/web/src/sessions/components/session-filters.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useSessionFilters } from "@/sessions/hooks/use-session-filters";
 import { FilterDialogShell } from "@/shared/components/filter-dialog-shell";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
@@ -25,73 +25,38 @@ interface SessionFiltersProps {
 	stores: Array<{ id: string; name: string }>;
 }
 
-function countActiveFilters(filters: SessionFilterValues): number {
-	let count = 0;
-	if (filters.type) {
-		count++;
-	}
-	if (filters.storeId) {
-		count++;
-	}
-	if (filters.currencyId) {
-		count++;
-	}
-	if (filters.dateFrom) {
-		count++;
-	}
-	if (filters.dateTo) {
-		count++;
-	}
-	return count;
-}
-
 export function SessionFilters({
 	currencies,
 	filters,
 	onFiltersChange,
 	stores,
 }: SessionFiltersProps) {
-	const [isOpen, setIsOpen] = useState(false);
-	const [draft, setDraft] = useState<SessionFilterValues>(filters);
-	const activeCount = countActiveFilters(filters);
-
-	const handleOpen = () => {
-		setDraft(filters);
-		setIsOpen(true);
-	};
-
-	const handleApply = () => {
-		onFiltersChange(draft);
-		setIsOpen(false);
-	};
-
-	const handleReset = () => {
-		const empty: SessionFilterValues = {};
-		setDraft(empty);
-		onFiltersChange(empty);
-		setIsOpen(false);
-	};
+	const {
+		activeCount,
+		draft,
+		isOpen,
+		onApply,
+		onOpen,
+		onOpenChange,
+		onReset,
+		updateDraft,
+	} = useSessionFilters({ filters, onFiltersChange });
 
 	return (
 		<FilterDialogShell
 			activeCount={activeCount}
 			description="Refine the session list by type, venue, currency, or date."
-			onApply={handleApply}
-			onOpen={handleOpen}
-			onOpenChange={(open) => {
-				if (!open) {
-					setIsOpen(false);
-				}
-			}}
-			onReset={handleReset}
+			onApply={onApply}
+			onOpen={onOpen}
+			onOpenChange={onOpenChange}
+			onReset={onReset}
 			open={isOpen}
 			title="Filters"
 		>
 			<Field label="Type">
 				<Select
 					onValueChange={(value) =>
-						setDraft({
-							...draft,
+						updateDraft({
 							type:
 								value === "all"
 									? undefined
@@ -114,10 +79,7 @@ export function SessionFilters({
 			<Field label="Store">
 				<Select
 					onValueChange={(value) =>
-						setDraft({
-							...draft,
-							storeId: value === "all" ? undefined : value,
-						})
+						updateDraft({ storeId: value === "all" ? undefined : value })
 					}
 					value={draft.storeId ?? "all"}
 				>
@@ -138,10 +100,7 @@ export function SessionFilters({
 			<Field label="Currency">
 				<Select
 					onValueChange={(value) =>
-						setDraft({
-							...draft,
-							currencyId: value === "all" ? undefined : value,
-						})
+						updateDraft({ currencyId: value === "all" ? undefined : value })
 					}
 					value={draft.currencyId ?? "all"}
 				>
@@ -165,10 +124,7 @@ export function SessionFilters({
 						aria-label="Date From"
 						className="flex-1"
 						onChange={(event) =>
-							setDraft({
-								...draft,
-								dateFrom: event.target.value || undefined,
-							})
+							updateDraft({ dateFrom: event.target.value || undefined })
 						}
 						placeholder="From"
 						type="date"
@@ -179,10 +135,7 @@ export function SessionFilters({
 						aria-label="Date To"
 						className="flex-1"
 						onChange={(event) =>
-							setDraft({
-								...draft,
-								dateTo: event.target.value || undefined,
-							})
+							updateDraft({ dateTo: event.target.value || undefined })
 						}
 						placeholder="To"
 						type="date"

--- a/apps/web/src/sessions/hooks/use-session-card.ts
+++ b/apps/web/src/sessions/hooks/use-session-card.ts
@@ -1,0 +1,21 @@
+import { useState } from "react";
+import type { ShareableSession } from "@/sessions/utils/share-session";
+import { shareSession } from "@/sessions/utils/share-session";
+
+export function useSessionCard(session: ShareableSession) {
+	const [isSharing, setIsSharing] = useState(false);
+
+	const handleShare = async () => {
+		setIsSharing(true);
+		try {
+			await shareSession(session);
+		} finally {
+			setIsSharing(false);
+		}
+	};
+
+	return {
+		isSharing,
+		onShare: handleShare,
+	};
+}

--- a/apps/web/src/sessions/hooks/use-session-filters.ts
+++ b/apps/web/src/sessions/hooks/use-session-filters.ts
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import type { SessionFilterValues } from "@/sessions/components/session-filters";
+import { countActiveFilters } from "@/sessions/utils/session-filters-helpers";
+
+interface UseSessionFiltersProps {
+	filters: SessionFilterValues;
+	onFiltersChange: (filters: SessionFilterValues) => void;
+}
+
+export function useSessionFilters({
+	filters,
+	onFiltersChange,
+}: UseSessionFiltersProps) {
+	const [isOpen, setIsOpen] = useState(false);
+	const [draft, setDraft] = useState<SessionFilterValues>(filters);
+	const activeCount = countActiveFilters(filters);
+
+	const handleOpen = () => {
+		setDraft(filters);
+		setIsOpen(true);
+	};
+
+	const handleApply = () => {
+		onFiltersChange(draft);
+		setIsOpen(false);
+	};
+
+	const handleReset = () => {
+		const empty: SessionFilterValues = {};
+		setDraft(empty);
+		onFiltersChange(empty);
+		setIsOpen(false);
+	};
+
+	const handleOpenChange = (open: boolean) => {
+		if (!open) {
+			setIsOpen(false);
+		}
+	};
+
+	const updateDraft = (patch: Partial<SessionFilterValues>) => {
+		setDraft((prev) => ({ ...prev, ...patch }));
+	};
+
+	return {
+		activeCount,
+		draft,
+		isOpen,
+		onApply: handleApply,
+		onOpen: handleOpen,
+		onOpenChange: handleOpenChange,
+		onReset: handleReset,
+		updateDraft,
+	};
+}

--- a/apps/web/src/sessions/hooks/use-sessions-page.ts
+++ b/apps/web/src/sessions/hooks/use-sessions-page.ts
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import type { SessionFilterValues } from "@/sessions/components/session-filters";
+import type {
+	SessionFormValues,
+	SessionItem,
+} from "@/sessions/hooks/use-sessions";
+import { useSessions } from "@/sessions/hooks/use-sessions";
+import { useEntityLists, useStoreGames } from "@/stores/hooks/use-store-games";
+
+export function useSessionsPage() {
+	const [isCreateOpen, setIsCreateOpen] = useState(false);
+	const [isTagManagerOpen, setIsTagManagerOpen] = useState(false);
+	const [editingSession, setEditingSession] = useState<SessionItem | null>(
+		null
+	);
+	const [selectedStoreId, setSelectedStoreId] = useState<string | undefined>();
+	const [editStoreId, setEditStoreId] = useState<string | undefined>();
+	const [filters, setFilters] = useState<SessionFilterValues>({});
+	const [bbBiMode, setBbBiMode] = useState(false);
+
+	const {
+		sessions,
+		availableTags,
+		isCreatePending,
+		isUpdatePending,
+		create,
+		update,
+		delete: deleteSession,
+		reopen,
+		createTag,
+	} = useSessions(filters);
+
+	const { stores, currencies } = useEntityLists();
+	const createGames = useStoreGames(selectedStoreId);
+	const editGames = useStoreGames(editStoreId);
+
+	const handleCreate = (values: SessionFormValues) => {
+		create(values).then(() => {
+			setIsCreateOpen(false);
+		});
+	};
+
+	const handleUpdate = (values: SessionFormValues) => {
+		if (!editingSession) {
+			return;
+		}
+		const isLiveLinked =
+			editingSession.liveCashGameSessionId !== null ||
+			editingSession.liveTournamentSessionId !== null;
+		update({ id: editingSession.id, isLiveLinked, ...values }).then(() => {
+			setEditingSession(null);
+		});
+	};
+
+	const handleDelete = (id: string) => {
+		deleteSession(id);
+	};
+
+	const handleReopen = (liveCashGameSessionId: string) => {
+		reopen(liveCashGameSessionId);
+	};
+
+	const handleOpenEdit = (session: SessionItem) => {
+		setEditingSession(session);
+		setEditStoreId(session.storeId ?? undefined);
+	};
+
+	const handleCloseEdit = () => {
+		setEditingSession(null);
+		setEditStoreId(undefined);
+	};
+
+	const handleCreateDialogOpenChange = (open: boolean) => {
+		setIsCreateOpen(open);
+		if (!open) {
+			setSelectedStoreId(undefined);
+		}
+	};
+
+	const isEditLiveLinked =
+		editingSession !== null &&
+		(editingSession.liveCashGameSessionId !== null ||
+			editingSession.liveTournamentSessionId !== null);
+
+	return {
+		sessions,
+		availableTags,
+		isCreatePending,
+		isUpdatePending,
+		isCreateOpen,
+		isTagManagerOpen,
+		editingSession,
+		filters,
+		bbBiMode,
+		stores,
+		currencies,
+		createGames,
+		editGames,
+		isEditLiveLinked,
+		setIsTagManagerOpen,
+		setFilters,
+		setBbBiMode,
+		setSelectedStoreId,
+		setEditStoreId,
+		handleCreate,
+		handleUpdate,
+		handleDelete,
+		handleReopen,
+		handleOpenEdit,
+		handleCloseEdit,
+		handleCreateDialogOpenChange,
+		createTag,
+	};
+}

--- a/apps/web/src/sessions/utils/session-filters-helpers.ts
+++ b/apps/web/src/sessions/utils/session-filters-helpers.ts
@@ -1,0 +1,21 @@
+import type { SessionFilterValues } from "@/sessions/components/session-filters";
+
+export function countActiveFilters(filters: SessionFilterValues): number {
+	let count = 0;
+	if (filters.type) {
+		count++;
+	}
+	if (filters.storeId) {
+		count++;
+	}
+	if (filters.currencyId) {
+		count++;
+	}
+	if (filters.dateFrom) {
+		count++;
+	}
+	if (filters.dateTo) {
+		count++;
+	}
+	return count;
+}

--- a/apps/web/src/shared/components/linked-accounts.tsx
+++ b/apps/web/src/shared/components/linked-accounts.tsx
@@ -1,13 +1,10 @@
 import { IconLink, IconUnlink } from "@tabler/icons-react";
-import { useForm } from "@tanstack/react-form";
-import { useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
-import z from "zod";
-import { authClient } from "@/lib/auth-client";
 import {
 	ManagementList,
 	ManagementListItem,
 } from "@/shared/components/management/management-list";
+import { useLinkedAccounts } from "@/shared/hooks/use-linked-accounts";
+import { useSetPasswordForm } from "@/shared/hooks/use-set-password-form";
 import { DiscordIcon } from "./icons/discord";
 import { GoogleIcon } from "./icons/google";
 import { Badge } from "./ui/badge";
@@ -16,12 +13,6 @@ import { DialogActionRow } from "./ui/dialog-action-row";
 import { Field } from "./ui/field";
 import { Input } from "./ui/input";
 import { ResponsiveDialog } from "./ui/responsive-dialog";
-
-interface LinkedAccount {
-	accountId: string;
-	id: string;
-	providerId: string;
-}
 
 const PROVIDERS = [
 	{ id: "google", label: "Google", icon: <GoogleIcon className="h-4 w-4" /> },
@@ -41,44 +32,7 @@ function SetPasswordDialog({
 	onSuccess: () => void;
 	open: boolean;
 }) {
-	const form = useForm({
-		defaultValues: {
-			confirmPassword: "",
-			newPassword: "",
-		},
-		onSubmit: async ({ value }) => {
-			const { error } = await authClient.$fetch("/set-password", {
-				method: "POST",
-				body: { newPassword: value.newPassword },
-			});
-
-			if (error) {
-				toast.error(
-					(error as { message?: string }).message || "Failed to set password"
-				);
-				return;
-			}
-
-			toast.success("Password set successfully");
-			onSuccess();
-			onOpenChange(false);
-		},
-		validators: {
-			onSubmit: z
-				.object({
-					confirmPassword: z
-						.string()
-						.min(8, "Password must be at least 8 characters"),
-					newPassword: z
-						.string()
-						.min(8, "Password must be at least 8 characters"),
-				})
-				.refine((data) => data.newPassword === data.confirmPassword, {
-					message: "Passwords do not match",
-					path: ["confirmPassword"],
-				}),
-		},
-	});
+	const { form } = useSetPasswordForm({ onOpenChange, onSuccess });
 
 	return (
 		<ResponsiveDialog
@@ -160,51 +114,23 @@ function SetPasswordDialog({
 }
 
 export function LinkedAccounts() {
-	const [accounts, setAccounts] = useState<LinkedAccount[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [setPasswordOpen, setSetPasswordOpen] = useState(false);
-
-	const fetchAccounts = useCallback(async () => {
-		const result = await authClient.listAccounts();
-		setAccounts((result.data as LinkedAccount[]) ?? []);
-		setLoading(false);
-	}, []);
-
-	useEffect(() => {
-		fetchAccounts();
-	}, [fetchAccounts]);
-
-	const handleLink = async (provider: string) => {
-		await authClient.linkSocial({
-			provider: provider as "google" | "discord",
-			callbackURL: `${window.location.origin}/settings`,
-		});
-	};
-
-	const handleUnlink = async (providerId: string) => {
-		const result = await authClient.unlinkAccount({ providerId });
-		if (result.error) {
-			toast.error(result.error.message || "Failed to unlink account");
-			return;
-		}
-
-		toast.success("Account unlinked");
-		fetchAccounts();
-	};
+	const {
+		fetchAccounts,
+		handleLink,
+		handleUnlink,
+		hasCredential,
+		isSetPasswordOpen,
+		linkedProviderIds,
+		loading,
+		onSetPasswordOpenChange,
+		totalLinked,
+	} = useLinkedAccounts();
 
 	if (loading) {
 		return (
 			<div className="text-muted-foreground text-sm">Loading accounts...</div>
 		);
 	}
-
-	const linkedProviderIds = new Set(
-		accounts.map((account) => account.providerId)
-	);
-	const hasCredential = accounts.some(
-		(account) => account.providerId === "credential"
-	);
-	const totalLinked = accounts.length;
 
 	return (
 		<div className="space-y-3">
@@ -213,7 +139,7 @@ export function LinkedAccounts() {
 					actions={
 						hasCredential ? undefined : (
 							<Button
-								onClick={() => setSetPasswordOpen(true)}
+								onClick={() => onSetPasswordOpenChange(true)}
 								size="sm"
 								variant="outline"
 							>
@@ -293,9 +219,9 @@ export function LinkedAccounts() {
 			) : null}
 
 			<SetPasswordDialog
-				onOpenChange={setSetPasswordOpen}
+				onOpenChange={onSetPasswordOpenChange}
 				onSuccess={fetchAccounts}
-				open={setPasswordOpen}
+				open={isSetPasswordOpen}
 			/>
 		</div>
 	);

--- a/apps/web/src/shared/components/management/entity-list-item.tsx
+++ b/apps/web/src/shared/components/management/entity-list-item.tsx
@@ -1,11 +1,11 @@
 import { IconEdit, IconTrash, IconX } from "@tabler/icons-react";
-import { useState } from "react";
 import { cn } from "@/lib/utils";
 import {
 	ExpandableItem,
 	ExpandableItemList,
 } from "@/shared/components/management/expandable-item-list";
 import { Button } from "@/shared/components/ui/button";
+import { useEntityListItem } from "@/shared/hooks/use-entity-list-item";
 
 interface EntityListItemProps {
 	actions?: React.ReactNode;
@@ -34,12 +34,17 @@ export function EntityListItem({
 	summary,
 	summaryClassName,
 }: EntityListItemProps) {
-	const [confirmingDelete, setConfirmingDelete] = useState(false);
-	const [internalExpandedValue, setInternalExpandedValue] = useState<
-		string | null
-	>(null);
-
 	const isControlled = controlledExpandedValue !== undefined;
+
+	const {
+		confirmingDelete,
+		handleCancelDelete,
+		handleConfirmDelete,
+		handleExpandedValueChange,
+		handleStartDelete,
+		internalExpandedValue,
+	} = useEntityListItem({ isControlled, onExpandedValueChange });
+
 	const expandedValue = isControlled
 		? controlledExpandedValue
 		: internalExpandedValue;
@@ -47,13 +52,7 @@ export function EntityListItem({
 	return (
 		<ExpandableItemList
 			className={cn("rounded-lg border bg-card", className)}
-			onValueChange={(nextValue) => {
-				if (!isControlled) {
-					setInternalExpandedValue(nextValue);
-				}
-				setConfirmingDelete(false);
-				onExpandedValueChange?.(nextValue);
-			}}
+			onValueChange={handleExpandedValueChange}
 			value={expandedValue}
 		>
 			<ExpandableItem
@@ -80,15 +79,7 @@ export function EntityListItem({
 								<Button
 									aria-label="Confirm delete"
 									className="text-destructive hover:text-destructive"
-									onClick={(event) => {
-										event.stopPropagation();
-										onDelete();
-										setConfirmingDelete(false);
-										if (!isControlled) {
-											setInternalExpandedValue(null);
-										}
-										onExpandedValueChange?.(null);
-									}}
+									onClick={(event) => handleConfirmDelete(event, onDelete)}
 									size="xs"
 									type="button"
 									variant="ghost"
@@ -98,10 +89,7 @@ export function EntityListItem({
 								</Button>
 								<Button
 									aria-label="Cancel delete"
-									onClick={(event) => {
-										event.stopPropagation();
-										setConfirmingDelete(false);
-									}}
+									onClick={handleCancelDelete}
 									size="xs"
 									type="button"
 									variant="ghost"
@@ -126,10 +114,7 @@ export function EntityListItem({
 								</Button>
 								<Button
 									className="text-destructive hover:text-destructive"
-									onClick={(event) => {
-										event.stopPropagation();
-										setConfirmingDelete(true);
-									}}
+									onClick={handleStartDelete}
 									size="xs"
 									type="button"
 									variant="ghost"

--- a/apps/web/src/shared/components/management/tag-manager.tsx
+++ b/apps/web/src/shared/components/management/tag-manager.tsx
@@ -1,6 +1,5 @@
 import { IconEdit, IconPlus, IconTrash } from "@tabler/icons-react";
 import type * as React from "react";
-import { useState } from "react";
 import {
 	ManagementList,
 	ManagementListItem,
@@ -10,6 +9,7 @@ import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
+import { useTagManager } from "@/shared/hooks/use-tag-manager";
 
 interface TagManagerProps<TTag extends { id: string; name: string }> {
 	deleteError?: React.ReactNode;
@@ -38,9 +38,17 @@ export function TagManager<TTag extends { id: string; name: string }>({
 	renderCreateForm,
 	renderEditForm,
 }: TagManagerProps<TTag>) {
-	const [isCreateOpen, setIsCreateOpen] = useState(false);
-	const [editingTag, setEditingTag] = useState<TTag | null>(null);
-	const [deletingTag, setDeletingTag] = useState<TTag | null>(null);
+	const {
+		deletingTag,
+		editingTag,
+		isCreateOpen,
+		onCloseCreate,
+		onCloseDelete,
+		onCloseEdit,
+		onOpenCreate,
+		onStartDelete,
+		onStartEdit,
+	} = useTagManager<TTag>();
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -48,7 +56,7 @@ export function TagManager<TTag extends { id: string; name: string }>({
 				<p className="font-medium text-sm">
 					{tags.length} {tags.length === 1 ? noun : `${noun}s`}
 				</p>
-				<Button onClick={() => setIsCreateOpen(true)} size="sm">
+				<Button onClick={onOpenCreate} size="sm">
 					<IconPlus size={16} />
 					New {noun.charAt(0).toUpperCase() + noun.slice(1)}
 				</Button>
@@ -68,7 +76,7 @@ export function TagManager<TTag extends { id: string; name: string }>({
 								<div className="flex gap-1">
 									<Button
 										aria-label={`Edit ${noun} ${tag.name}`}
-										onClick={() => setEditingTag(tag)}
+										onClick={() => onStartEdit(tag)}
 										size="sm"
 										variant="ghost"
 									>
@@ -76,7 +84,7 @@ export function TagManager<TTag extends { id: string; name: string }>({
 									</Button>
 									<Button
 										aria-label={`Delete ${noun} ${tag.name}`}
-										onClick={() => setDeletingTag(tag)}
+										onClick={() => onStartDelete(tag)}
 										size="sm"
 										variant="ghost"
 									>
@@ -92,29 +100,33 @@ export function TagManager<TTag extends { id: string; name: string }>({
 			)}
 
 			<ResponsiveDialog
-				onOpenChange={setIsCreateOpen}
+				onOpenChange={(open) => {
+					if (!open) {
+						onCloseCreate();
+					}
+				}}
 				open={isCreateOpen}
 				title={`New ${noun.charAt(0).toUpperCase() + noun.slice(1)}`}
 			>
-				{renderCreateForm(() => setIsCreateOpen(false))}
+				{renderCreateForm(onCloseCreate)}
 			</ResponsiveDialog>
 
 			<ResponsiveDialog
 				onOpenChange={(open) => {
 					if (!open) {
-						setEditingTag(null);
+						onCloseEdit();
 					}
 				}}
 				open={editingTag !== null}
 				title={`Edit ${noun.charAt(0).toUpperCase() + noun.slice(1)}`}
 			>
-				{editingTag && renderEditForm(editingTag, () => setEditingTag(null))}
+				{editingTag && renderEditForm(editingTag, onCloseEdit)}
 			</ResponsiveDialog>
 
 			<ResponsiveDialog
 				onOpenChange={(open) => {
 					if (!open) {
-						setDeletingTag(null);
+						onCloseDelete();
 					}
 				}}
 				open={deletingTag !== null}
@@ -129,14 +141,14 @@ export function TagManager<TTag extends { id: string; name: string }>({
 							</Alert>
 						) : null}
 						<DialogActionRow>
-							<Button onClick={() => setDeletingTag(null)} variant="outline">
+							<Button onClick={onCloseDelete} variant="outline">
 								Cancel
 							</Button>
 							<Button
 								disabled={isDeletePending}
 								onClick={() =>
 									onDelete(deletingTag.id)
-										.then(() => setDeletingTag(null))
+										.then(() => onCloseDelete())
 										.catch(() => {
 											// Error handled by caller via deleteError prop
 										})

--- a/apps/web/src/shared/components/management/tag-name-form.tsx
+++ b/apps/web/src/shared/components/management/tag-name-form.tsx
@@ -1,16 +1,8 @@
-import { useForm } from "@tanstack/react-form";
 import type * as React from "react";
-import { z } from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
-
-const tagNameFormSchema = z.object({
-	name: z
-		.string()
-		.min(1, "Tag name is required")
-		.max(50, "Tag name must be 50 characters or less"),
-});
+import { useTagNameForm } from "@/shared/hooks/use-tag-name-form";
 
 export function TagNameForm({
 	children,
@@ -23,17 +15,7 @@ export function TagNameForm({
 	isLoading?: boolean;
 	onSubmit: (name: string) => void;
 }) {
-	const form = useForm({
-		defaultValues: {
-			name: defaultName ?? "",
-		},
-		onSubmit: ({ value }) => {
-			onSubmit(value.name);
-		},
-		validators: {
-			onSubmit: tagNameFormSchema,
-		},
-	});
+	const { form } = useTagNameForm({ defaultName, onSubmit });
 
 	return (
 		<form

--- a/apps/web/src/shared/components/mobile-nav.tsx
+++ b/apps/web/src/shared/components/mobile-nav.tsx
@@ -1,17 +1,9 @@
-import { IconBolt, IconPlayerPlay, IconPlus } from "@tabler/icons-react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
-import { useState } from "react";
+import { Link } from "@tanstack/react-router";
 import { cn } from "@/lib/utils";
 import { CreateSessionDialog } from "@/live-sessions/components/create-session-dialog";
-import { useActiveSession } from "@/live-sessions/hooks/use-active-session";
-import { useStackSheet } from "@/live-sessions/hooks/use-stack-sheet";
-import { createSessionEventMutationOptions } from "@/live-sessions/utils/optimistic-session-event";
 import {
-	getMobileNavigationItems,
 	isActiveItem,
 	MobileNavItem,
-	type NavigationCenterAction,
 	NavigationCenterButton,
 	type NavigationItem,
 	RESOURCE_ITEMS,
@@ -21,7 +13,8 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/shared/components/ui/popover";
-import { trpcClient } from "@/utils/trpc";
+import { useMobileNav } from "@/shared/hooks/use-mobile-nav";
+import { useMobileNavPopover } from "@/shared/hooks/use-mobile-nav-popover";
 
 function MobileNavPopoverItem({
 	active,
@@ -32,11 +25,11 @@ function MobileNavPopoverItem({
 	item: NavigationItem;
 	children: readonly NavigationItem[];
 }) {
-	const [open, setOpen] = useState(false);
+	const { isOpen, onClose, onOpenChange } = useMobileNavPopover();
 
 	return (
 		<li className="flex-1">
-			<Popover onOpenChange={setOpen} open={open}>
+			<Popover onOpenChange={onOpenChange} open={isOpen}>
 				<PopoverTrigger asChild>
 					<button
 						className={cn(
@@ -57,7 +50,7 @@ function MobileNavPopoverItem({
 							<li key={child.to}>
 								<Link
 									className="flex items-center gap-3 rounded-md px-3 py-2.5 text-sm transition-colors hover:bg-accent"
-									onClick={() => setOpen(false)}
+									onClick={onClose}
 									to={child.to}
 								>
 									<child.icon size={18} stroke={1.5} />
@@ -73,74 +66,15 @@ function MobileNavPopoverItem({
 }
 
 export function MobileNav() {
-	const pathname = useRouterState({
-		select: (s) => s.location.pathname,
-	});
-	const navigate = useNavigate();
-	const { activeSession, hasActive } = useActiveSession();
-	const stackSheet = useStackSheet();
-	const queryClient = useQueryClient();
-	const [isCreateOpen, setIsCreateOpen] = useState(false);
-	const isPaused = activeSession?.status === "paused";
-	const { leftItems, rightItems } = getMobileNavigationItems(
-		hasActive && !isPaused
-	);
-
-	const optimisticOptions = activeSession
-		? createSessionEventMutationOptions({
-				queryClient,
-				sessionId: activeSession.id,
-				sessionType: activeSession.type,
-				eventType: "session_resume",
-				getPayload: () => ({}),
-				changesStatus: true,
-			})
-		: {};
-
-	const resumeMutation = useMutation({
-		mutationFn: async () => {
-			if (!activeSession) {
-				return;
-			}
-			const sessionIdKey =
-				activeSession.type === "cash_game"
-					? "liveCashGameSessionId"
-					: "liveTournamentSessionId";
-			await trpcClient.sessionEvent.create.mutate({
-				[sessionIdKey]: activeSession.id,
-				eventType: "session_resume",
-				payload: {},
-			});
-		},
-		...optimisticOptions,
-	});
-
-	let centerAction: NavigationCenterAction;
-	if (hasActive && activeSession?.status === "paused") {
-		centerAction = {
-			icon: IconPlayerPlay,
-			label: "Resume",
-			onClick: () => {
-				resumeMutation.mutate();
-				navigate({ to: "/active-session" });
-			},
-			tone: "live" as const,
-		};
-	} else if (hasActive) {
-		centerAction = {
-			icon: IconBolt,
-			label: "Stack",
-			onClick: () => stackSheet.open(),
-			tone: "live" as const,
-		};
-	} else {
-		centerAction = {
-			icon: IconPlus,
-			label: "New",
-			onClick: () => setIsCreateOpen(true),
-			tone: "accent" as const,
-		};
-	}
+	const {
+		centerAction,
+		hasActive,
+		isCreateOpen,
+		leftItems,
+		onCreateOpenChange,
+		pathname,
+		rightItems,
+	} = useMobileNav();
 
 	return (
 		<>
@@ -180,7 +114,7 @@ export function MobileNav() {
 
 			{!hasActive && (
 				<CreateSessionDialog
-					onOpenChange={setIsCreateOpen}
+					onOpenChange={onCreateOpenChange}
 					open={isCreateOpen}
 				/>
 			)}

--- a/apps/web/src/shared/components/online-status-bar.tsx
+++ b/apps/web/src/shared/components/online-status-bar.tsx
@@ -1,8 +1,5 @@
 import { IconRefresh, IconWifi, IconWifiOff } from "@tabler/icons-react";
-import { useIsMutating } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
-
-import { useOnlineStatus } from "@/shared/hooks/use-online-status";
+import { useOnlineStatusBar } from "@/shared/hooks/use-online-status-bar";
 
 type DisplayState = "hidden" | "offline" | "syncing" | "back-online";
 
@@ -19,45 +16,7 @@ function getBarClassName(displayState: DisplayState): string {
 }
 
 export function OnlineStatusBar() {
-	const isOnline = useOnlineStatus();
-	const isMutating = useIsMutating();
-	const [displayState, setDisplayState] = useState<DisplayState>("hidden");
-	const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const wasOfflineRef = useRef(false);
-
-	useEffect(() => {
-		if (!isOnline) {
-			wasOfflineRef.current = true;
-			if (fadeTimerRef.current) {
-				clearTimeout(fadeTimerRef.current);
-				fadeTimerRef.current = null;
-			}
-			setDisplayState("offline");
-			return;
-		}
-
-		if (!wasOfflineRef.current) {
-			setDisplayState("hidden");
-			return;
-		}
-
-		if (isMutating > 0) {
-			setDisplayState("syncing");
-			return;
-		}
-
-		setDisplayState("back-online");
-		fadeTimerRef.current = setTimeout(() => {
-			setDisplayState("hidden");
-			wasOfflineRef.current = false;
-		}, 2000);
-
-		return () => {
-			if (fadeTimerRef.current) {
-				clearTimeout(fadeTimerRef.current);
-			}
-		};
-	}, [isOnline, isMutating]);
+	const { displayState } = useOnlineStatusBar();
 
 	if (displayState === "hidden") {
 		return null;

--- a/apps/web/src/shared/components/preview-auto-login.tsx
+++ b/apps/web/src/shared/components/preview-auto-login.tsx
@@ -1,34 +1,6 @@
-import { env } from "@sapphire2/env/web";
-import { useNavigate } from "@tanstack/react-router";
-import { useEffect, useRef } from "react";
-import { authClient } from "@/lib/auth-client";
+import { usePreviewAutoLogin } from "@/shared/hooks/use-preview-auto-login";
 
 export function PreviewAutoLogin() {
-	const attempted = useRef(false);
-	const navigate = useNavigate();
-
-	useEffect(() => {
-		if (attempted.current) {
-			return;
-		}
-		if (env.VITE_PREVIEW_AUTO_LOGIN !== "true") {
-			return;
-		}
-
-		const email = env.VITE_PREVIEW_LOGIN_EMAIL;
-		const password = env.VITE_PREVIEW_LOGIN_PASSWORD;
-		if (!(email && password)) {
-			return;
-		}
-
-		attempted.current = true;
-
-		authClient.signIn.email({ email, password }).then((result) => {
-			if (result.data) {
-				navigate({ to: "/dashboard" });
-			}
-		});
-	}, [navigate]);
-
+	usePreviewAutoLogin();
 	return null;
 }

--- a/apps/web/src/shared/components/sign-in-form.tsx
+++ b/apps/web/src/shared/components/sign-in-form.tsx
@@ -12,10 +12,10 @@ export default function SignInForm({
 }: {
 	onSwitchToSignUp: () => void;
 }) {
-	const { form, isSessionPending, signInWithGoogle, signInWithDiscord } =
+	const { form, isPending, onSignInWithDiscord, onSignInWithGoogle } =
 		useSignIn();
 
-	if (isSessionPending) {
+	if (isPending) {
 		return <Loader />;
 	}
 
@@ -23,12 +23,12 @@ export default function SignInForm({
 		{
 			label: "Sign in with Google",
 			icon: <GoogleIcon className="mr-2 h-4 w-4" />,
-			onClick: signInWithGoogle,
+			onClick: onSignInWithGoogle,
 		},
 		{
 			label: "Sign in with Discord",
 			icon: <DiscordIcon className="mr-2 h-4 w-4" />,
-			onClick: signInWithDiscord,
+			onClick: onSignInWithDiscord,
 		},
 	];
 

--- a/apps/web/src/shared/components/sign-up-form.tsx
+++ b/apps/web/src/shared/components/sign-up-form.tsx
@@ -1,9 +1,4 @@
-import { useForm } from "@tanstack/react-form";
-import { useNavigate } from "@tanstack/react-router";
-import { toast } from "sonner";
-import z from "zod";
-
-import { authClient } from "@/lib/auth-client";
+import { useSignUp } from "@/shared/hooks/use-sign-up";
 import { AuthFormShell, authSubmitLabels } from "./auth-form-shell";
 import { DiscordIcon } from "./icons/discord";
 import { GoogleIcon } from "./icons/google";
@@ -17,45 +12,8 @@ export default function SignUpForm({
 }: {
 	onSwitchToSignIn: () => void;
 }) {
-	const navigate = useNavigate({
-		from: "/",
-	});
-	const { isPending } = authClient.useSession();
-
-	const form = useForm({
-		defaultValues: {
-			email: "",
-			password: "",
-			name: "",
-		},
-		onSubmit: async ({ value }) => {
-			await authClient.signUp.email(
-				{
-					email: value.email,
-					password: value.password,
-					name: value.name,
-				},
-				{
-					onSuccess: () => {
-						navigate({
-							to: "/dashboard",
-						});
-						toast.success("Sign up successful");
-					},
-					onError: (error) => {
-						toast.error(error.error.message || error.error.statusText);
-					},
-				}
-			);
-		},
-		validators: {
-			onSubmit: z.object({
-				name: z.string().min(2, "Name must be at least 2 characters"),
-				email: z.email("Invalid email address"),
-				password: z.string().min(8, "Password must be at least 8 characters"),
-			}),
-		},
-	});
+	const { form, isPending, onSignInWithDiscord, onSignInWithGoogle } =
+		useSignUp();
 
 	if (isPending) {
 		return <Loader />;
@@ -65,28 +23,12 @@ export default function SignUpForm({
 		{
 			label: "Sign up with Google",
 			icon: <GoogleIcon className="mr-2 h-4 w-4" />,
-			onClick: async () => {
-				const result = await authClient.signIn.social({
-					provider: "google",
-					callbackURL: `${window.location.origin}/dashboard`,
-				});
-				if (result.error) {
-					toast.error(result.error.message || "Google sign up unavailable");
-				}
-			},
+			onClick: onSignInWithGoogle,
 		},
 		{
 			label: "Sign up with Discord",
 			icon: <DiscordIcon className="mr-2 h-4 w-4" />,
-			onClick: async () => {
-				const result = await authClient.signIn.social({
-					provider: "discord",
-					callbackURL: `${window.location.origin}/dashboard`,
-				});
-				if (result.error) {
-					toast.error(result.error.message || "Discord sign up unavailable");
-				}
-			},
+			onClick: onSignInWithDiscord,
 		},
 	];
 

--- a/apps/web/src/shared/components/ui/hooks/use-rich-text-editor.ts
+++ b/apps/web/src/shared/components/ui/hooks/use-rich-text-editor.ts
@@ -1,0 +1,102 @@
+import Link from "@tiptap/extension-link";
+import type { Editor } from "@tiptap/react";
+import { useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { useCallback, useState } from "react";
+
+interface UseRichTextEditorOptions {
+	initialContent?: string | null;
+	onChange: (html: string) => void;
+}
+
+interface UseRichTextEditorResult {
+	applyLink: () => void;
+	cancelLinkInput: () => void;
+	editor: Editor | null;
+	linkUrl: string;
+	onLinkUrlChange: (url: string) => void;
+	openLinkInput: () => void;
+	removeLink: () => void;
+	showLinkInput: boolean;
+}
+
+export function useRichTextEditor({
+	initialContent,
+	onChange,
+}: UseRichTextEditorOptions): UseRichTextEditorResult {
+	const [showLinkInput, setShowLinkInput] = useState(false);
+	const [linkUrl, setLinkUrl] = useState("");
+
+	const editor = useEditor({
+		extensions: [
+			StarterKit.configure({
+				heading: { levels: [2, 3] },
+			}),
+			Link.configure({
+				openOnClick: false,
+				HTMLAttributes: { rel: "noopener noreferrer", target: "_blank" },
+			}),
+		],
+		content: initialContent ?? "",
+		shouldRerenderOnTransaction: true,
+		onUpdate: ({ editor: ed }) => {
+			const html = ed.getHTML();
+			const emptyContent = "<p></p>";
+			onChange(html === emptyContent ? "" : html);
+		},
+	});
+
+	const openLinkInput = useCallback(() => {
+		if (!editor) {
+			return;
+		}
+		const existingHref = editor.getAttributes("link").href as
+			| string
+			| undefined;
+		setLinkUrl(existingHref ?? "https://");
+		setShowLinkInput(true);
+	}, [editor]);
+
+	const applyLink = useCallback(() => {
+		if (!editor) {
+			return;
+		}
+		if (linkUrl.trim() === "") {
+			editor.chain().focus().extendMarkRange("link").unsetLink().run();
+		} else {
+			editor
+				.chain()
+				.focus()
+				.extendMarkRange("link")
+				.setLink({ href: linkUrl.trim() })
+				.run();
+		}
+		setShowLinkInput(false);
+		setLinkUrl("");
+	}, [editor, linkUrl]);
+
+	const removeLink = useCallback(() => {
+		if (!editor) {
+			return;
+		}
+		editor.chain().focus().extendMarkRange("link").unsetLink().run();
+		setShowLinkInput(false);
+		setLinkUrl("");
+	}, [editor]);
+
+	const cancelLinkInput = () => {
+		setShowLinkInput(false);
+		setLinkUrl("");
+	};
+
+	return {
+		applyLink,
+		cancelLinkInput,
+		editor,
+		linkUrl,
+		onLinkUrlChange: setLinkUrl,
+		openLinkInput,
+		removeLink,
+		showLinkInput,
+	};
+}

--- a/apps/web/src/shared/components/ui/hooks/use-tag-picker-base.ts
+++ b/apps/web/src/shared/components/ui/hooks/use-tag-picker-base.ts
@@ -1,0 +1,125 @@
+import { useEffect, useRef, useState } from "react";
+
+interface TagItemBase {
+	id: string;
+	name: string;
+}
+
+interface UseTagPickerBaseOptions<TTag extends TagItemBase> {
+	availableTags?: TTag[];
+	onAdd: (tag: TTag) => void;
+	onCreateTag?: (name: string) => Promise<TTag>;
+	onRemove: (tag: TTag) => void;
+	selectedTags: TTag[];
+}
+
+interface UseTagPickerBaseResult<TTag extends TagItemBase> {
+	anchorRef: React.RefObject<HTMLDivElement>;
+	canCreate: boolean;
+	closeAndReset: () => void;
+	contentWidth: number | undefined;
+	filteredTags: TTag[];
+	focusInput: () => void;
+	handleInputSubmit: () => Promise<void>;
+	handleTagSelect: (tag: TTag) => void;
+	inputRef: React.RefObject<HTMLInputElement>;
+	inputValue: string;
+	isOpen: boolean;
+	normalizedInput: string;
+	onInputChange: (value: string) => void;
+	onOpenChange: (open: boolean) => void;
+	shouldRenderPopover: boolean;
+}
+
+export function useTagPickerBase<TTag extends TagItemBase>({
+	availableTags,
+	onAdd,
+	onCreateTag,
+	onRemove: _onRemove,
+	selectedTags,
+}: UseTagPickerBaseOptions<TTag>): UseTagPickerBaseResult<TTag> {
+	const [inputValue, setInputValue] = useState("");
+	const [isOpen, setIsOpen] = useState(false);
+	const [contentWidth, setContentWidth] = useState<number>();
+	const anchorRef = useRef<HTMLDivElement>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const normalizedInput = inputValue.trim();
+	const allTags = availableTags ?? [];
+	const selectedTagIds = new Set(selectedTags.map((tag) => tag.id));
+	const filteredTags = allTags.filter((tag) => {
+		if (selectedTagIds.has(tag.id)) {
+			return false;
+		}
+		if (!normalizedInput) {
+			return true;
+		}
+		return tag.name.toLowerCase().includes(normalizedInput.toLowerCase());
+	});
+	const matchingTag = allTags.find(
+		(tag) => tag.name.toLowerCase() === normalizedInput.toLowerCase()
+	);
+	const canCreate = Boolean(onCreateTag && normalizedInput && !matchingTag);
+	const shouldRenderPopover =
+		isOpen && (allTags.length > 0 || Boolean(normalizedInput));
+
+	useEffect(() => {
+		if (!(shouldRenderPopover && anchorRef.current)) {
+			return;
+		}
+		setContentWidth(anchorRef.current.offsetWidth);
+	}, [shouldRenderPopover]);
+
+	const focusInput = () => {
+		inputRef.current?.focus();
+	};
+
+	const closeAndReset = () => {
+		setInputValue("");
+		setIsOpen(false);
+	};
+
+	const handleTagSelect = (tag: TTag) => {
+		onAdd(tag);
+		closeAndReset();
+		focusInput();
+	};
+
+	const handleInputSubmit = async () => {
+		if (!normalizedInput) {
+			return;
+		}
+
+		if (matchingTag) {
+			if (!selectedTagIds.has(matchingTag.id)) {
+				handleTagSelect(matchingTag);
+			}
+			return;
+		}
+
+		if (!onCreateTag) {
+			return;
+		}
+
+		const createdTag = await onCreateTag(normalizedInput);
+		handleTagSelect(createdTag);
+	};
+
+	return {
+		anchorRef,
+		canCreate,
+		closeAndReset,
+		contentWidth,
+		filteredTags,
+		focusInput,
+		handleInputSubmit,
+		handleTagSelect,
+		inputRef,
+		inputValue,
+		isOpen,
+		normalizedInput,
+		onInputChange: setInputValue,
+		onOpenChange: setIsOpen,
+		shouldRenderPopover,
+	};
+}

--- a/apps/web/src/shared/components/ui/rich-text-editor.tsx
+++ b/apps/web/src/shared/components/ui/rich-text-editor.tsx
@@ -10,11 +10,9 @@ import {
 	IconListNumbers,
 	IconX,
 } from "@tabler/icons-react";
-import Link from "@tiptap/extension-link";
-import { EditorContent, useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
-import { useCallback, useState } from "react";
+import { EditorContent } from "@tiptap/react";
 import { Button } from "@/shared/components/ui/button";
+import { useRichTextEditor } from "@/shared/components/ui/hooks/use-rich-text-editor";
 import { Input } from "@/shared/components/ui/input";
 
 interface RichTextEditorProps {
@@ -26,65 +24,16 @@ export function RichTextEditor({
 	initialContent,
 	onChange,
 }: RichTextEditorProps) {
-	const [showLinkInput, setShowLinkInput] = useState(false);
-	const [linkUrl, setLinkUrl] = useState("");
-
-	const editor = useEditor({
-		extensions: [
-			StarterKit.configure({
-				heading: { levels: [2, 3] },
-			}),
-			Link.configure({
-				openOnClick: false,
-				HTMLAttributes: { rel: "noopener noreferrer", target: "_blank" },
-			}),
-		],
-		content: initialContent ?? "",
-		shouldRerenderOnTransaction: true,
-		onUpdate: ({ editor: ed }) => {
-			const html = ed.getHTML();
-			const emptyContent = "<p></p>";
-			onChange(html === emptyContent ? "" : html);
-		},
-	});
-
-	const openLinkInput = useCallback(() => {
-		if (!editor) {
-			return;
-		}
-		const existingHref = editor.getAttributes("link").href as
-			| string
-			| undefined;
-		setLinkUrl(existingHref ?? "https://");
-		setShowLinkInput(true);
-	}, [editor]);
-
-	const applyLink = useCallback(() => {
-		if (!editor) {
-			return;
-		}
-		if (linkUrl.trim() === "") {
-			editor.chain().focus().extendMarkRange("link").unsetLink().run();
-		} else {
-			editor
-				.chain()
-				.focus()
-				.extendMarkRange("link")
-				.setLink({ href: linkUrl.trim() })
-				.run();
-		}
-		setShowLinkInput(false);
-		setLinkUrl("");
-	}, [editor, linkUrl]);
-
-	const removeLink = useCallback(() => {
-		if (!editor) {
-			return;
-		}
-		editor.chain().focus().extendMarkRange("link").unsetLink().run();
-		setShowLinkInput(false);
-		setLinkUrl("");
-	}, [editor]);
+	const {
+		applyLink,
+		cancelLinkInput,
+		editor,
+		linkUrl,
+		onLinkUrlChange,
+		openLinkInput,
+		removeLink,
+		showLinkInput,
+	} = useRichTextEditor({ initialContent, onChange });
 
 	if (!editor) {
 		return null;
@@ -153,15 +102,14 @@ export function RichTextEditor({
 					<Input
 						autoFocus
 						className="h-8 flex-1"
-						onChange={(e) => setLinkUrl(e.target.value)}
+						onChange={(e) => onLinkUrlChange(e.target.value)}
 						onKeyDown={(e) => {
 							if (e.key === "Enter") {
 								e.preventDefault();
 								applyLink();
 							}
 							if (e.key === "Escape") {
-								setShowLinkInput(false);
-								setLinkUrl("");
+								cancelLinkInput();
 							}
 						}}
 						placeholder="https://example.com"
@@ -190,10 +138,7 @@ export function RichTextEditor({
 					)}
 					<Button
 						aria-label="Cancel"
-						onClick={() => {
-							setShowLinkInput(false);
-							setLinkUrl("");
-						}}
+						onClick={cancelLinkInput}
 						size="sm"
 						type="button"
 						variant="ghost"

--- a/apps/web/src/shared/components/ui/tag-picker-base.tsx
+++ b/apps/web/src/shared/components/ui/tag-picker-base.tsx
@@ -1,11 +1,11 @@
 import type * as React from "react";
-import { useEffect, useRef, useState } from "react";
 import {
 	Command,
 	CommandEmpty,
 	CommandItem,
 	CommandList,
 } from "@/shared/components/ui/command";
+import { useTagPickerBase } from "@/shared/components/ui/hooks/use-tag-picker-base";
 import { Input } from "@/shared/components/ui/input";
 import {
 	Popover,
@@ -43,72 +43,26 @@ export function TagPickerBase<TTag extends TagItemBase>({
 	searchAriaLabel,
 	selectedTags,
 }: TagPickerBaseProps<TTag>) {
-	const [inputValue, setInputValue] = useState("");
-	const [isOpen, setIsOpen] = useState(false);
-	const [contentWidth, setContentWidth] = useState<number>();
-	const anchorRef = useRef<HTMLDivElement>(null);
-	const inputRef = useRef<HTMLInputElement>(null);
-
-	const normalizedInput = inputValue.trim();
-	const allTags = availableTags ?? [];
-	const selectedTagIds = new Set(selectedTags.map((tag) => tag.id));
-	const filteredTags = allTags.filter((tag) => {
-		if (selectedTagIds.has(tag.id)) {
-			return false;
-		}
-		if (!normalizedInput) {
-			return true;
-		}
-		return tag.name.toLowerCase().includes(normalizedInput.toLowerCase());
+	const {
+		anchorRef,
+		canCreate,
+		contentWidth,
+		filteredTags,
+		handleInputSubmit,
+		handleTagSelect,
+		inputRef,
+		inputValue,
+		normalizedInput,
+		onInputChange,
+		onOpenChange,
+		shouldRenderPopover,
+	} = useTagPickerBase({
+		availableTags,
+		onAdd,
+		onCreateTag,
+		onRemove,
+		selectedTags,
 	});
-	const matchingTag = allTags.find(
-		(tag) => tag.name.toLowerCase() === normalizedInput.toLowerCase()
-	);
-	const canCreate = Boolean(onCreateTag && normalizedInput && !matchingTag);
-	const shouldRenderPopover =
-		isOpen && (allTags.length > 0 || Boolean(normalizedInput));
-
-	useEffect(() => {
-		if (!(shouldRenderPopover && anchorRef.current)) {
-			return;
-		}
-		setContentWidth(anchorRef.current.offsetWidth);
-	}, [shouldRenderPopover]);
-
-	const focusInput = () => {
-		inputRef.current?.focus();
-	};
-
-	const closeAndReset = () => {
-		setInputValue("");
-		setIsOpen(false);
-	};
-
-	const handleTagSelect = (tag: TTag) => {
-		onAdd(tag);
-		closeAndReset();
-		focusInput();
-	};
-
-	const handleInputSubmit = async () => {
-		if (!normalizedInput) {
-			return;
-		}
-
-		if (matchingTag) {
-			if (!selectedTagIds.has(matchingTag.id)) {
-				handleTagSelect(matchingTag);
-			}
-			return;
-		}
-
-		if (!onCreateTag) {
-			return;
-		}
-
-		const createdTag = await onCreateTag(normalizedInput);
-		handleTagSelect(createdTag);
-	};
 
 	return (
 		<div className="flex flex-col gap-2">
@@ -124,7 +78,7 @@ export function TagPickerBase<TTag extends TagItemBase>({
 
 			<Popover
 				modal={false}
-				onOpenChange={setIsOpen}
+				onOpenChange={onOpenChange}
 				open={shouldRenderPopover}
 			>
 				<PopoverAnchor asChild>
@@ -134,17 +88,17 @@ export function TagPickerBase<TTag extends TagItemBase>({
 							aria-label={searchAriaLabel}
 							autoComplete="off"
 							onChange={(event) => {
-								setInputValue(event.target.value);
-								setIsOpen(true);
+								onInputChange(event.target.value);
+								onOpenChange(true);
 							}}
-							onFocus={() => setIsOpen(true)}
+							onFocus={() => onOpenChange(true)}
 							onKeyDown={(event) => {
 								if (event.key === "Enter") {
 									event.preventDefault();
 									handleInputSubmit().catch(() => undefined);
 								}
 								if (event.key === "Escape") {
-									setIsOpen(false);
+									onOpenChange(false);
 								}
 							}}
 							placeholder={placeholder}

--- a/apps/web/src/shared/hooks/use-entity-list-item.ts
+++ b/apps/web/src/shared/hooks/use-entity-list-item.ts
@@ -1,0 +1,65 @@
+import { useState } from "react";
+
+interface UseEntityListItemOptions {
+	isControlled: boolean;
+	onExpandedValueChange?: (value: string | null) => void;
+}
+
+interface UseEntityListItemResult {
+	confirmingDelete: boolean;
+	handleCancelDelete: (event: React.MouseEvent) => void;
+	handleConfirmDelete: (event: React.MouseEvent, onDelete: () => void) => void;
+	handleExpandedValueChange: (nextValue: string | null) => void;
+	handleStartDelete: (event: React.MouseEvent) => void;
+	internalExpandedValue: string | null;
+}
+
+export function useEntityListItem({
+	isControlled,
+	onExpandedValueChange,
+}: UseEntityListItemOptions): UseEntityListItemResult {
+	const [confirmingDelete, setConfirmingDelete] = useState(false);
+	const [internalExpandedValue, setInternalExpandedValue] = useState<
+		string | null
+	>(null);
+
+	const handleExpandedValueChange = (nextValue: string | null) => {
+		if (!isControlled) {
+			setInternalExpandedValue(nextValue);
+		}
+		setConfirmingDelete(false);
+		onExpandedValueChange?.(nextValue);
+	};
+
+	const handleStartDelete = (event: React.MouseEvent) => {
+		event.stopPropagation();
+		setConfirmingDelete(true);
+	};
+
+	const handleCancelDelete = (event: React.MouseEvent) => {
+		event.stopPropagation();
+		setConfirmingDelete(false);
+	};
+
+	const handleConfirmDelete = (
+		event: React.MouseEvent,
+		onDelete: () => void
+	) => {
+		event.stopPropagation();
+		onDelete();
+		setConfirmingDelete(false);
+		if (!isControlled) {
+			setInternalExpandedValue(null);
+		}
+		onExpandedValueChange?.(null);
+	};
+
+	return {
+		confirmingDelete,
+		handleCancelDelete,
+		handleConfirmDelete,
+		handleExpandedValueChange,
+		handleStartDelete,
+		internalExpandedValue,
+	};
+}

--- a/apps/web/src/shared/hooks/use-home-page.ts
+++ b/apps/web/src/shared/hooks/use-home-page.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { authClient } from "@/lib/auth-client";
+import { trpc } from "@/utils/trpc";
+
+export function useHomePage() {
+	const healthCheck = useQuery(trpc.healthCheck.queryOptions());
+	const { data: session } = authClient.useSession();
+
+	const isConnected = Boolean(healthCheck.data);
+	const isSignedIn = Boolean(session);
+	const isLoading = healthCheck.isLoading;
+	const userName = session?.user.name ?? null;
+
+	return {
+		isConnected,
+		isSignedIn,
+		isLoading,
+		userName,
+	};
+}

--- a/apps/web/src/shared/hooks/use-linked-accounts.ts
+++ b/apps/web/src/shared/hooks/use-linked-accounts.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { authClient } from "@/lib/auth-client";
+
+interface LinkedAccount {
+	accountId: string;
+	id: string;
+	providerId: string;
+}
+
+interface UseLinkedAccountsResult {
+	accounts: LinkedAccount[];
+	fetchAccounts: () => Promise<void>;
+	handleLink: (provider: string) => Promise<void>;
+	handleUnlink: (providerId: string) => Promise<void>;
+	hasCredential: boolean;
+	isSetPasswordOpen: boolean;
+	linkedProviderIds: Set<string>;
+	loading: boolean;
+	onSetPasswordOpenChange: (open: boolean) => void;
+	totalLinked: number;
+}
+
+export function useLinkedAccounts(): UseLinkedAccountsResult {
+	const [accounts, setAccounts] = useState<LinkedAccount[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [isSetPasswordOpen, setIsSetPasswordOpen] = useState(false);
+
+	const fetchAccounts = useCallback(async () => {
+		const result = await authClient.listAccounts();
+		setAccounts((result.data as LinkedAccount[]) ?? []);
+		setLoading(false);
+	}, []);
+
+	useEffect(() => {
+		fetchAccounts();
+	}, [fetchAccounts]);
+
+	const handleLink = async (provider: string) => {
+		await authClient.linkSocial({
+			provider: provider as "google" | "discord",
+			callbackURL: `${window.location.origin}/settings`,
+		});
+	};
+
+	const handleUnlink = async (providerId: string) => {
+		const result = await authClient.unlinkAccount({ providerId });
+		if (result.error) {
+			toast.error(result.error.message ?? "Failed to unlink account");
+			return;
+		}
+
+		toast.success("Account unlinked");
+		await fetchAccounts();
+	};
+
+	const linkedProviderIds = new Set(
+		accounts.map((account) => account.providerId)
+	);
+	const hasCredential = accounts.some(
+		(account) => account.providerId === "credential"
+	);
+	const totalLinked = accounts.length;
+
+	return {
+		accounts,
+		fetchAccounts,
+		handleLink,
+		handleUnlink,
+		hasCredential,
+		isSetPasswordOpen,
+		linkedProviderIds,
+		loading,
+		onSetPasswordOpenChange: setIsSetPasswordOpen,
+		totalLinked,
+	};
+}

--- a/apps/web/src/shared/hooks/use-login-page.ts
+++ b/apps/web/src/shared/hooks/use-login-page.ts
@@ -1,0 +1,11 @@
+import { useState } from "react";
+
+export function useLoginPage() {
+	const [showSignIn, setShowSignIn] = useState(false);
+
+	return {
+		showSignIn,
+		onSwitchToSignIn: () => setShowSignIn(true),
+		onSwitchToSignUp: () => setShowSignIn(false),
+	};
+}

--- a/apps/web/src/shared/hooks/use-mobile-nav-popover.ts
+++ b/apps/web/src/shared/hooks/use-mobile-nav-popover.ts
@@ -1,0 +1,17 @@
+import { useState } from "react";
+
+interface UseMobileNavPopoverResult {
+	isOpen: boolean;
+	onClose: () => void;
+	onOpenChange: (open: boolean) => void;
+}
+
+export function useMobileNavPopover(): UseMobileNavPopoverResult {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return {
+		isOpen,
+		onClose: () => setIsOpen(false),
+		onOpenChange: setIsOpen,
+	};
+}

--- a/apps/web/src/shared/hooks/use-mobile-nav.ts
+++ b/apps/web/src/shared/hooks/use-mobile-nav.ts
@@ -1,0 +1,106 @@
+import { IconBolt, IconPlayerPlay, IconPlus } from "@tabler/icons-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { useState } from "react";
+import { useActiveSession } from "@/live-sessions/hooks/use-active-session";
+import { useStackSheet } from "@/live-sessions/hooks/use-stack-sheet";
+import { createSessionEventMutationOptions } from "@/live-sessions/utils/optimistic-session-event";
+import {
+	getMobileNavigationItems,
+	type NavigationCenterAction,
+} from "@/shared/components/app-navigation";
+import { trpcClient } from "@/utils/trpc";
+
+interface UseMobileNavResult {
+	activeSession: ReturnType<typeof useActiveSession>["activeSession"];
+	centerAction: NavigationCenterAction;
+	hasActive: boolean;
+	isCreateOpen: boolean;
+	leftItems: ReturnType<typeof getMobileNavigationItems>["leftItems"];
+	onCreateOpenChange: (open: boolean) => void;
+	pathname: string;
+	rightItems: ReturnType<typeof getMobileNavigationItems>["rightItems"];
+}
+
+export function useMobileNav(): UseMobileNavResult {
+	const pathname = useRouterState({
+		select: (s) => s.location.pathname,
+	});
+	const navigate = useNavigate();
+	const { activeSession, hasActive } = useActiveSession();
+	const stackSheet = useStackSheet();
+	const queryClient = useQueryClient();
+	const [isCreateOpen, setIsCreateOpen] = useState(false);
+
+	const isPaused = activeSession?.status === "paused";
+	const { leftItems, rightItems } = getMobileNavigationItems(
+		hasActive && !isPaused
+	);
+
+	const optimisticOptions = activeSession
+		? createSessionEventMutationOptions({
+				queryClient,
+				sessionId: activeSession.id,
+				sessionType: activeSession.type,
+				eventType: "session_resume",
+				getPayload: () => ({}),
+				changesStatus: true,
+			})
+		: {};
+
+	const resumeMutation = useMutation({
+		mutationFn: async () => {
+			if (!activeSession) {
+				return;
+			}
+			const sessionIdKey =
+				activeSession.type === "cash_game"
+					? "liveCashGameSessionId"
+					: "liveTournamentSessionId";
+			await trpcClient.sessionEvent.create.mutate({
+				[sessionIdKey]: activeSession.id,
+				eventType: "session_resume",
+				payload: {},
+			});
+		},
+		...optimisticOptions,
+	});
+
+	let centerAction: NavigationCenterAction;
+	if (hasActive && activeSession?.status === "paused") {
+		centerAction = {
+			icon: IconPlayerPlay,
+			label: "Resume",
+			onClick: () => {
+				resumeMutation.mutate();
+				navigate({ to: "/active-session" });
+			},
+			tone: "live" as const,
+		};
+	} else if (hasActive) {
+		centerAction = {
+			icon: IconBolt,
+			label: "Stack",
+			onClick: () => stackSheet.open(),
+			tone: "live" as const,
+		};
+	} else {
+		centerAction = {
+			icon: IconPlus,
+			label: "New",
+			onClick: () => setIsCreateOpen(true),
+			tone: "accent" as const,
+		};
+	}
+
+	return {
+		activeSession,
+		centerAction,
+		hasActive,
+		isCreateOpen,
+		leftItems,
+		onCreateOpenChange: setIsCreateOpen,
+		pathname,
+		rightItems,
+	};
+}

--- a/apps/web/src/shared/hooks/use-online-status-bar.ts
+++ b/apps/web/src/shared/hooks/use-online-status-bar.ts
@@ -1,0 +1,53 @@
+import { useIsMutating } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+import { useOnlineStatus } from "@/shared/hooks/use-online-status";
+
+type DisplayState = "hidden" | "offline" | "syncing" | "back-online";
+
+interface UseOnlineStatusBarResult {
+	displayState: DisplayState;
+}
+
+export function useOnlineStatusBar(): UseOnlineStatusBarResult {
+	const isOnline = useOnlineStatus();
+	const isMutating = useIsMutating();
+	const [displayState, setDisplayState] = useState<DisplayState>("hidden");
+	const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const wasOfflineRef = useRef(false);
+
+	useEffect(() => {
+		if (!isOnline) {
+			wasOfflineRef.current = true;
+			if (fadeTimerRef.current) {
+				clearTimeout(fadeTimerRef.current);
+				fadeTimerRef.current = null;
+			}
+			setDisplayState("offline");
+			return;
+		}
+
+		if (!wasOfflineRef.current) {
+			setDisplayState("hidden");
+			return;
+		}
+
+		if (isMutating > 0) {
+			setDisplayState("syncing");
+			return;
+		}
+
+		setDisplayState("back-online");
+		fadeTimerRef.current = setTimeout(() => {
+			setDisplayState("hidden");
+			wasOfflineRef.current = false;
+		}, 2000);
+
+		return () => {
+			if (fadeTimerRef.current) {
+				clearTimeout(fadeTimerRef.current);
+			}
+		};
+	}, [isOnline, isMutating]);
+
+	return { displayState };
+}

--- a/apps/web/src/shared/hooks/use-preview-auto-login.ts
+++ b/apps/web/src/shared/hooks/use-preview-auto-login.ts
@@ -1,0 +1,32 @@
+import { env } from "@sapphire2/env/web";
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
+import { authClient } from "@/lib/auth-client";
+
+export function usePreviewAutoLogin(): void {
+	const attempted = useRef(false);
+	const navigate = useNavigate();
+
+	useEffect(() => {
+		if (attempted.current) {
+			return;
+		}
+		if (env.VITE_PREVIEW_AUTO_LOGIN !== "true") {
+			return;
+		}
+
+		const email = env.VITE_PREVIEW_LOGIN_EMAIL;
+		const password = env.VITE_PREVIEW_LOGIN_PASSWORD;
+		if (!(email && password)) {
+			return;
+		}
+
+		attempted.current = true;
+
+		authClient.signIn.email({ email, password }).then((result) => {
+			if (result.data) {
+				navigate({ to: "/dashboard" });
+			}
+		});
+	}, [navigate]);
+}

--- a/apps/web/src/shared/hooks/use-set-password-form.ts
+++ b/apps/web/src/shared/hooks/use-set-password-form.ts
@@ -1,0 +1,55 @@
+import { useForm } from "@tanstack/react-form";
+import { toast } from "sonner";
+import z from "zod";
+import { authClient } from "@/lib/auth-client";
+
+interface UseSetPasswordFormOptions {
+	onOpenChange: (open: boolean) => void;
+	onSuccess: () => void;
+}
+
+const setPasswordSchema = z
+	.object({
+		confirmPassword: z
+			.string()
+			.min(8, "Password must be at least 8 characters"),
+		newPassword: z.string().min(8, "Password must be at least 8 characters"),
+	})
+	.refine((data) => data.newPassword === data.confirmPassword, {
+		message: "Passwords do not match",
+		path: ["confirmPassword"],
+	});
+
+export function useSetPasswordForm({
+	onOpenChange,
+	onSuccess,
+}: UseSetPasswordFormOptions) {
+	const form = useForm({
+		defaultValues: {
+			confirmPassword: "",
+			newPassword: "",
+		},
+		onSubmit: async ({ value }) => {
+			const { error } = await authClient.$fetch("/set-password", {
+				method: "POST",
+				body: { newPassword: value.newPassword },
+			});
+
+			if (error) {
+				toast.error(
+					(error as { message?: string }).message ?? "Failed to set password"
+				);
+				return;
+			}
+
+			toast.success("Password set successfully");
+			onSuccess();
+			onOpenChange(false);
+		},
+		validators: {
+			onSubmit: setPasswordSchema,
+		},
+	});
+
+	return { form };
+}

--- a/apps/web/src/shared/hooks/use-sign-in.ts
+++ b/apps/web/src/shared/hooks/use-sign-in.ts
@@ -4,12 +4,14 @@ import { toast } from "sonner";
 import z from "zod";
 import { authClient } from "@/lib/auth-client";
 
-const signInSchema = z.object({
-	email: z.email("Invalid email address"),
-	password: z.string().min(8, "Password must be at least 8 characters"),
-});
+interface UseSignInResult {
+	form: ReturnType<typeof useForm<{ email: string; password: string }>>;
+	isPending: boolean;
+	onSignInWithDiscord: () => Promise<void>;
+	onSignInWithGoogle: () => Promise<void>;
+}
 
-export function useSignIn() {
+export function useSignIn(): UseSignInResult {
 	const navigate = useNavigate({ from: "/" });
 	const { isPending } = authClient.useSession();
 
@@ -36,11 +38,14 @@ export function useSignIn() {
 			);
 		},
 		validators: {
-			onSubmit: signInSchema,
+			onSubmit: z.object({
+				email: z.email("Invalid email address"),
+				password: z.string().min(8, "Password must be at least 8 characters"),
+			}),
 		},
 	});
 
-	const signInWithGoogle = async () => {
+	const onSignInWithGoogle = async () => {
 		const result = await authClient.signIn.social({
 			provider: "google",
 			callbackURL: `${window.location.origin}/dashboard`,
@@ -50,7 +55,7 @@ export function useSignIn() {
 		}
 	};
 
-	const signInWithDiscord = async () => {
+	const onSignInWithDiscord = async () => {
 		const result = await authClient.signIn.social({
 			provider: "discord",
 			callbackURL: `${window.location.origin}/dashboard`,
@@ -60,10 +65,5 @@ export function useSignIn() {
 		}
 	};
 
-	return {
-		form,
-		isSessionPending: isPending,
-		signInWithGoogle,
-		signInWithDiscord,
-	};
+	return { form, isPending, onSignInWithDiscord, onSignInWithGoogle };
 }

--- a/apps/web/src/shared/hooks/use-sign-up.ts
+++ b/apps/web/src/shared/hooks/use-sign-up.ts
@@ -1,0 +1,74 @@
+import { useForm } from "@tanstack/react-form";
+import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
+import z from "zod";
+import { authClient } from "@/lib/auth-client";
+
+interface UseSignUpResult {
+	form: ReturnType<
+		typeof useForm<{ email: string; name: string; password: string }>
+	>;
+	isPending: boolean;
+	onSignInWithDiscord: () => Promise<void>;
+	onSignInWithGoogle: () => Promise<void>;
+}
+
+export function useSignUp(): UseSignUpResult {
+	const navigate = useNavigate({ from: "/" });
+	const { isPending } = authClient.useSession();
+
+	const form = useForm({
+		defaultValues: {
+			email: "",
+			name: "",
+			password: "",
+		},
+		onSubmit: async ({ value }) => {
+			await authClient.signUp.email(
+				{
+					email: value.email,
+					password: value.password,
+					name: value.name,
+				},
+				{
+					onSuccess: () => {
+						navigate({ to: "/dashboard" });
+						toast.success("Sign up successful");
+					},
+					onError: (error) => {
+						toast.error(error.error.message || error.error.statusText);
+					},
+				}
+			);
+		},
+		validators: {
+			onSubmit: z.object({
+				name: z.string().min(2, "Name must be at least 2 characters"),
+				email: z.email("Invalid email address"),
+				password: z.string().min(8, "Password must be at least 8 characters"),
+			}),
+		},
+	});
+
+	const onSignInWithGoogle = async () => {
+		const result = await authClient.signIn.social({
+			provider: "google",
+			callbackURL: `${window.location.origin}/dashboard`,
+		});
+		if (result.error) {
+			toast.error(result.error.message || "Google sign up unavailable");
+		}
+	};
+
+	const onSignInWithDiscord = async () => {
+		const result = await authClient.signIn.social({
+			provider: "discord",
+			callbackURL: `${window.location.origin}/dashboard`,
+		});
+		if (result.error) {
+			toast.error(result.error.message || "Discord sign up unavailable");
+		}
+	};
+
+	return { form, isPending, onSignInWithDiscord, onSignInWithGoogle };
+}

--- a/apps/web/src/shared/hooks/use-tag-manager.ts
+++ b/apps/web/src/shared/hooks/use-tag-manager.ts
@@ -1,0 +1,33 @@
+import { useState } from "react";
+
+interface UseTagManagerResult<TTag> {
+	deletingTag: TTag | null;
+	editingTag: TTag | null;
+	isCreateOpen: boolean;
+	onCloseCreate: () => void;
+	onCloseDelete: () => void;
+	onCloseEdit: () => void;
+	onOpenCreate: () => void;
+	onStartDelete: (tag: TTag) => void;
+	onStartEdit: (tag: TTag) => void;
+}
+
+export function useTagManager<
+	TTag extends { id: string; name: string },
+>(): UseTagManagerResult<TTag> {
+	const [isCreateOpen, setIsCreateOpen] = useState(false);
+	const [editingTag, setEditingTag] = useState<TTag | null>(null);
+	const [deletingTag, setDeletingTag] = useState<TTag | null>(null);
+
+	return {
+		deletingTag,
+		editingTag,
+		isCreateOpen,
+		onCloseCreate: () => setIsCreateOpen(false),
+		onCloseDelete: () => setDeletingTag(null),
+		onCloseEdit: () => setEditingTag(null),
+		onOpenCreate: () => setIsCreateOpen(true),
+		onStartDelete: (tag) => setDeletingTag(tag),
+		onStartEdit: (tag) => setEditingTag(tag),
+	};
+}

--- a/apps/web/src/shared/hooks/use-tag-name-form.ts
+++ b/apps/web/src/shared/hooks/use-tag-name-form.ts
@@ -1,0 +1,33 @@
+import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
+
+const tagNameFormSchema = z.object({
+	name: z
+		.string()
+		.min(1, "Tag name is required")
+		.max(50, "Tag name must be 50 characters or less"),
+});
+
+interface UseTagNameFormOptions {
+	defaultName?: string;
+	onSubmit: (name: string) => void;
+}
+
+export function useTagNameForm({
+	defaultName,
+	onSubmit,
+}: UseTagNameFormOptions) {
+	const form = useForm({
+		defaultValues: {
+			name: defaultName ?? "",
+		},
+		onSubmit: ({ value }) => {
+			onSubmit(value.name);
+		},
+		validators: {
+			onSubmit: tagNameFormSchema,
+		},
+	});
+
+	return { form };
+}

--- a/apps/web/src/stores/components/ai-extract-input.tsx
+++ b/apps/web/src/stores/components/ai-extract-input.tsx
@@ -5,141 +5,28 @@ import {
 	IconSparkles,
 	IconTrash,
 } from "@tabler/icons-react";
-import { useMutation } from "@tanstack/react-query";
-import { useRef, useState } from "react";
 import { Button } from "@/shared/components/ui/button";
 import { Input } from "@/shared/components/ui/input";
-import { trpc } from "@/utils/trpc";
-
-interface UrlItem {
-	id: string;
-	kind: "url";
-	value: string;
-}
-interface ImageItem {
-	base64: string;
-	id: string;
-	kind: "image";
-	mediaType: "image/gif" | "image/jpeg" | "image/png" | "image/webp";
-	name: string;
-	previewUrl: string;
-}
-type SourceItem = ImageItem | UrlItem;
-
-const ACCEPTED_TYPES = [
-	"image/jpeg",
-	"image/png",
-	"image/gif",
-	"image/webp",
-] as const;
-type AcceptedMediaType = (typeof ACCEPTED_TYPES)[number];
-
-function isAcceptedMediaType(type: string): type is AcceptedMediaType {
-	return (ACCEPTED_TYPES as readonly string[]).includes(type);
-}
-
-function fileToBase64(file: File): Promise<string> {
-	return new Promise((resolve, reject) => {
-		const reader = new FileReader();
-		reader.onload = () => {
-			const result = reader.result as string;
-			resolve(result.split(",")[1] ?? "");
-		};
-		reader.onerror = reject;
-		reader.readAsDataURL(file);
-	});
-}
+import { useAiExtractInput } from "@/stores/hooks/use-ai-extract-input";
 
 interface AiExtractInputProps {
 	onExtracted: (data: ExtractedTournamentData) => void;
 }
 
 export function AiExtractInput({ onExtracted }: AiExtractInputProps) {
-	const [items, setItems] = useState<SourceItem[]>([
-		{ id: crypto.randomUUID(), kind: "url", value: "" },
-	]);
-	const fileInputRef = useRef<HTMLInputElement>(null);
-
-	const mutation = useMutation(
-		trpc.aiExtract.extractTournamentData.mutationOptions({
-			onSuccess: onExtracted,
-		})
-	);
-
-	const addUrl = () => {
-		if (items.length >= 5) {
-			return;
-		}
-		setItems((prev) => [
-			...prev,
-			{ id: crypto.randomUUID(), kind: "url", value: "" },
-		]);
-	};
-
-	const removeItem = (id: string) => {
-		setItems((prev) => prev.filter((item) => item.id !== id));
-	};
-
-	const updateUrl = (id: string, value: string) => {
-		setItems((prev) =>
-			prev.map((item) =>
-				item.id === id && item.kind === "url" ? { ...item, value } : item
-			)
-		);
-	};
-
-	const handleImageSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
-		const file = e.target.files?.[0];
-		if (!file) {
-			return;
-		}
-		const mediaType = file.type;
-		if (!isAcceptedMediaType(mediaType)) {
-			return;
-		}
-		if (items.length >= 5) {
-			return;
-		}
-
-		const base64 = await fileToBase64(file);
-		const previewUrl = URL.createObjectURL(file);
-		setItems((prev) => [
-			...prev,
-			{
-				id: crypto.randomUUID(),
-				kind: "image",
-				base64,
-				mediaType,
-				name: file.name,
-				previewUrl,
-			},
-		]);
-		// Reset so same file can be re-selected
-		e.target.value = "";
-	};
-
-	const handleAnalyze = () => {
-		const sources = items.flatMap(
-			(item): Parameters<typeof mutation.mutate>[0]["sources"] => {
-				if (item.kind === "url") {
-					const url = item.value.trim();
-					if (!url) {
-						return [];
-					}
-					return [{ kind: "url", url }];
-				}
-				return [
-					{ kind: "image", data: item.base64, mediaType: item.mediaType },
-				];
-			}
-		);
-		if (sources.length === 0) {
-			return;
-		}
-		mutation.mutate({ sources });
-	};
-
-	const canAdd = items.length < 5;
+	const {
+		items,
+		fileInputRef,
+		canAdd,
+		isPending,
+		error,
+		addUrl,
+		removeItem,
+		updateUrl,
+		handleImageSelect,
+		handleAnalyze,
+		triggerFileInput,
+	} = useAiExtractInput({ onExtracted });
 
 	return (
 		<div className="flex flex-col gap-2">
@@ -199,7 +86,7 @@ export function AiExtractInput({ onExtracted }: AiExtractInputProps) {
 						URLを追加
 					</Button>
 					<Button
-						onClick={() => fileInputRef.current?.click()}
+						onClick={triggerFileInput}
 						size="xs"
 						type="button"
 						variant="outline"
@@ -217,18 +104,16 @@ export function AiExtractInput({ onExtracted }: AiExtractInputProps) {
 				</div>
 			)}
 
-			{mutation.error && (
-				<p className="text-destructive text-xs">{mutation.error.message}</p>
-			)}
+			{error && <p className="text-destructive text-xs">{error.message}</p>}
 
 			<Button
-				disabled={mutation.isPending}
+				disabled={isPending}
 				onClick={handleAnalyze}
 				size="sm"
 				type="button"
 			>
 				<IconSparkles size={14} />
-				{mutation.isPending ? "解析中..." : "解析"}
+				{isPending ? "解析中..." : "解析"}
 			</Button>
 		</div>
 	);

--- a/apps/web/src/stores/components/blind-level-editor.tsx
+++ b/apps/web/src/stores/components/blind-level-editor.tsx
@@ -2,13 +2,10 @@ import {
 	closestCenter,
 	DndContext,
 	type DragEndEvent,
-	PointerSensor,
-	TouchSensor,
-	useSensor,
-	useSensors,
+	type SensorDescriptor,
+	type SensorOptions,
 } from "@dnd-kit/core";
 import {
-	arrayMove,
 	SortableContext,
 	useSortable,
 	verticalListSortingStrategy,
@@ -21,12 +18,15 @@ import {
 	IconTrash,
 } from "@tabler/icons-react";
 import type { ComponentProps } from "react";
-import { useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/shared/components/ui/button";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
+import { useLocalBlindStructure } from "@/stores/hooks/use-blind-level-editor";
 import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
 import { useBlindLevels } from "@/stores/hooks/use-blind-levels";
+import { useEmptyRow } from "@/stores/hooks/use-empty-row";
+import { useSortableLevelRow } from "@/stores/hooks/use-sortable-level-row";
+import type { NewLevelValues } from "@/stores/utils/blind-level-helpers";
 
 const GAME_VARIANTS = {
 	nlh: {
@@ -105,56 +105,17 @@ function SortableLevelRow({ row, onDelete, onUpdate }: SortableLevelRowProps) {
 		isDragging,
 	} = useSortable({ id: row.id });
 
-	// Track current input values for auto-fill logic on blur
-	const currentBlind2Ref = useRef(row.blind2 == null ? "" : String(row.blind2));
-	const currentAnteRef = useRef(row.ante == null ? "" : String(row.ante));
+	const {
+		handleBlind1Blur,
+		handleBlind2Blur,
+		handleAnteBlur,
+		handleMinutesBlur,
+	} = useSortableLevelRow({ row, onUpdate });
 
 	const style = {
 		transform: CSS.Transform.toString(transform),
 		transition,
 		opacity: isDragging ? 0.5 : 1,
-	};
-
-	const handleBlind1Blur = (e: React.FocusEvent<HTMLInputElement>) => {
-		const val = e.target.value;
-		const parsed = parseIntOrNull(val);
-		const updates: Record<string, number | null> = { blind1: parsed };
-		if (parsed != null) {
-			if (!currentBlind2Ref.current) {
-				const bb = parsed * 2;
-				currentBlind2Ref.current = String(bb);
-				updates.blind2 = bb;
-				if (!currentAnteRef.current) {
-					currentAnteRef.current = String(bb);
-					updates.ante = bb;
-				}
-			} else if (!currentAnteRef.current) {
-				currentAnteRef.current = String(parsed);
-				updates.ante = parsed;
-			}
-		}
-		onUpdate(row.id, updates);
-	};
-
-	const handleBlind2Blur = (e: React.FocusEvent<HTMLInputElement>) => {
-		const val = e.target.value;
-		currentBlind2Ref.current = val;
-		const parsed = parseIntOrNull(val);
-		const updates: Record<string, number | null> = { blind2: parsed };
-		if (parsed != null && !currentAnteRef.current) {
-			currentAnteRef.current = val;
-			updates.ante = parsed;
-		}
-		onUpdate(row.id, updates);
-	};
-
-	const handleAnteBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-		currentAnteRef.current = e.target.value;
-		onUpdate(row.id, { ante: parseIntOrNull(e.target.value) });
-	};
-
-	const handleMinutesBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-		onUpdate(row.id, { minutes: parseIntOrNull(e.target.value) });
 	};
 
 	return (
@@ -293,84 +254,21 @@ function SortableBreakRow({ row, onDelete, onUpdate }: SortableBreakRowProps) {
 
 // ---- Empty bottom row for adding a new level ----
 
-interface NewLevelValues {
-	ante: number | null;
-	blind1: number | null;
-	blind2: number | null;
-	minutes: number | null;
-}
-
 interface EmptyRowProps {
 	onCreateLevel: (values: NewLevelValues) => void;
 }
 
 function EmptyRow({ onCreateLevel }: EmptyRowProps) {
-	const blind1Ref = useRef<HTMLInputElement>(null);
-	const blind2Ref = useRef<HTMLInputElement>(null);
-	const anteRef = useRef<HTMLInputElement>(null);
-	const minutesRef = useRef<HTMLInputElement>(null);
-
-	const resetRow = () => {
-		for (const ref of [blind1Ref, blind2Ref, anteRef, minutesRef]) {
-			if (ref.current) {
-				ref.current.value = "";
-			}
-		}
-	};
-
-	const tryCreate = (relatedTarget: EventTarget | null) => {
-		const cells = [
-			blind1Ref.current,
-			blind2Ref.current,
-			anteRef.current,
-			minutesRef.current,
-		];
-		if (cells.includes(relatedTarget as HTMLInputElement)) {
-			return;
-		}
-		const blind1Val = parseIntOrNull(blind1Ref.current?.value ?? "");
-		if (blind1Val == null) {
-			return;
-		}
-		onCreateLevel({
-			blind1: blind1Val,
-			blind2: parseIntOrNull(blind2Ref.current?.value ?? ""),
-			ante: parseIntOrNull(anteRef.current?.value ?? ""),
-			minutes: parseIntOrNull(minutesRef.current?.value ?? ""),
-		});
-		resetRow();
-	};
-
-	const handleBlind1Blur = (e: React.FocusEvent<HTMLInputElement>) => {
-		const val = e.target.value;
-		const parsed = parseIntOrNull(val);
-		if (parsed != null) {
-			if (blind2Ref.current && !blind2Ref.current.value) {
-				blind2Ref.current.value = String(parsed * 2);
-			}
-			if (anteRef.current && !anteRef.current.value) {
-				anteRef.current.value = blind2Ref.current?.value ?? val;
-			}
-		}
-		tryCreate(e.relatedTarget);
-	};
-
-	const handleBlind2Blur = (e: React.FocusEvent<HTMLInputElement>) => {
-		const val = e.target.value;
-		const parsed = parseIntOrNull(val);
-		if (parsed != null && anteRef.current && !anteRef.current.value) {
-			anteRef.current.value = val;
-		}
-		tryCreate(e.relatedTarget);
-	};
-
-	const handleAnteBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-		tryCreate(e.relatedTarget);
-	};
-
-	const handleMinutesBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-		tryCreate(e.relatedTarget);
-	};
+	const {
+		blind1Ref,
+		blind2Ref,
+		anteRef,
+		minutesRef,
+		handleBlind1Blur,
+		handleBlind2Blur,
+		handleAnteBlur,
+		handleMinutesBlur,
+	} = useEmptyRow({ onCreateLevel });
 
 	return (
 		<tr className="border-t border-dashed">
@@ -430,7 +328,7 @@ interface BlindStructureTableProps {
 	handleUpdate: (id: string, updates: Record<string, number | null>) => void;
 	isAdding?: boolean;
 	levels: BlindLevelRow[];
-	sensors: ReturnType<typeof useSensors>;
+	sensors: SensorDescriptor<SensorOptions>[];
 }
 
 function BlindStructureTable({
@@ -543,6 +441,7 @@ export function BlindStructureContent({
 		levels,
 		isLoading,
 		isAdding,
+		sensors,
 		handleDragEnd,
 		handleAddLevel,
 		handleAddBreak,
@@ -555,13 +454,6 @@ export function BlindStructureContent({
 		variant in GAME_VARIANTS ? variant : "nlh"
 	) as keyof typeof GAME_VARIANTS;
 	const blindLabels = GAME_VARIANTS[variantKey].blindLabels;
-
-	const sensors = useSensors(
-		useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-		useSensor(TouchSensor, {
-			activationConstraint: { delay: 250, tolerance: 8 },
-		})
-	);
 
 	if (isLoading) {
 		return (
@@ -600,117 +492,20 @@ export function LocalBlindStructureContent({
 	onChange,
 	variant = "nlh",
 }: LocalBlindStructureContentProps) {
-	const [lastMinutes, setLastMinutes] = useState<number | null>(null);
-
-	const effectiveLastMinutes = (() => {
-		if (lastMinutes != null) {
-			return lastMinutes;
-		}
-		for (let i = value.length - 1; i >= 0; i--) {
-			if (value[i].minutes != null) {
-				return value[i].minutes;
-			}
-		}
-		return null;
-	})();
+	const {
+		sensors,
+		handleDragEnd,
+		handleAddLevel,
+		handleAddBreak,
+		handleDelete,
+		handleUpdate,
+		handleCreateLevel,
+	} = useLocalBlindStructure({ value, onChange });
 
 	const variantKey = (
 		variant in GAME_VARIANTS ? variant : "nlh"
 	) as keyof typeof GAME_VARIANTS;
 	const blindLabels = GAME_VARIANTS[variantKey].blindLabels;
-
-	const sensors = useSensors(
-		useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-		useSensor(TouchSensor, {
-			activationConstraint: { delay: 250, tolerance: 8 },
-		})
-	);
-
-	const handleDragEnd = (event: DragEndEvent) => {
-		const { active, over } = event;
-		if (!over || active.id === over.id) {
-			return;
-		}
-		const oldIndex = value.findIndex((l) => l.id === active.id);
-		const newIndex = value.findIndex((l) => l.id === over.id);
-		if (oldIndex === -1 || newIndex === -1) {
-			return;
-		}
-		onChange(
-			arrayMove(value, oldIndex, newIndex).map((l, i) => ({
-				...l,
-				level: i + 1,
-			}))
-		);
-	};
-
-	const handleAddLevel = () => {
-		onChange([
-			...value,
-			{
-				id: crypto.randomUUID(),
-				tournamentId: "",
-				level: value.length + 1,
-				isBreak: false,
-				blind1: null,
-				blind2: null,
-				blind3: null,
-				ante: null,
-				minutes: effectiveLastMinutes,
-			},
-		]);
-	};
-
-	const handleAddBreak = () => {
-		onChange([
-			...value,
-			{
-				id: crypto.randomUUID(),
-				tournamentId: "",
-				level: value.length + 1,
-				isBreak: true,
-				blind1: null,
-				blind2: null,
-				blind3: null,
-				ante: null,
-				minutes: effectiveLastMinutes,
-			},
-		]);
-	};
-
-	const handleDelete = (id: string) => {
-		onChange(
-			value.filter((l) => l.id !== id).map((l, i) => ({ ...l, level: i + 1 }))
-		);
-	};
-
-	const handleUpdate = (id: string, updates: Record<string, number | null>) => {
-		onChange(value.map((l) => (l.id === id ? { ...l, ...updates } : l)));
-		if (updates.minutes != null) {
-			setLastMinutes(updates.minutes);
-		}
-	};
-
-	const handleCreateLevel = (vals: NewLevelValues) => {
-		const minutes = vals.minutes ?? effectiveLastMinutes;
-		onChange([
-			...value,
-			{
-				id: crypto.randomUUID(),
-				tournamentId: "",
-				level: value.length + 1,
-				isBreak: false,
-				blind1: vals.blind1,
-				blind2: vals.blind2,
-				blind3: null,
-				ante: vals.ante,
-				minutes,
-			},
-		]);
-		if (minutes != null) {
-			setLastMinutes(minutes);
-		}
-	};
 
 	return (
 		<BlindStructureTable

--- a/apps/web/src/stores/components/ring-game-tab.tsx
+++ b/apps/web/src/stores/components/ring-game-tab.tsx
@@ -6,7 +6,6 @@ import {
 	IconTrash,
 	IconX,
 } from "@tabler/icons-react";
-import { useEffect, useState } from "react";
 import {
 	ExpandableItem,
 	ExpandableItemList,
@@ -17,11 +16,9 @@ import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
 import { RingGameForm } from "@/stores/components/ring-game-form";
-import type {
-	RingGame,
-	RingGameFormValues,
-} from "@/stores/hooks/use-ring-games";
-import { useRingGames } from "@/stores/hooks/use-ring-games";
+import { useRingGameRow } from "@/stores/hooks/use-ring-game-row";
+import { useRingGameTab } from "@/stores/hooks/use-ring-game-tab";
+import type { RingGame } from "@/stores/hooks/use-ring-games";
 import { createGroupFormatter } from "@/utils/format-number";
 import { getTableSizeClassName } from "@/utils/table-size-colors";
 
@@ -242,18 +239,14 @@ function RingGameRow({
 	onEdit,
 	onRestore,
 }: RingGameRowProps) {
-	const [confirmingDelete, setConfirmingDelete] = useState(false);
+	const { confirmingDelete, setConfirmingDelete } = useRingGameRow({
+		expanded,
+	});
 	const currency = currencies.find((c) => c.id === game.currencyId);
 	const blindLine = formatBlindsLine(game, currency?.unit);
 	const variantLabel =
 		VARIANT_LABELS[game.variant] ?? game.variant.toUpperCase();
 	const fmt = createGroupFormatter([game.minBuyIn, game.maxBuyIn]);
-
-	useEffect(() => {
-		if (!expanded) {
-			setConfirmingDelete(false);
-		}
-	}, [expanded]);
 
 	return (
 		<ExpandableItem
@@ -404,11 +397,13 @@ export function RingGameTab({
 	expandedGameId,
 	onToggleGame,
 }: RingGameTabProps) {
-	const [showArchived, setShowArchived] = useState(false);
-	const [isCreateOpen, setIsCreateOpen] = useState(false);
-	const [editingGame, setEditingGame] = useState<RingGame | null>(null);
-
 	const {
+		showArchived,
+		setShowArchived,
+		isCreateOpen,
+		setIsCreateOpen,
+		editingGame,
+		setEditingGame,
 		activeGames,
 		archivedGames,
 		currencies,
@@ -416,27 +411,12 @@ export function RingGameTab({
 		archivedLoading,
 		isCreatePending,
 		isUpdatePending,
-		create,
-		update,
 		archive,
 		restore,
-		delete: deleteGame,
-	} = useRingGames({ storeId, showArchived });
-
-	const handleCreate = (values: RingGameFormValues) => {
-		create(values).then(() => {
-			setIsCreateOpen(false);
-		});
-	};
-
-	const handleUpdate = (values: RingGameFormValues) => {
-		if (!editingGame) {
-			return;
-		}
-		update({ id: editingGame.id, ...values }).then(() => {
-			setEditingGame(null);
-		});
-	};
+		deleteGame,
+		handleCreate,
+		handleUpdate,
+	} = useRingGameTab({ storeId });
 
 	return (
 		<div>

--- a/apps/web/src/stores/components/store-card.tsx
+++ b/apps/web/src/stores/components/store-card.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
 import { EntityListItem } from "@/shared/components/management/entity-list-item";
 import { RingGameTab } from "@/stores/components/ring-game-tab";
 import { TournamentTab } from "@/stores/components/tournament-tab";
+import { useStoreCard } from "@/stores/hooks/use-store-card";
 
 interface StoreCardProps {
 	onDelete: (id: string) => void;
@@ -14,11 +14,7 @@ interface StoreCardProps {
 }
 
 export function StoreCard({ store, onEdit, onDelete }: StoreCardProps) {
-	const [expandedGameId, setExpandedGameId] = useState<string | null>(null);
-
-	const handleToggleGame = (id: string | null) => {
-		setExpandedGameId(id);
-	};
+	const { expandedGameId, handleToggleGame } = useStoreCard();
 
 	return (
 		<EntityListItem

--- a/apps/web/src/stores/components/store-form.tsx
+++ b/apps/web/src/stores/components/store-form.tsx
@@ -1,14 +1,9 @@
-import { useForm } from "@tanstack/react-form";
-import { z } from "zod";
 import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
 import { Textarea } from "@/shared/components/ui/textarea";
-
-interface StoreFormValues {
-	memo?: string;
-	name: string;
-}
+import type { StoreFormValues } from "@/stores/hooks/use-store-form";
+import { useStoreForm } from "@/stores/hooks/use-store-form";
 
 interface StoreFormProps {
 	defaultValues?: StoreFormValues;
@@ -16,31 +11,12 @@ interface StoreFormProps {
 	onSubmit: (values: StoreFormValues) => void;
 }
 
-const storeFormSchema = z.object({
-	name: z.string().min(1, "Store name is required"),
-	memo: z.string(),
-});
-
 export function StoreForm({
 	onSubmit,
 	defaultValues,
 	isLoading = false,
 }: StoreFormProps) {
-	const form = useForm({
-		defaultValues: {
-			name: defaultValues?.name ?? "",
-			memo: defaultValues?.memo ?? "",
-		},
-		onSubmit: ({ value }) => {
-			onSubmit({
-				name: value.name,
-				memo: value.memo ? value.memo : undefined,
-			});
-		},
-		validators: {
-			onSubmit: storeFormSchema,
-		},
-	});
+	const { form } = useStoreForm({ onSubmit, defaultValues });
 
 	return (
 		<form

--- a/apps/web/src/stores/components/tournament-edit-dialog.tsx
+++ b/apps/web/src/stores/components/tournament-edit-dialog.tsx
@@ -1,6 +1,4 @@
-import type { ExtractedTournamentData } from "@sapphire2/api/routers/ai-extract";
 import { IconSparkles } from "@tabler/icons-react";
-import { useEffect, useState } from "react";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
@@ -10,6 +8,7 @@ import {
 	type TournamentPartialFormValues,
 } from "@/stores/components/tournament-modal-content";
 import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+import { useTournamentEditDialog } from "@/stores/hooks/use-tournament-edit-dialog";
 import type { TournamentFormValues } from "@/stores/hooks/use-tournaments";
 
 export type TournamentEditDialogMode = "create" | "edit";
@@ -30,55 +29,6 @@ interface TournamentEditDialogProps {
 	title: string;
 }
 
-function extractedToBlindLevels(
-	data: ExtractedTournamentData
-): BlindLevelRow[] {
-	return (data.blindLevels ?? []).map((l, i) => ({
-		id: crypto.randomUUID(),
-		tournamentId: "",
-		level: i + 1,
-		isBreak: l.isBreak,
-		blind1: l.blind1 ?? null,
-		blind2: l.blind2 ?? null,
-		blind3: l.blind3 ?? null,
-		ante: l.ante ?? null,
-		minutes: l.minutes ?? null,
-	}));
-}
-
-function extractedToCreateFormValues(
-	data: ExtractedTournamentData
-): TournamentPartialFormValues {
-	return {
-		name: data.name ?? "",
-		buyIn: data.buyIn,
-		entryFee: data.entryFee,
-		startingStack: data.startingStack,
-		tableSize: data.tableSize,
-		chipPurchases: data.chipPurchases ?? [],
-		variant: "nlh",
-	};
-}
-
-function mergeExtractedIntoEditFormValues(
-	data: ExtractedTournamentData,
-	base: TournamentPartialFormValues | undefined
-): TournamentPartialFormValues {
-	return {
-		...base,
-		// Use || so empty strings fall back to the existing value
-		name: data.name || base?.name || "",
-		variant: base?.variant ?? "nlh",
-		...(data.buyIn !== undefined && { buyIn: data.buyIn }),
-		...(data.entryFee !== undefined && { entryFee: data.entryFee }),
-		...(data.startingStack !== undefined && {
-			startingStack: data.startingStack,
-		}),
-		...(data.tableSize !== undefined && { tableSize: data.tableSize }),
-		...(data.chipPurchases?.length && { chipPurchases: data.chipPurchases }),
-	};
-}
-
 export function TournamentEditDialog({
 	aiMode,
 	initialBlindLevels,
@@ -91,21 +41,21 @@ export function TournamentEditDialog({
 	resetKey,
 	title,
 }: TournamentEditDialogProps) {
-	const [aiSheetOpen, setAiSheetOpen] = useState(false);
-	const [aiFormValues, setAiFormValues] = useState<
-		TournamentPartialFormValues | undefined
-	>();
-	const [aiBlindLevels, setAiBlindLevels] = useState<BlindLevelRow[]>([]);
-	const [aiKey, setAiKey] = useState(0);
-
-	useEffect(() => {
-		if (!open) {
-			setAiFormValues(undefined);
-			setAiBlindLevels([]);
-			setAiKey(0);
-			setAiSheetOpen(false);
-		}
-	}, [open]);
+	const {
+		aiSheetOpen,
+		setAiSheetOpen,
+		aiKey,
+		effectiveFormValues,
+		effectiveLevels,
+		contentKey,
+		handleAiExtracted,
+	} = useTournamentEditDialog({
+		aiMode,
+		initialBlindLevels,
+		initialFormValues,
+		open,
+		resetKey,
+	});
 
 	const aiButton = aiMode ? (
 		<Button
@@ -121,27 +71,6 @@ export function TournamentEditDialog({
 			</Badge>
 		</Button>
 	) : undefined;
-
-	const handleAiExtracted = (data: ExtractedTournamentData) => {
-		const extractedLevels = extractedToBlindLevels(data);
-		if (aiMode === "create") {
-			setAiFormValues(extractedToCreateFormValues(data));
-			setAiBlindLevels(extractedLevels);
-		} else {
-			setAiFormValues(
-				mergeExtractedIntoEditFormValues(data, initialFormValues)
-			);
-			setAiBlindLevels(
-				extractedLevels.length > 0 ? extractedLevels : initialBlindLevels
-			);
-		}
-		setAiKey((k) => k + 1);
-		setAiSheetOpen(false);
-	};
-
-	const effectiveFormValues = aiKey > 0 ? aiFormValues : initialFormValues;
-	const effectiveLevels = aiKey > 0 ? aiBlindLevels : initialBlindLevels;
-	const contentKey = `${resetKey ?? "tournament"}-${aiKey}`;
 
 	return (
 		<>

--- a/apps/web/src/stores/components/tournament-modal-content.tsx
+++ b/apps/web/src/stores/components/tournament-modal-content.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import {
 	Tabs,
 	TabsContent,
@@ -8,6 +7,7 @@ import {
 import { LocalBlindStructureContent } from "@/stores/components/blind-level-editor";
 import { TournamentForm } from "@/stores/components/tournament-form";
 import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+import { useTournamentModalContent } from "@/stores/hooks/use-tournament-modal-content";
 import type { TournamentFormValues } from "@/stores/hooks/use-tournaments";
 
 export type TournamentPartialFormValues = Omit<
@@ -34,8 +34,9 @@ export function TournamentModalContent({
 	isLoading,
 	onSave,
 }: TournamentModalContentProps) {
-	const [localBlindLevels, setLocalBlindLevels] =
-		useState<BlindLevelRow[]>(initialBlindLevels);
+	const { localBlindLevels, setLocalBlindLevels } = useTournamentModalContent({
+		initialBlindLevels,
+	});
 
 	return (
 		<Tabs defaultValue="details">

--- a/apps/web/src/stores/components/tournament-tab.tsx
+++ b/apps/web/src/stores/components/tournament-tab.tsx
@@ -6,7 +6,6 @@ import {
 	IconTrash,
 	IconX,
 } from "@tabler/icons-react";
-import { useEffect, useState } from "react";
 import {
 	ExpandableItem,
 	ExpandableItemList,
@@ -17,6 +16,7 @@ import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import { TournamentEditDialog } from "@/stores/components/tournament-edit-dialog";
 import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+import { useTournamentRow } from "@/stores/hooks/use-tournament-row";
 import {
 	useBlindStructureSummary,
 	useTournamentTab,
@@ -217,15 +217,11 @@ function TournamentRow({
 	onEdit,
 	onRestore,
 }: TournamentRowProps) {
-	const [confirmingDelete, setConfirmingDelete] = useState(false);
+	const { confirmingDelete, setConfirmingDelete } = useTournamentRow({
+		expanded,
+	});
 	const currency = currencies.find((c) => c.id === tournament.currencyId);
 	const buyInStr = formatBuyInShort(tournament, currency?.unit);
-
-	useEffect(() => {
-		if (!expanded) {
-			setConfirmingDelete(false);
-		}
-	}, [expanded]);
 
 	return (
 		<ExpandableItem

--- a/apps/web/src/stores/hooks/use-ai-extract-input.ts
+++ b/apps/web/src/stores/hooks/use-ai-extract-input.ts
@@ -1,0 +1,155 @@
+import type { ExtractedTournamentData } from "@sapphire2/api/routers/ai-extract";
+import { useMutation } from "@tanstack/react-query";
+import { useRef, useState } from "react";
+import { trpc } from "@/utils/trpc";
+
+export interface UrlItem {
+	id: string;
+	kind: "url";
+	value: string;
+}
+
+export interface ImageItem {
+	base64: string;
+	id: string;
+	kind: "image";
+	mediaType: "image/gif" | "image/jpeg" | "image/png" | "image/webp";
+	name: string;
+	previewUrl: string;
+}
+
+export type SourceItem = ImageItem | UrlItem;
+
+const ACCEPTED_TYPES = [
+	"image/jpeg",
+	"image/png",
+	"image/gif",
+	"image/webp",
+] as const;
+type AcceptedMediaType = (typeof ACCEPTED_TYPES)[number];
+
+function isAcceptedMediaType(type: string): type is AcceptedMediaType {
+	return (ACCEPTED_TYPES as readonly string[]).includes(type);
+}
+
+function fileToBase64(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => {
+			const result = reader.result as string;
+			resolve(result.split(",")[1] ?? "");
+		};
+		reader.onerror = reject;
+		reader.readAsDataURL(file);
+	});
+}
+
+interface UseAiExtractInputOptions {
+	onExtracted: (data: ExtractedTournamentData) => void;
+}
+
+export function useAiExtractInput({ onExtracted }: UseAiExtractInputOptions) {
+	const [items, setItems] = useState<SourceItem[]>([
+		{ id: crypto.randomUUID(), kind: "url", value: "" },
+	]);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const mutation = useMutation(
+		trpc.aiExtract.extractTournamentData.mutationOptions({
+			onSuccess: onExtracted,
+		})
+	);
+
+	const addUrl = () => {
+		if (items.length >= 5) {
+			return;
+		}
+		setItems((prev) => [
+			...prev,
+			{ id: crypto.randomUUID(), kind: "url", value: "" },
+		]);
+	};
+
+	const removeItem = (id: string) => {
+		setItems((prev) => prev.filter((item) => item.id !== id));
+	};
+
+	const updateUrl = (id: string, value: string) => {
+		setItems((prev) =>
+			prev.map((item) =>
+				item.id === id && item.kind === "url" ? { ...item, value } : item
+			)
+		);
+	};
+
+	const handleImageSelect = async (
+		e: React.ChangeEvent<HTMLInputElement>
+	): Promise<void> => {
+		const file = e.target.files?.[0];
+		if (!file) {
+			return;
+		}
+		const mediaType = file.type;
+		if (!isAcceptedMediaType(mediaType)) {
+			return;
+		}
+		if (items.length >= 5) {
+			return;
+		}
+
+		const base64 = await fileToBase64(file);
+		const previewUrl = URL.createObjectURL(file);
+		setItems((prev) => [
+			...prev,
+			{
+				id: crypto.randomUUID(),
+				kind: "image",
+				base64,
+				mediaType,
+				name: file.name,
+				previewUrl,
+			},
+		]);
+		// Reset so same file can be re-selected
+		e.target.value = "";
+	};
+
+	const handleAnalyze = () => {
+		const sources = items.flatMap(
+			(item): Parameters<typeof mutation.mutate>[0]["sources"] => {
+				if (item.kind === "url") {
+					const url = item.value.trim();
+					if (!url) {
+						return [];
+					}
+					return [{ kind: "url", url }];
+				}
+				return [
+					{ kind: "image", data: item.base64, mediaType: item.mediaType },
+				];
+			}
+		);
+		if (sources.length === 0) {
+			return;
+		}
+		mutation.mutate({ sources });
+	};
+
+	const triggerFileInput = () => {
+		fileInputRef.current?.click();
+	};
+
+	return {
+		items,
+		fileInputRef,
+		canAdd: items.length < 5,
+		isPending: mutation.isPending,
+		error: mutation.error,
+		addUrl,
+		removeItem,
+		updateUrl,
+		handleImageSelect,
+		handleAnalyze,
+		triggerFileInput,
+	};
+}

--- a/apps/web/src/stores/hooks/use-blind-level-editor.ts
+++ b/apps/web/src/stores/hooks/use-blind-level-editor.ts
@@ -1,0 +1,83 @@
+import type { DragEndEvent } from "@dnd-kit/core";
+import {
+	PointerSensor,
+	TouchSensor,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
+import { useState } from "react";
+import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+import {
+	addLevel,
+	createLevel,
+	deleteLevel,
+	getEffectiveLastMinutes,
+	type NewLevelValues,
+	reorderLevels,
+	updateLevel,
+} from "@/stores/utils/blind-level-helpers";
+
+interface UseLocalBlindStructureOptions {
+	onChange: (levels: BlindLevelRow[]) => void;
+	value: BlindLevelRow[];
+}
+
+export function useLocalBlindStructure({
+	value,
+	onChange,
+}: UseLocalBlindStructureOptions) {
+	const [lastMinutes, setLastMinutes] = useState<number | null>(null);
+
+	const effectiveLastMinutes = getEffectiveLastMinutes(lastMinutes, value);
+
+	const sensors = useSensors(
+		useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+		useSensor(TouchSensor, {
+			activationConstraint: { delay: 250, tolerance: 8 },
+		})
+	);
+
+	const handleDragEnd = (event: DragEndEvent) => {
+		const reordered = reorderLevels(value, event);
+		if (reordered) {
+			onChange(reordered);
+		}
+	};
+
+	const handleAddLevel = () => {
+		onChange(addLevel(value, effectiveLastMinutes, false));
+	};
+
+	const handleAddBreak = () => {
+		onChange(addLevel(value, effectiveLastMinutes, true));
+	};
+
+	const handleDelete = (id: string) => {
+		onChange(deleteLevel(value, id));
+	};
+
+	const handleUpdate = (id: string, updates: Record<string, number | null>) => {
+		onChange(updateLevel(value, id, updates));
+		if (updates.minutes != null) {
+			setLastMinutes(updates.minutes);
+		}
+	};
+
+	const handleCreateLevel = (vals: NewLevelValues) => {
+		const minutes = vals.minutes ?? effectiveLastMinutes;
+		onChange(createLevel(value, vals, effectiveLastMinutes));
+		if (minutes != null) {
+			setLastMinutes(minutes);
+		}
+	};
+
+	return {
+		sensors,
+		handleDragEnd,
+		handleAddLevel,
+		handleAddBreak,
+		handleDelete,
+		handleUpdate,
+		handleCreateLevel,
+	};
+}

--- a/apps/web/src/stores/hooks/use-blind-levels.ts
+++ b/apps/web/src/stores/hooks/use-blind-levels.ts
@@ -1,4 +1,10 @@
 import type { DragEndEvent } from "@dnd-kit/core";
+import {
+	PointerSensor,
+	TouchSensor,
+	useSensor,
+	useSensors,
+} from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -243,10 +249,18 @@ export function useBlindLevels({ tournamentId }: UseBlindLevelsOptions) {
 		}
 	};
 
+	const sensors = useSensors(
+		useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+		useSensor(TouchSensor, {
+			activationConstraint: { delay: 250, tolerance: 8 },
+		})
+	);
+
 	return {
 		levels: levels as BlindLevelRow[],
 		isLoading: levelsQuery.isLoading,
 		isAdding: addLevelMutation.isPending,
+		sensors,
 		handleDragEnd,
 		handleAddLevel,
 		handleAddBreak,

--- a/apps/web/src/stores/hooks/use-empty-row.ts
+++ b/apps/web/src/stores/hooks/use-empty-row.ts
@@ -1,0 +1,94 @@
+import { useRef } from "react";
+import type { NewLevelValues } from "@/stores/utils/blind-level-helpers";
+
+function parseIntOrNull(value: string): number | null {
+	if (!value) {
+		return null;
+	}
+	const parsed = Number.parseInt(value, 10);
+	return Number.isNaN(parsed) ? null : parsed;
+}
+
+interface UseEmptyRowOptions {
+	onCreateLevel: (values: NewLevelValues) => void;
+}
+
+export function useEmptyRow({ onCreateLevel }: UseEmptyRowOptions) {
+	const blind1Ref = useRef<HTMLInputElement>(null);
+	const blind2Ref = useRef<HTMLInputElement>(null);
+	const anteRef = useRef<HTMLInputElement>(null);
+	const minutesRef = useRef<HTMLInputElement>(null);
+
+	const resetRow = () => {
+		for (const ref of [blind1Ref, blind2Ref, anteRef, minutesRef]) {
+			if (ref.current) {
+				ref.current.value = "";
+			}
+		}
+	};
+
+	const tryCreate = (relatedTarget: EventTarget | null) => {
+		const cells = [
+			blind1Ref.current,
+			blind2Ref.current,
+			anteRef.current,
+			minutesRef.current,
+		];
+		if (cells.includes(relatedTarget as HTMLInputElement)) {
+			return;
+		}
+		const blind1Val = parseIntOrNull(blind1Ref.current?.value ?? "");
+		if (blind1Val == null) {
+			return;
+		}
+		onCreateLevel({
+			blind1: blind1Val,
+			blind2: parseIntOrNull(blind2Ref.current?.value ?? ""),
+			ante: parseIntOrNull(anteRef.current?.value ?? ""),
+			minutes: parseIntOrNull(minutesRef.current?.value ?? ""),
+		});
+		resetRow();
+	};
+
+	const handleBlind1Blur = (e: React.FocusEvent<HTMLInputElement>) => {
+		const val = e.target.value;
+		const parsed = parseIntOrNull(val);
+		if (parsed != null) {
+			if (blind2Ref.current && !blind2Ref.current.value) {
+				blind2Ref.current.value = String(parsed * 2);
+			}
+			if (anteRef.current && !anteRef.current.value) {
+				anteRef.current.value = blind2Ref.current?.value ?? val;
+			}
+		}
+		tryCreate(e.relatedTarget);
+	};
+
+	const handleBlind2Blur = (e: React.FocusEvent<HTMLInputElement>) => {
+		const val = e.target.value;
+		const parsed = parseIntOrNull(val);
+		if (parsed != null && anteRef.current && !anteRef.current.value) {
+			anteRef.current.value = val;
+		}
+		tryCreate(e.relatedTarget);
+	};
+
+	const handleAnteBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+		tryCreate(e.relatedTarget);
+	};
+
+	const handleMinutesBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+		tryCreate(e.relatedTarget);
+	};
+
+	return {
+		blind1Ref,
+		blind2Ref,
+		anteRef,
+		minutesRef,
+		handleBlind1Blur,
+		handleBlind2Blur,
+		handleAnteBlur,
+		handleMinutesBlur,
+	};
+}

--- a/apps/web/src/stores/hooks/use-ring-game-row.ts
+++ b/apps/web/src/stores/hooks/use-ring-game-row.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+interface UseRingGameRowOptions {
+	expanded: boolean;
+}
+
+export function useRingGameRow({ expanded }: UseRingGameRowOptions) {
+	const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+	useEffect(() => {
+		if (!expanded) {
+			setConfirmingDelete(false);
+		}
+	}, [expanded]);
+
+	return {
+		confirmingDelete,
+		setConfirmingDelete,
+	};
+}

--- a/apps/web/src/stores/hooks/use-ring-game-tab.ts
+++ b/apps/web/src/stores/hooks/use-ring-game-tab.ts
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import type {
+	RingGame,
+	RingGameFormValues,
+} from "@/stores/hooks/use-ring-games";
+import { useRingGames } from "@/stores/hooks/use-ring-games";
+
+interface UseRingGameTabOptions {
+	storeId: string;
+}
+
+export function useRingGameTab({ storeId }: UseRingGameTabOptions) {
+	const [showArchived, setShowArchived] = useState(false);
+	const [isCreateOpen, setIsCreateOpen] = useState(false);
+	const [editingGame, setEditingGame] = useState<RingGame | null>(null);
+
+	const {
+		activeGames,
+		archivedGames,
+		currencies,
+		activeLoading,
+		archivedLoading,
+		isCreatePending,
+		isUpdatePending,
+		create,
+		update,
+		archive,
+		restore,
+		delete: deleteGame,
+	} = useRingGames({ storeId, showArchived });
+
+	const handleCreate = (values: RingGameFormValues) => {
+		create(values).then(() => {
+			setIsCreateOpen(false);
+		});
+	};
+
+	const handleUpdate = (values: RingGameFormValues) => {
+		if (!editingGame) {
+			return;
+		}
+		update({ id: editingGame.id, ...values }).then(() => {
+			setEditingGame(null);
+		});
+	};
+
+	return {
+		showArchived,
+		setShowArchived,
+		isCreateOpen,
+		setIsCreateOpen,
+		editingGame,
+		setEditingGame,
+		activeGames,
+		archivedGames,
+		currencies,
+		activeLoading,
+		archivedLoading,
+		isCreatePending,
+		isUpdatePending,
+		archive,
+		restore,
+		deleteGame,
+		handleCreate,
+		handleUpdate,
+	};
+}

--- a/apps/web/src/stores/hooks/use-sortable-level-row.ts
+++ b/apps/web/src/stores/hooks/use-sortable-level-row.ts
@@ -1,0 +1,72 @@
+import { useRef } from "react";
+import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+
+function parseIntOrNull(value: string): number | null {
+	if (!value) {
+		return null;
+	}
+	const parsed = Number.parseInt(value, 10);
+	return Number.isNaN(parsed) ? null : parsed;
+}
+
+interface UseSortableLevelRowOptions {
+	onUpdate: (id: string, updates: Record<string, number | null>) => void;
+	row: BlindLevelRow;
+}
+
+export function useSortableLevelRow({
+	row,
+	onUpdate,
+}: UseSortableLevelRowOptions) {
+	const currentBlind2Ref = useRef(row.blind2 == null ? "" : String(row.blind2));
+	const currentAnteRef = useRef(row.ante == null ? "" : String(row.ante));
+
+	const handleBlind1Blur = (e: React.FocusEvent<HTMLInputElement>) => {
+		const val = e.target.value;
+		const parsed = parseIntOrNull(val);
+		const updates: Record<string, number | null> = { blind1: parsed };
+		if (parsed != null) {
+			if (!currentBlind2Ref.current) {
+				const bb = parsed * 2;
+				currentBlind2Ref.current = String(bb);
+				updates.blind2 = bb;
+				if (!currentAnteRef.current) {
+					currentAnteRef.current = String(bb);
+					updates.ante = bb;
+				}
+			} else if (!currentAnteRef.current) {
+				currentAnteRef.current = String(parsed);
+				updates.ante = parsed;
+			}
+		}
+		onUpdate(row.id, updates);
+	};
+
+	const handleBlind2Blur = (e: React.FocusEvent<HTMLInputElement>) => {
+		const val = e.target.value;
+		currentBlind2Ref.current = val;
+		const parsed = parseIntOrNull(val);
+		const updates: Record<string, number | null> = { blind2: parsed };
+		if (parsed != null && !currentAnteRef.current) {
+			currentAnteRef.current = val;
+			updates.ante = parsed;
+		}
+		onUpdate(row.id, updates);
+	};
+
+	const handleAnteBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+		currentAnteRef.current = e.target.value;
+		onUpdate(row.id, { ante: parseIntOrNull(e.target.value) });
+	};
+
+	const handleMinutesBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+		onUpdate(row.id, { minutes: parseIntOrNull(e.target.value) });
+	};
+
+	return {
+		handleBlind1Blur,
+		handleBlind2Blur,
+		handleAnteBlur,
+		handleMinutesBlur,
+	};
+}

--- a/apps/web/src/stores/hooks/use-store-card.ts
+++ b/apps/web/src/stores/hooks/use-store-card.ts
@@ -1,0 +1,14 @@
+import { useState } from "react";
+
+export function useStoreCard() {
+	const [expandedGameId, setExpandedGameId] = useState<string | null>(null);
+
+	const handleToggleGame = (id: string | null) => {
+		setExpandedGameId(id);
+	};
+
+	return {
+		expandedGameId,
+		handleToggleGame,
+	};
+}

--- a/apps/web/src/stores/hooks/use-store-detail-page.ts
+++ b/apps/web/src/stores/hooks/use-store-detail-page.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { trpc } from "@/utils/trpc";
+
+export function useStoreDetailPage(storeId: string) {
+	const storeQuery = useQuery(trpc.store.getById.queryOptions({ id: storeId }));
+	const [expandedGameId, setExpandedGameId] = useState<string | null>(null);
+
+	const handleToggleGame = (id: string | null) => {
+		setExpandedGameId(id);
+	};
+
+	return {
+		store: storeQuery.data,
+		isLoading: storeQuery.isLoading,
+		expandedGameId,
+		handleToggleGame,
+	};
+}

--- a/apps/web/src/stores/hooks/use-store-form.ts
+++ b/apps/web/src/stores/hooks/use-store-form.ts
@@ -1,0 +1,37 @@
+import { useForm } from "@tanstack/react-form";
+import { z } from "zod";
+
+export interface StoreFormValues {
+	memo?: string;
+	name: string;
+}
+
+const storeFormSchema = z.object({
+	name: z.string().min(1, "Store name is required"),
+	memo: z.string(),
+});
+
+interface UseStoreFormOptions {
+	defaultValues?: StoreFormValues;
+	onSubmit: (values: StoreFormValues) => void;
+}
+
+export function useStoreForm({ onSubmit, defaultValues }: UseStoreFormOptions) {
+	const form = useForm({
+		defaultValues: {
+			name: defaultValues?.name ?? "",
+			memo: defaultValues?.memo ?? "",
+		},
+		onSubmit: ({ value }) => {
+			onSubmit({
+				name: value.name,
+				memo: value.memo ? value.memo : undefined,
+			});
+		},
+		validators: {
+			onSubmit: storeFormSchema,
+		},
+	});
+
+	return { form };
+}

--- a/apps/web/src/stores/hooks/use-stores-page.ts
+++ b/apps/web/src/stores/hooks/use-stores-page.ts
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import type { StoreItem, StoreValues } from "@/stores/hooks/use-stores";
+import { useStores } from "@/stores/hooks/use-stores";
+
+export function useStoresPage() {
+	const [isCreateOpen, setIsCreateOpen] = useState(false);
+	const [editingStore, setEditingStore] = useState<StoreItem | null>(null);
+
+	const {
+		stores,
+		isCreatePending,
+		isUpdatePending,
+		create,
+		update,
+		delete: deleteStore,
+	} = useStores();
+
+	const handleCreate = (values: StoreValues) => {
+		create(values).then(() => {
+			setIsCreateOpen(false);
+		});
+	};
+
+	const handleUpdate = (values: StoreValues) => {
+		if (!editingStore) {
+			return;
+		}
+		update({ id: editingStore.id, ...values }).then(() => {
+			setEditingStore(null);
+		});
+	};
+
+	const handleDelete = (id: string) => {
+		deleteStore(id);
+	};
+
+	const handleCloseEdit = () => {
+		setEditingStore(null);
+	};
+
+	return {
+		stores,
+		isCreatePending,
+		isUpdatePending,
+		isCreateOpen,
+		editingStore,
+		setIsCreateOpen,
+		setEditingStore,
+		handleCreate,
+		handleUpdate,
+		handleDelete,
+		handleCloseEdit,
+	};
+}

--- a/apps/web/src/stores/hooks/use-tournament-edit-dialog.ts
+++ b/apps/web/src/stores/hooks/use-tournament-edit-dialog.ts
@@ -1,0 +1,117 @@
+import type { ExtractedTournamentData } from "@sapphire2/api/routers/ai-extract";
+import { useEffect, useState } from "react";
+import type { TournamentEditDialogMode } from "@/stores/components/tournament-edit-dialog";
+import type { TournamentPartialFormValues } from "@/stores/components/tournament-modal-content";
+import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+
+function extractedToBlindLevels(
+	data: ExtractedTournamentData
+): BlindLevelRow[] {
+	return (data.blindLevels ?? []).map((l, i) => ({
+		id: crypto.randomUUID(),
+		tournamentId: "",
+		level: i + 1,
+		isBreak: l.isBreak,
+		blind1: l.blind1 ?? null,
+		blind2: l.blind2 ?? null,
+		blind3: l.blind3 ?? null,
+		ante: l.ante ?? null,
+		minutes: l.minutes ?? null,
+	}));
+}
+
+function extractedToCreateFormValues(
+	data: ExtractedTournamentData
+): TournamentPartialFormValues {
+	return {
+		name: data.name ?? "",
+		buyIn: data.buyIn,
+		entryFee: data.entryFee,
+		startingStack: data.startingStack,
+		tableSize: data.tableSize,
+		chipPurchases: data.chipPurchases ?? [],
+		variant: "nlh",
+	};
+}
+
+function mergeExtractedIntoEditFormValues(
+	data: ExtractedTournamentData,
+	base: TournamentPartialFormValues | undefined
+): TournamentPartialFormValues {
+	return {
+		...base,
+		// Use || so empty strings fall back to the existing value
+		name: data.name || base?.name || "",
+		variant: base?.variant ?? "nlh",
+		...(data.buyIn !== undefined && { buyIn: data.buyIn }),
+		...(data.entryFee !== undefined && { entryFee: data.entryFee }),
+		...(data.startingStack !== undefined && {
+			startingStack: data.startingStack,
+		}),
+		...(data.tableSize !== undefined && { tableSize: data.tableSize }),
+		...(data.chipPurchases?.length && { chipPurchases: data.chipPurchases }),
+	};
+}
+
+interface UseTournamentEditDialogOptions {
+	aiMode?: TournamentEditDialogMode;
+	initialBlindLevels: BlindLevelRow[];
+	initialFormValues?: TournamentPartialFormValues;
+	open: boolean;
+	resetKey?: string;
+}
+
+export function useTournamentEditDialog({
+	aiMode,
+	initialBlindLevels,
+	initialFormValues,
+	open,
+	resetKey,
+}: UseTournamentEditDialogOptions) {
+	const [aiSheetOpen, setAiSheetOpen] = useState(false);
+	const [aiFormValues, setAiFormValues] = useState<
+		TournamentPartialFormValues | undefined
+	>();
+	const [aiBlindLevels, setAiBlindLevels] = useState<BlindLevelRow[]>([]);
+	const [aiKey, setAiKey] = useState(0);
+
+	useEffect(() => {
+		if (!open) {
+			setAiFormValues(undefined);
+			setAiBlindLevels([]);
+			setAiKey(0);
+			setAiSheetOpen(false);
+		}
+	}, [open]);
+
+	const handleAiExtracted = (data: ExtractedTournamentData) => {
+		const extractedLevels = extractedToBlindLevels(data);
+		if (aiMode === "create") {
+			setAiFormValues(extractedToCreateFormValues(data));
+			setAiBlindLevels(extractedLevels);
+		} else {
+			setAiFormValues(
+				mergeExtractedIntoEditFormValues(data, initialFormValues)
+			);
+			setAiBlindLevels(
+				extractedLevels.length > 0 ? extractedLevels : initialBlindLevels
+			);
+		}
+		setAiKey((k) => k + 1);
+		setAiSheetOpen(false);
+	};
+
+	const effectiveFormValues = aiKey > 0 ? aiFormValues : initialFormValues;
+	const effectiveLevels = aiKey > 0 ? aiBlindLevels : initialBlindLevels;
+	const contentKey = `${resetKey ?? "tournament"}-${aiKey}`;
+
+	return {
+		aiSheetOpen,
+		setAiSheetOpen,
+		aiKey,
+		effectiveFormValues,
+		effectiveLevels,
+		contentKey,
+		handleAiExtracted,
+	};
+}

--- a/apps/web/src/stores/hooks/use-tournament-modal-content.ts
+++ b/apps/web/src/stores/hooks/use-tournament-modal-content.ts
@@ -1,0 +1,18 @@
+import { useState } from "react";
+import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+
+interface UseTournamentModalContentOptions {
+	initialBlindLevels: BlindLevelRow[];
+}
+
+export function useTournamentModalContent({
+	initialBlindLevels,
+}: UseTournamentModalContentOptions) {
+	const [localBlindLevels, setLocalBlindLevels] =
+		useState<BlindLevelRow[]>(initialBlindLevels);
+
+	return {
+		localBlindLevels,
+		setLocalBlindLevels,
+	};
+}

--- a/apps/web/src/stores/hooks/use-tournament-row.ts
+++ b/apps/web/src/stores/hooks/use-tournament-row.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+interface UseTournamentRowOptions {
+	expanded: boolean;
+}
+
+export function useTournamentRow({ expanded }: UseTournamentRowOptions) {
+	const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+	useEffect(() => {
+		if (!expanded) {
+			setConfirmingDelete(false);
+		}
+	}, [expanded]);
+
+	return {
+		confirmingDelete,
+		setConfirmingDelete,
+	};
+}

--- a/apps/web/src/stores/utils/blind-level-helpers.ts
+++ b/apps/web/src/stores/utils/blind-level-helpers.ts
@@ -1,0 +1,104 @@
+import type { DragEndEvent } from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
+import type { BlindLevelRow } from "@/stores/hooks/use-blind-levels";
+
+export interface NewLevelValues {
+	ante: number | null;
+	blind1: number | null;
+	blind2: number | null;
+	minutes: number | null;
+}
+
+export function getEffectiveLastMinutes(
+	lastMinutes: number | null,
+	levels: BlindLevelRow[]
+): number | null {
+	if (lastMinutes != null) {
+		return lastMinutes;
+	}
+	for (let i = levels.length - 1; i >= 0; i--) {
+		if (levels[i].minutes != null) {
+			return levels[i].minutes;
+		}
+	}
+	return null;
+}
+
+export function reorderLevels(
+	levels: BlindLevelRow[],
+	event: DragEndEvent
+): BlindLevelRow[] | null {
+	const { active, over } = event;
+	if (!over || active.id === over.id) {
+		return null;
+	}
+	const oldIndex = levels.findIndex((l) => l.id === active.id);
+	const newIndex = levels.findIndex((l) => l.id === over.id);
+	if (oldIndex === -1 || newIndex === -1) {
+		return null;
+	}
+	return arrayMove(levels, oldIndex, newIndex).map((l, i) => ({
+		...l,
+		level: i + 1,
+	}));
+}
+
+export function addLevel(
+	levels: BlindLevelRow[],
+	effectiveLastMinutes: number | null,
+	isBreak: boolean
+): BlindLevelRow[] {
+	return [
+		...levels,
+		{
+			id: crypto.randomUUID(),
+			tournamentId: "",
+			level: levels.length + 1,
+			isBreak,
+			blind1: null,
+			blind2: null,
+			blind3: null,
+			ante: null,
+			minutes: effectiveLastMinutes,
+		},
+	];
+}
+
+export function deleteLevel(
+	levels: BlindLevelRow[],
+	id: string
+): BlindLevelRow[] {
+	return levels
+		.filter((l) => l.id !== id)
+		.map((l, i) => ({ ...l, level: i + 1 }));
+}
+
+export function updateLevel(
+	levels: BlindLevelRow[],
+	id: string,
+	updates: Record<string, number | null>
+): BlindLevelRow[] {
+	return levels.map((l) => (l.id === id ? { ...l, ...updates } : l));
+}
+
+export function createLevel(
+	levels: BlindLevelRow[],
+	vals: NewLevelValues,
+	effectiveLastMinutes: number | null
+): BlindLevelRow[] {
+	const minutes = vals.minutes ?? effectiveLastMinutes;
+	return [
+		...levels,
+		{
+			id: crypto.randomUUID(),
+			tournamentId: "",
+			level: levels.length + 1,
+			isBreak: false,
+			blind1: vals.blind1,
+			blind2: vals.blind2,
+			blind3: null,
+			ante: vals.ante,
+			minutes,
+		},
+	];
+}


### PR DESCRIPTION
## Summary

`apps/web/` 配下のすべてのコンポーネント・ルートページから、React 組み込みフック (`useState`/`useEffect`/`useMemo`/`useRef`/`useCallback` 等) と第三者フック (`useForm`/`useQuery`/`useMutation`/`useQueryClient`/`useIsMutating` 等) を排除し、プロジェクト定義のカスタムフック (`apps/web/src/**/hooks/use-*.ts`) のみを呼び出す形に統一した。

単一 PR で全面リファクタ。以下をカバー:
- **live-sessions/components** (26 ファイル)
- **stores/components** (8 ファイル)
- **players + sessions/components** (6 ファイル)
- **currencies + dashboard/components** (7 ファイル)
- **shared/components + ui プリミティブ** (11 ファイル) — `rich-text-editor.tsx` と `tag-picker-base.tsx` も hook 化
- **routes** (8 ファイル) — 各ルートに対応する `use-<page>-page.ts` を作成

合計約 66 違反ファイルを修正、約 80 の新規 hook/utils ファイルを追加。

## CLAUDE.md 更新

`UI/Logic Separation` セクションを **STRICT MANDATORY** に昇格。禁止リスト、許容リスト、検証用 ripgrep コマンド、リファレンス実装 (`use-players-page.ts` + `routes/players/index.tsx` 等) を明記。

## Verification

- `rg '\b(useState|useEffect|...)\b' apps/web/src/**/components/**/*.tsx apps/web/src/routes/**/*.tsx -g '!**/__tests__/**'` → **0 件**
- `bun x ultracite check apps/web/src` → **380 files clean**
- `bun x vitest run` → **327 tests / 67 files all passed** (ローカル計測時)

## Test plan

- [x] 全テスト通過
- [x] lint クリア
- [x] 違反スキャン 0 件
- [ ] 手動 golden path: sign-in/sign-up, dashboard, live-sessions 開始/座席/イベント/完了, sessions/players/stores/currencies CRUD + フィルタ

## Scope

- 変更: **150 ファイル** (+5770 insertions / -3255 deletions)
- 新規作成: `apps/web/src/**/hooks/use-*.ts` 約 80 ファイル
- 修正: コンポーネント 66 + route 8 + CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)