### PR TITLE
docs(claude): rewrite CLAUDE.md and split into .claude/rules/

### DIFF
--- a/.claude/rules/web-data-fetching.md
+++ b/.claude/rules/web-data-fetching.md
@@ -1,0 +1,23 @@
+---
+paths:
+  - "apps/web/**"
+---
+
+# Data Fetching & Optimistic Updates
+
+All tRPC query and mutation work lives inside custom hooks (never in components — see [`web-hooks-separation.md`](web-hooks-separation.md)).
+
+## Optimistic updates must use the shared helpers
+
+Use [`apps/web/src/utils/optimistic-update.ts`](apps/web/src/utils/optimistic-update.ts):
+
+- `snapshotQuery` / `snapshotQueries` — capture rollback state before the optimistic write.
+- `cancelTargets` — cancel in-flight queries on the same keys.
+- `restoreSnapshots` — call from `onError`.
+- `invalidateTargets` — call from `onSettled` with an array of targets.
+
+**Do not** hand-roll `queryClient.setQueryData` + `invalidateQueries` chains, even inside hooks. If a case is not covered by the helpers, extend the helpers instead of bypassing them.
+
+## Mutation hook shape
+
+Return `{ on*Handler, is*Pending, error, … }`. Keep optimistic state changes isolated inside the mutation's `onMutate`; never leak `queryClient` calls to components.

--- a/.claude/rules/web-forms.md
+++ b/.claude/rules/web-forms.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - "apps/web/**"
+---
+
+# Forms (MANDATORY)
+
+All forms in `apps/web` are built with [`@tanstack/react-form`](https://tanstack.com/form/latest), driven from a custom `use-*-form` hook colocated next to the component. The component renders only — it never calls `useForm` directly.
+
+## Rules
+
+1. **`useForm({ defaultValues, onSubmit, validators })` lives in the hook.** The component consumes `form` and renders `<form.Field>` / `<form.Subscribe>` + shadcn primitives only.
+2. **Validate with `validators.onSubmit: zodSchema`** (and per-field `onChange` when useful). Keep the schema next to the hook.
+3. **Never use `<input type="number">`.** Use `type="text" inputMode="numeric"` and validate / convert via Zod. Helpers: `requiredNumericString`, `optionalNumericString`, `parseOptionalInt` from [`apps/web/src/shared/lib/form-fields.ts`](apps/web/src/shared/lib/form-fields.ts).
+4. **No placeholder UI copy.** `placeholder="e.g. …"` is banned, and example text must not be moved into `Field.description` either — drop it entirely.
+5. **Required / optional visibility**: required fields are marked with `<Field required>` (renders a red `*`). Unmarked fields are implicitly optional.
+6. **Clearable selects use [`SelectWithClear`](apps/web/src/shared/components/ui/select/select-with-clear.tsx)**, not raw shadcn `Select`. The native `<SelectValue placeholder>` prop is permitted only where the Radix primitive's own rendering requires it.
+7. **Mobile form dialogs are bottom sheets.** Use shadcn `Drawer` for mobile-first forms, not `Dialog`.
+8. **Zod imports**: `import z from "zod"` (default import). A Vite bundler issue breaks the namespace import.
+
+## Reference implementations
+
+- [`use-player-form.ts`](apps/web/src/features/players/components/player-form/use-player-form.ts) + [`player-form.tsx`](apps/web/src/features/players/components/player-form/player-form.tsx).
+- [`use-session-form-state.ts`](apps/web/src/features/sessions/components/session-form/use-session-form-state.ts) + [`session-form.tsx`](apps/web/src/features/sessions/components/session-form/session-form.tsx).
+- [`use-sign-in.ts`](apps/web/src/shared/components/sign-in-form/use-sign-in.ts) + [`sign-in-form.tsx`](apps/web/src/shared/components/sign-in-form/sign-in-form.tsx).

--- a/.claude/rules/web-hooks-separation.md
+++ b/.claude/rules/web-hooks-separation.md
@@ -1,0 +1,47 @@
+---
+paths:
+  - "apps/web/**"
+---
+
+# UI / Logic Separation (STRICT)
+
+Components and route pages under `apps/web/src` **must not call React builtin or third-party hooks directly**. They may only invoke project-defined custom hooks (colocated `use-<component>.ts`, `features/**/hooks/use-*.ts`, `shared/**/hooks/use-*.ts`, or route-local `-use-<page>-page.ts`).
+
+## Forbidden in `*.tsx` under `components/` or `routes/`
+
+- **React**: `useState`, `useEffect`, `useMemo`, `useRef`, `useCallback`, `useReducer`, `useContext`, `useDeferredValue`, `useTransition`, `useLayoutEffect`.
+- **`@tanstack/react-form`**: `useForm`.
+- **`@tanstack/react-query`**: `useQuery`, `useMutation`, `useQueryClient`, `useIsMutating`.
+
+## Allowed
+
+- Calls to custom hooks: `const { ... } = useXxx(args)`. The custom hook internally uses whatever it needs.
+- `Route.useParams()` / `Route.useSearch()` inside route page components — these are param accessors, not state.
+- Purely presentational child components defined in the same file that take only props and call no hooks.
+
+## File layout
+
+- **Component-specific hook**: colocated next to the component — `apps/web/src/features/<feature>/components/<component>/use-<component>.ts`.
+- **Route page hook**: colocated next to the route file with a leading dash to exclude it from routing — `apps/web/src/routes/<path>/-use-<page>-page.ts`.
+- **Cross-component data hook**: `apps/web/src/features/<feature>/hooks/use-*.ts`.
+- **Cross-feature / app-wide hook**: `apps/web/src/shared/hooks/use-*.ts`.
+- **Pure helpers / constants / types**: `apps/web/src/features/<feature>/utils/*.ts` or `apps/web/src/shared/lib/*.ts`.
+
+## Hook return shape
+
+`{ data…, is*Pending, on*Handler, state, setState, … }`.
+
+## Verification
+
+This check must return 0 hits:
+
+```sh
+rg '\b(useState|useEffect|useMemo|useRef|useCallback|useForm|useQuery|useMutation|useQueryClient|useReducer|useDeferredValue|useTransition|useLayoutEffect|useIsMutating)\b' 'apps/web/src/**/components/**/*.tsx' 'apps/web/src/routes/**/*.tsx' -g '!**/__tests__/**' -g '!**/*.test.tsx'
+```
+
+## Reference implementations
+
+- Route page pair: [`routes/players/-use-players-page.ts`](apps/web/src/routes/players/-use-players-page.ts) + [`routes/players/index.tsx`](apps/web/src/routes/players/index.tsx).
+- Component + hook (colocated): [`use-player-form.ts`](apps/web/src/features/players/components/player-form/use-player-form.ts) + [`player-form.tsx`](apps/web/src/features/players/components/player-form/player-form.tsx).
+- Cross-component data hook: [`use-currencies.ts`](apps/web/src/features/currencies/hooks/use-currencies.ts), [`use-cash-game-session.ts`](apps/web/src/features/live-sessions/hooks/use-cash-game-session.ts).
+- Auth (shared composite): [`use-sign-in.ts`](apps/web/src/shared/components/sign-in-form/use-sign-in.ts) + [`sign-in-form.tsx`](apps/web/src/shared/components/sign-in-form/sign-in-form.tsx).

--- a/.claude/rules/web-ui.md
+++ b/.claude/rules/web-ui.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "apps/web/**"
+---
+
+# Web UI Conventions
+
+## Page scaffolding
+
+Every top-level page composes its header with [`PageHeader`](apps/web/src/shared/components/page-header/page-header.tsx). It supports an inline actions slot and an optional badge slot. Do not hand-roll page titles or action rows.
+
+## Use shadcn primitives
+
+Reach for existing shadcn components before building a custom wrapper:
+
+- Data tables → [shadcn `Table`](apps/web/src/shared/components/ui/table/table.tsx). Native `<table>` is banned for tabular data.
+- Status pills, counts → shadcn `Badge`. Do not reintroduce the old `ColorBadge` wrapper.
+- User avatars → shadcn `Avatar`. Do not reintroduce the old `PlayerAvatar` wrapper.
+- Single-choice selection (swatches, enum pickers) → shadcn `RadioGroup`.
+- Clearable `Select` → [`SelectWithClear`](apps/web/src/shared/components/ui/select/select-with-clear.tsx). See [`.claude/rules/web-forms.md`](web-forms.md).
+
+## Language
+
+UI copy is **English-only**. Do not put Japanese into user-facing strings (labels, empty states, toasts, errors). Japanese is fine in code comments, commit messages, and PR descriptions.
+
+## Platform
+
+Mobile-first dialogs are bottom sheets — use shadcn `Drawer`, not `Dialog`.
+
+## Icons
+
+Use `@tabler/icons-react` exclusively for new icons. Do not add `lucide-react` imports in new code.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 # Auto-stage routeTree.gen.ts if it has unstaged changes
 # (prevents lint-staged stash conflicts with this auto-generated file)
 if git diff --name-only | grep -q 'routeTree.gen.ts'; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,97 +1,125 @@
-# sapphire2 Development Guidelines
+# sapphire2 — Project Guide for Claude
 
-Auto-generated from all feature plans. Last updated: 2026-04-11
+This file is loaded into every Claude Code session for this repo. Keep it concise (≤200 lines): general facts that must be remembered across turns. Historical context (PR numbers, past refactors) belongs in git / PR descriptions, not here.
 
-## Active Technologies
-- TypeScript (strict mode) + React 19, TanStack Router, TanStack Query, shadcn/ui, Tailwind v4, tRPC v11, Hono, Drizzle ORM (008-session-bb-bi-display)
-- Cloudflare D1 (SQLite) — 変更なし (008-session-bb-bi-display)
-- TypeScript (strict mode) + tRPC v11, Hono, Drizzle ORM, Zod (009-session-recalculation-redesign)
-- TypeScript (strict mode) + React 19, TanStack Router, TanStack Query, shadcn/ui (Accordion, ResponsiveDialog, Badge), Tailwind v4, tRPC v11, Hono, Drizzle ORM (009-update-notes-display)
-- Cloudflare D1 (SQLite) via Drizzle ORM — `update_note_view` テーブルを追加 (009-update-notes-display)
-- TypeScript (strict mode) + React 19, TanStack Router, TanStack Query, shadcn/ui, Tailwind v4, tRPC v11, Hono, Drizzle ORM, Zod (011-redesign-session-events)
-- Cloudflare D1 (SQLite) via Drizzle ORM — セッションイベントデータマイグレーション (011-redesign-session-events)
-- TypeScript (strict mode) + React 19, Tailwind v4, Radix UI, Vitest, Testing Library (007-improve-tag-colorpicker)
+Companion memory files (auto-loaded):
 
-## Project Structure
+- [`.claude/CLAUDE.md`](.claude/CLAUDE.md) — Ultracite / Biome code standards.
+- [`.claude/rules/`](.claude/rules/) — path-scoped rule files; loaded only when files under the matching paths are touched. See the table near the bottom.
 
-```text
-src/
-tests/
-```
+## Stack
+
+- **Runtime / package manager**: Bun 1.3 (workspaces). Always use `bun`, never `npm` / `yarn` / `pnpm`.
+- **Web**: React 19, Vite, TanStack Router, TanStack Query, tRPC v11 client, Tailwind v4, shadcn/ui, `@tanstack/react-form`.
+- **Server**: Hono on Cloudflare Workers, tRPC v11 server, Better Auth.
+- **DB**: Cloudflare D1 (SQLite) via Drizzle ORM. Migrations in `packages/db/src/migrations`.
+- **Validation**: Zod (workspace catalog). Import as `import z from "zod"` (default import) — a Vite bundler issue breaks the namespace import.
+- **Tests**: Vitest + Testing Library (jsdom).
+- **Lint / format**: Ultracite (Biome preset). Details: [`.claude/CLAUDE.md`](.claude/CLAUDE.md).
+- **Icons**: `@tabler/icons-react` only. Do not add `lucide-react` imports in new code.
 
 ## Commands
 
-npm test && npm run lint
+Run from repo root:
 
-## Code Style
-
-TypeScript (strict mode): Follow standard conventions
-
-## Recent Changes
-- 011-redesign-session-events: Added TypeScript (strict mode) + React 19, TanStack Router, TanStack Query, shadcn/ui, Tailwind v4, tRPC v11, Hono, Drizzle ORM, Zod
-- 009-update-notes-display: Added TypeScript (strict mode) + React 19, TanStack Router, TanStack Query, shadcn/ui (Accordion, ResponsiveDialog, Badge), Tailwind v4, tRPC v11, Hono, Drizzle ORM
-- 009-session-recalculation-redesign: Added TypeScript (strict mode) + tRPC v11, Hono, Drizzle ORM, Zod
-- 008-session-bb-bi-display: Added TypeScript (strict mode) + React 19, TanStack Router, TanStack Query, shadcn/ui, Tailwind v4, tRPC v11, Hono, Drizzle ORM
-
-- 007-improve-tag-colorpicker: Added TypeScript (strict mode) + React 19, Tailwind v4, Radix UI, Vitest, Testing Library
-
-<!-- MANUAL ADDITIONS START -->
-
-## Forms (MANDATORY)
-
-**All forms in `apps/web` MUST be built with [`@tanstack/react-form`](https://tanstack.com/form/latest).**
-
-- Do not use raw `<form onSubmit={handleSubmit}>` with `FormData`/`useState` for form state. Use `useForm({ defaultValues, onSubmit, validators })` instead.
-- Attach validation via `validators.onSubmit: zodSchema` (and/or `onChange` per-field). Keep the schema close to the form.
-- **Number inputs must not use `type="number"`.** Keep inputs as `type="text"` + `inputMode="numeric"`, store the raw string in form state, and validate/convert via Zod. `type="number"` has inconsistent cross-browser behavior (scroll-to-change, locale handling, allowed characters) and hides errors behind silent coercion.
-- Use helpers from `@/shared/lib/form-fields` (`requiredNumericString`, `optionalNumericString`, `parseOptionalInt`, etc.) to keep numeric validation uniform.
-- Reference implementations: `apps/web/src/shared/hooks/use-sign-in.ts`, `apps/web/src/players/components/player-form.tsx`, `apps/web/src/live-sessions/components/event-editors/update-stack-editor.tsx`.
-
-## UI/Logic Separation (STRICT MANDATORY)
-
-**All state management and hook usage in `apps/web` components/routes is FORBIDDEN. Components may ONLY call project-defined custom hooks (`useXxx` from `apps/web/src/**/hooks/use-*.ts`).**
-
-### Forbidden in components (including route page components)
-React builtin hooks: `useState`, `useEffect`, `useMemo`, `useRef`, `useCallback`, `useReducer`, `useDeferredValue`, `useTransition`, `useLayoutEffect`, `useContext`.
-Third-party hooks: `useForm` (`@tanstack/react-form`), `useQuery` / `useMutation` / `useQueryClient` / `useIsMutating` (`@tanstack/react-query`), `useRouter` / `useNavigate` (when used for side-effectful navigation logic — prefer routing via props or hooks).
-
-### Allowed in components
-- Calls to custom hooks: `const { ... } = useXxx(args)`.
-- `Route.useParams()` / `Route.useSearch()` inside route page components for reading params (these are param accessors, not state).
-- Pure JSX rendering from destructured values.
-
-### File layout
-- **Custom hook**: `apps/web/src/<feature>/hooks/use-<name>.ts` (or `.tsx` when returning JSX).
-- **Pure helpers, constants, types**: `apps/web/src/<feature>/utils/*.ts`.
-- **UI primitive hooks**: `apps/web/src/shared/components/ui/hooks/use-*.ts`.
-- **Route page hooks**: `apps/web/src/<feature>/hooks/use-<page>-page.ts`.
-
-### Hook return shape
-`{ data系, is*Pending, on*Handler, state, setState, ... }`. See references below.
-
-### Optimistic updates / invalidation
-Use shared helpers in [apps/web/src/utils/optimistic-update.ts](apps/web/src/utils/optimistic-update.ts) (`snapshotQuery`, `snapshotQueries`, `restoreSnapshots`, `cancelTargets`, `invalidateTargets`). Do not hand-roll `queryClient.invalidateQueries(...)` chains, even inside hooks.
-
-### Forms
-The `useForm` call from `@tanstack/react-form` lives in a hook. The component receives `form` and renders `<form.Field>` / `<form.Subscribe>` only.
-
-### Acceptable colocation
-Purely presentational subcomponents (`DetailRow`, `XxxCard`, etc.) that take **only props** and call **no hooks** may stay in the same file. Pure helper functions already at module level need not be moved to `utils/` unless they grow or become shared.
-
-### Reference implementations
-- Pair: [use-players-page.ts](apps/web/src/players/hooks/use-players-page.ts) + [routes/players/index.tsx](apps/web/src/routes/players/index.tsx)
-- Form: [use-player-form.ts](apps/web/src/players/hooks/use-player-form.ts) + [player-form.tsx](apps/web/src/players/components/player-form.tsx)
-- tRPC: [use-currencies.ts](apps/web/src/currencies/hooks/use-currencies.ts), [use-cash-game-session.ts](apps/web/src/live-sessions/hooks/use-cash-game-session.ts)
-- Auth: [use-sign-in.ts](apps/web/src/shared/hooks/use-sign-in.ts) + [sign-in-form.tsx](apps/web/src/shared/components/sign-in-form.tsx)
-
-### Verification
-Run this check — it MUST return 0 hits (excluding `__tests__/`):
 ```sh
-rg '\b(useState|useEffect|useMemo|useRef|useCallback|useForm|useQuery|useMutation|useQueryClient|useReducer|useDeferredValue|useTransition|useLayoutEffect|useIsMutating)\b' apps/web/src/**/components/**/*.tsx apps/web/src/routes/**/*.tsx -g '!**/__tests__/**'
+bun run dev              # all apps (web on :3001, server)
+bun run dev:web          # web only
+bun run dev:server       # server only
+bun run test             # vitest run (all workspaces)
+bun run test:watch       # vitest watch
+bun run lint             # ultracite check
+bun run fix              # ultracite fix (auto-format & auto-fix)
+bun run check-types      # tsc --noEmit (all workspaces)
+bun run build            # build all workspaces
+bun run db:generate      # drizzle-kit generate
+bun run db:migrate:local # apply migrations to local D1
+bun run db:studio        # drizzle-kit studio
 ```
 
-### Reference refactor series (2026-04-21 → 2026-04-22)
-- PRs [#207](https://github.com/HIRO15254/sapphire2/pull/207) session-form, [#208](https://github.com/HIRO15254/sapphire2/pull/208) seat-from-screenshot, [#209](https://github.com/HIRO15254/sapphire2/pull/209) active-session-game-scene, [#210](https://github.com/HIRO15254/sapphire2/pull/210) misc (sign-in / add-player / assign-tournament / session-events), [#212](https://github.com/HIRO15254/sapphire2/pull/212) shared formatters, [#213](https://github.com/HIRO15254/sapphire2/pull/213) widgets / ring-game-form / tournament-form / tournament-tab / update-notes-sheet
-- Full enforcement: `refactor/strict-hooks-extraction` (this PR) — extracted hooks for every remaining violating component + route, covering live-sessions (26), stores (8), players + sessions (6), currencies + dashboard (7), shared + ui primitives (11), routes (8) — ~66 files total.
+Pre-PR verification: `bun run lint && bun run check-types && bun run test`.
 
-<!-- MANUAL ADDITIONS END -->
+## Repository Layout
+
+```text
+apps/
+  web/     React SPA (apps/web/src/**)
+  server/  Hono + tRPC on Cloudflare Workers
+packages/
+  api/     tRPC routers — source of truth for client types
+  db/      Drizzle schema + migrations (Cloudflare D1)
+  auth/    Better Auth setup
+  env/     Zod-typed env vars
+  config/  Shared TS / Biome configs
+```
+
+`apps/web/src/` layout:
+
+```text
+features/<feature>/
+  components/<component>/  <component>.tsx + use-<component>.ts + index.ts (colocated)
+  hooks/                   cross-component data hooks (use-players.ts, use-currencies.ts, ...)
+  utils/                   feature-local pure helpers
+  __tests__/               feature-local tests
+routes/                    TanStack Router tree; page-level hooks live here as `-use-<page>-page.ts`
+shared/
+  components/ui/           shadcn primitives (Button, Select, Avatar, Badge, Table, ...)
+  components/              cross-feature composites (PageHeader, AuthenticatedShell, sign-in-form, ...)
+  hooks/                   cross-feature hooks (use-media-query, use-online-status, ...)
+  lib/                     cross-feature helpers (form-fields, ...)
+utils/                     truly global helpers (optimistic-update, formatters, ...)
+```
+
+When adding a feature, create `apps/web/src/features/<name>/` and colocate everything. Promote to `shared/` only when a second feature imports it.
+
+## Web UI Essentials (cross-cutting)
+
+Detailed rules live in [`.claude/rules/`](.claude/rules/); the points below apply everywhere in `apps/web/` and are worth keeping top of mind:
+
+- **UI copy is English-only.** No Japanese in user-facing strings (labels, empty states, toasts, errors). Japanese is fine in comments, commit messages, and PR descriptions.
+- **Mobile forms are bottom sheets.** Use shadcn `Drawer`, not `Dialog`.
+- **Pages start with [`PageHeader`](apps/web/src/shared/components/page-header/page-header.tsx).** Do not hand-roll titles / action rows.
+- **Logic lives in `useXxx` hooks, not in components.** Components render JSX from destructured hook returns. Verification & full forbidden list: [`.claude/rules/web-hooks-separation.md`](.claude/rules/web-hooks-separation.md).
+
+## Testing
+
+- `bun run test` (`vitest run`) is the source of truth.
+- Colocate tests as `__tests__/foo.test.ts(x)` next to the code under test, or as `<component>.test.tsx` inside the component's own folder.
+- When the logic is the point, prefer testing the hook (`renderHook` from Testing Library) over the component.
+- Black-box: assert on returned state and handler side effects, not internal implementation details.
+
+## Path-scoped Rule Files
+
+The following rule files live in `.claude/rules/` and are loaded automatically when files under their `paths:` glob are touched:
+
+| File | Paths | Summary |
+|---|---|---|
+| `web-hooks-separation.md` | `apps/web/**` | STRICT: components may only call custom `useXxx` hooks; verification script included. |
+| `web-forms.md` | `apps/web/**` | `@tanstack/react-form` in hooks, no `type="number"`, no placeholders, `SelectWithClear` for clearable selects. |
+| `web-ui.md` | `apps/web/**` | PageHeader, shadcn primitives (Table / Badge / Avatar / RadioGroup), mobile = Drawer, tabler-icons. |
+| `web-data-fetching.md` | `apps/web/**` | Optimistic updates must go through `utils/optimistic-update.ts` helpers. |
+
+## Maintaining This File (Self-Evolution)
+
+This file evolves as the codebase evolves. Claude should **propose an update to `CLAUDE.md` or `.claude/rules/*.md` in-session** whenever one of these triggers fires, instead of silently absorbing the correction into one-off responses:
+
+1. **The user corrects the same behavior twice.** The second correction is a signal the rule is missing. Capture it, including the *why* (the incident or preference that motivated it).
+2. **A reference here is stale.** A path no longer resolves, a command name changed, a helper moved, or a "reference implementation" was deleted. Fix it in the same task that discovered the staleness.
+3. **A merged PR establishes a new cross-cutting convention** — a new shared helper, a new directory pattern, a new mandatory primitive, or a new banned pattern. Document it immediately while the reasoning is fresh.
+4. **A verification script in a rule file starts failing.** Decide whether the rule or the code is wrong; update the losing side and the rule's wording if the intent has drifted.
+5. **A rule is no longer true.** Delete it (do not comment it out) and note what replaced it in the PR description.
+
+### Procedure for adding a rule
+
+1. **Verify it is not already enforced** by Ultracite, TypeScript, a pre-commit hook, or a route-level constraint. If it is, reference the enforcement instead of duplicating the rule.
+2. **Decide scope**: narrow path (e.g., `apps/web/**`, `apps/server/**`, `packages/db/**`) → `.claude/rules/<topic>.md` with a `paths:` frontmatter. Truly cross-cutting → this file.
+3. **Write the rule with a one-line "why"** — the incident, PR, or decision that created it — so future edits can judge edge cases instead of blindly following the letter.
+4. **Prefer concrete over abstract.** "Use `SelectWithClear` for clearable selects" beats "prefer consistent select behavior". Include explicit file paths and commands.
+5. **If you add a new file under `.claude/rules/`**, update the index table above.
+6. **For large rewrites or ambiguous scope**, propose the change in chat before writing it — this file is shared across the team.
+
+### Hygiene
+
+- Keep `CLAUDE.md` ≤200 lines. If a new top-level rule would push it over, split the lowest-value existing section into a path-scoped rule file.
+- Delete rules that no longer apply. Historical context belongs in git / PR descriptions, not here.
+- If two rules overlap, merge them; cross-link rule files that reference each other.


### PR DESCRIPTION
## Summary
- Replace the stale auto-generated `CLAUDE.md` with a concise English rewrite (125 lines, ≤200 per Anthropic's memory guidance) covering stack, commands, repo layout, and cross-cutting rules.
- Split detailed rules into path-scoped `.claude/rules/*.md` files that only load when `apps/web/**` is touched — reduces session context and keeps `CLAUDE.md` lean.
- Reflect conventions established in recent PRs: `features/` colocation (#218), shadcn migration (#219), `PageHeader` (#221), form conventions + `SelectWithClear` + English-only UI (#222), optimistic-update helpers (#223).
- Codify a self-evolution procedure so future rule additions stay concrete, scoped, and justified with a "why".

## Files
- `CLAUDE.md` — rewritten.
- `.claude/rules/web-hooks-separation.md` — STRICT UI/Logic separation + `rg` verification.
- `.claude/rules/web-forms.md` — `@tanstack/react-form` conventions, `SelectWithClear`, no `type="number"`, no placeholders, mobile = `Drawer`, Zod default import.
- `.claude/rules/web-ui.md` — `PageHeader`, shadcn primitives, English-only UI, `@tabler/icons-react` only.
- `.claude/rules/web-data-fetching.md` — `utils/optimistic-update.ts` helpers are mandatory.

## Dependency
Includes the hook fix from #224 so the pre-commit hook can actually run on Windows while working on this branch. Once #224 merges, the diff on this PR will drop that commit automatically. Please merge #224 first.

## Test plan
- [ ] `bun run lint` passes
- [ ] `bun run check-types` passes
- [ ] All referenced file paths in `CLAUDE.md` and rule files resolve
- [ ] `/memory` in Claude Code shows the new structure
- [ ] Touching a file under `apps/web/**` causes the matching `.claude/rules/*.md` to load

🤖 Generated with [Claude Code](https://claude.com/claude-code)