### PR TITLE
refactor(web): migrate self-implemented UI to shadcn primitives

### DIFF
--- a/apps/web/src/features/dashboard/widgets/active-session-widget/active-session-widget.tsx
+++ b/apps/web/src/features/dashboard/widgets/active-session-widget/active-session-widget.tsx
@@ -1,21 +1,24 @@
 import { IconBolt, IconPokerChip, IconTrophy } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
-import { useState } from "react";
 import type {
 	WidgetEditProps,
 	WidgetRenderProps,
 } from "@/features/dashboard/widgets/registry";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
-import { Label } from "@/shared/components/ui/label";
+import { Field } from "@/shared/components/ui/field";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/shared/components/ui/select";
 import { Skeleton } from "@/shared/components/ui/skeleton";
 import { useElapsedTime } from "@/shared/hooks/use-elapsed-time";
 import { formatCompactNumber } from "@/utils/format-number";
-import {
-	type ActiveSessionWidgetSessionType,
-	parseActiveSessionWidgetConfig,
-	useActiveSessionWidget,
-} from "./use-active-session-widget";
+import { useActiveSessionEditForm } from "./use-active-session-edit-form";
+import { useActiveSessionWidget } from "./use-active-session-widget";
 
 interface ActiveSessionRowProps {
 	latestStackAmount: number | null;
@@ -118,45 +121,52 @@ export function ActiveSessionEditForm({
 	onSave,
 	onCancel,
 }: WidgetEditProps) {
-	const parsed = parseActiveSessionWidgetConfig(config);
-	const [sessionType, setSessionType] =
-		useState<ActiveSessionWidgetSessionType>(parsed.sessionType);
-	const [isSaving, setIsSaving] = useState(false);
-
-	const handleSave = async () => {
-		setIsSaving(true);
-		try {
-			await onSave({ sessionType });
-		} finally {
-			setIsSaving(false);
-		}
-	};
+	const { form } = useActiveSessionEditForm({ config, onSave });
 
 	return (
-		<div className="flex flex-col gap-4">
-			<div className="flex flex-col gap-2">
-				<Label htmlFor="active-session-type">Session Type</Label>
-				<select
-					className="rounded-md border bg-background px-3 py-2 text-sm"
-					id="active-session-type"
-					onChange={(e) =>
-						setSessionType(e.target.value as ActiveSessionWidgetSessionType)
-					}
-					value={sessionType}
-				>
-					<option value="all">All</option>
-					<option value="cash_game">Cash Game</option>
-					<option value="tournament">Tournament</option>
-				</select>
-			</div>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="sessionType">
+				{(field) => (
+					<Field htmlFor={field.name} label="Session Type">
+						<Select
+							onValueChange={(value) =>
+								field.handleChange(value as typeof field.state.value)
+							}
+							value={field.state.value}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue placeholder="Select type" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All</SelectItem>
+								<SelectItem value="cash_game">Cash Game</SelectItem>
+								<SelectItem value="tournament">Tournament</SelectItem>
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
 			<DialogActionRow>
-				<Button onClick={onCancel} variant="outline">
+				<Button onClick={onCancel} type="button" variant="outline">
 					Cancel
 				</Button>
-				<Button disabled={isSaving} onClick={handleSave}>
-					{isSaving ? "Saving..." : "Save"}
-				</Button>
+				<form.Subscribe
+					selector={(state) => [state.canSubmit, state.isSubmitting]}
+				>
+					{([canSubmit, isSubmitting]) => (
+						<Button disabled={!canSubmit || isSubmitting} type="submit">
+							{isSubmitting ? "Saving..." : "Save"}
+						</Button>
+					)}
+				</form.Subscribe>
 			</DialogActionRow>
-		</div>
+		</form>
 	);
 }

--- a/apps/web/src/features/dashboard/widgets/active-session-widget/use-active-session-edit-form.ts
+++ b/apps/web/src/features/dashboard/widgets/active-session-widget/use-active-session-edit-form.ts
@@ -1,0 +1,38 @@
+import { useForm } from "@tanstack/react-form";
+import z from "zod";
+import type { WidgetEditProps } from "@/features/dashboard/widgets/registry";
+import {
+	type ActiveSessionWidgetSessionType,
+	parseActiveSessionWidgetConfig,
+} from "./use-active-session-widget";
+
+const SESSION_TYPE_VALUES = ["all", "cash_game", "tournament"] as const;
+
+const editFormSchema = z.object({
+	sessionType: z.enum(SESSION_TYPE_VALUES),
+});
+
+interface UseActiveSessionEditFormOptions {
+	config: WidgetEditProps["config"];
+	onSave: WidgetEditProps["onSave"];
+}
+
+export function useActiveSessionEditForm({
+	config,
+	onSave,
+}: UseActiveSessionEditFormOptions) {
+	const parsed = parseActiveSessionWidgetConfig(config);
+	const form = useForm({
+		defaultValues: {
+			sessionType: parsed.sessionType as ActiveSessionWidgetSessionType,
+		},
+		onSubmit: async ({ value }) => {
+			await onSave({ sessionType: value.sessionType });
+		},
+		validators: {
+			onSubmit: editFormSchema,
+		},
+	});
+
+	return { form };
+}

--- a/apps/web/src/features/dashboard/widgets/currency-balance-widget/currency-balance-widget.tsx
+++ b/apps/web/src/features/dashboard/widgets/currency-balance-widget/currency-balance-widget.tsx
@@ -1,19 +1,23 @@
 import { IconCoin } from "@tabler/icons-react";
-import { useState } from "react";
 import type {
 	WidgetEditProps,
 	WidgetRenderProps,
 } from "@/features/dashboard/widgets/registry";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
-import { Label } from "@/shared/components/ui/label";
+import { Field } from "@/shared/components/ui/field";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/shared/components/ui/select";
 import { Skeleton } from "@/shared/components/ui/skeleton";
 import { formatCompactNumber } from "@/utils/format-number";
 import { profitLossColorClass } from "@/utils/format-profit-loss";
-import {
-	useCurrencyBalanceOptions,
-	useCurrencyBalanceWidget,
-} from "./use-currency-balance-widget";
+import { useCurrencyBalanceEditForm } from "./use-currency-balance-edit-form";
+import { useCurrencyBalanceWidget } from "./use-currency-balance-widget";
 
 export function CurrencyBalanceWidget({ config }: WidgetRenderProps) {
 	const { isLoading, currencies, selected } = useCurrencyBalanceWidget(config);
@@ -68,49 +72,58 @@ export function CurrencyBalanceEditForm({
 	onSave,
 	onCancel,
 }: WidgetEditProps) {
-	const currencyIdFromConfig =
-		typeof config.currencyId === "string" ? config.currencyId : null;
-	const [currencyId, setCurrencyId] = useState<string | null>(
-		currencyIdFromConfig
-	);
-	const [isSaving, setIsSaving] = useState(false);
-	const currencies = useCurrencyBalanceOptions();
-
-	const handleSave = async () => {
-		setIsSaving(true);
-		try {
-			await onSave({ currencyId });
-		} finally {
-			setIsSaving(false);
-		}
-	};
+	const { form, currencies, FIRST_AVAILABLE } = useCurrencyBalanceEditForm({
+		config,
+		onSave,
+	});
 
 	return (
-		<div className="flex flex-col gap-4">
-			<div className="flex flex-col gap-2">
-				<Label htmlFor="currency-balance-id">Currency</Label>
-				<select
-					className="rounded-md border bg-background px-3 py-2 text-sm"
-					id="currency-balance-id"
-					onChange={(e) => setCurrencyId(e.target.value || null)}
-					value={currencyId ?? ""}
-				>
-					<option value="">(First available)</option>
-					{currencies.map((c) => (
-						<option key={c.id} value={c.id}>
-							{c.name}
-						</option>
-					))}
-				</select>
-			</div>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="currencyId">
+				{(field) => (
+					<Field htmlFor={field.name} label="Currency">
+						<Select
+							onValueChange={(value) => field.handleChange(value)}
+							value={field.state.value}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue placeholder="Select currency" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value={FIRST_AVAILABLE}>
+									(First available)
+								</SelectItem>
+								{currencies.map((c) => (
+									<SelectItem key={c.id} value={c.id}>
+										{c.name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
 			<DialogActionRow>
-				<Button onClick={onCancel} variant="outline">
+				<Button onClick={onCancel} type="button" variant="outline">
 					Cancel
 				</Button>
-				<Button disabled={isSaving} onClick={handleSave}>
-					{isSaving ? "Saving..." : "Save"}
-				</Button>
+				<form.Subscribe
+					selector={(state) => [state.canSubmit, state.isSubmitting]}
+				>
+					{([canSubmit, isSubmitting]) => (
+						<Button disabled={!canSubmit || isSubmitting} type="submit">
+							{isSubmitting ? "Saving..." : "Save"}
+						</Button>
+					)}
+				</form.Subscribe>
 			</DialogActionRow>
-		</div>
+		</form>
 	);
 }

--- a/apps/web/src/features/dashboard/widgets/currency-balance-widget/use-currency-balance-edit-form.ts
+++ b/apps/web/src/features/dashboard/widgets/currency-balance-widget/use-currency-balance-edit-form.ts
@@ -1,0 +1,33 @@
+import { useForm } from "@tanstack/react-form";
+import type { WidgetEditProps } from "@/features/dashboard/widgets/registry";
+import { useCurrencyBalanceOptions } from "./use-currency-balance-widget";
+
+const FIRST_AVAILABLE = "__first__";
+
+interface UseCurrencyBalanceEditFormOptions {
+	config: WidgetEditProps["config"];
+	onSave: WidgetEditProps["onSave"];
+}
+
+export function useCurrencyBalanceEditForm({
+	config,
+	onSave,
+}: UseCurrencyBalanceEditFormOptions) {
+	const currencies = useCurrencyBalanceOptions();
+	const initialCurrencyId =
+		typeof config.currencyId === "string" ? config.currencyId : FIRST_AVAILABLE;
+
+	const form = useForm({
+		defaultValues: {
+			currencyId: initialCurrencyId,
+		},
+		onSubmit: async ({ value }) => {
+			await onSave({
+				currencyId:
+					value.currencyId === FIRST_AVAILABLE ? null : value.currencyId,
+			});
+		},
+	});
+
+	return { form, currencies, FIRST_AVAILABLE };
+}

--- a/apps/web/src/features/dashboard/widgets/recent-sessions-widget/recent-sessions-widget.tsx
+++ b/apps/web/src/features/dashboard/widgets/recent-sessions-widget/recent-sessions-widget.tsx
@@ -1,24 +1,28 @@
 import { IconPokerChip, IconTrophy } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
-import { useState } from "react";
 import type {
 	WidgetEditProps,
 	WidgetRenderProps,
 } from "@/features/dashboard/widgets/registry";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
-import { Label } from "@/shared/components/ui/label";
+import { Field } from "@/shared/components/ui/field";
+import { Input } from "@/shared/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/shared/components/ui/select";
 import { Skeleton } from "@/shared/components/ui/skeleton";
 import { formatYmdSlash } from "@/utils/format-number";
 import {
 	formatProfitLoss,
 	profitLossColorClass,
 } from "@/utils/format-profit-loss";
-import {
-	parseRecentSessionsWidgetConfig,
-	type RecentSessionsWidgetTypeFilter,
-	useRecentSessionsWidget,
-} from "./use-recent-sessions-widget";
+import { useRecentSessionsEditForm } from "./use-recent-sessions-edit-form";
+import { useRecentSessionsWidget } from "./use-recent-sessions-widget";
 
 export function RecentSessionsWidget({ config }: WidgetRenderProps) {
 	const { isLoading, items, limit } = useRecentSessionsWidget(config);
@@ -90,57 +94,69 @@ export function RecentSessionsEditForm({
 	onSave,
 	onCancel,
 }: WidgetEditProps) {
-	const parsed = parseRecentSessionsWidgetConfig(config);
-	const [limit, setLimit] = useState<number>(parsed.limit);
-	const [type, setType] = useState<RecentSessionsWidgetTypeFilter>(parsed.type);
-	const [isSaving, setIsSaving] = useState(false);
-
-	const handleSave = async () => {
-		setIsSaving(true);
-		try {
-			await onSave({ limit, type });
-		} finally {
-			setIsSaving(false);
-		}
-	};
+	const { form } = useRecentSessionsEditForm({ config, onSave });
 
 	return (
-		<div className="flex flex-col gap-4">
-			<div className="flex flex-col gap-2">
-				<Label htmlFor="recent-sessions-limit">Number of Sessions</Label>
-				<input
-					className="rounded-md border bg-background px-3 py-2 text-sm"
-					id="recent-sessions-limit"
-					max={20}
-					min={1}
-					onChange={(e) => setLimit(Math.max(1, Number(e.target.value)))}
-					type="number"
-					value={limit}
-				/>
-			</div>
-			<div className="flex flex-col gap-2">
-				<Label htmlFor="recent-sessions-type">Type</Label>
-				<select
-					className="rounded-md border bg-background px-3 py-2 text-sm"
-					id="recent-sessions-type"
-					onChange={(e) =>
-						setType(e.target.value as RecentSessionsWidgetTypeFilter)
-					}
-					value={type}
-				>
-					<option value="all">All</option>
-					<option value="cash_game">Cash Game</option>
-					<option value="tournament">Tournament</option>
-				</select>
-			</div>
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="limit">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Number of Sessions"
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
+			<form.Field name="type">
+				{(field) => (
+					<Field htmlFor={field.name} label="Type">
+						<Select
+							onValueChange={(value) =>
+								field.handleChange(value as typeof field.state.value)
+							}
+							value={field.state.value}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue placeholder="Select type" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All</SelectItem>
+								<SelectItem value="cash_game">Cash Game</SelectItem>
+								<SelectItem value="tournament">Tournament</SelectItem>
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
 			<DialogActionRow>
-				<Button onClick={onCancel} variant="outline">
+				<Button onClick={onCancel} type="button" variant="outline">
 					Cancel
 				</Button>
-				<Button disabled={isSaving} onClick={handleSave}>
-					{isSaving ? "Saving..." : "Save"}
-				</Button>
+				<form.Subscribe
+					selector={(state) => [state.canSubmit, state.isSubmitting]}
+				>
+					{([canSubmit, isSubmitting]) => (
+						<Button disabled={!canSubmit || isSubmitting} type="submit">
+							{isSubmitting ? "Saving..." : "Save"}
+						</Button>
+					)}
+				</form.Subscribe>
 			</DialogActionRow>
-		</div>
+		</form>
 	);
 }

--- a/apps/web/src/features/dashboard/widgets/recent-sessions-widget/use-recent-sessions-edit-form.ts
+++ b/apps/web/src/features/dashboard/widgets/recent-sessions-widget/use-recent-sessions-edit-form.ts
@@ -1,0 +1,44 @@
+import { useForm } from "@tanstack/react-form";
+import z from "zod";
+import type { WidgetEditProps } from "@/features/dashboard/widgets/registry";
+import { requiredNumericString } from "@/shared/lib/form-fields";
+import {
+	parseRecentSessionsWidgetConfig,
+	type RecentSessionsWidgetTypeFilter,
+} from "./use-recent-sessions-widget";
+
+const TYPE_VALUES = ["all", "cash_game", "tournament"] as const;
+
+const editFormSchema = z.object({
+	limit: requiredNumericString({ integer: true, min: 1, max: 20 }),
+	type: z.enum(TYPE_VALUES),
+});
+
+interface UseRecentSessionsEditFormOptions {
+	config: WidgetEditProps["config"];
+	onSave: WidgetEditProps["onSave"];
+}
+
+export function useRecentSessionsEditForm({
+	config,
+	onSave,
+}: UseRecentSessionsEditFormOptions) {
+	const parsed = parseRecentSessionsWidgetConfig(config);
+	const form = useForm({
+		defaultValues: {
+			limit: String(parsed.limit),
+			type: parsed.type as RecentSessionsWidgetTypeFilter,
+		},
+		onSubmit: async ({ value }) => {
+			await onSave({
+				limit: Number.parseInt(value.limit, 10),
+				type: value.type,
+			});
+		},
+		validators: {
+			onSubmit: editFormSchema,
+		},
+	});
+
+	return { form };
+}

--- a/apps/web/src/features/dashboard/widgets/summary-stats-widget/summary-stats-widget.tsx
+++ b/apps/web/src/features/dashboard/widgets/summary-stats-widget/summary-stats-widget.tsx
@@ -1,23 +1,30 @@
-import { useState } from "react";
 import type {
 	WidgetEditProps,
 	WidgetRenderProps,
 } from "@/features/dashboard/widgets/registry";
 import { Button } from "@/shared/components/ui/button";
+import { Checkbox } from "@/shared/components/ui/checkbox";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
+import { Field } from "@/shared/components/ui/field";
+import { Input } from "@/shared/components/ui/input";
 import { Label } from "@/shared/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/shared/components/ui/select";
 import { Skeleton } from "@/shared/components/ui/skeleton";
 import {
 	formatProfitLoss,
 	profitLossColorClass,
 } from "@/utils/format-profit-loss";
+import { useSummaryStatsEditForm } from "./use-summary-stats-edit-form";
 import {
-	parseSummaryStatsWidgetConfig,
 	SUMMARY_STATS_ALL_METRICS,
-	SUMMARY_STATS_DEFAULT_METRICS,
 	type SummaryStatsMetricKey,
 	type SummaryStatsSummary,
-	type SummaryStatsWidgetType,
 	useSummaryStatsWidget,
 } from "./use-summary-stats-widget";
 
@@ -114,91 +121,106 @@ export function SummaryStatsEditForm({
 	onSave,
 	onCancel,
 }: WidgetEditProps) {
-	const parsed = parseSummaryStatsWidgetConfig(config);
-	const [metrics, setMetrics] = useState<SummaryStatsMetricKey[]>(
-		parsed.metrics
-	);
-	const [type, setType] = useState<SummaryStatsWidgetType>(parsed.type);
-	const [dateRangeDays, setDateRangeDays] = useState<number | null>(
-		parsed.dateRangeDays
-	);
-	const [isSaving, setIsSaving] = useState(false);
-
-	const toggleMetric = (key: SummaryStatsMetricKey) => {
-		setMetrics((prev) =>
-			prev.includes(key) ? prev.filter((m) => m !== key) : [...prev, key]
-		);
-	};
-
-	const handleSave = async () => {
-		setIsSaving(true);
-		try {
-			await onSave({
-				metrics: metrics.length > 0 ? metrics : SUMMARY_STATS_DEFAULT_METRICS,
-				type,
-				dateRangeDays,
-			});
-		} finally {
-			setIsSaving(false);
-		}
-	};
+	const { form } = useSummaryStatsEditForm({ config, onSave });
 
 	return (
-		<div className="flex flex-col gap-4">
-			<div className="flex flex-col gap-2">
-				<Label>Metrics</Label>
-				<div className="grid grid-cols-2 gap-2">
-					{SUMMARY_STATS_ALL_METRICS.map((m) => (
-						<label
-							className="flex cursor-pointer items-center gap-2 text-sm"
-							key={m.key}
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="metrics">
+				{(field) => (
+					<Field label="Metrics">
+						<div className="grid grid-cols-2 gap-2">
+							{SUMMARY_STATS_ALL_METRICS.map((m) => {
+								const id = `summary-stats-metric-${m.key}`;
+								const checked = field.state.value.includes(m.key);
+								return (
+									<div className="flex items-center gap-2" key={m.key}>
+										<Checkbox
+											checked={checked}
+											id={id}
+											onCheckedChange={(next) => {
+												if (next === true) {
+													field.handleChange(
+														field.state.value.includes(m.key)
+															? field.state.value
+															: [...field.state.value, m.key]
+													);
+												} else {
+													field.handleChange(
+														field.state.value.filter((k) => k !== m.key)
+													);
+												}
+											}}
+										/>
+										<Label className="cursor-pointer text-sm" htmlFor={id}>
+											{m.label}
+										</Label>
+									</div>
+								);
+							})}
+						</div>
+					</Field>
+				)}
+			</form.Field>
+			<form.Field name="type">
+				{(field) => (
+					<Field htmlFor={field.name} label="Session Type">
+						<Select
+							onValueChange={(value) =>
+								field.handleChange(value as typeof field.state.value)
+							}
+							value={field.state.value}
 						>
-							<input
-								checked={metrics.includes(m.key)}
-								onChange={() => toggleMetric(m.key)}
-								type="checkbox"
-							/>
-							<span>{m.label}</span>
-						</label>
-					))}
-				</div>
-			</div>
-			<div className="flex flex-col gap-2">
-				<Label htmlFor="summary-stats-type">Session Type</Label>
-				<select
-					className="rounded-md border bg-background px-3 py-2 text-sm"
-					id="summary-stats-type"
-					onChange={(e) => setType(e.target.value as SummaryStatsWidgetType)}
-					value={type}
-				>
-					<option value="all">All</option>
-					<option value="cash_game">Cash Game</option>
-					<option value="tournament">Tournament</option>
-				</select>
-			</div>
-			<div className="flex flex-col gap-2">
-				<Label htmlFor="summary-stats-range">Date Range (days)</Label>
-				<input
-					className="rounded-md border bg-background px-3 py-2 text-sm"
-					id="summary-stats-range"
-					min={1}
-					onChange={(e) => {
-						const value = e.target.value;
-						setDateRangeDays(value === "" ? null : Number(value));
-					}}
-					placeholder="All time"
-					type="number"
-					value={dateRangeDays ?? ""}
-				/>
-			</div>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue placeholder="Select type" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All</SelectItem>
+								<SelectItem value="cash_game">Cash Game</SelectItem>
+								<SelectItem value="tournament">Tournament</SelectItem>
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
+			<form.Field name="dateRangeDays">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Date Range (days)"
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							placeholder="All time"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
 			<DialogActionRow>
-				<Button onClick={onCancel} variant="outline">
+				<Button onClick={onCancel} type="button" variant="outline">
 					Cancel
 				</Button>
-				<Button disabled={isSaving} onClick={handleSave}>
-					{isSaving ? "Saving..." : "Save"}
-				</Button>
+				<form.Subscribe
+					selector={(state) => [state.canSubmit, state.isSubmitting]}
+				>
+					{([canSubmit, isSubmitting]) => (
+						<Button disabled={!canSubmit || isSubmitting} type="submit">
+							{isSubmitting ? "Saving..." : "Save"}
+						</Button>
+					)}
+				</form.Subscribe>
 			</DialogActionRow>
-		</div>
+		</form>
 	);
 }

--- a/apps/web/src/features/dashboard/widgets/summary-stats-widget/use-summary-stats-edit-form.ts
+++ b/apps/web/src/features/dashboard/widgets/summary-stats-widget/use-summary-stats-edit-form.ts
@@ -1,0 +1,63 @@
+import { useForm } from "@tanstack/react-form";
+import z from "zod";
+import type { WidgetEditProps } from "@/features/dashboard/widgets/registry";
+import { optionalNumericString } from "@/shared/lib/form-fields";
+import {
+	parseSummaryStatsWidgetConfig,
+	SUMMARY_STATS_DEFAULT_METRICS,
+	type SummaryStatsMetricKey,
+	type SummaryStatsWidgetType,
+} from "./use-summary-stats-widget";
+
+const TYPE_VALUES = ["all", "cash_game", "tournament"] as const;
+
+const METRIC_VALUES: readonly SummaryStatsMetricKey[] = [
+	"totalSessions",
+	"totalProfitLoss",
+	"winRate",
+	"avgProfitLoss",
+	"totalEvProfitLoss",
+	"totalEvDiff",
+] as const;
+
+const editFormSchema = z.object({
+	metrics: z.array(z.enum(METRIC_VALUES)),
+	type: z.enum(TYPE_VALUES),
+	dateRangeDays: optionalNumericString({ integer: true, min: 1 }),
+});
+
+interface UseSummaryStatsEditFormOptions {
+	config: WidgetEditProps["config"];
+	onSave: WidgetEditProps["onSave"];
+}
+
+export function useSummaryStatsEditForm({
+	config,
+	onSave,
+}: UseSummaryStatsEditFormOptions) {
+	const parsed = parseSummaryStatsWidgetConfig(config);
+	const form = useForm({
+		defaultValues: {
+			metrics: parsed.metrics,
+			type: parsed.type as SummaryStatsWidgetType,
+			dateRangeDays:
+				parsed.dateRangeDays === null ? "" : String(parsed.dateRangeDays),
+		},
+		onSubmit: async ({ value }) => {
+			const trimmed = value.dateRangeDays.trim();
+			await onSave({
+				metrics:
+					value.metrics.length > 0
+						? value.metrics
+						: SUMMARY_STATS_DEFAULT_METRICS,
+				type: value.type,
+				dateRangeDays: trimmed === "" ? null : Number.parseInt(trimmed, 10),
+			});
+		},
+		validators: {
+			onSubmit: editFormSchema,
+		},
+	});
+
+	return { form };
+}

--- a/apps/web/src/features/live-sessions/components/active-session-game-scene/active-session-game-scene.tsx
+++ b/apps/web/src/features/live-sessions/components/active-session-game-scene/active-session-game-scene.tsx
@@ -31,6 +31,14 @@ import {
 } from "@/shared/components/ui/card";
 import { EmptyState } from "@/shared/components/ui/empty-state";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/shared/components/ui/table";
 import { createGroupFormatter } from "@/utils/format-number";
 import { getTableSizeClassName } from "@/utils/table-size-colors";
 
@@ -269,75 +277,69 @@ function TournamentStructureTable({ levels }: { levels: BlindLevelRow[] }) {
 	}
 
 	return (
-		<div className="w-full overflow-x-auto">
-			<table className="w-full table-fixed border-collapse text-[11px]">
-				<thead>
-					<tr>
-						<th className="w-6 pb-0.5 text-center font-medium text-muted-foreground">
-							#
-						</th>
-						<th className="pb-0.5 text-center font-medium text-muted-foreground">
-							SB
-						</th>
-						<th className="pb-0.5 text-center font-medium text-muted-foreground">
-							BB
-						</th>
-						<th className="pb-0.5 text-center font-medium text-muted-foreground">
-							Ante
-						</th>
-						<th className="w-8 pb-0.5 text-center font-medium text-muted-foreground">
-							Min
-						</th>
-					</tr>
-				</thead>
-				<tbody>
-					{levels.map((row) => {
-						if (row.isBreak) {
-							return (
-								<tr className="bg-muted/30" key={row.id}>
-									<td className="py-0.5 text-center text-muted-foreground">
-										{row.level}
-									</td>
-									<td
-										className="py-0.5 text-center text-muted-foreground"
-										colSpan={3}
-									>
-										Break
-									</td>
-									<td className="py-0.5 text-center text-muted-foreground">
-										{row.minutes ?? "—"}
-									</td>
-								</tr>
-							);
-						}
-						const fmt = createGroupFormatter([
-							row.blind1,
-							row.blind2,
-							row.ante,
-						]);
+		<Table className="table-fixed text-[11px]">
+			<TableHeader>
+				<TableRow>
+					<TableHead className="h-auto w-6 pb-0.5 text-center font-medium text-muted-foreground">
+						#
+					</TableHead>
+					<TableHead className="h-auto pb-0.5 text-center font-medium text-muted-foreground">
+						SB
+					</TableHead>
+					<TableHead className="h-auto pb-0.5 text-center font-medium text-muted-foreground">
+						BB
+					</TableHead>
+					<TableHead className="h-auto pb-0.5 text-center font-medium text-muted-foreground">
+						Ante
+					</TableHead>
+					<TableHead className="h-auto w-8 pb-0.5 text-center font-medium text-muted-foreground">
+						Min
+					</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{levels.map((row) => {
+					if (row.isBreak) {
 						return (
-							<tr key={row.id}>
-								<td className="py-0.5 text-center text-muted-foreground">
+							<TableRow className="bg-muted/30" key={row.id}>
+								<TableCell className="py-0.5 text-center text-muted-foreground">
 									{row.level}
-								</td>
-								<td className="py-0.5 text-center">
-									{row.blind1 == null ? "—" : fmt(row.blind1)}
-								</td>
-								<td className="py-0.5 text-center">
-									{row.blind2 == null ? "—" : fmt(row.blind2)}
-								</td>
-								<td className="py-0.5 text-center">
-									{row.ante == null ? "—" : fmt(row.ante)}
-								</td>
-								<td className="py-0.5 text-center text-muted-foreground">
+								</TableCell>
+								<TableCell
+									className="py-0.5 text-center text-muted-foreground"
+									colSpan={3}
+								>
+									Break
+								</TableCell>
+								<TableCell className="py-0.5 text-center text-muted-foreground">
 									{row.minutes ?? "—"}
-								</td>
-							</tr>
+								</TableCell>
+							</TableRow>
 						);
-					})}
-				</tbody>
-			</table>
-		</div>
+					}
+					const fmt = createGroupFormatter([row.blind1, row.blind2, row.ante]);
+					return (
+						<TableRow key={row.id}>
+							<TableCell className="py-0.5 text-center text-muted-foreground">
+								{row.level}
+							</TableCell>
+							<TableCell className="py-0.5 text-center">
+								{row.blind1 == null ? "—" : fmt(row.blind1)}
+							</TableCell>
+							<TableCell className="py-0.5 text-center">
+								{row.blind2 == null ? "—" : fmt(row.blind2)}
+							</TableCell>
+							<TableCell className="py-0.5 text-center">
+								{row.ante == null ? "—" : fmt(row.ante)}
+							</TableCell>
+							<TableCell className="py-0.5 text-center text-muted-foreground">
+								{row.minutes ?? "—"}
+							</TableCell>
+						</TableRow>
+					);
+				})}
+			</TableBody>
+		</Table>
 	);
 }
 

--- a/apps/web/src/features/players/components/color-badge/color-badge.tsx
+++ b/apps/web/src/features/players/components/color-badge/color-badge.tsx
@@ -3,6 +3,7 @@ import {
 	type TagColor,
 } from "@/features/players/constants/player-tag-colors";
 import { cn } from "@/lib/utils";
+import { Badge } from "@/shared/components/ui/badge";
 
 interface ColorBadgeProps {
 	children: React.ReactNode;
@@ -14,15 +15,8 @@ export function ColorBadge({ color, children, className }: ColorBadgeProps) {
 	const colorConfig = TAG_COLORS[color as TagColor] ?? TAG_COLORS.gray;
 
 	return (
-		<span
-			className={cn(
-				"inline-flex items-center rounded-full px-2 py-0.5 font-medium text-xs",
-				colorConfig.bg,
-				colorConfig.text,
-				className
-			)}
-		>
+		<Badge className={cn(colorConfig.bg, colorConfig.text, className)}>
 			{children}
-		</span>
+		</Badge>
 	);
 }

--- a/apps/web/src/features/players/components/player-avatar/player-avatar.tsx
+++ b/apps/web/src/features/players/components/player-avatar/player-avatar.tsx
@@ -1,5 +1,6 @@
 import { IconUser, IconUserQuestion } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
+import { Avatar, AvatarFallback } from "@/shared/components/ui/avatar";
 
 interface PlayerAvatarProps {
 	className?: string;
@@ -13,18 +14,24 @@ export function PlayerAvatar({
 	isTemporary = false,
 }: PlayerAvatarProps) {
 	return (
-		<div
+		<Avatar
 			className={cn(
-				"flex size-10 items-center justify-center rounded-full border-2 shadow-md",
-				isHero && "border-amber-400 bg-amber-500/80 text-white",
-				!isHero &&
-					isTemporary &&
-					"border-zinc-500/60 bg-zinc-700 text-white/80",
-				!(isHero || isTemporary) && "border-white/30 bg-slate-500 text-white",
+				"size-10 border-2 shadow-md after:hidden",
+				isHero && "border-amber-400",
+				!isHero && isTemporary && "border-zinc-500/60",
+				!(isHero || isTemporary) && "border-white/30",
 				className
 			)}
 		>
-			{isTemporary ? <IconUserQuestion size={16} /> : <IconUser size={16} />}
-		</div>
+			<AvatarFallback
+				className={cn(
+					isHero && "bg-amber-500/80 text-white",
+					!isHero && isTemporary && "bg-zinc-700 text-white/80",
+					!(isHero || isTemporary) && "bg-slate-500 text-white"
+				)}
+			>
+				{isTemporary ? <IconUserQuestion size={16} /> : <IconUser size={16} />}
+			</AvatarFallback>
+		</Avatar>
 	);
 }

--- a/apps/web/src/features/players/components/tag-color-picker/tag-color-picker.tsx
+++ b/apps/web/src/features/players/components/tag-color-picker/tag-color-picker.tsx
@@ -1,9 +1,11 @@
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
 import {
 	TAG_COLOR_NAMES,
 	TAG_COLORS,
 	type TagColor,
 } from "@/features/players/constants/player-tag-colors";
 import { cn } from "@/lib/utils";
+import { RadioGroup } from "@/shared/components/ui/radio-group";
 
 interface TagColorPickerProps {
 	onChange: (color: TagColor) => void;
@@ -12,32 +14,26 @@ interface TagColorPickerProps {
 
 export function TagColorPicker({ value, onChange }: TagColorPickerProps) {
 	return (
-		<div
+		<RadioGroup
 			aria-label="Tag color"
 			className="flex flex-wrap gap-2"
-			role="radiogroup"
+			onValueChange={(next) => onChange(next as TagColor)}
+			value={value}
 		>
 			{TAG_COLOR_NAMES.map((color) => (
-				<label
+				<RadioGroupPrimitive.Item
+					aria-label={`Select ${color} color`}
 					className={cn(
-						"block h-7 w-7 cursor-pointer rounded-full transition-transform",
+						"block h-7 w-7 cursor-pointer rounded-full outline-none transition-transform",
+						"focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
 						TAG_COLORS[color].swatch,
 						value === color &&
 							"scale-110 ring-2 ring-white ring-offset-2 dark:ring-offset-gray-900"
 					)}
 					key={color}
-				>
-					<input
-						aria-label={`Select ${color} color`}
-						checked={value === color}
-						className="sr-only"
-						name="tag-color"
-						onChange={() => onChange(color)}
-						type="radio"
-						value={color}
-					/>
-				</label>
+					value={color}
+				/>
 			))}
-		</div>
+		</RadioGroup>
 	);
 }

--- a/apps/web/src/features/stores/components/blind-level-editor/blind-level-editor.tsx
+++ b/apps/web/src/features/stores/components/blind-level-editor/blind-level-editor.tsx
@@ -26,6 +26,14 @@ import type { NewLevelValues } from "@/features/stores/utils/blind-level-helpers
 import { cn } from "@/lib/utils";
 import { Button } from "@/shared/components/ui/button";
 import { ResponsiveDialog } from "@/shared/components/ui/responsive-dialog";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/shared/components/ui/table";
 import { useLocalBlindStructure } from "./use-blind-level-editor";
 
 const GAME_VARIANTS = {
@@ -119,18 +127,18 @@ function SortableLevelRow({ row, onDelete, onUpdate }: SortableLevelRowProps) {
 	};
 
 	return (
-		<tr
-			className={isDragging ? "opacity-50" : ""}
+		<TableRow
+			className={cn("hover:bg-transparent", isDragging && "opacity-50")}
 			ref={setNodeRef}
 			style={style}
 		>
-			<td className="w-10 px-0.5 text-center">
+			<TableCell className="w-10 p-0 px-0.5 text-center">
 				<div className="flex items-center justify-center gap-0.5">
 					<DragHandle attributes={attributes} listeners={listeners} />
 					<span className="text-muted-foreground text-xs">{row.level}</span>
 				</div>
-			</td>
-			<td className="px-0.5">
+			</TableCell>
+			<TableCell className="p-0 px-0.5">
 				<BlindLevelInput
 					defaultValue={row.blind1 ?? ""}
 					inputMode="numeric"
@@ -139,8 +147,8 @@ function SortableLevelRow({ row, onDelete, onUpdate }: SortableLevelRowProps) {
 					placeholder="—"
 					type="number"
 				/>
-			</td>
-			<td className="px-0.5">
+			</TableCell>
+			<TableCell className="p-0 px-0.5">
 				<BlindLevelInput
 					defaultValue={row.blind2 ?? ""}
 					inputMode="numeric"
@@ -149,8 +157,8 @@ function SortableLevelRow({ row, onDelete, onUpdate }: SortableLevelRowProps) {
 					placeholder="—"
 					type="number"
 				/>
-			</td>
-			<td className="px-0.5">
+			</TableCell>
+			<TableCell className="p-0 px-0.5">
 				<BlindLevelInput
 					defaultValue={row.ante ?? ""}
 					inputMode="numeric"
@@ -159,8 +167,8 @@ function SortableLevelRow({ row, onDelete, onUpdate }: SortableLevelRowProps) {
 					placeholder="—"
 					type="number"
 				/>
-			</td>
-			<td className="w-12 px-0.5">
+			</TableCell>
+			<TableCell className="w-12 p-0 px-0.5">
 				<BlindLevelInput
 					defaultValue={row.minutes ?? ""}
 					inputMode="numeric"
@@ -169,8 +177,8 @@ function SortableLevelRow({ row, onDelete, onUpdate }: SortableLevelRowProps) {
 					placeholder="—"
 					type="number"
 				/>
-			</td>
-			<td className="w-8 px-0.5 text-center">
+			</TableCell>
+			<TableCell className="w-8 p-0 px-0.5 text-center">
 				<Button
 					aria-label="Delete level"
 					className="text-muted-foreground hover:text-destructive"
@@ -181,8 +189,8 @@ function SortableLevelRow({ row, onDelete, onUpdate }: SortableLevelRowProps) {
 				>
 					<IconTrash size={14} />
 				</Button>
-			</td>
-		</tr>
+			</TableCell>
+		</TableRow>
 	);
 }
 
@@ -211,20 +219,24 @@ function SortableBreakRow({ row, onDelete, onUpdate }: SortableBreakRowProps) {
 	};
 
 	return (
-		<tr className="bg-muted/30" ref={setNodeRef} style={style}>
-			<td className="w-10 px-0.5 text-center">
+		<TableRow
+			className="bg-muted/30 hover:bg-muted/30"
+			ref={setNodeRef}
+			style={style}
+		>
+			<TableCell className="w-10 p-0 px-0.5 text-center">
 				<div className="flex items-center justify-center gap-0.5">
 					<DragHandle attributes={attributes} listeners={listeners} />
 					<span className="text-muted-foreground text-xs">{row.level}</span>
 				</div>
-			</td>
-			<td className="px-1.5 py-1" colSpan={3}>
+			</TableCell>
+			<TableCell className="p-0 px-1.5 py-1" colSpan={3}>
 				<div className="flex items-center gap-1 text-muted-foreground text-sm">
 					<IconCoffee size={14} />
 					<span>Break</span>
 				</div>
-			</td>
-			<td className="w-12 px-0.5">
+			</TableCell>
+			<TableCell className="w-12 p-0 px-0.5">
 				<BlindLevelInput
 					defaultValue={row.minutes ?? ""}
 					inputMode="numeric"
@@ -235,8 +247,8 @@ function SortableBreakRow({ row, onDelete, onUpdate }: SortableBreakRowProps) {
 					placeholder="—"
 					type="number"
 				/>
-			</td>
-			<td className="w-8 px-0.5 text-center">
+			</TableCell>
+			<TableCell className="w-8 p-0 px-0.5 text-center">
 				<Button
 					aria-label="Delete break"
 					className="text-muted-foreground hover:text-destructive"
@@ -247,8 +259,8 @@ function SortableBreakRow({ row, onDelete, onUpdate }: SortableBreakRowProps) {
 				>
 					<IconTrash size={14} />
 				</Button>
-			</td>
-		</tr>
+			</TableCell>
+		</TableRow>
 	);
 }
 
@@ -271,11 +283,11 @@ function EmptyRow({ onCreateLevel }: EmptyRowProps) {
 	} = useEmptyRow({ onCreateLevel });
 
 	return (
-		<tr className="border-t border-dashed">
-			<td className="w-10 px-0.5 text-center">
+		<TableRow className="border-t border-dashed hover:bg-transparent">
+			<TableCell className="w-10 p-0 px-0.5 text-center">
 				<span className="text-muted-foreground text-xs">+</span>
-			</td>
-			<td className="px-0.5">
+			</TableCell>
+			<TableCell className="p-0 px-0.5">
 				<BlindLevelInput
 					inputMode="numeric"
 					onBlur={handleBlind1Blur}
@@ -283,8 +295,8 @@ function EmptyRow({ onCreateLevel }: EmptyRowProps) {
 					ref={blind1Ref}
 					type="number"
 				/>
-			</td>
-			<td className="px-0.5">
+			</TableCell>
+			<TableCell className="p-0 px-0.5">
 				<BlindLevelInput
 					inputMode="numeric"
 					onBlur={handleBlind2Blur}
@@ -292,8 +304,8 @@ function EmptyRow({ onCreateLevel }: EmptyRowProps) {
 					ref={blind2Ref}
 					type="number"
 				/>
-			</td>
-			<td className="px-0.5">
+			</TableCell>
+			<TableCell className="p-0 px-0.5">
 				<BlindLevelInput
 					inputMode="numeric"
 					onBlur={handleAnteBlur}
@@ -301,8 +313,8 @@ function EmptyRow({ onCreateLevel }: EmptyRowProps) {
 					ref={anteRef}
 					type="number"
 				/>
-			</td>
-			<td className="w-12 px-0.5">
+			</TableCell>
+			<TableCell className="w-12 p-0 px-0.5">
 				<BlindLevelInput
 					inputMode="numeric"
 					onBlur={handleMinutesBlur}
@@ -310,9 +322,9 @@ function EmptyRow({ onCreateLevel }: EmptyRowProps) {
 					ref={minutesRef}
 					type="number"
 				/>
-			</td>
-			<td className="w-8" />
-		</tr>
+			</TableCell>
+			<TableCell className="w-8 p-0" />
+		</TableRow>
 	);
 }
 
@@ -365,63 +377,61 @@ function BlindStructureTable({
 				</Button>
 			</div>
 
-			<div className="w-full overflow-x-auto">
-				<table className="w-full table-fixed border-collapse">
-					<thead>
-						<tr>
-							<th className="w-10 pb-1 text-center font-medium text-muted-foreground text-xs">
-								#
-							</th>
-							<th className="pb-1 text-center font-medium text-muted-foreground text-xs">
-								{blindLabels.blind1}
-							</th>
-							<th className="pb-1 text-center font-medium text-muted-foreground text-xs">
-								{blindLabels.blind2}
-							</th>
-							<th className="pb-1 text-center font-medium text-muted-foreground text-xs">
-								Ante
-							</th>
-							<th className="w-12 pb-1 text-center font-medium text-muted-foreground text-xs">
-								Min
-							</th>
-							<th className="w-8 pb-1" />
-						</tr>
-					</thead>
-					<tbody>
-						{levels.length > 0 && (
-							<DndContext
-								collisionDetection={closestCenter}
-								onDragEnd={handleDragEnd}
-								sensors={sensors}
+			<Table className="table-fixed">
+				<TableHeader>
+					<TableRow className="hover:bg-transparent">
+						<TableHead className="h-auto w-10 pb-1 text-center font-medium text-muted-foreground text-xs">
+							#
+						</TableHead>
+						<TableHead className="h-auto pb-1 text-center font-medium text-muted-foreground text-xs">
+							{blindLabels.blind1}
+						</TableHead>
+						<TableHead className="h-auto pb-1 text-center font-medium text-muted-foreground text-xs">
+							{blindLabels.blind2}
+						</TableHead>
+						<TableHead className="h-auto pb-1 text-center font-medium text-muted-foreground text-xs">
+							Ante
+						</TableHead>
+						<TableHead className="h-auto w-12 pb-1 text-center font-medium text-muted-foreground text-xs">
+							Min
+						</TableHead>
+						<TableHead className="h-auto w-8 pb-1" />
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{levels.length > 0 && (
+						<DndContext
+							collisionDetection={closestCenter}
+							onDragEnd={handleDragEnd}
+							sensors={sensors}
+						>
+							<SortableContext
+								items={levels.map((l) => l.id)}
+								strategy={verticalListSortingStrategy}
 							>
-								<SortableContext
-									items={levels.map((l) => l.id)}
-									strategy={verticalListSortingStrategy}
-								>
-									{levels.map((row) =>
-										row.isBreak ? (
-											<SortableBreakRow
-												key={row.id}
-												onDelete={handleDelete}
-												onUpdate={handleUpdate}
-												row={row}
-											/>
-										) : (
-											<SortableLevelRow
-												key={row.id}
-												onDelete={handleDelete}
-												onUpdate={handleUpdate}
-												row={row}
-											/>
-										)
-									)}
-								</SortableContext>
-							</DndContext>
-						)}
-						<EmptyRow onCreateLevel={handleCreateLevel} />
-					</tbody>
-				</table>
-			</div>
+								{levels.map((row) =>
+									row.isBreak ? (
+										<SortableBreakRow
+											key={row.id}
+											onDelete={handleDelete}
+											onUpdate={handleUpdate}
+											row={row}
+										/>
+									) : (
+										<SortableLevelRow
+											key={row.id}
+											onDelete={handleDelete}
+											onUpdate={handleUpdate}
+											row={row}
+										/>
+									)
+								)}
+							</SortableContext>
+						</DndContext>
+					)}
+					<EmptyRow onCreateLevel={handleCreateLevel} />
+				</TableBody>
+			</Table>
 		</div>
 	);
 }

--- a/apps/web/src/features/stores/components/tournament-tab/tournament-tab.tsx
+++ b/apps/web/src/features/stores/components/tournament-tab/tournament-tab.tsx
@@ -19,6 +19,14 @@ import { ManagementSectionState } from "@/shared/components/management/managemen
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/shared/components/ui/table";
+import {
 	createGroupFormatter,
 	formatCompactNumber,
 } from "@/utils/format-number";
@@ -459,75 +467,69 @@ function BlindStructureSummary({ tournamentId }: { tournamentId: string }) {
 	}
 
 	return (
-		<div className="w-full overflow-x-auto">
-			<table className="w-full table-fixed border-collapse text-[10px]">
-				<thead>
-					<tr>
-						<th className="w-6 pb-0.5 text-center font-medium text-muted-foreground">
-							#
-						</th>
-						<th className="pb-0.5 text-center font-medium text-muted-foreground">
-							SB
-						</th>
-						<th className="pb-0.5 text-center font-medium text-muted-foreground">
-							BB
-						</th>
-						<th className="pb-0.5 text-center font-medium text-muted-foreground">
-							Ante
-						</th>
-						<th className="w-8 pb-0.5 text-center font-medium text-muted-foreground">
-							Min
-						</th>
-					</tr>
-				</thead>
-				<tbody>
-					{levels.map((row: BlindLevelRow) => {
-						if (row.isBreak) {
-							return (
-								<tr className="bg-muted/30" key={row.id}>
-									<td className="py-0.5 text-center text-muted-foreground">
-										{row.level}
-									</td>
-									<td
-										className="py-0.5 text-center text-muted-foreground"
-										colSpan={3}
-									>
-										Break
-									</td>
-									<td className="py-0.5 text-center text-muted-foreground">
-										{row.minutes ?? "—"}
-									</td>
-								</tr>
-							);
-						}
-						const fmt = createGroupFormatter([
-							row.blind1,
-							row.blind2,
-							row.ante,
-						]);
+		<Table className="table-fixed text-[10px]">
+			<TableHeader>
+				<TableRow>
+					<TableHead className="h-auto w-6 pb-0.5 text-center font-medium text-muted-foreground">
+						#
+					</TableHead>
+					<TableHead className="h-auto pb-0.5 text-center font-medium text-muted-foreground">
+						SB
+					</TableHead>
+					<TableHead className="h-auto pb-0.5 text-center font-medium text-muted-foreground">
+						BB
+					</TableHead>
+					<TableHead className="h-auto pb-0.5 text-center font-medium text-muted-foreground">
+						Ante
+					</TableHead>
+					<TableHead className="h-auto w-8 pb-0.5 text-center font-medium text-muted-foreground">
+						Min
+					</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{levels.map((row: BlindLevelRow) => {
+					if (row.isBreak) {
 						return (
-							<tr key={row.id}>
-								<td className="py-0.5 text-center text-muted-foreground">
+							<TableRow className="bg-muted/30" key={row.id}>
+								<TableCell className="py-0.5 text-center text-muted-foreground">
 									{row.level}
-								</td>
-								<td className="py-0.5 text-center">
-									{row.blind1 == null ? "—" : fmt(row.blind1)}
-								</td>
-								<td className="py-0.5 text-center">
-									{row.blind2 == null ? "—" : fmt(row.blind2)}
-								</td>
-								<td className="py-0.5 text-center">
-									{row.ante == null ? "—" : fmt(row.ante)}
-								</td>
-								<td className="py-0.5 text-center text-muted-foreground">
+								</TableCell>
+								<TableCell
+									className="py-0.5 text-center text-muted-foreground"
+									colSpan={3}
+								>
+									Break
+								</TableCell>
+								<TableCell className="py-0.5 text-center text-muted-foreground">
 									{row.minutes ?? "—"}
-								</td>
-							</tr>
+								</TableCell>
+							</TableRow>
 						);
-					})}
-				</tbody>
-			</table>
-		</div>
+					}
+					const fmt = createGroupFormatter([row.blind1, row.blind2, row.ante]);
+					return (
+						<TableRow key={row.id}>
+							<TableCell className="py-0.5 text-center text-muted-foreground">
+								{row.level}
+							</TableCell>
+							<TableCell className="py-0.5 text-center">
+								{row.blind1 == null ? "—" : fmt(row.blind1)}
+							</TableCell>
+							<TableCell className="py-0.5 text-center">
+								{row.blind2 == null ? "—" : fmt(row.blind2)}
+							</TableCell>
+							<TableCell className="py-0.5 text-center">
+								{row.ante == null ? "—" : fmt(row.ante)}
+							</TableCell>
+							<TableCell className="py-0.5 text-center text-muted-foreground">
+								{row.minutes ?? "—"}
+							</TableCell>
+						</TableRow>
+					);
+				})}
+			</TableBody>
+		</Table>
 	);
 }
 

--- a/apps/web/src/shared/components/ui/avatar/avatar.tsx
+++ b/apps/web/src/shared/components/ui/avatar/avatar.tsx
@@ -1,0 +1,109 @@
+import { Avatar as AvatarPrimitive } from "radix-ui";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Avatar({
+	className,
+	size = "default",
+	...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+	size?: "default" | "sm" | "lg";
+}) {
+	return (
+		<AvatarPrimitive.Root
+			className={cn(
+				"group/avatar relative flex size-8 shrink-0 select-none rounded-full after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
+				className
+			)}
+			data-size={size}
+			data-slot="avatar"
+			{...props}
+		/>
+	);
+}
+
+function AvatarImage({
+	className,
+	...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+	return (
+		<AvatarPrimitive.Image
+			className={cn(
+				"aspect-square size-full rounded-full object-cover",
+				className
+			)}
+			data-slot="avatar-image"
+			{...props}
+		/>
+	);
+}
+
+function AvatarFallback({
+	className,
+	...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+	return (
+		<AvatarPrimitive.Fallback
+			className={cn(
+				"flex size-full items-center justify-center rounded-full bg-muted text-muted-foreground text-sm group-data-[size=sm]/avatar:text-xs",
+				className
+			)}
+			data-slot="avatar-fallback"
+			{...props}
+		/>
+	);
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+	return (
+		<span
+			className={cn(
+				"absolute right-0 bottom-0 z-10 inline-flex select-none items-center justify-center rounded-full bg-primary text-primary-foreground bg-blend-color ring-2 ring-background",
+				"group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+				"group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+				"group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+				className
+			)}
+			data-slot="avatar-badge"
+			{...props}
+		/>
+	);
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn(
+				"group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+				className
+			)}
+			data-slot="avatar-group"
+			{...props}
+		/>
+	);
+}
+
+function AvatarGroupCount({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn(
+				"relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground text-sm ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+				className
+			)}
+			data-slot="avatar-group-count"
+			{...props}
+		/>
+	);
+}
+
+export {
+	Avatar,
+	AvatarBadge,
+	AvatarFallback,
+	AvatarGroup,
+	AvatarGroupCount,
+	AvatarImage,
+};

--- a/apps/web/src/shared/components/ui/avatar/index.ts
+++ b/apps/web/src/shared/components/ui/avatar/index.ts
@@ -1,0 +1,8 @@
+export {
+	Avatar,
+	AvatarBadge,
+	AvatarFallback,
+	AvatarGroup,
+	AvatarGroupCount,
+	AvatarImage,
+} from "./avatar";

--- a/apps/web/src/shared/components/ui/radio-group/index.ts
+++ b/apps/web/src/shared/components/ui/radio-group/index.ts
@@ -1,0 +1,1 @@
+export { RadioGroup, RadioGroupItem } from "./radio-group";

--- a/apps/web/src/shared/components/ui/radio-group/radio-group.tsx
+++ b/apps/web/src/shared/components/ui/radio-group/radio-group.tsx
@@ -1,0 +1,41 @@
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function RadioGroup({
+	className,
+	...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+	return (
+		<RadioGroupPrimitive.Root
+			className={cn("grid w-full gap-2", className)}
+			data-slot="radio-group"
+			{...props}
+		/>
+	);
+}
+
+function RadioGroupItem({
+	className,
+	...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+	return (
+		<RadioGroupPrimitive.Item
+			className={cn(
+				"group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:bg-input/30 dark:data-checked:bg-primary dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+				className
+			)}
+			data-slot="radio-group-item"
+			{...props}
+		>
+			<RadioGroupPrimitive.Indicator
+				className="flex size-4 items-center justify-center"
+				data-slot="radio-group-indicator"
+			>
+				<span className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-foreground" />
+			</RadioGroupPrimitive.Indicator>
+		</RadioGroupPrimitive.Item>
+	);
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/apps/web/src/shared/components/ui/table/index.ts
+++ b/apps/web/src/shared/components/ui/table/index.ts
@@ -1,0 +1,10 @@
+export {
+	Table,
+	TableBody,
+	TableCaption,
+	TableCell,
+	TableFooter,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "./table";

--- a/apps/web/src/shared/components/ui/table/table.tsx
+++ b/apps/web/src/shared/components/ui/table/table.tsx
@@ -1,0 +1,113 @@
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+	return (
+		<div
+			className="relative w-full overflow-x-auto"
+			data-slot="table-container"
+		>
+			<table
+				className={cn("w-full caption-bottom text-sm", className)}
+				data-slot="table"
+				{...props}
+			/>
+		</div>
+	);
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+	return (
+		<thead
+			className={cn("[&_tr]:border-b", className)}
+			data-slot="table-header"
+			{...props}
+		/>
+	);
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+	return (
+		<tbody
+			className={cn("[&_tr:last-child]:border-0", className)}
+			data-slot="table-body"
+			{...props}
+		/>
+	);
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+	return (
+		<tfoot
+			className={cn(
+				"border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+				className
+			)}
+			data-slot="table-footer"
+			{...props}
+		/>
+	);
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+	return (
+		<tr
+			className={cn(
+				"border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+				className
+			)}
+			data-slot="table-row"
+			{...props}
+		/>
+	);
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+	return (
+		<th
+			className={cn(
+				"h-10 whitespace-nowrap px-2 text-left align-middle font-medium text-foreground [&:has([role=checkbox])]:pr-0",
+				className
+			)}
+			data-slot="table-head"
+			{...props}
+		/>
+	);
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+	return (
+		<td
+			className={cn(
+				"whitespace-nowrap p-2 align-middle [&:has([role=checkbox])]:pr-0",
+				className
+			)}
+			data-slot="table-cell"
+			{...props}
+		/>
+	);
+}
+
+function TableCaption({
+	className,
+	...props
+}: React.ComponentProps<"caption">) {
+	return (
+		<caption
+			className={cn("mt-4 text-muted-foreground text-sm", className)}
+			data-slot="table-caption"
+			{...props}
+		/>
+	);
+}
+
+export {
+	Table,
+	TableBody,
+	TableCaption,
+	TableCell,
+	TableFooter,
+	TableHead,
+	TableHeader,
+	TableRow,
+};


### PR DESCRIPTION
## Summary

`apps/web/src` 全体を横断調査し、shadcn/ui で提供されている (またはインストール可能な) コンポーネント相当を自前実装している箇所を 5 段階でリファクタした。

| Tier | 対象 | 概要 |
|---|---|---|
| 1 | `ColorBadge` | shadcn `Badge` への委譲 (基本スタイル再実装の解消) |
| 2 | Dashboard Widget × 4 EditForm | ネイティブ `<input>` `<select>` `<input type=\"checkbox\">` を shadcn `Input` / `Select` / `Checkbox` に置換。同時に `@tanstack/react-form` + 抽出 hooks (CLAUDE.md 規約準拠) + `inputMode=\"numeric\"` 化 |
| 3 | ネイティブ `<table>` × 3 | shadcn `Table` を新規追加し `blind-level-editor` / `tournament-tab` / `active-session-game-scene` を置換 |
| 4 | `tag-color-picker` | shadcn `RadioGroup` を新規追加し `<input type=\"radio\" sr-only>` + 自前 `role=\"radiogroup\"` を置換 |
| 5 | `PlayerAvatar` | shadcn `Avatar` を新規追加し自前丸 `<div>` + アイコン fallback を置換 |

## Notes

- 新規 shadcn コンポーネント (Table / RadioGroup / Avatar) は CLI 出力先 (`src/components/ui/`) から既存規約 (`src/shared/components/ui/<name>/<name>.tsx` + `index.ts`) に手動移設
- AlertDialog は `ResponsiveDialog` (Dialog/Drawer 自動切替) でモバイル対応されているため UX 退化となるため対象外
- インライン削除確認 (`EntityListItem` / `TransactionList`) はモーダルではなくリスト内アクションのため対象外
- Loader / 隠し `<input type=\"file\">` / `BlindLevelInput` は意図的な実装のため対象外

## Test plan

- [x] \`bun run check-types\` パス
- [x] \`bun x ultracite check\` パス
- [x] \`bun x vitest run\` パス (327 tests)
- [x] CLAUDE.md 検証コマンド: dashboard widgets 内の禁止 hooks 0
- [ ] ブラウザ動作確認: ダッシュボードでウィジェット編集 (4 種) が機能し Save が反映
- [ ] ブラウザ動作確認: トーナメント詳細・ブラインドエディタ (DnD) ・アクティブセッション中ゲーム画面の構造表示テーブル
- [ ] ブラウザ動作確認: プレイヤータグ編集ダイアログでカラーピッカーが選択中色を ring で強調
- [ ] ブラウザ動作確認: プレイヤー一覧・着席画面でアバターが 3 バリアント (hero/temporary/通常) で表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)