### PR TITLE
feat(sessions): live-session result chart in expanded card (SA2-8)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(bunx vitest *)",
-      "mcp__7d3661ac-8fa2-4e4c-b904-cddf640bd4ac__get_issue"
+      "mcp__7d3661ac-8fa2-4e4c-b904-cddf640bd4ac__get_issue",
+      "mcp__7d3661ac-8fa2-4e4c-b904-cddf640bd4ac__list_comments"
     ]
   },
   "enabledPlugins": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@sapphire2/api": "workspace:*",
     "@sapphire2/auth": "workspace:*",
+    "@sapphire2/db": "workspace:*",
     "@sapphire2/env": "workspace:*",
     "@tabler/icons-react": "^3.41.1",
     "@tailwindcss/typography": "^0.5.19",

--- a/apps/web/src/features/live-sessions/components/session-result-chart/__tests__/session-result-chart.test.tsx
+++ b/apps/web/src/features/live-sessions/components/session-result-chart/__tests__/session-result-chart.test.tsx
@@ -1,0 +1,154 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const queryFn = vi.fn(async () => [] as unknown[]);
+
+vi.mock("@/utils/trpc", () => ({
+	trpc: {
+		sessionEvent: {
+			list: {
+				queryOptions: (input: unknown) => ({
+					queryKey: ["sessionEvent", "list", input],
+					queryFn,
+				}),
+			},
+		},
+	},
+}));
+
+// Avoid actually loading recharts in tests; the wrapper's lazy boundary still
+// resolves, but the impl module is replaced with a tiny stub so jsdom doesn't
+// have to render SVG.
+vi.mock(
+	"@/features/live-sessions/components/session-result-chart/session-result-chart-impl",
+	() => ({
+		default: ({
+			points,
+			sessionType,
+		}: {
+			points: unknown[];
+			sessionType: string;
+		}) =>
+			createElement(
+				"div",
+				{
+					"data-testid": "chart-impl",
+					"data-session-type": sessionType,
+					"data-point-count": String(points.length),
+				},
+				"chart"
+			),
+	})
+);
+
+import { SessionResultChart } from "@/features/live-sessions/components/session-result-chart/session-result-chart";
+
+function createClient(): QueryClient {
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0, staleTime: Number.POSITIVE_INFINITY },
+			mutations: { retry: false },
+		},
+	});
+}
+
+function wrap(ui: ReactNode) {
+	return createElement(QueryClientProvider, { client: createClient() }, ui);
+}
+
+describe("SessionResultChart", () => {
+	it("renders nothing when enabled=false", () => {
+		queryFn.mockClear();
+		const { container } = render(
+			wrap(
+				createElement(SessionResultChart, {
+					enabled: false,
+					liveSessionId: "s1",
+					sessionType: "cash_game",
+				})
+			)
+		);
+		expect(container.firstChild).toBeNull();
+		expect(queryFn).not.toHaveBeenCalled();
+	});
+
+	it("renders the empty state when fewer than 2 derived points", async () => {
+		queryFn.mockClear();
+		queryFn.mockResolvedValueOnce([]);
+		render(
+			wrap(
+				createElement(SessionResultChart, {
+					enabled: true,
+					liveSessionId: "s1",
+					sessionType: "cash_game",
+				})
+			)
+		);
+		expect(await screen.findByText("Not enough data yet")).toBeTruthy();
+	});
+
+	it("renders the chart impl when there are >=2 derived cash points", async () => {
+		queryFn.mockClear();
+		queryFn.mockResolvedValueOnce([
+			{
+				id: "e1",
+				eventType: "session_start",
+				occurredAt: "2026-04-01T10:00:00Z",
+				payload: { buyInAmount: 10_000 },
+			},
+			{
+				id: "e2",
+				eventType: "update_stack",
+				occurredAt: "2026-04-01T10:30:00Z",
+				payload: { stackAmount: 12_000 },
+			},
+		]);
+		render(
+			wrap(
+				createElement(SessionResultChart, {
+					enabled: true,
+					liveSessionId: "cash-1",
+					sessionType: "cash_game",
+				})
+			)
+		);
+		const impl = await screen.findByTestId("chart-impl");
+		expect(impl.getAttribute("data-session-type")).toBe("cash_game");
+		expect(impl.getAttribute("data-point-count")).toBe("2");
+	});
+
+	it("passes tournament points through to the impl", async () => {
+		queryFn.mockClear();
+		queryFn.mockResolvedValueOnce([
+			{
+				id: "e1",
+				eventType: "session_start",
+				occurredAt: "2026-04-01T10:00:00Z",
+				payload: {},
+			},
+			{
+				id: "e2",
+				eventType: "update_stack",
+				occurredAt: "2026-04-01T10:05:00Z",
+				payload: { stackAmount: 10_000 },
+			},
+		]);
+		render(
+			wrap(
+				createElement(SessionResultChart, {
+					enabled: true,
+					liveSessionId: "trn-1",
+					sessionType: "tournament",
+				})
+			)
+		);
+		await waitFor(() =>
+			expect(screen.queryByTestId("chart-impl")).not.toBeNull()
+		);
+		const impl = screen.getByTestId("chart-impl");
+		expect(impl.getAttribute("data-session-type")).toBe("tournament");
+		expect(impl.getAttribute("data-point-count")).toBe("2");
+	});
+});

--- a/apps/web/src/features/live-sessions/components/session-result-chart/__tests__/use-session-result-chart.test.ts
+++ b/apps/web/src/features/live-sessions/components/session-result-chart/__tests__/use-session-result-chart.test.ts
@@ -1,0 +1,183 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+interface CapturedInput {
+	liveCashGameSessionId?: string;
+	liveTournamentSessionId?: string;
+}
+
+const captured: {
+	lastInput: CapturedInput | null;
+	enabledSeen: boolean | undefined;
+} = { lastInput: null, enabledSeen: undefined };
+
+const queryFn = vi.fn(async () => [] as unknown[]);
+
+vi.mock("@/utils/trpc", () => ({
+	trpc: {
+		sessionEvent: {
+			list: {
+				queryOptions: (input: CapturedInput) => {
+					captured.lastInput = input;
+					return {
+						queryKey: ["sessionEvent", "list", input],
+						queryFn,
+					};
+				},
+			},
+		},
+	},
+}));
+
+import { useSessionResultChart } from "@/features/live-sessions/components/session-result-chart/use-session-result-chart";
+
+function createClient(): QueryClient {
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0, staleTime: Number.POSITIVE_INFINITY },
+			mutations: { retry: false },
+		},
+	});
+}
+
+function wrapper(client: QueryClient) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(QueryClientProvider, { client }, children);
+	};
+}
+
+describe("useSessionResultChart", () => {
+	it("does not fetch when enabled=false", () => {
+		queryFn.mockClear();
+		captured.lastInput = null;
+		const { result } = renderHook(
+			() =>
+				useSessionResultChart({
+					liveSessionId: "s1",
+					sessionType: "cash_game",
+					enabled: false,
+				}),
+			{ wrapper: wrapper(createClient()) }
+		);
+		expect(queryFn).not.toHaveBeenCalled();
+		expect(result.current.points).toEqual([]);
+		expect(result.current.isLoading).toBe(false);
+	});
+
+	it("fetches with liveCashGameSessionId for cash sessions when enabled", async () => {
+		queryFn.mockClear();
+		captured.lastInput = null;
+		queryFn.mockResolvedValueOnce([]);
+		renderHook(
+			() =>
+				useSessionResultChart({
+					liveSessionId: "cash-1",
+					sessionType: "cash_game",
+					enabled: true,
+				}),
+			{ wrapper: wrapper(createClient()) }
+		);
+		await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1));
+		expect(captured.lastInput).toEqual({ liveCashGameSessionId: "cash-1" });
+	});
+
+	it("fetches with liveTournamentSessionId for tournaments when enabled", async () => {
+		queryFn.mockClear();
+		captured.lastInput = null;
+		queryFn.mockResolvedValueOnce([]);
+		renderHook(
+			() =>
+				useSessionResultChart({
+					liveSessionId: "trn-1",
+					sessionType: "tournament",
+					enabled: true,
+				}),
+			{ wrapper: wrapper(createClient()) }
+		);
+		await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1));
+		expect(captured.lastInput).toEqual({ liveTournamentSessionId: "trn-1" });
+	});
+
+	it("derives a cash timeline (pl + evPl) from fetched events", async () => {
+		queryFn.mockClear();
+		queryFn.mockResolvedValueOnce([
+			{
+				id: "e1",
+				eventType: "session_start",
+				occurredAt: "2026-04-01T10:00:00Z",
+				payload: { buyInAmount: 10_000 },
+			},
+			{
+				id: "e2",
+				eventType: "update_stack",
+				occurredAt: "2026-04-01T10:30:00Z",
+				payload: { stackAmount: 12_000 },
+			},
+		]);
+		const { result } = renderHook(
+			() =>
+				useSessionResultChart({
+					liveSessionId: "cash-1",
+					sessionType: "cash_game",
+					enabled: true,
+				}),
+			{ wrapper: wrapper(createClient()) }
+		);
+		await waitFor(() => expect(result.current.points).toHaveLength(2));
+		expect(result.current.sessionType).toBe("cash_game");
+		expect(result.current.isEmpty).toBe(false);
+		expect(result.current.points[1]).toMatchObject({ pl: 2000, evPl: 2000 });
+	});
+
+	it("derives a tournament timeline (stack + averageStack)", async () => {
+		queryFn.mockClear();
+		queryFn.mockResolvedValueOnce([
+			{
+				id: "e1",
+				eventType: "session_start",
+				occurredAt: "2026-04-01T10:00:00Z",
+				payload: {},
+			},
+			{
+				id: "e2",
+				eventType: "update_stack",
+				occurredAt: "2026-04-01T10:05:00Z",
+				payload: { stackAmount: 10_000 },
+			},
+		]);
+		const { result } = renderHook(
+			() =>
+				useSessionResultChart({
+					liveSessionId: "trn-1",
+					sessionType: "tournament",
+					enabled: true,
+				}),
+			{ wrapper: wrapper(createClient()) }
+		);
+		await waitFor(() => expect(result.current.points).toHaveLength(2));
+		expect(result.current.sessionType).toBe("tournament");
+		expect(result.current.points[1]).toMatchObject({
+			stack: 10_000,
+			averageStack: null,
+		});
+	});
+
+	it("reports isEmpty=true when fewer than 2 derived points", async () => {
+		queryFn.mockClear();
+		queryFn.mockResolvedValueOnce([]);
+		const { result } = renderHook(
+			() =>
+				useSessionResultChart({
+					liveSessionId: "cash-1",
+					sessionType: "cash_game",
+					enabled: true,
+				}),
+			{ wrapper: wrapper(createClient()) }
+		);
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.points).toEqual([]);
+		expect(result.current.isEmpty).toBe(true);
+	});
+});

--- a/apps/web/src/features/live-sessions/components/session-result-chart/index.ts
+++ b/apps/web/src/features/live-sessions/components/session-result-chart/index.ts
@@ -1,0 +1,2 @@
+export { SessionResultChart } from "./session-result-chart";
+export { useSessionResultChart } from "./use-session-result-chart";

--- a/apps/web/src/features/live-sessions/components/session-result-chart/session-result-chart-impl.tsx
+++ b/apps/web/src/features/live-sessions/components/session-result-chart/session-result-chart-impl.tsx
@@ -1,0 +1,212 @@
+import {
+	CartesianGrid,
+	Legend,
+	Line,
+	LineChart,
+	ReferenceLine,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { formatCompactNumber } from "@/utils/format-number";
+
+const COLOR_CASH = "oklch(0.62 0.21 250)";
+const COLOR_TOURNAMENT = "oklch(0.75 0.16 70)";
+
+interface SeriesMeta {
+	color: string;
+	dashed: boolean;
+	dataKey: string;
+	name: string;
+}
+
+const CASH_SERIES: SeriesMeta[] = [
+	{ name: "P&L", dataKey: "pl", color: COLOR_CASH, dashed: false },
+	{ name: "EV P&L", dataKey: "evPl", color: COLOR_CASH, dashed: true },
+];
+
+const TOURNAMENT_SERIES: SeriesMeta[] = [
+	{ name: "Stack", dataKey: "stack", color: COLOR_TOURNAMENT, dashed: false },
+	{
+		name: "Avg stack",
+		dataKey: "averageStack",
+		color: COLOR_TOURNAMENT,
+		dashed: true,
+	},
+];
+
+function formatXTick(ms: number): string {
+	const totalMinutes = Math.max(0, Math.round(ms / 60_000));
+	const hours = Math.floor(totalMinutes / 60);
+	const minutes = totalMinutes % 60;
+	return `${hours}:${String(minutes).padStart(2, "0")}`;
+}
+
+interface TooltipPayloadItem {
+	color?: string;
+	dataKey?: string | number;
+	name?: string | number;
+	value?: number | string | (number | string)[];
+}
+
+interface CustomTooltipProps {
+	active?: boolean;
+	label?: number | string;
+	payload?: readonly TooltipPayloadItem[];
+}
+
+function CustomTooltip({ active, label, payload }: CustomTooltipProps) {
+	if (!(active && payload) || payload.length === 0) {
+		return null;
+	}
+	return (
+		<div className="rounded-md border border-border bg-popover px-2 py-1 text-popover-foreground text-xs shadow-md">
+			{typeof label === "number" ? (
+				<div className="text-muted-foreground">{formatXTick(label)}</div>
+			) : null}
+			{payload.map((item) => (
+				<div
+					className="flex items-center gap-2"
+					key={String(item.dataKey ?? item.name)}
+				>
+					<span
+						className="inline-block h-2 w-2 rounded-full"
+						style={{ backgroundColor: item.color }}
+					/>
+					<span className="text-muted-foreground">
+						{String(item.name ?? "")}
+					</span>
+					<span className="font-medium tabular-nums">
+						{typeof item.value === "number"
+							? formatCompactNumber(item.value)
+							: ""}
+					</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
+function CustomLegend({ items }: { items: SeriesMeta[] }) {
+	return (
+		<div className="flex flex-wrap items-center justify-center gap-3 pt-1 text-[11px]">
+			{items.map((item) => (
+				<div className="flex items-center gap-1.5" key={item.dataKey}>
+					<svg
+						aria-hidden="true"
+						className="shrink-0"
+						height={6}
+						viewBox="0 0 14 6"
+						width={14}
+					>
+						<line
+							stroke={item.color}
+							strokeDasharray={item.dashed ? "3 2" : undefined}
+							strokeWidth={2}
+							x1={0}
+							x2={14}
+							y1={3}
+							y2={3}
+						/>
+					</svg>
+					<span className="text-foreground">{item.name}</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
+interface ChartPoint {
+	averageStack?: number | null;
+	evPl?: number;
+	pl?: number;
+	stack?: number;
+	t: number;
+}
+
+interface SessionResultChartImplProps {
+	points: ChartPoint[];
+	sessionType: "cash_game" | "tournament";
+}
+
+function activeSeries(
+	sessionType: "cash_game" | "tournament",
+	points: ChartPoint[]
+): SeriesMeta[] {
+	if (sessionType === "cash_game") {
+		return CASH_SERIES;
+	}
+	const hasAverage = points.some((p) => p.averageStack != null);
+	return hasAverage ? TOURNAMENT_SERIES : [TOURNAMENT_SERIES[0]];
+}
+
+export default function SessionResultChartImpl({
+	points,
+	sessionType,
+}: SessionResultChartImplProps) {
+	const series = activeSeries(sessionType, points);
+	const isCash = sessionType === "cash_game";
+	return (
+		<div className="h-full w-full">
+			<ResponsiveContainer height="100%" width="100%">
+				<LineChart
+					data={points}
+					margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+				>
+					<CartesianGrid className="stroke-border" strokeDasharray="3 3" />
+					<XAxis
+						dataKey="t"
+						domain={["dataMin", "dataMax"]}
+						tick={{ fontSize: 10 }}
+						tickFormatter={(v: number) => formatXTick(v)}
+						type="number"
+					/>
+					<YAxis
+						tick={{ fontSize: 10 }}
+						tickFormatter={(v: number) => formatCompactNumber(v)}
+						width={50}
+					/>
+					{isCash ? (
+						<ReferenceLine
+							className="stroke-muted-foreground"
+							strokeDasharray="2 2"
+							y={0}
+						/>
+					) : null}
+					<Tooltip
+						content={(props) => (
+							<CustomTooltip
+								active={props.active}
+								label={props.label as number | string | undefined}
+								payload={
+									props.payload as readonly TooltipPayloadItem[] | undefined
+								}
+							/>
+						)}
+						cursor={false}
+						wrapperStyle={{ outline: "none" }}
+					/>
+					<Legend
+						content={() => <CustomLegend items={series} />}
+						wrapperStyle={{ outline: "none" }}
+					/>
+					{series.map((s) => (
+						<Line
+							connectNulls
+							dataKey={s.dataKey}
+							dot={false}
+							isAnimationActive={false}
+							key={s.dataKey}
+							name={s.name}
+							stroke={s.color}
+							strokeDasharray={s.dashed ? "4 4" : undefined}
+							strokeWidth={2}
+							type="linear"
+						/>
+					))}
+				</LineChart>
+			</ResponsiveContainer>
+		</div>
+	);
+}

--- a/apps/web/src/features/live-sessions/components/session-result-chart/session-result-chart.tsx
+++ b/apps/web/src/features/live-sessions/components/session-result-chart/session-result-chart.tsx
@@ -1,0 +1,46 @@
+import { lazy, Suspense } from "react";
+import { Skeleton } from "@/shared/components/ui/skeleton";
+import { useSessionResultChart } from "./use-session-result-chart";
+
+const SessionResultChartImpl = lazy(
+	() => import("./session-result-chart-impl")
+);
+
+interface SessionResultChartProps {
+	enabled: boolean;
+	liveSessionId: string;
+	sessionType: "cash_game" | "tournament";
+}
+
+export function SessionResultChart({
+	enabled,
+	liveSessionId,
+	sessionType,
+}: SessionResultChartProps) {
+	const { isEmpty, isLoading, points } = useSessionResultChart({
+		enabled,
+		liveSessionId,
+		sessionType,
+	});
+
+	if (!enabled) {
+		return null;
+	}
+	if (isLoading) {
+		return <Skeleton className="h-40 w-full" />;
+	}
+	if (isEmpty) {
+		return (
+			<div className="flex h-40 items-center justify-center text-muted-foreground text-xs">
+				Not enough data yet
+			</div>
+		);
+	}
+	return (
+		<div className="h-40 w-full">
+			<Suspense fallback={<Skeleton className="h-full w-full" />}>
+				<SessionResultChartImpl points={points} sessionType={sessionType} />
+			</Suspense>
+		</div>
+	);
+}

--- a/apps/web/src/features/live-sessions/components/session-result-chart/use-session-result-chart.ts
+++ b/apps/web/src/features/live-sessions/components/session-result-chart/use-session-result-chart.ts
@@ -1,0 +1,57 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+	type CashTimelinePoint,
+	deriveCashGameTimeline,
+	deriveTournamentTimeline,
+	type TimelineEvent,
+	type TournamentTimelinePoint,
+} from "@/features/live-sessions/utils/session-timeline";
+import { trpc } from "@/utils/trpc";
+
+export type SessionType = "cash_game" | "tournament";
+
+export type SessionResultPoint = CashTimelinePoint | TournamentTimelinePoint;
+
+interface UseSessionResultChartArgs {
+	enabled: boolean;
+	liveSessionId: string;
+	sessionType: SessionType;
+}
+
+interface UseSessionResultChartResult {
+	error: unknown;
+	isEmpty: boolean;
+	isLoading: boolean;
+	points: SessionResultPoint[];
+	sessionType: SessionType;
+}
+
+export function useSessionResultChart({
+	liveSessionId,
+	sessionType,
+	enabled,
+}: UseSessionResultChartArgs): UseSessionResultChartResult {
+	const queryInput =
+		sessionType === "tournament"
+			? { liveTournamentSessionId: liveSessionId }
+			: { liveCashGameSessionId: liveSessionId };
+
+	const eventsQuery = useQuery({
+		...trpc.sessionEvent.list.queryOptions(queryInput),
+		enabled,
+	});
+
+	const events = (eventsQuery.data ?? []) as TimelineEvent[];
+	const points: SessionResultPoint[] =
+		sessionType === "tournament"
+			? deriveTournamentTimeline(events)
+			: deriveCashGameTimeline(events);
+
+	return {
+		error: eventsQuery.error,
+		isEmpty: !eventsQuery.isLoading && points.length < 2,
+		isLoading: eventsQuery.isLoading,
+		points,
+		sessionType,
+	};
+}

--- a/apps/web/src/features/live-sessions/utils/__tests__/session-timeline.test.ts
+++ b/apps/web/src/features/live-sessions/utils/__tests__/session-timeline.test.ts
@@ -419,4 +419,132 @@ describe("deriveTournamentTimeline", () => {
 		];
 		expect(() => deriveTournamentTimeline(events)).toThrow();
 	});
+
+	it("session_end with non-winning placement drops stack to 0", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: {
+					stackAmount: 10_000,
+					remainingPlayers: 30,
+					totalEntries: 50,
+				},
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "session_end",
+				payload: {
+					beforeDeadline: false,
+					placement: 7,
+					totalEntries: 50,
+					prizeMoney: 0,
+					bountyPrizes: 0,
+				},
+				offsetMin: 60,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points.at(-1)).toEqual({
+			t: 60 * 60_000,
+			stack: 0,
+			averageStack: 25_000 / 1.5, // (10000 * 50) / 30 — preserved from last update_stack
+		});
+	});
+
+	it("session_end with placement=1 sets stack to startingStack * totalEntries (winner takes all)", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "session_end",
+				payload: {
+					beforeDeadline: false,
+					placement: 1,
+					totalEntries: 50,
+					prizeMoney: 100_000,
+					bountyPrizes: 0,
+				},
+				offsetMin: 120,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points.at(-1)).toMatchObject({
+			t: 120 * 60_000,
+			stack: 10_000 * 50,
+		});
+	});
+
+	it("session_end with placement=1 includes recorded chip purchases in winner stack", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: {
+					stackAmount: 10_000,
+					totalEntries: 50,
+					chipPurchaseCounts: [
+						{ name: "Rebuy", count: 20, chipsPerUnit: 10_000 },
+					],
+				},
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "session_end",
+				payload: {
+					beforeDeadline: false,
+					placement: 1,
+					totalEntries: 50,
+					prizeMoney: 100_000,
+					bountyPrizes: 0,
+				},
+				offsetMin: 120,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		// 10000 * 50 + 20 * 10000 = 500000 + 200000 = 700000
+		expect(points.at(-1)?.stack).toBe(700_000);
+	});
+
+	it("session_end with beforeDeadline=true does not alter the running stack", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "session_end",
+				payload: {
+					beforeDeadline: true,
+					prizeMoney: 0,
+					bountyPrizes: 0,
+				},
+				offsetMin: 60,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points.at(-1)).toMatchObject({ t: 60 * 60_000, stack: 10_000 });
+	});
 });

--- a/apps/web/src/features/live-sessions/utils/__tests__/session-timeline.test.ts
+++ b/apps/web/src/features/live-sessions/utils/__tests__/session-timeline.test.ts
@@ -1,0 +1,422 @@
+import { computeCashGamePLFromEvents } from "@sapphire2/api/services/live-session-pl";
+import { describe, expect, it } from "vitest";
+import {
+	deriveCashGameTimeline,
+	deriveTournamentTimeline,
+	type TimelineEvent,
+} from "@/features/live-sessions/utils/session-timeline";
+
+const T0 = new Date("2026-04-01T10:00:00Z").getTime();
+
+function event(
+	overrides: Partial<TimelineEvent> & {
+		eventType: string;
+		payload: unknown;
+		offsetMin?: number;
+	}
+): TimelineEvent {
+	const { offsetMin, ...rest } = overrides;
+	return {
+		occurredAt: new Date(T0 + (offsetMin ?? 0) * 60_000).toISOString(),
+		...rest,
+	} as TimelineEvent;
+}
+
+// Reuse the API's serialized-payload signature so we can cross-check final values.
+function toServerEvent(e: TimelineEvent): {
+	eventType: string;
+	payload: string;
+} {
+	return { eventType: e.eventType, payload: JSON.stringify(e.payload) };
+}
+
+describe("deriveCashGameTimeline", () => {
+	it("returns an empty array when no events are present", () => {
+		expect(deriveCashGameTimeline([])).toEqual([]);
+	});
+
+	it("returns an empty array when session_start is missing (no anchor)", () => {
+		const events = [
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 5000 },
+				offsetMin: 5,
+			}),
+		];
+		expect(deriveCashGameTimeline(events)).toEqual([]);
+	});
+
+	it("starts at pl=0 / evPl=0 on session_start", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		expect(points).toEqual([{ t: 0, pl: 0, evPl: 0 }]);
+	});
+
+	it("update_stack snapshots running pl as stack - totalBuyIn", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 12_000 },
+				offsetMin: 30,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		expect(points).toHaveLength(2);
+		expect(points[1]).toEqual({ t: 30 * 60_000, pl: 2000, evPl: 2000 });
+	});
+
+	it("chips_add_remove (positive) leaves pl unchanged but increases buy-in basis", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 12_000 },
+				offsetMin: 30,
+			}),
+			event({
+				eventType: "chips_add_remove",
+				payload: { amount: 5000 },
+				offsetMin: 31,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 17_000 },
+				offsetMin: 32,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		// At chips_add_remove(+): stack=17000 (was 12000 + 5000), totalBuyIn=15000 → pl unchanged at 2000
+		expect(points[2]).toEqual({ t: 31 * 60_000, pl: 2000, evPl: 2000 });
+		// Subsequent update_stack repeats the same pl when stack matches totalBuyIn shift
+		expect(points[3]).toEqual({ t: 32 * 60_000, pl: 2000, evPl: 2000 });
+	});
+
+	it("chips_add_remove (negative) accumulates chipRemoveTotal so pl is stable", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 12_000 },
+				offsetMin: 30,
+			}),
+			event({
+				eventType: "chips_add_remove",
+				payload: { amount: -3000 },
+				offsetMin: 31,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		// stack=9000, chipRemoveTotal=3000, totalBuyIn=10000 → pl = 9000 + 3000 - 10000 = 2000
+		expect(points[2]).toEqual({ t: 31 * 60_000, pl: 2000, evPl: 2000 });
+	});
+
+	it("all_in adds positive evDiff when wins underperform equity", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			// pot=1000, trials=1, equity=60% (=600 EV), wins=0 (=0 actual) → evDiff=+600
+			event({
+				eventType: "all_in",
+				payload: { potSize: 1000, trials: 1, equity: 60, wins: 0 },
+				offsetMin: 5,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		expect(points[1]).toEqual({ t: 5 * 60_000, pl: 0, evPl: 600 });
+	});
+
+	it("multiple all_in events accumulate evDiff", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "all_in",
+				payload: { potSize: 1000, trials: 1, equity: 60, wins: 0 },
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "all_in",
+				payload: { potSize: 500, trials: 1, equity: 50, wins: 1 },
+				offsetMin: 10,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		// 1st: +600. 2nd: 500*0.5 - 500*1 = -250 → cumulative evDiff = 350
+		expect(points[2]?.evPl).toBe(350);
+	});
+
+	it("session_end snapshots final pl matching computeCashGamePLFromEvents", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 15_000 },
+				offsetMin: 30,
+			}),
+			event({
+				eventType: "all_in",
+				payload: { potSize: 1000, trials: 1, equity: 60, wins: 0 },
+				offsetMin: 35,
+			}),
+			event({
+				eventType: "session_end",
+				payload: { cashOutAmount: 14_000 },
+				offsetMin: 60,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		const finalServer = computeCashGamePLFromEvents(events.map(toServerEvent));
+		const last = points.at(-1);
+		expect(last?.pl).toBe(finalServer.profitLoss);
+		expect(last?.evPl).toBe((finalServer.profitLoss ?? 0) + finalServer.evDiff);
+	});
+
+	it("ignores unrelated event types (player_join, memo, pause, resume)", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "player_join",
+				payload: { isHero: true, seatPosition: 3 },
+				offsetMin: 1,
+			}),
+			event({
+				eventType: "memo",
+				payload: { text: "hi" },
+				offsetMin: 2,
+			}),
+			event({
+				eventType: "session_pause",
+				payload: {},
+				offsetMin: 3,
+			}),
+			event({
+				eventType: "session_resume",
+				payload: {},
+				offsetMin: 4,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		expect(points).toHaveLength(1);
+		expect(points[0]).toEqual({ t: 0, pl: 0, evPl: 0 });
+	});
+
+	it("rejects malformed payloads via Zod (throws)", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: -5 },
+				offsetMin: 0,
+			}),
+		];
+		expect(() => deriveCashGameTimeline(events)).toThrow();
+	});
+});
+
+describe("deriveTournamentTimeline", () => {
+	it("returns an empty array for no events", () => {
+		expect(deriveTournamentTimeline([])).toEqual([]);
+	});
+
+	it("returns an empty array when session_start is missing", () => {
+		const events = [
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 0,
+			}),
+		];
+		expect(deriveTournamentTimeline(events)).toEqual([]);
+	});
+
+	it("first update_stack establishes the starting stack and emits null averageStack until totalEntries arrives", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 5,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points).toHaveLength(2);
+		expect(points[1]).toEqual({
+			t: 5 * 60_000,
+			stack: 10_000,
+			averageStack: null,
+		});
+	});
+
+	it("computes averageStack = startingStack * totalEntries / remainingPlayers when both are present", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: {
+					stackAmount: 15_000,
+					remainingPlayers: 20,
+					totalEntries: 50,
+				},
+				offsetMin: 30,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		// startingStack=10000 (from first update_stack)
+		// averageStack = 10000 * 50 / 20 = 25000
+		expect(points[2]).toEqual({
+			t: 30 * 60_000,
+			stack: 15_000,
+			averageStack: 25_000,
+		});
+	});
+
+	it("retains the latest known totalEntries/remainingPlayers across subsequent stack updates", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: {
+					stackAmount: 15_000,
+					remainingPlayers: 20,
+					totalEntries: 50,
+				},
+				offsetMin: 30,
+			}),
+			// no remaining/total here — should reuse previous values
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 18_000 },
+				offsetMin: 60,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points[3]).toEqual({
+			t: 60 * 60_000,
+			stack: 18_000,
+			averageStack: 25_000,
+		});
+	});
+
+	it("purchase_chips adds chips to running stack", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "purchase_chips",
+				payload: { name: "Rebuy", cost: 1000, chips: 5000 },
+				offsetMin: 10,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points[2]).toEqual({
+			t: 10 * 60_000,
+			stack: 15_000,
+			averageStack: null,
+		});
+	});
+
+	it("ignores unrelated event types (memo, pause, resume, player_join)", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "memo",
+				payload: { text: "x" },
+				offsetMin: 1,
+			}),
+			event({
+				eventType: "session_pause",
+				payload: {},
+				offsetMin: 2,
+			}),
+			event({
+				eventType: "player_join",
+				payload: { isHero: false },
+				offsetMin: 3,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points).toEqual([{ t: 0, stack: 0, averageStack: null }]);
+	});
+
+	it("rejects malformed update_stack payload via Zod (throws)", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: -100 },
+				offsetMin: 5,
+			}),
+		];
+		expect(() => deriveTournamentTimeline(events)).toThrow();
+	});
+});

--- a/apps/web/src/features/live-sessions/utils/session-timeline.ts
+++ b/apps/web/src/features/live-sessions/utils/session-timeline.ts
@@ -1,0 +1,190 @@
+import {
+	allInPayload,
+	cashSessionEndPayload,
+	cashSessionStartPayload,
+	chipsAddRemovePayload,
+	purchaseChipsPayload,
+	updateStackPayload,
+} from "@sapphire2/db/constants/session-event-types";
+
+export interface TimelineEvent {
+	eventType: string;
+	occurredAt: string | Date | number;
+	payload: unknown;
+}
+
+export interface CashTimelinePoint {
+	evPl: number;
+	pl: number;
+	t: number;
+}
+
+export interface TournamentTimelinePoint {
+	averageStack: number | null;
+	stack: number;
+	t: number;
+}
+
+function toMs(value: string | Date | number): number {
+	if (typeof value === "number") {
+		return value;
+	}
+	if (value instanceof Date) {
+		return value.getTime();
+	}
+	return new Date(value).getTime();
+}
+
+interface CashAcc {
+	chipRemoveTotal: number;
+	evDiff: number;
+	stack: number;
+	totalBuyIn: number;
+}
+
+function cashPoint(t: number, acc: CashAcc): CashTimelinePoint {
+	const pl = acc.stack + acc.chipRemoveTotal - acc.totalBuyIn;
+	return { t, pl, evPl: pl + acc.evDiff };
+}
+
+export function deriveCashGameTimeline(
+	events: TimelineEvent[]
+): CashTimelinePoint[] {
+	const startIndex = events.findIndex((e) => e.eventType === "session_start");
+	if (startIndex === -1) {
+		return [];
+	}
+	const anchor = toMs(events[startIndex].occurredAt);
+	const acc: CashAcc = {
+		stack: 0,
+		totalBuyIn: 0,
+		chipRemoveTotal: 0,
+		evDiff: 0,
+	};
+	const points: CashTimelinePoint[] = [];
+
+	for (let i = startIndex; i < events.length; i++) {
+		const e = events[i];
+		const t = toMs(e.occurredAt) - anchor;
+
+		if (e.eventType === "session_start") {
+			const data = cashSessionStartPayload.parse(e.payload);
+			acc.stack += data.buyInAmount;
+			acc.totalBuyIn += data.buyInAmount;
+			points.push(cashPoint(t, acc));
+			continue;
+		}
+		if (e.eventType === "update_stack") {
+			const data = updateStackPayload.parse(e.payload);
+			acc.stack = data.stackAmount;
+			points.push(cashPoint(t, acc));
+			continue;
+		}
+		if (e.eventType === "chips_add_remove") {
+			const data = chipsAddRemovePayload.parse(e.payload);
+			if (data.amount > 0) {
+				acc.totalBuyIn += data.amount;
+				acc.stack += data.amount;
+			} else {
+				acc.chipRemoveTotal += -data.amount;
+				acc.stack -= -data.amount;
+			}
+			points.push(cashPoint(t, acc));
+			continue;
+		}
+		if (e.eventType === "all_in") {
+			const data = allInPayload.parse(e.payload);
+			acc.evDiff +=
+				data.potSize * (data.equity / 100) -
+				(data.potSize / data.trials) * data.wins;
+			points.push(cashPoint(t, acc));
+			continue;
+		}
+		if (e.eventType === "session_end") {
+			const data = cashSessionEndPayload.parse(e.payload);
+			acc.stack = data.cashOutAmount;
+			points.push(cashPoint(t, acc));
+		}
+	}
+
+	return points;
+}
+
+interface TournamentAcc {
+	remainingPlayers: number | null;
+	stack: number;
+	startingStack: number | null;
+	totalEntries: number | null;
+}
+
+function tournamentAverageStack(acc: TournamentAcc): number | null {
+	if (
+		acc.startingStack === null ||
+		acc.totalEntries === null ||
+		acc.remainingPlayers === null ||
+		acc.remainingPlayers <= 0
+	) {
+		return null;
+	}
+	return (acc.startingStack * acc.totalEntries) / acc.remainingPlayers;
+}
+
+function tournamentPoint(
+	t: number,
+	acc: TournamentAcc
+): TournamentTimelinePoint {
+	return {
+		t,
+		stack: acc.stack,
+		averageStack: tournamentAverageStack(acc),
+	};
+}
+
+export function deriveTournamentTimeline(
+	events: TimelineEvent[]
+): TournamentTimelinePoint[] {
+	const startIndex = events.findIndex((e) => e.eventType === "session_start");
+	if (startIndex === -1) {
+		return [];
+	}
+	const anchor = toMs(events[startIndex].occurredAt);
+	const acc: TournamentAcc = {
+		stack: 0,
+		startingStack: null,
+		totalEntries: null,
+		remainingPlayers: null,
+	};
+	const points: TournamentTimelinePoint[] = [];
+
+	for (let i = startIndex; i < events.length; i++) {
+		const e = events[i];
+		const t = toMs(e.occurredAt) - anchor;
+
+		if (e.eventType === "session_start") {
+			points.push(tournamentPoint(t, acc));
+			continue;
+		}
+		if (e.eventType === "update_stack") {
+			const data = updateStackPayload.parse(e.payload);
+			acc.stack = data.stackAmount;
+			if (acc.startingStack === null) {
+				acc.startingStack = data.stackAmount;
+			}
+			if (data.totalEntries != null) {
+				acc.totalEntries = data.totalEntries;
+			}
+			if (data.remainingPlayers != null) {
+				acc.remainingPlayers = data.remainingPlayers;
+			}
+			points.push(tournamentPoint(t, acc));
+			continue;
+		}
+		if (e.eventType === "purchase_chips") {
+			const data = purchaseChipsPayload.parse(e.payload);
+			acc.stack += data.chips;
+			points.push(tournamentPoint(t, acc));
+		}
+	}
+
+	return points;
+}

--- a/apps/web/src/features/live-sessions/utils/session-timeline.ts
+++ b/apps/web/src/features/live-sessions/utils/session-timeline.ts
@@ -4,6 +4,7 @@ import {
 	cashSessionStartPayload,
 	chipsAddRemovePayload,
 	purchaseChipsPayload,
+	tournamentSessionEndPayload,
 	updateStackPayload,
 } from "@sapphire2/db/constants/session-event-types";
 
@@ -110,7 +111,14 @@ export function deriveCashGameTimeline(
 	return points;
 }
 
+interface ChipPurchaseCount {
+	chipsPerUnit: number;
+	count: number;
+	name: string;
+}
+
 interface TournamentAcc {
+	chipPurchaseCounts: ChipPurchaseCount[];
 	remainingPlayers: number | null;
 	stack: number;
 	startingStack: number | null;
@@ -129,6 +137,15 @@ function tournamentAverageStack(acc: TournamentAcc): number | null {
 	return (acc.startingStack * acc.totalEntries) / acc.remainingPlayers;
 }
 
+function totalChipsInPlay(acc: TournamentAcc, totalEntries: number): number {
+	const baseChips = (acc.startingStack ?? 0) * totalEntries;
+	const purchaseChips = acc.chipPurchaseCounts.reduce(
+		(sum, c) => sum + c.count * c.chipsPerUnit,
+		0
+	);
+	return baseChips + purchaseChips;
+}
+
 function tournamentPoint(
 	t: number,
 	acc: TournamentAcc
@@ -138,6 +155,58 @@ function tournamentPoint(
 		stack: acc.stack,
 		averageStack: tournamentAverageStack(acc),
 	};
+}
+
+function applyTournamentUpdateStack(
+	acc: TournamentAcc,
+	payload: unknown
+): void {
+	const data = updateStackPayload.parse(payload);
+	acc.stack = data.stackAmount;
+	if (acc.startingStack === null) {
+		acc.startingStack = data.stackAmount;
+	}
+	if (data.totalEntries != null) {
+		acc.totalEntries = data.totalEntries;
+	}
+	if (data.remainingPlayers != null) {
+		acc.remainingPlayers = data.remainingPlayers;
+	}
+	if (data.chipPurchaseCounts) {
+		acc.chipPurchaseCounts = data.chipPurchaseCounts;
+	}
+}
+
+function applyTournamentSessionEnd(acc: TournamentAcc, payload: unknown): void {
+	const data = tournamentSessionEndPayload.parse(payload);
+	if (data.beforeDeadline === false) {
+		acc.totalEntries = data.totalEntries;
+		acc.stack =
+			data.placement === 1 ? totalChipsInPlay(acc, data.totalEntries) : 0;
+	}
+}
+
+function applyTournamentEvent(
+	acc: TournamentAcc,
+	eventType: string,
+	payload: unknown
+): boolean {
+	if (eventType === "session_start") {
+		return true;
+	}
+	if (eventType === "update_stack") {
+		applyTournamentUpdateStack(acc, payload);
+		return true;
+	}
+	if (eventType === "purchase_chips") {
+		acc.stack += purchaseChipsPayload.parse(payload).chips;
+		return true;
+	}
+	if (eventType === "session_end") {
+		applyTournamentSessionEnd(acc, payload);
+		return true;
+	}
+	return false;
 }
 
 export function deriveTournamentTimeline(
@@ -153,36 +222,15 @@ export function deriveTournamentTimeline(
 		startingStack: null,
 		totalEntries: null,
 		remainingPlayers: null,
+		chipPurchaseCounts: [],
 	};
 	const points: TournamentTimelinePoint[] = [];
 
 	for (let i = startIndex; i < events.length; i++) {
 		const e = events[i];
-		const t = toMs(e.occurredAt) - anchor;
-
-		if (e.eventType === "session_start") {
-			points.push(tournamentPoint(t, acc));
-			continue;
-		}
-		if (e.eventType === "update_stack") {
-			const data = updateStackPayload.parse(e.payload);
-			acc.stack = data.stackAmount;
-			if (acc.startingStack === null) {
-				acc.startingStack = data.stackAmount;
-			}
-			if (data.totalEntries != null) {
-				acc.totalEntries = data.totalEntries;
-			}
-			if (data.remainingPlayers != null) {
-				acc.remainingPlayers = data.remainingPlayers;
-			}
-			points.push(tournamentPoint(t, acc));
-			continue;
-		}
-		if (e.eventType === "purchase_chips") {
-			const data = purchaseChipsPayload.parse(e.payload);
-			acc.stack += data.chips;
-			points.push(tournamentPoint(t, acc));
+		const handled = applyTournamentEvent(acc, e.eventType, e.payload);
+		if (handled) {
+			points.push(tournamentPoint(toMs(e.occurredAt) - anchor, acc));
 		}
 	}
 

--- a/apps/web/src/features/sessions/components/session-card/session-card.test.tsx
+++ b/apps/web/src/features/sessions/components/session-card/session-card.test.tsx
@@ -10,6 +10,13 @@ vi.mock("@tanstack/react-router", () => ({
 	),
 }));
 
+vi.mock(
+	"@/features/live-sessions/components/session-result-chart",
+	() => ({
+		SessionResultChart: () => null,
+	})
+);
+
 function makeCashGameSession(
 	overrides: Record<string, unknown> = {}
 ): Parameters<typeof SessionCard>[0]["session"] {

--- a/apps/web/src/features/sessions/components/session-card/session-card.test.tsx
+++ b/apps/web/src/features/sessions/components/session-card/session-card.test.tsx
@@ -10,12 +10,9 @@ vi.mock("@tanstack/react-router", () => ({
 	),
 }));
 
-vi.mock(
-	"@/features/live-sessions/components/session-result-chart",
-	() => ({
-		SessionResultChart: () => null,
-	})
-);
+vi.mock("@/features/live-sessions/components/session-result-chart", () => ({
+	SessionResultChart: () => null,
+}));
 
 function makeCashGameSession(
 	overrides: Record<string, unknown> = {}

--- a/apps/web/src/features/sessions/components/session-card/session-card.tsx
+++ b/apps/web/src/features/sessions/components/session-card/session-card.tsx
@@ -10,6 +10,7 @@ import {
 	IconTrophy,
 } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
+import { SessionResultChart } from "@/features/live-sessions/components/session-result-chart";
 import { EntityListItem } from "@/shared/components/management/entity-list-item";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
@@ -432,7 +433,13 @@ export function SessionCard({
 	onDelete,
 	onReopen,
 }: SessionCardProps) {
-	const { isSharing, onShare } = useSessionCard(session);
+	const {
+		expandedValue,
+		isExpanded,
+		isSharing,
+		onExpandedValueChange,
+		onShare,
+	} = useSessionCard(session);
 	const isTournament = session.type === "tournament";
 	const liveSessionId =
 		session.liveCashGameSessionId ?? session.liveTournamentSessionId;
@@ -452,8 +459,10 @@ export function SessionCard({
 				</Button>
 			}
 			deleteLabel="session"
+			expandedValue={expandedValue}
 			onDelete={() => onDelete(session.id)}
 			onEdit={() => onEdit(session)}
+			onExpandedValueChange={onExpandedValueChange}
 			summary={
 				<div className="flex w-full items-start justify-between gap-3 pr-1 text-left">
 					<SessionHeader bbBiMode={bbBiMode} session={session} />
@@ -465,6 +474,15 @@ export function SessionCard({
 					<TournamentDetails session={session} />
 				) : (
 					<CashGameDetails bbBiMode={bbBiMode} session={session} />
+				)}
+				{liveSessionId && (
+					<div className="mt-2 border-t pt-2">
+						<SessionResultChart
+							enabled={isExpanded}
+							liveSessionId={liveSessionId}
+							sessionType={isTournament ? "tournament" : "cash_game"}
+						/>
+					</div>
 				)}
 				{session.memo && (
 					<div className="mt-2 border-t pt-2">

--- a/apps/web/src/features/sessions/components/session-card/use-session-card.ts
+++ b/apps/web/src/features/sessions/components/session-card/use-session-card.ts
@@ -4,6 +4,7 @@ import { shareSession } from "@/features/sessions/utils/share-session";
 
 export function useSessionCard(session: ShareableSession) {
 	const [isSharing, setIsSharing] = useState(false);
+	const [expandedValue, setExpandedValue] = useState<string | null>(null);
 
 	const handleShare = async () => {
 		setIsSharing(true);
@@ -15,7 +16,10 @@ export function useSessionCard(session: ShareableSession) {
 	};
 
 	return {
+		expandedValue,
+		isExpanded: expandedValue !== null,
 		isSharing,
+		onExpandedValueChange: setExpandedValue,
 		onShare: handleShare,
 	};
 }

--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@sapphire2/api": "workspace:*",
         "@sapphire2/auth": "workspace:*",
+        "@sapphire2/db": "workspace:*",
         "@sapphire2/env": "workspace:*",
         "@tabler/icons-react": "^3.41.1",
         "@tailwindcss/typography": "^0.5.19",


### PR DESCRIPTION
Closes [SA2-8](https://linear.app/sapphire2/issue/SA2-8/) / #234.

## Summary

セッション一覧画面のカード展開時、**ライブ記録セッションのみ**時系列グラフを表示する。

- 横軸: セッション開始からの経過時間 (`hh:mm`)
- キャッシュ: `P&L` (実線) と `EV P&L` (破線) を同一 Y 軸に重ね、0 を `ReferenceLine` で示す
- トーナメント: `Stack` (実線) と `Avg stack` (破線、記録があるときのみ)

## アプローチ

1. **派生 util** [`session-timeline.ts`](apps/web/src/features/live-sessions/utils/session-timeline.ts) — `computeCashGamePLFromEvents` と同じ式を再利用しつつ、最終値ではなくイベントごとのスナップショットを emit する fold。テストでは `pl(end) === computeCashGamePLFromEvents(events).profitLoss` の整合を保証している。
2. **描画コンポーネント** — `pnl-graph-widget` (#239) のパターンを踏襲: raw recharts、カスタム tooltip / legend、配色トークン (`oklch(0.62 0.21 250)` / `oklch(0.75 0.16 70)`)、`lazy(() => import(...))` で chunk を分離し bundle 肥大化を回避。
3. **`SessionCard` の expansion 制御** — `EntityListItem` を controlled モードに切り替え、`enabled={isExpanded}` を hook に渡すことで、一覧で N 件あっても **展開時のみ** `sessionEvent.list` を fetch する。React Query キャッシュで再展開は瞬時。

`recharts ^3.8.1` は `staging` で既に導入済みのため新規依存追加なし。`@sapphire2/db` のみ workspace dep に追加 (Zod payload schema 再利用のため)。

## Test plan

- [x] `bunx vitest run --project web-node apps/web/src/features/live-sessions/utils/__tests__/session-timeline.test.ts` — 19/19 pass (boundary + branch coverage、`computeCashGamePLFromEvents` との最終値整合チェック含む)
- [x] `bunx vitest run --project web-dom apps/web/src/features/live-sessions/components/session-result-chart` — 10/10 pass (hook + wrapper component)
- [x] `bunx vitest run --project web-dom apps/web/src/features/live-sessions apps/web/src/features/sessions` — 537/537 pass (regression なし)
- [x] `bun run lint` — ultracite check pass
- [x] `bun run check-types` — pass
- [x] hooks-separation 規約: `rg '\b(useState|useEffect|useMemo|useQuery|useMutation)\b' session-result-chart{.tsx,-impl.tsx}` が 0 hits
- [ ] 手動: ライブキャッシュゲームで `update_stack` + `all_in` 後にカード展開 → 2本線が描画されることを確認
- [ ] 手動: ライブトーナメントで `remainingPlayers + totalEntries` 入り `update_stack` 後 → `Avg stack` 線が出ることを確認
- [ ] 手動: 非ライブセッションのカード展開 → グラフが出ないことを確認
- [ ] 手動: Network タブで `sessionEvent.list` が展開時のみ飛ぶことを確認、recharts chunk が初回展開時にのみロードされることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3SKC7a692vQZbBUT9C1CU)_