### PR TITLE
fix: SA2-9/SA2-12/SA2-13 - session UI improvements and archived game bug fix

### DIFF
--- a/apps/web/src/__tests__/mobile-nav.test.tsx
+++ b/apps/web/src/__tests__/mobile-nav.test.tsx
@@ -186,12 +186,12 @@ describe("MobileNav - Paused Session Mode", () => {
 		expect(screen.getByText("Resume")).toBeInTheDocument();
 	});
 
-	it("does not display live session nav items (Events, Game, Overview)", async () => {
+	it("does not display live session nav items (Timeline, Game, Overview)", async () => {
 		const router = createTestRouter("/sessions");
 		render(<RouterProvider router={router} />);
 
 		await screen.findByText("Dashboard");
-		expect(screen.queryByText("Events")).not.toBeInTheDocument();
+		expect(screen.queryByText("Timeline")).not.toBeInTheDocument();
 		expect(screen.queryByText("Game")).not.toBeInTheDocument();
 		expect(screen.queryByText("Overview")).not.toBeInTheDocument();
 	});
@@ -225,7 +225,7 @@ describe("MobileNav - Live Session Mode (active session)", () => {
 		);
 		render(<RouterProvider router={router} />);
 
-		await screen.findByText("Events");
+		await screen.findByText("Timeline");
 		expect(screen.getByText("Game")).toBeInTheDocument();
 		expect(screen.getByText("Overview")).toBeInTheDocument();
 		expect(screen.getByText("Settings")).toBeInTheDocument();

--- a/apps/web/src/__tests__/sessions-route.test.tsx
+++ b/apps/web/src/__tests__/sessions-route.test.tsx
@@ -212,7 +212,7 @@ describe("SessionsPage", () => {
 
 		render(<Component />);
 
-		await user.click(screen.getAllByRole("button", { name: "New Session" })[0]);
+		await user.click(screen.getAllByRole("button", { name: "New" })[0]);
 
 		expect(
 			screen.getByRole("heading", { name: "New Session" })
@@ -226,7 +226,7 @@ describe("SessionsPage", () => {
 
 		render(<Component />);
 
-		await user.click(screen.getByRole("button", { name: "Manage Tags" }));
+		await user.click(screen.getByRole("button", { name: "Tags" }));
 
 		expect(
 			screen.getByRole("heading", { name: "Manage Tags" })

--- a/apps/web/src/__tests__/tournament-lifecycle.test.tsx
+++ b/apps/web/src/__tests__/tournament-lifecycle.test.tsx
@@ -603,11 +603,11 @@ describe("ActiveSessionEventsPage — tournament events display", () => {
 		});
 	});
 
-	it("renders Events heading", async () => {
+	it("renders Timeline heading", async () => {
 		const router = createEventsRouter();
 		renderWithProviders(router);
 
-		await screen.findByRole("heading", { name: "Events" });
+		await screen.findByRole("heading", { name: "Timeline" });
 	});
 
 	it("renders update_stack events with 'Stack Update' label", async () => {

--- a/apps/web/src/features/live-sessions/components/cash-game-stack-form/cash-game-stack-form.tsx
+++ b/apps/web/src/features/live-sessions/components/cash-game-stack-form/cash-game-stack-form.tsx
@@ -113,7 +113,7 @@ export function CashGameStackForm({
 			<div className="-mx-4 border-t" />
 
 			<div className="flex flex-col gap-2">
-				<p className="font-medium text-muted-foreground text-xs">Events</p>
+				<p className="font-medium text-muted-foreground text-xs">Timeline</p>
 				<div className="grid grid-cols-2 gap-2">
 					<Button
 						onClick={() => setAllInBottomSheetOpen(true)}

--- a/apps/web/src/features/live-sessions/components/session-events-scene/session-events-scene.tsx
+++ b/apps/web/src/features/live-sessions/components/session-events-scene/session-events-scene.tsx
@@ -145,7 +145,7 @@ export function SessionEventsScene({
 
 	return (
 		<div className="p-4 md:p-6">
-			<PageHeader heading="Events" />
+			<PageHeader heading="Timeline" />
 			{events.length === 0 ? (
 				<EmptyState
 					className="border-none bg-transparent px-0 py-8"

--- a/apps/web/src/features/live-sessions/components/tournament-stack-form/tournament-stack-form.tsx
+++ b/apps/web/src/features/live-sessions/components/tournament-stack-form/tournament-stack-form.tsx
@@ -194,7 +194,7 @@ export function TournamentStackForm({
 			<div className="-mx-4 border-t" />
 
 			<div className="flex flex-col gap-2">
-				<p className="font-medium text-muted-foreground text-xs">Events</p>
+				<p className="font-medium text-muted-foreground text-xs">Timeline</p>
 				<div className="grid grid-cols-2 gap-2">
 					<Button
 						onClick={() => setChipPurchaseSheetOpen(true)}

--- a/apps/web/src/features/sessions/components/session-card/session-card.test.tsx
+++ b/apps/web/src/features/sessions/components/session-card/session-card.test.tsx
@@ -484,7 +484,7 @@ describe("SessionCard", () => {
 
 		await user.click(screen.getByRole("button", { expanded: false }));
 
-		expect(screen.getByRole("link", { name: "Events" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Timeline" })).toBeInTheDocument();
 
 		await user.click(screen.getByRole("button", { name: "Reopen" }));
 		expect(onReopen).toHaveBeenCalledWith("live-1");

--- a/apps/web/src/features/sessions/components/session-card/session-card.tsx
+++ b/apps/web/src/features/sessions/components/session-card/session-card.tsx
@@ -484,7 +484,7 @@ export function SessionCard({
 								to="/live-sessions/$sessionType/$sessionId/events"
 							>
 								<IconList size={12} />
-								Events
+								Timeline
 							</Link>
 						</Button>
 						{onReopen && (

--- a/apps/web/src/features/stores/hooks/__tests__/use-store-games.test.ts
+++ b/apps/web/src/features/stores/hooks/__tests__/use-store-games.test.ts
@@ -170,6 +170,119 @@ describe("useStoreGames", () => {
 			});
 		});
 	});
+
+	describe("with includeAll: true", () => {
+		const BASE_RING = {
+			variant: "holdem",
+			blind1: 1,
+			blind2: 2,
+			blind3: null,
+			ante: 0,
+			anteType: "none",
+			tableSize: 9,
+			currencyId: "c1",
+		};
+
+		it("merges active and archived ring games into a single list", async () => {
+			const qc = createClient();
+			qc.setQueryData(
+				["ringGame", "listByStore", { storeId: "store-1" }],
+				[
+					{
+						id: "r-active",
+						name: "Active Game",
+						...BASE_RING,
+						archivedAt: null,
+					},
+				]
+			);
+			qc.setQueryData(
+				[
+					"ringGame",
+					"listByStore",
+					{ storeId: "store-1", includeArchived: true },
+				],
+				[
+					{
+						id: "r-archived",
+						name: "Archived Game",
+						...BASE_RING,
+						archivedAt: "2026-01-01",
+					},
+				]
+			);
+			const { result } = renderHook(
+				() => useStoreGames("store-1", { includeAll: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await waitFor(() => expect(result.current.ringGames).toHaveLength(2));
+			expect(result.current.ringGames.map((g) => g.id)).toEqual(
+				expect.arrayContaining(["r-active", "r-archived"])
+			);
+		});
+
+		it("merges active and archived tournaments into a single list", async () => {
+			const qc = createClient();
+			qc.setQueryData(
+				["tournament", "listByStore", { storeId: "s-1" }],
+				[{ id: "t-active", name: "Active Tourney", buyIn: 100, entryFee: 10 }]
+			);
+			qc.setQueryData(
+				[
+					"tournament",
+					"listByStore",
+					{ storeId: "s-1", includeArchived: true },
+				],
+				[
+					{
+						id: "t-archived",
+						name: "Archived Tourney",
+						buyIn: 200,
+						entryFee: 20,
+					},
+				]
+			);
+			const { result } = renderHook(
+				() => useStoreGames("s-1", { includeAll: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await waitFor(() => expect(result.current.tournaments).toHaveLength(2));
+			expect(result.current.tournaments.map((t) => t.id)).toEqual(
+				expect.arrayContaining(["t-active", "t-archived"])
+			);
+		});
+
+		it("excludes archived games when includeAll is not set", async () => {
+			const qc = createClient();
+			qc.setQueryData(
+				["ringGame", "listByStore", { storeId: "store-2" }],
+				[{ id: "r-only-active", name: "Active", ...BASE_RING }]
+			);
+			qc.setQueryData(
+				[
+					"ringGame",
+					"listByStore",
+					{ storeId: "store-2", includeArchived: true },
+				],
+				[{ id: "r-archived-only", name: "Archived", ...BASE_RING }]
+			);
+			const { result } = renderHook(() => useStoreGames("store-2"), {
+				wrapper: makeWrapper(qc),
+			});
+			await waitFor(() => expect(result.current.ringGames).toHaveLength(1));
+			expect(result.current.ringGames[0].id).toBe("r-only-active");
+		});
+
+		it("returns empty arrays when storeId is undefined even with includeAll", () => {
+			const qc = createClient();
+			const { result } = renderHook(
+				() => useStoreGames(undefined, { includeAll: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			expect(result.current.ringGames).toEqual([]);
+			expect(result.current.tournaments).toEqual([]);
+		});
+	});
 });
 
 describe("useEntityLists", () => {

--- a/apps/web/src/features/stores/hooks/use-store-games.ts
+++ b/apps/web/src/features/stores/hooks/use-store-games.ts
@@ -1,17 +1,46 @@
 import { useQuery } from "@tanstack/react-query";
 import { trpc } from "@/utils/trpc";
 
-export function useStoreGames(storeId: string | undefined) {
+export function useStoreGames(
+	storeId: string | undefined,
+	options?: { includeAll?: boolean }
+) {
+	const includeAll = options?.includeAll ?? false;
+
 	const ringGamesQuery = useQuery({
 		...trpc.ringGame.listByStore.queryOptions({ storeId: storeId ?? "" }),
 		enabled: !!storeId,
+	});
+	const archivedRingGamesQuery = useQuery({
+		...trpc.ringGame.listByStore.queryOptions({
+			storeId: storeId ?? "",
+			includeArchived: true,
+		}),
+		enabled: !!storeId && includeAll,
 	});
 	const tournamentsQuery = useQuery({
 		...trpc.tournament.listByStore.queryOptions({ storeId: storeId ?? "" }),
 		enabled: !!storeId,
 	});
+	const archivedTournamentsQuery = useQuery({
+		...trpc.tournament.listByStore.queryOptions({
+			storeId: storeId ?? "",
+			includeArchived: true,
+		}),
+		enabled: !!storeId && includeAll,
+	});
+
+	const allRingGames = [
+		...(ringGamesQuery.data ?? []),
+		...(includeAll ? (archivedRingGamesQuery.data ?? []) : []),
+	];
+	const allTournaments = [
+		...(tournamentsQuery.data ?? []),
+		...(includeAll ? (archivedTournamentsQuery.data ?? []) : []),
+	];
+
 	return {
-		ringGames: (ringGamesQuery.data ?? []).map((g) => ({
+		ringGames: allRingGames.map((g) => ({
 			id: g.id,
 			name: g.name,
 			variant: g.variant,
@@ -23,7 +52,7 @@ export function useStoreGames(storeId: string | undefined) {
 			tableSize: g.tableSize,
 			currencyId: g.currencyId,
 		})),
-		tournaments: (tournamentsQuery.data ?? []).map((t) => ({
+		tournaments: allTournaments.map((t) => ({
 			id: t.id,
 			name: t.name,
 			buyIn: t.buyIn,

--- a/apps/web/src/routes/sessions/-use-sessions-page.ts
+++ b/apps/web/src/routes/sessions/-use-sessions-page.ts
@@ -35,7 +35,7 @@ export function useSessionsPage() {
 
 	const { stores, currencies } = useEntityLists();
 	const createGames = useStoreGames(selectedStoreId);
-	const editGames = useStoreGames(editStoreId);
+	const editGames = useStoreGames(editStoreId, { includeAll: true });
 
 	const handleCreate = (values: SessionFormValues) => {
 		create(values).then(() => {

--- a/apps/web/src/routes/sessions/__tests__/use-sessions-page.test.ts
+++ b/apps/web/src/routes/sessions/__tests__/use-sessions-page.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
 	lastFilters: null as Record<string, unknown> | null,
 	lastCreateGamesStoreId: null as string | undefined | null,
 	lastEditGamesStoreId: null as string | undefined | null,
+	lastEditIncludeAll: null as boolean | null,
 	lastCalledSlot: "create" as "create" | "edit",
 	sessions: [] as Record<string, unknown>[],
 	availableTags: [] as Array<{ id: string; name: string }>,
@@ -48,7 +49,10 @@ vi.mock("@/features/stores/hooks/use-store-games", () => ({
 		stores: mocks.stores,
 		currencies: mocks.currencies,
 	}),
-	useStoreGames: (storeId: string | undefined) => {
+	useStoreGames: (
+		storeId: string | undefined,
+		options?: { includeAll?: boolean }
+	) => {
 		// useSessionsPage calls useStoreGames twice per render (create + edit
 		// slots). Track each by alternating the slot name.
 		if (mocks.lastCalledSlot === "create") {
@@ -56,6 +60,7 @@ vi.mock("@/features/stores/hooks/use-store-games", () => ({
 			mocks.lastCalledSlot = "edit";
 		} else {
 			mocks.lastEditGamesStoreId = storeId;
+			mocks.lastEditIncludeAll = options?.includeAll ?? false;
 			mocks.lastCalledSlot = "create";
 		}
 		return { ringGames: [], tournaments: [], isLoading: false };
@@ -87,6 +92,7 @@ describe("useSessionsPage", () => {
 		mocks.lastFilters = null;
 		mocks.lastCreateGamesStoreId = null;
 		mocks.lastEditGamesStoreId = null;
+		mocks.lastEditIncludeAll = null;
 		mocks.lastCalledSlot = "create";
 		mocks.sessions = [];
 		mocks.availableTags = [];
@@ -272,6 +278,14 @@ describe("useSessionsPage", () => {
 				);
 			});
 			expect(result.current.editingSession?.id).toBe("s1");
+		});
+	});
+
+	describe("edit games use includeAll", () => {
+		it("passes includeAll: true to useStoreGames for the edit slot", () => {
+			renderHook(() => useSessionsPage());
+			// The edit slot is the second call to useStoreGames each render cycle.
+			expect(mocks.lastEditIncludeAll).toBe(true);
 		});
 	});
 

--- a/apps/web/src/routes/sessions/index.tsx
+++ b/apps/web/src/routes/sessions/index.tsx
@@ -59,11 +59,11 @@ function SessionsPage() {
 							variant="outline"
 						>
 							<IconTags size={16} />
-							Manage Tags
+							Tags
 						</Button>
 						<Button onClick={() => handleCreateDialogOpenChange(true)}>
 							<IconPlus size={16} />
-							New Session
+							New
 						</Button>
 					</>
 				}

--- a/apps/web/src/shared/components/app-navigation/app-navigation.tsx
+++ b/apps/web/src/shared/components/app-navigation/app-navigation.tsx
@@ -61,7 +61,7 @@ const NORMAL_RIGHT_ITEMS: readonly NavigationItem[] = [
 ] as const;
 
 const LIVE_LEFT_ITEMS: readonly NavigationItem[] = [
-	{ to: "/active-session/events", label: "Events", icon: IconList },
+	{ to: "/active-session/events", label: "Timeline", icon: IconList },
 	{ to: "/active-session/game", label: "Game", icon: IconCards },
 ] as const;
 


### PR DESCRIPTION
## Summary

- **SA2-9** (#235): セッション一覧画面のヘッダーボタンを縮小 — "New Session" → "New"、"Manage Tags" → "Tags"
- **SA2-12** (#238): アーカイブ済みゲームがセッション編集モーダルで空文字列になるバグを修正 — `useStoreGames` に `includeAll` オプションを追加し、編集時はアクティブ・アーカイブ双方のゲームを取得してマージするよう変更
- **SA2-13** (#241): セッションカードおよびライブセッションスタックフォーム内の "Events" 表記を "Timeline" に変更。セッションイベントページのページタイトルも同様に変更

## Changes

- `use-store-games.ts`: `useStoreGames(storeId, { includeAll?: boolean })` — `includeAll: true` のとき archived games クエリを追加発行してマージ
- `-use-sessions-page.ts`: `editGames` に `{ includeAll: true }` を渡すよう変更
- `session-card.tsx` / `session-events-scene.tsx` / `cash-game-stack-form.tsx` / `tournament-stack-form.tsx`: "Events" → "Timeline"
- `routes/sessions/index.tsx`: ボタンラベル変更

## Test plan

- [ ] 全変更ファイルに対応するテストを追加・更新済み (116 tests passing)
- [ ] `bun run check-types` 通過
- [ ] `bun x ultracite check` 通過
- [ ] アーカイブ済みゲームを持つセッションの編集モーダルで、ゲームが空にならないことを手動確認推奨

Closes #235, #238, #241

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXDGtb36WcfWuQuSUNzkiT)_