### PR TITLE
refactor(web): unify optimistic updates with snapshot helpers

### DIFF
--- a/apps/web/src/features/currencies/hooks/use-currencies.ts
+++ b/apps/web/src/features/currencies/hooks/use-currencies.ts
@@ -1,5 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
+import {
+	cancelTargets,
+	invalidateTargets,
+	restoreSnapshots,
+	snapshotQuery,
+} from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 export interface CurrencyValues {
@@ -70,8 +76,8 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 		mutationFn: (values: CurrencyValues) =>
 			trpcClient.currency.create.mutate(values),
 		onMutate: async (newCurrency) => {
-			await queryClient.cancelQueries({ queryKey: currencyListKey });
-			const previous = queryClient.getQueryData(currencyListKey);
+			await cancelTargets(queryClient, [{ queryKey: currencyListKey }]);
+			const previous = snapshotQuery(queryClient, currencyListKey);
 			queryClient.setQueryData(currencyListKey, (old) => {
 				if (!old) {
 					return old;
@@ -91,12 +97,10 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(currencyListKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: currencyListKey });
+			invalidateTargets(queryClient, [{ queryKey: currencyListKey }]);
 		},
 	});
 
@@ -104,40 +108,36 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 		mutationFn: (values: CurrencyValues & { id: string }) =>
 			trpcClient.currency.update.mutate(values),
 		onMutate: async (updated) => {
-			await queryClient.cancelQueries({ queryKey: currencyListKey });
-			const previous = queryClient.getQueryData(currencyListKey);
+			await cancelTargets(queryClient, [{ queryKey: currencyListKey }]);
+			const previous = snapshotQuery(queryClient, currencyListKey);
 			queryClient.setQueryData(currencyListKey, (old) =>
 				old?.map((c) => (c.id === updated.id ? { ...c, ...updated } : c))
 			);
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(currencyListKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: currencyListKey });
+			invalidateTargets(queryClient, [{ queryKey: currencyListKey }]);
 		},
 	});
 
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => trpcClient.currency.delete.mutate({ id }),
 		onMutate: async (id) => {
-			await queryClient.cancelQueries({ queryKey: currencyListKey });
-			const previous = queryClient.getQueryData(currencyListKey);
+			await cancelTargets(queryClient, [{ queryKey: currencyListKey }]);
+			const previous = snapshotQuery(queryClient, currencyListKey);
 			queryClient.setQueryData(currencyListKey, (old) =>
 				old?.filter((c) => c.id !== id)
 			);
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(currencyListKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: currencyListKey });
+			invalidateTargets(queryClient, [{ queryKey: currencyListKey }]);
 		},
 	});
 
@@ -145,10 +145,10 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 		mutationFn: (values: TransactionValues & { currencyId: string }) =>
 			trpcClient.currencyTransaction.create.mutate(values),
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: currencyListKey });
-			queryClient.invalidateQueries({
-				queryKey: transactionsQueryOptions.queryKey,
-			});
+			invalidateTargets(queryClient, [
+				{ queryKey: currencyListKey },
+				{ queryKey: transactionsQueryOptions.queryKey },
+			]);
 		},
 		onSuccess: () => {
 			resetTransactionState();
@@ -171,10 +171,10 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 				memo: values.memo,
 			}),
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: currencyListKey });
-			queryClient.invalidateQueries({
-				queryKey: transactionsQueryOptions.queryKey,
-			});
+			invalidateTargets(queryClient, [
+				{ queryKey: currencyListKey },
+				{ queryKey: transactionsQueryOptions.queryKey },
+			]);
 		},
 		onSuccess: () => {
 			resetTransactionState();
@@ -195,10 +195,10 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 			}
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: currencyListKey });
-			queryClient.invalidateQueries({
-				queryKey: transactionsQueryOptions.queryKey,
-			});
+			invalidateTargets(queryClient, [
+				{ queryKey: currencyListKey },
+				{ queryKey: transactionsQueryOptions.queryKey },
+			]);
 		},
 		onSuccess: () => {
 			resetTransactionState();

--- a/apps/web/src/features/dashboard/hooks/use-dashboard-widgets.ts
+++ b/apps/web/src/features/dashboard/hooks/use-dashboard-widgets.ts
@@ -1,5 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import {
+	cancelTargets,
+	invalidateTargets,
+	restoreSnapshots,
+	snapshotQuery,
+} from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 import type { Device } from "./use-current-device";
 
@@ -37,7 +43,7 @@ export function useDashboardWidgets(device: Device) {
 	);
 
 	const invalidateList = useCallback(() => {
-		return queryClient.invalidateQueries({ queryKey: listKey });
+		return invalidateTargets(queryClient, [{ queryKey: listKey }]);
 	}, [queryClient, listKey]);
 
 	const createMutation = useMutation({
@@ -59,22 +65,19 @@ export function useDashboardWidgets(device: Device) {
 				config: input.config,
 			}),
 		onMutate: async (input) => {
-			await queryClient.cancelQueries({ queryKey: listKey });
-			const previous = queryClient.getQueryData<DashboardWidget[]>(listKey);
-			if (previous) {
-				queryClient.setQueryData<DashboardWidget[]>(
-					listKey,
-					previous.map((w) =>
+			await cancelTargets(queryClient, [{ queryKey: listKey }]);
+			const previous = snapshotQuery<DashboardWidget[]>(queryClient, listKey);
+			queryClient.setQueryData<DashboardWidget[]>(
+				listKey,
+				(old) =>
+					old?.map((w) =>
 						w.id === input.id ? { ...w, config: input.config ?? w.config } : w
-					)
-				);
-			}
+					) ?? []
+			);
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(listKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: async () => {
 			await invalidateList();
@@ -85,20 +88,16 @@ export function useDashboardWidgets(device: Device) {
 		mutationFn: (id: string) =>
 			trpcClient.dashboardWidget.delete.mutate({ id }),
 		onMutate: async (id) => {
-			await queryClient.cancelQueries({ queryKey: listKey });
-			const previous = queryClient.getQueryData<DashboardWidget[]>(listKey);
-			if (previous) {
-				queryClient.setQueryData<DashboardWidget[]>(
-					listKey,
-					previous.filter((w) => w.id !== id)
-				);
-			}
+			await cancelTargets(queryClient, [{ queryKey: listKey }]);
+			const previous = snapshotQuery<DashboardWidget[]>(queryClient, listKey);
+			queryClient.setQueryData<DashboardWidget[]>(
+				listKey,
+				(old) => old?.filter((w) => w.id !== id) ?? []
+			);
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(listKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: async () => {
 			await invalidateList();

--- a/apps/web/src/features/dashboard/hooks/use-layout-sync.ts
+++ b/apps/web/src/features/dashboard/hooks/use-layout-sync.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef, useState } from "react";
+import { invalidateTargets } from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 import type { Device } from "./use-current-device";
 import type { DashboardWidget } from "./use-dashboard-widgets";
@@ -22,7 +23,7 @@ export function useLayoutSync(device: Device) {
 		mutationFn: (items: LayoutItem[]) =>
 			trpcClient.dashboardWidget.updateLayouts.mutate({ device, items }),
 		onError: async () => {
-			await queryClient.invalidateQueries({ queryKey: listKey });
+			await invalidateTargets(queryClient, [{ queryKey: listKey }]);
 		},
 	});
 
@@ -60,7 +61,7 @@ export function useLayoutSync(device: Device) {
 	const discard = useCallback(() => {
 		pendingRef.current.clear();
 		setHasPendingChanges(false);
-		queryClient.invalidateQueries({ queryKey: listKey });
+		invalidateTargets(queryClient, [{ queryKey: listKey }]);
 	}, [queryClient, listKey]);
 
 	return {

--- a/apps/web/src/features/live-sessions/hooks/use-cash-game-session.ts
+++ b/apps/web/src/features/live-sessions/hooks/use-cash-game-session.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import { invalidateTargets } from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 export function useCashGameSession(sessionId: string) {
@@ -24,13 +25,9 @@ export function useCashGameSession(sessionId: string) {
 		mutationFn: () =>
 			trpcClient.liveCashGameSession.discard.mutate({ id: sessionId }),
 		onSuccess: async () => {
-			await Promise.all([
-				queryClient.invalidateQueries({
-					queryKey: trpc.liveCashGameSession.list.queryOptions({}).queryKey,
-				}),
-				queryClient.invalidateQueries({
-					queryKey: trpc.session.list.queryOptions({}).queryKey,
-				}),
+			await invalidateTargets(queryClient, [
+				{ queryKey: trpc.liveCashGameSession.list.queryOptions({}).queryKey },
+				{ queryKey: trpc.session.list.queryOptions({}).queryKey },
 			]);
 			await navigate({ to: "/sessions" });
 		},

--- a/apps/web/src/features/live-sessions/hooks/use-cash-game-stack.ts
+++ b/apps/web/src/features/live-sessions/hooks/use-cash-game-stack.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { createSessionEventMutationOptions } from "@/features/live-sessions/utils/optimistic-session-event";
+import { invalidateTargets } from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 export function useCashGameStack({ sessionId }: { sessionId: string }) {
@@ -140,11 +141,9 @@ export function useCashGameStack({ sessionId }: { sessionId: string }) {
 				finalStack: values.finalStack,
 			}),
 		onSuccess: async () => {
-			await Promise.all([
-				queryClient.invalidateQueries({ queryKey: listKey }),
-				queryClient.invalidateQueries({
-					queryKey: trpc.session.list.queryOptions({}).queryKey,
-				}),
+			await invalidateTargets(queryClient, [
+				{ queryKey: listKey },
+				{ queryKey: trpc.session.list.queryOptions({}).queryKey },
 			]);
 			await navigate({ to: "/sessions" });
 		},

--- a/apps/web/src/features/live-sessions/hooks/use-create-session.ts
+++ b/apps/web/src/features/live-sessions/hooks/use-create-session.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
+import { invalidateTargets } from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 function useStoreRingGames(storeId: string | undefined) {
@@ -71,9 +72,9 @@ export function useCreateSession({ onClose }: { onClose: () => void }) {
 			storeId?: string;
 		}) => trpcClient.liveCashGameSession.create.mutate(values),
 		onSuccess: async () => {
-			await Promise.all([
-				queryClient.invalidateQueries({ queryKey: cashListKey }),
-				queryClient.invalidateQueries({ queryKey: sessionListKey }),
+			await invalidateTargets(queryClient, [
+				{ queryKey: cashListKey },
+				{ queryKey: sessionListKey },
 			]);
 			onClose();
 			await navigate({ to: "/active-session" });
@@ -105,9 +106,9 @@ export function useCreateSession({ onClose }: { onClose: () => void }) {
 			return result;
 		},
 		onSuccess: async () => {
-			await Promise.all([
-				queryClient.invalidateQueries({ queryKey: tournamentListKey }),
-				queryClient.invalidateQueries({ queryKey: sessionListKey }),
+			await invalidateTargets(queryClient, [
+				{ queryKey: tournamentListKey },
+				{ queryKey: sessionListKey },
 			]);
 			onClose();
 			await navigate({ to: "/active-session" });

--- a/apps/web/src/features/live-sessions/hooks/use-tournament-session.ts
+++ b/apps/web/src/features/live-sessions/hooks/use-tournament-session.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import { invalidateTargets } from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 export function useTournamentSession(sessionId: string) {
@@ -20,13 +21,9 @@ export function useTournamentSession(sessionId: string) {
 		mutationFn: () =>
 			trpcClient.liveTournamentSession.discard.mutate({ id: sessionId }),
 		onSuccess: async () => {
-			await Promise.all([
-				queryClient.invalidateQueries({
-					queryKey: trpc.liveTournamentSession.list.queryOptions({}).queryKey,
-				}),
-				queryClient.invalidateQueries({
-					queryKey: trpc.session.list.queryOptions({}).queryKey,
-				}),
+			await invalidateTargets(queryClient, [
+				{ queryKey: trpc.liveTournamentSession.list.queryOptions({}).queryKey },
+				{ queryKey: trpc.session.list.queryOptions({}).queryKey },
 			]);
 			await navigate({ to: "/sessions" });
 		},
@@ -42,7 +39,9 @@ export function useTournamentSession(sessionId: string) {
 						: Math.floor(timerStartedAt.getTime() / 1000),
 			}),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: sessionQueryOptions.queryKey });
+			invalidateTargets(queryClient, [
+				{ queryKey: sessionQueryOptions.queryKey },
+			]);
 		},
 	});
 

--- a/apps/web/src/features/live-sessions/hooks/use-tournament-stack.ts
+++ b/apps/web/src/features/live-sessions/hooks/use-tournament-stack.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { createSessionEventMutationOptions } from "@/features/live-sessions/utils/optimistic-session-event";
+import { invalidateTargets } from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 export function useTournamentStack({ sessionId }: { sessionId: string }) {
@@ -176,11 +177,9 @@ export function useTournamentStack({ sessionId }: { sessionId: string }) {
 				...values,
 			}),
 		onSuccess: async () => {
-			await Promise.all([
-				queryClient.invalidateQueries({ queryKey: listKey }),
-				queryClient.invalidateQueries({
-					queryKey: trpc.session.list.queryOptions({}).queryKey,
-				}),
+			await invalidateTargets(queryClient, [
+				{ queryKey: listKey },
+				{ queryKey: trpc.session.list.queryOptions({}).queryKey },
 			]);
 			await navigate({ to: "/sessions" });
 		},

--- a/apps/web/src/features/players/hooks/use-players.ts
+++ b/apps/web/src/features/players/hooks/use-players.ts
@@ -1,5 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { PlayerFormValues } from "@/features/players/components/player-form";
+import {
+	cancelTargets,
+	invalidateTargets,
+	restoreSnapshots,
+	snapshotQuery,
+} from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 export interface PlayerItem {
@@ -33,9 +39,9 @@ export function usePlayers(filterTagIds: string[]) {
 
 	const createTag = async (name: string) => {
 		const created = await trpcClient.playerTag.create.mutate({ name });
-		queryClient.invalidateQueries({
-			queryKey: trpc.playerTag.list.queryOptions().queryKey,
-		});
+		invalidateTargets(queryClient, [
+			{ queryKey: trpc.playerTag.list.queryOptions().queryKey },
+		]);
 		return { id: created.id, name: created.name, color: created.color };
 	};
 
@@ -46,8 +52,8 @@ export function usePlayers(filterTagIds: string[]) {
 				memo: values.memo ?? undefined,
 			}),
 		onMutate: async (newPlayer) => {
-			await queryClient.cancelQueries({ queryKey: playerListKey });
-			const previous = queryClient.getQueryData(playerListKey);
+			await cancelTargets(queryClient, [{ queryKey: playerListKey }]);
+			const previous = snapshotQuery(queryClient, playerListKey);
 			queryClient.setQueryData(
 				playerListKey,
 				(old: PlayerItem[] | undefined) => {
@@ -75,12 +81,10 @@ export function usePlayers(filterTagIds: string[]) {
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(playerListKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: playerListKey });
+			invalidateTargets(queryClient, [{ queryKey: playerListKey }]);
 		},
 	});
 
@@ -88,8 +92,8 @@ export function usePlayers(filterTagIds: string[]) {
 		mutationFn: (values: PlayerFormValues & { id: string }) =>
 			trpcClient.player.update.mutate(values),
 		onMutate: async (updated) => {
-			await queryClient.cancelQueries({ queryKey: playerListKey });
-			const previous = queryClient.getQueryData(playerListKey);
+			await cancelTargets(queryClient, [{ queryKey: playerListKey }]);
+			const previous = snapshotQuery(queryClient, playerListKey);
 			queryClient.setQueryData(
 				playerListKey,
 				(old: PlayerItem[] | undefined) => {
@@ -115,32 +119,28 @@ export function usePlayers(filterTagIds: string[]) {
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(playerListKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: playerListKey });
+			invalidateTargets(queryClient, [{ queryKey: playerListKey }]);
 		},
 	});
 
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => trpcClient.player.delete.mutate({ id }),
 		onMutate: async (id) => {
-			await queryClient.cancelQueries({ queryKey: playerListKey });
-			const previous = queryClient.getQueryData(playerListKey);
+			await cancelTargets(queryClient, [{ queryKey: playerListKey }]);
+			const previous = snapshotQuery(queryClient, playerListKey);
 			queryClient.setQueryData(playerListKey, (old: PlayerItem[] | undefined) =>
 				old?.filter((p) => p.id !== id)
 			);
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(playerListKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: playerListKey });
+			invalidateTargets(queryClient, [{ queryKey: playerListKey }]);
 		},
 	});
 

--- a/apps/web/src/features/players/hooks/use-table-players.ts
+++ b/apps/web/src/features/players/hooks/use-table-players.ts
@@ -1,4 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	cancelTargets,
+	invalidateTargets,
+	restoreSnapshots,
+	snapshotQuery,
+} from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 interface UseTablePlayersOptions {
@@ -43,9 +49,6 @@ export function useTablePlayers({
 	const playersKey =
 		trpc.sessionTablePlayer.list.queryOptions(sessionParam).queryKey;
 
-	const invalidatePlayers = () =>
-		queryClient.invalidateQueries({ queryKey: playersKey });
-
 	const addMutation = useMutation({
 		mutationFn: (params: {
 			playerId: string;
@@ -58,12 +61,15 @@ export function useTablePlayers({
 				seatPosition: params.seatPosition,
 			}),
 		onMutate: async (params) => {
-			await queryClient.cancelQueries({ queryKey: playersKey });
-			const prev = queryClient.getQueryData<TablePlayerData>(playersKey);
-			if (prev) {
-				queryClient.setQueryData<TablePlayerData>(playersKey, {
+			await cancelTargets(queryClient, [{ queryKey: playersKey }]);
+			const previous = snapshotQuery<TablePlayerData>(queryClient, playersKey);
+			queryClient.setQueryData<TablePlayerData>(playersKey, (old) => {
+				if (!old) {
+					return old;
+				}
+				return {
 					items: [
-						...prev.items,
+						...old.items,
 						{
 							id: `optimistic-${Date.now()}`,
 							player: {
@@ -78,16 +84,16 @@ export function useTablePlayers({
 							seatPosition: params.seatPosition,
 						},
 					],
-				});
-			}
-			return { prev };
+				};
+			});
+			return { previous };
 		},
-		onError: (_err, _vars, ctx) => {
-			if (ctx?.prev) {
-				queryClient.setQueryData(playersKey, ctx.prev);
-			}
+		onError: (_err, _vars, context) => {
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
-		onSettled: invalidatePlayers,
+		onSettled: () => {
+			invalidateTargets(queryClient, [{ queryKey: playersKey }]);
+		},
 	});
 
 	const addNewMutation = useMutation({
@@ -105,12 +111,15 @@ export function useTablePlayers({
 				seatPosition: params.seatPosition,
 			}),
 		onMutate: async (params) => {
-			await queryClient.cancelQueries({ queryKey: playersKey });
-			const prev = queryClient.getQueryData<TablePlayerData>(playersKey);
-			if (prev) {
-				queryClient.setQueryData<TablePlayerData>(playersKey, {
+			await cancelTargets(queryClient, [{ queryKey: playersKey }]);
+			const previous = snapshotQuery<TablePlayerData>(queryClient, playersKey);
+			queryClient.setQueryData<TablePlayerData>(playersKey, (old) => {
+				if (!old) {
+					return old;
+				}
+				return {
 					items: [
-						...prev.items,
+						...old.items,
 						{
 							id: `optimistic-${Date.now()}`,
 							player: {
@@ -125,20 +134,18 @@ export function useTablePlayers({
 							seatPosition: params.seatPosition,
 						},
 					],
-				});
-			}
-			return { prev };
+				};
+			});
+			return { previous };
 		},
-		onError: (_err, _vars, ctx) => {
-			if (ctx?.prev) {
-				queryClient.setQueryData(playersKey, ctx.prev);
-			}
+		onError: (_err, _vars, context) => {
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			invalidatePlayers();
-			queryClient.invalidateQueries({
-				queryKey: trpc.player.list.queryOptions().queryKey,
-			});
+			invalidateTargets(queryClient, [
+				{ queryKey: playersKey },
+				{ queryKey: trpc.player.list.queryOptions().queryKey },
+			]);
 		},
 	});
 
@@ -149,12 +156,15 @@ export function useTablePlayers({
 				seatPosition: params.seatPosition,
 			}),
 		onMutate: async (params) => {
-			await queryClient.cancelQueries({ queryKey: playersKey });
-			const prev = queryClient.getQueryData<TablePlayerData>(playersKey);
-			if (prev) {
-				queryClient.setQueryData<TablePlayerData>(playersKey, {
+			await cancelTargets(queryClient, [{ queryKey: playersKey }]);
+			const previous = snapshotQuery<TablePlayerData>(queryClient, playersKey);
+			queryClient.setQueryData<TablePlayerData>(playersKey, (old) => {
+				if (!old) {
+					return old;
+				}
+				return {
 					items: [
-						...prev.items,
+						...old.items,
 						{
 							id: `optimistic-${Date.now()}`,
 							player: {
@@ -169,16 +179,16 @@ export function useTablePlayers({
 							seatPosition: params.seatPosition,
 						},
 					],
-				});
-			}
-			return { prev };
+				};
+			});
+			return { previous };
 		},
-		onError: (_err, _vars, ctx) => {
-			if (ctx?.prev) {
-				queryClient.setQueryData(playersKey, ctx.prev);
-			}
+		onError: (_err, _vars, context) => {
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
-		onSettled: invalidatePlayers,
+		onSettled: () => {
+			invalidateTargets(queryClient, [{ queryKey: playersKey }]);
+		},
 	});
 
 	const removeMutation = useMutation({
@@ -188,25 +198,28 @@ export function useTablePlayers({
 				playerId,
 			}),
 		onMutate: async (playerId) => {
-			await queryClient.cancelQueries({ queryKey: playersKey });
-			const prev = queryClient.getQueryData<TablePlayerData>(playersKey);
-			if (prev) {
-				queryClient.setQueryData<TablePlayerData>(playersKey, {
-					items: prev.items.map((item) =>
+			await cancelTargets(queryClient, [{ queryKey: playersKey }]);
+			const previous = snapshotQuery<TablePlayerData>(queryClient, playersKey);
+			queryClient.setQueryData<TablePlayerData>(playersKey, (old) => {
+				if (!old) {
+					return old;
+				}
+				return {
+					items: old.items.map((item) =>
 						item.player.id === playerId
 							? { ...item, isActive: false, leftAt: new Date().toISOString() }
 							: item
 					),
-				});
-			}
-			return { prev };
+				};
+			});
+			return { previous };
 		},
-		onError: (_err, _vars, ctx) => {
-			if (ctx?.prev) {
-				queryClient.setQueryData(playersKey, ctx.prev);
-			}
+		onError: (_err, _vars, context) => {
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
-		onSettled: invalidatePlayers,
+		onSettled: () => {
+			invalidateTargets(queryClient, [{ queryKey: playersKey }]);
+		},
 	});
 
 	const updateSeatMutation = useMutation({
@@ -217,25 +230,28 @@ export function useTablePlayers({
 				seatPosition: params.seatPosition,
 			}),
 		onMutate: async (params) => {
-			await queryClient.cancelQueries({ queryKey: playersKey });
-			const prev = queryClient.getQueryData<TablePlayerData>(playersKey);
-			if (prev) {
-				queryClient.setQueryData<TablePlayerData>(playersKey, {
-					items: prev.items.map((item) =>
+			await cancelTargets(queryClient, [{ queryKey: playersKey }]);
+			const previous = snapshotQuery<TablePlayerData>(queryClient, playersKey);
+			queryClient.setQueryData<TablePlayerData>(playersKey, (old) => {
+				if (!old) {
+					return old;
+				}
+				return {
+					items: old.items.map((item) =>
 						item.player.id === params.playerId
 							? { ...item, seatPosition: params.seatPosition }
 							: item
 					),
-				});
-			}
-			return { prev };
+				};
+			});
+			return { previous };
 		},
-		onError: (_err, _vars, ctx) => {
-			if (ctx?.prev) {
-				queryClient.setQueryData(playersKey, ctx.prev);
-			}
+		onError: (_err, _vars, context) => {
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
-		onSettled: invalidatePlayers,
+		onSettled: () => {
+			invalidateTargets(queryClient, [{ queryKey: playersKey }]);
+		},
 	});
 
 	const players = (playersQuery.data?.items ?? []).map((item) => ({

--- a/apps/web/src/features/sessions/hooks/use-sessions.ts
+++ b/apps/web/src/features/sessions/hooks/use-sessions.ts
@@ -1,6 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import type { SessionFilterValues } from "@/features/sessions/components/session-filters";
+import {
+	cancelTargets,
+	invalidateTargets,
+	restoreSnapshots,
+	snapshotQuery,
+} from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 export interface CashGameFormValues {
@@ -339,9 +345,9 @@ export function useSessions(filters: SessionFilterValues) {
 	const createTagMutation = useMutation({
 		mutationFn: (name: string) => trpcClient.sessionTag.create.mutate({ name }),
 		onSettled: () => {
-			queryClient.invalidateQueries({
-				queryKey: trpc.sessionTag.list.queryOptions().queryKey,
-			});
+			invalidateTargets(queryClient, [
+				{ queryKey: trpc.sessionTag.list.queryOptions().queryKey },
+			]);
 		},
 	});
 
@@ -354,8 +360,8 @@ export function useSessions(filters: SessionFilterValues) {
 		mutationFn: (values: SessionFormValues) =>
 			trpcClient.session.create.mutate(buildCreatePayload(values)),
 		onMutate: async (newSession) => {
-			await queryClient.cancelQueries({ queryKey: sessionListKey });
-			const previous = queryClient.getQueryData(sessionListKey);
+			await cancelTargets(queryClient, [{ queryKey: sessionListKey }]);
+			const previous = snapshotQuery(queryClient, sessionListKey);
 			queryClient.setQueryData(sessionListKey, (old) => {
 				if (!old) {
 					return old;
@@ -368,12 +374,10 @@ export function useSessions(filters: SessionFilterValues) {
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(sessionListKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: sessionListKey });
+			invalidateTargets(queryClient, [{ queryKey: sessionListKey }]);
 		},
 	});
 
@@ -387,8 +391,8 @@ export function useSessions(filters: SessionFilterValues) {
 					: buildUpdatePayload(values)
 			),
 		onMutate: async (updated) => {
-			await queryClient.cancelQueries({ queryKey: sessionListKey });
-			const previous = queryClient.getQueryData(sessionListKey);
+			await cancelTargets(queryClient, [{ queryKey: sessionListKey }]);
+			const previous = snapshotQuery(queryClient, sessionListKey);
 			queryClient.setQueryData(sessionListKey, (old) => {
 				if (!old) {
 					return old;
@@ -409,20 +413,18 @@ export function useSessions(filters: SessionFilterValues) {
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(sessionListKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: sessionListKey });
+			invalidateTargets(queryClient, [{ queryKey: sessionListKey }]);
 		},
 	});
 
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => trpcClient.session.delete.mutate({ id }),
 		onMutate: async (id) => {
-			await queryClient.cancelQueries({ queryKey: sessionListKey });
-			const previous = queryClient.getQueryData(sessionListKey);
+			await cancelTargets(queryClient, [{ queryKey: sessionListKey }]);
+			const previous = snapshotQuery(queryClient, sessionListKey);
 			queryClient.setQueryData(sessionListKey, (old) => {
 				if (!old) {
 					return old;
@@ -432,12 +434,10 @@ export function useSessions(filters: SessionFilterValues) {
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(sessionListKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: sessionListKey });
+			invalidateTargets(queryClient, [{ queryKey: sessionListKey }]);
 		},
 	});
 
@@ -447,23 +447,23 @@ export function useSessions(filters: SessionFilterValues) {
 				id: liveCashGameSessionId,
 			}),
 		onSuccess: async () => {
-			await Promise.all([
-				queryClient.invalidateQueries({ queryKey: sessionListKey }),
-				queryClient.invalidateQueries({
+			await invalidateTargets(queryClient, [
+				{ queryKey: sessionListKey },
+				{
 					queryKey: trpc.liveCashGameSession.list.queryOptions({}).queryKey,
-				}),
-				queryClient.invalidateQueries({
+				},
+				{
 					queryKey: trpc.liveCashGameSession.list.queryOptions({
 						status: "active",
 						limit: 1,
 					}).queryKey,
-				}),
-				queryClient.invalidateQueries({
+				},
+				{
 					queryKey: trpc.liveCashGameSession.list.queryOptions({
 						status: "paused",
 						limit: 1,
 					}).queryKey,
-				}),
+				},
 			]);
 			await navigate({ to: "/active-session" });
 		},

--- a/apps/web/src/features/stores/hooks/use-blind-levels.ts
+++ b/apps/web/src/features/stores/hooks/use-blind-levels.ts
@@ -8,6 +8,12 @@ import {
 import { arrayMove } from "@dnd-kit/sortable";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
+import {
+	cancelTargets,
+	invalidateTargets,
+	restoreSnapshots,
+	snapshotQuery,
+} from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 export interface BlindLevelRow {
@@ -78,10 +84,10 @@ export function useBlindLevels({ tournamentId }: UseBlindLevelsOptions) {
 				...(newLevel.minutes == null ? {} : { minutes: newLevel.minutes }),
 			}),
 		onMutate: async (newLevel) => {
-			await queryClient.cancelQueries({
-				queryKey: levelsQueryOptions.queryKey,
-			});
-			const previous = queryClient.getQueryData(levelsQueryOptions.queryKey);
+			await cancelTargets(queryClient, [
+				{ queryKey: levelsQueryOptions.queryKey },
+			]);
+			const previous = snapshotQuery(queryClient, levelsQueryOptions.queryKey);
 			const tempRow: BlindLevelRow = {
 				id: `temp-${Date.now()}`,
 				tournamentId,
@@ -100,22 +106,22 @@ export function useBlindLevels({ tournamentId }: UseBlindLevelsOptions) {
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(levelsQueryOptions.queryKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: levelsQueryOptions.queryKey });
+			invalidateTargets(queryClient, [
+				{ queryKey: levelsQueryOptions.queryKey },
+			]);
 		},
 	});
 
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => trpcClient.blindLevel.delete.mutate({ id }),
 		onMutate: async (id) => {
-			await queryClient.cancelQueries({
-				queryKey: levelsQueryOptions.queryKey,
-			});
-			const previous = queryClient.getQueryData(levelsQueryOptions.queryKey);
+			await cancelTargets(queryClient, [
+				{ queryKey: levelsQueryOptions.queryKey },
+			]);
+			const previous = snapshotQuery(queryClient, levelsQueryOptions.queryKey);
 			queryClient.setQueryData(
 				levelsQueryOptions.queryKey,
 				(old: BlindLevelRow[] | undefined) =>
@@ -124,12 +130,12 @@ export function useBlindLevels({ tournamentId }: UseBlindLevelsOptions) {
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(levelsQueryOptions.queryKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: levelsQueryOptions.queryKey });
+			invalidateTargets(queryClient, [
+				{ queryKey: levelsQueryOptions.queryKey },
+			]);
 		},
 	});
 
@@ -144,7 +150,9 @@ export function useBlindLevels({ tournamentId }: UseBlindLevelsOptions) {
 			value: number | null;
 		}) => trpcClient.blindLevel.update.mutate({ id, [field]: value }),
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: levelsQueryOptions.queryKey });
+			invalidateTargets(queryClient, [
+				{ queryKey: levelsQueryOptions.queryKey },
+			]);
 		},
 	});
 
@@ -152,10 +160,10 @@ export function useBlindLevels({ tournamentId }: UseBlindLevelsOptions) {
 		mutationFn: (levelIds: string[]) =>
 			trpcClient.blindLevel.reorder.mutate({ tournamentId, levelIds }),
 		onMutate: async (levelIds) => {
-			await queryClient.cancelQueries({
-				queryKey: levelsQueryOptions.queryKey,
-			});
-			const previous = queryClient.getQueryData(levelsQueryOptions.queryKey);
+			await cancelTargets(queryClient, [
+				{ queryKey: levelsQueryOptions.queryKey },
+			]);
+			const previous = snapshotQuery(queryClient, levelsQueryOptions.queryKey);
 			queryClient.setQueryData(
 				levelsQueryOptions.queryKey,
 				(old: BlindLevelRow[] | undefined) => {
@@ -170,12 +178,12 @@ export function useBlindLevels({ tournamentId }: UseBlindLevelsOptions) {
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(levelsQueryOptions.queryKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: levelsQueryOptions.queryKey });
+			invalidateTargets(queryClient, [
+				{ queryKey: levelsQueryOptions.queryKey },
+			]);
 		},
 	});
 

--- a/apps/web/src/features/stores/hooks/use-stores.ts
+++ b/apps/web/src/features/stores/hooks/use-stores.ts
@@ -1,4 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	cancelTargets,
+	invalidateTargets,
+	restoreSnapshots,
+	snapshotQuery,
+} from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 
 export interface StoreValues {
@@ -22,8 +28,8 @@ export function useStores() {
 	const createMutation = useMutation({
 		mutationFn: (values: StoreValues) => trpcClient.store.create.mutate(values),
 		onMutate: async (newStore) => {
-			await queryClient.cancelQueries({ queryKey: storeListKey });
-			const previous = queryClient.getQueryData(storeListKey);
+			await cancelTargets(queryClient, [{ queryKey: storeListKey }]);
+			const previous = snapshotQuery(queryClient, storeListKey);
 			queryClient.setQueryData(storeListKey, (old) => {
 				if (!old) {
 					return old;
@@ -42,12 +48,10 @@ export function useStores() {
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(storeListKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: storeListKey });
+			invalidateTargets(queryClient, [{ queryKey: storeListKey }]);
 		},
 	});
 
@@ -55,40 +59,36 @@ export function useStores() {
 		mutationFn: (values: StoreValues & { id: string }) =>
 			trpcClient.store.update.mutate(values),
 		onMutate: async (updated) => {
-			await queryClient.cancelQueries({ queryKey: storeListKey });
-			const previous = queryClient.getQueryData(storeListKey);
+			await cancelTargets(queryClient, [{ queryKey: storeListKey }]);
+			const previous = snapshotQuery(queryClient, storeListKey);
 			queryClient.setQueryData(storeListKey, (old) =>
 				old?.map((s) => (s.id === updated.id ? { ...s, ...updated } : s))
 			);
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(storeListKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: storeListKey });
+			invalidateTargets(queryClient, [{ queryKey: storeListKey }]);
 		},
 	});
 
 	const deleteMutation = useMutation({
 		mutationFn: (id: string) => trpcClient.store.delete.mutate({ id }),
 		onMutate: async (id) => {
-			await queryClient.cancelQueries({ queryKey: storeListKey });
-			const previous = queryClient.getQueryData(storeListKey);
+			await cancelTargets(queryClient, [{ queryKey: storeListKey }]);
+			const previous = snapshotQuery(queryClient, storeListKey);
 			queryClient.setQueryData(storeListKey, (old) =>
 				old?.filter((s) => s.id !== id)
 			);
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(storeListKey, context.previous);
-			}
+			restoreSnapshots(queryClient, [context?.previous]);
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: storeListKey });
+			invalidateTargets(queryClient, [{ queryKey: storeListKey }]);
 		},
 	});
 


### PR DESCRIPTION
## Summary
- 13 hook files の mutation を、手書きの `cancelQueries` / `getQueryData` / `setQueryData`(復元用) / `invalidateQueries` パターンから `utils/optimistic-update.ts` のヘルパー (`cancelTargets`, `snapshotQuery`, `restoreSnapshots`, `invalidateTargets`) に統一
- 振る舞いは変えていない（純粋な重複削減・一貫性改善）

## 対象ファイル
- currencies: use-currencies
- dashboard: use-dashboard-widgets, use-layout-sync
- live-sessions: use-cash-game-session, use-cash-game-stack, use-create-session, use-tournament-session, use-tournament-stack
- players: use-players, use-table-players
- sessions: use-sessions
- stores: use-blind-levels, use-stores

## Test plan
- [x] `bun x ultracite check apps/web/src` パス
- [x] 関連 feature のテスト（sessions/currencies/dashboard/players/live-sessions/stores の ring-game-form）は全通過