### PR TITLE
fix(husky): add shebang to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 # Auto-stage routeTree.gen.ts if it has unstaged changes
 # (prevents lint-staged stash conflicts with this auto-generated file)
 if git diff --name-only | grep -q 'routeTree.gen.ts'; then


### PR DESCRIPTION
## Summary
- Add `#!/usr/bin/env sh` to `.husky/pre-commit` so Git can spawn it on Windows (previously failed with `Exec format error` when the hook had no shebang).
- No behavior change on Linux/macOS — sh is already the de-facto interpreter there.

## Why
On Windows, Git requires an explicit shebang to know how to exec hook scripts. Without it, every commit attempt fails before `lint-staged` or `vitest related` even start. Other devs on Unix haven't seen this because their `sh` invocation implicitly handles shebangless files.

## Test plan
- [ ] `git commit` on Windows no longer prints `Exec format error`
- [ ] `lint-staged` and `vitest related` still run as before on existing platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)