### PR TITLE
feat(sessions): hide event-derived fields in live-linked edit modal

### DIFF
--- a/apps/web/src/features/sessions/components/cash-game-fields/cash-game-fields.tsx
+++ b/apps/web/src/features/sessions/components/cash-game-fields/cash-game-fields.tsx
@@ -75,118 +75,35 @@ export function CashGameFields({
 				</Field>
 			)}
 
-			<form.Field name="variant">
-				{(field) => (
-					<Field htmlFor={field.name} label="Variant">
-						<Select
-							disabled={isLiveLinked}
-							onValueChange={(v) => field.handleChange(v)}
-							value={field.state.value}
-						>
-							<SelectTrigger className="w-full" id={field.name}>
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value="nlh">NL Hold&apos;em</SelectItem>
-							</SelectContent>
-						</Select>
-					</Field>
-				)}
-			</form.Field>
+			{!isLiveLinked && (
+				<>
+					<form.Field name="variant">
+						{(field) => (
+							<Field htmlFor={field.name} label="Variant">
+								<Select
+									onValueChange={(v) => field.handleChange(v)}
+									value={field.state.value}
+								>
+									<SelectTrigger className="w-full" id={field.name}>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="nlh">NL Hold&apos;em</SelectItem>
+									</SelectContent>
+								</Select>
+							</Field>
+						)}
+					</form.Field>
 
-			<div className="grid grid-cols-3 gap-3">
-				<form.Field name="blind1">
-					{(field) => (
-						<Field
-							error={field.state.meta.errors[0]?.message}
-							htmlFor={field.name}
-							label="SB"
-						>
-							<Input
-								disabled={isLiveLinked}
-								id={field.name}
-								inputMode="numeric"
-								onBlur={field.handleBlur}
-								onChange={(e) => field.handleChange(e.target.value)}
-								value={field.state.value}
-							/>
-						</Field>
-					)}
-				</form.Field>
-				<form.Field name="blind2">
-					{(field) => (
-						<Field
-							error={field.state.meta.errors[0]?.message}
-							htmlFor={field.name}
-							label="BB"
-						>
-							<Input
-								disabled={isLiveLinked}
-								id={field.name}
-								inputMode="numeric"
-								onBlur={field.handleBlur}
-								onChange={(e) => field.handleChange(e.target.value)}
-								value={field.state.value}
-							/>
-						</Field>
-					)}
-				</form.Field>
-				<form.Field name="blind3">
-					{(field) => (
-						<Field
-							error={field.state.meta.errors[0]?.message}
-							htmlFor={field.name}
-							label="Straddle"
-						>
-							<Input
-								disabled={isLiveLinked}
-								id={field.name}
-								inputMode="numeric"
-								onBlur={field.handleBlur}
-								onChange={(e) => field.handleChange(e.target.value)}
-								value={field.state.value}
-							/>
-						</Field>
-					)}
-				</form.Field>
-			</div>
-
-			<div className="flex gap-3">
-				<form.Field name="anteType">
-					{(field) => (
-						<Field className="flex-1" htmlFor={field.name} label="Ante Type">
-							<Select
-								disabled={isLiveLinked}
-								onValueChange={(v) => field.handleChange(v)}
-								value={field.state.value}
-							>
-								<SelectTrigger className="w-full" id={field.name}>
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									{ANTE_TYPES.map((at) => (
-										<SelectItem key={at.value} value={at.value}>
-											{at.label}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</Field>
-					)}
-				</form.Field>
-
-				<form.Subscribe selector={(state) => state.values.anteType === "none"}>
-					{(isAnteDisabled) => (
-						<form.Field name="ante">
+					<div className="grid grid-cols-3 gap-3">
+						<form.Field name="blind1">
 							{(field) => (
 								<Field
-									className="flex-1"
 									error={field.state.meta.errors[0]?.message}
 									htmlFor={field.name}
-									label="Ante"
+									label="SB"
 								>
 									<Input
-										disabled={isLiveLinked || isAnteDisabled}
 										id={field.name}
 										inputMode="numeric"
 										onBlur={field.handleBlur}
@@ -196,32 +113,119 @@ export function CashGameFields({
 								</Field>
 							)}
 						</form.Field>
-					)}
-				</form.Subscribe>
-			</div>
+						<form.Field name="blind2">
+							{(field) => (
+								<Field
+									error={field.state.meta.errors[0]?.message}
+									htmlFor={field.name}
+									label="BB"
+								>
+									<Input
+										id={field.name}
+										inputMode="numeric"
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										value={field.state.value}
+									/>
+								</Field>
+							)}
+						</form.Field>
+						<form.Field name="blind3">
+							{(field) => (
+								<Field
+									error={field.state.meta.errors[0]?.message}
+									htmlFor={field.name}
+									label="Straddle"
+								>
+									<Input
+										id={field.name}
+										inputMode="numeric"
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										value={field.state.value}
+									/>
+								</Field>
+							)}
+						</form.Field>
+					</div>
 
-			<form.Field name="tableSize">
-				{(field) => (
-					<Field htmlFor={field.name} label="Table Size">
-						<Select
-							disabled={isLiveLinked}
-							onValueChange={(v) => field.handleChange(v)}
-							value={field.state.value}
+					<div className="flex gap-3">
+						<form.Field name="anteType">
+							{(field) => (
+								<Field
+									className="flex-1"
+									htmlFor={field.name}
+									label="Ante Type"
+								>
+									<Select
+										onValueChange={(v) => field.handleChange(v)}
+										value={field.state.value}
+									>
+										<SelectTrigger className="w-full" id={field.name}>
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{ANTE_TYPES.map((at) => (
+												<SelectItem key={at.value} value={at.value}>
+													{at.label}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</Field>
+							)}
+						</form.Field>
+
+						<form.Subscribe
+							selector={(state) => state.values.anteType === "none"}
 						>
-							<SelectTrigger className="w-full" id={field.name}>
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								{TABLE_SIZES.map((size) => (
-									<SelectItem key={size} value={size.toString()}>
-										{size}-max
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</Field>
-				)}
-			</form.Field>
+							{(isAnteDisabled) => (
+								<form.Field name="ante">
+									{(field) => (
+										<Field
+											className="flex-1"
+											error={field.state.meta.errors[0]?.message}
+											htmlFor={field.name}
+											label="Ante"
+										>
+											<Input
+												disabled={isAnteDisabled}
+												id={field.name}
+												inputMode="numeric"
+												onBlur={field.handleBlur}
+												onChange={(e) => field.handleChange(e.target.value)}
+												value={field.state.value}
+											/>
+										</Field>
+									)}
+								</form.Field>
+							)}
+						</form.Subscribe>
+					</div>
+
+					<form.Field name="tableSize">
+						{(field) => (
+							<Field htmlFor={field.name} label="Table Size">
+								<Select
+									onValueChange={(v) => field.handleChange(v)}
+									value={field.state.value}
+								>
+									<SelectTrigger className="w-full" id={field.name}>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{TABLE_SIZES.map((size) => (
+											<SelectItem key={size} value={size.toString()}>
+												{size}-max
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</Field>
+						)}
+					</form.Field>
+				</>
+			)}
 		</>
 	);
 }

--- a/apps/web/src/features/sessions/components/link-selectors/link-selectors.tsx
+++ b/apps/web/src/features/sessions/components/link-selectors/link-selectors.tsx
@@ -53,11 +53,10 @@ export function StoreGameSelectors({
 				</SelectWithClear>
 			</Field>
 
-			{selectedStoreId && (
+			{selectedStoreId && !isLiveLinked && (
 				<Field label={gameLabel}>
 					{hasGameOptions ? (
 						<SelectWithClear
-							disabled={isLiveLinked}
 							onValueChange={onGameChange}
 							value={selectedGameId}
 						>

--- a/apps/web/src/features/sessions/components/session-form/session-form.test.tsx
+++ b/apps/web/src/features/sessions/components/session-form/session-form.test.tsx
@@ -143,25 +143,95 @@ describe("SessionForm", () => {
 			expect(screen.getByTestId("live-linked-banner")).toBeInTheDocument();
 		});
 
-		it("disables session type switcher", () => {
+		it("hides the session type switcher", () => {
 			renderLiveLinkedCash();
-			expect(screen.getByRole("tab", { name: "Cash Game" })).toBeDisabled();
-			expect(screen.getByRole("tab", { name: "Tournament" })).toBeDisabled();
+			expect(
+				screen.queryByRole("tab", { name: "Cash Game" })
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole("tab", { name: "Tournament" })
+			).not.toBeInTheDocument();
 		});
 
-		it("disables the derived cash fields (buyIn, cashOut, evCashOut)", () => {
+		it("hides the derived cash fields (buyIn, cashOut, evCashOut)", () => {
 			renderLiveLinkedCash();
-			expect(document.getElementById("buyIn")).toBeDisabled();
-			expect(document.getElementById("cashOut")).toBeDisabled();
-			expect(document.getElementById("evCashOut")).toBeDisabled();
+			expect(document.getElementById("buyIn")).not.toBeInTheDocument();
+			expect(document.getElementById("cashOut")).not.toBeInTheDocument();
+			expect(document.getElementById("evCashOut")).not.toBeInTheDocument();
 		});
 
-		it("disables session date / time / break inputs", () => {
+		it("hides session date / time / break inputs", () => {
 			renderLiveLinkedCash();
-			expect(screen.getByLabelText(SESSION_DATE_RE)).toBeDisabled();
-			expect(screen.getByLabelText("Start Time")).toBeDisabled();
-			expect(screen.getByLabelText("End Time")).toBeDisabled();
-			expect(screen.getByLabelText("Break Time (min)")).toBeDisabled();
+			expect(screen.queryByLabelText(SESSION_DATE_RE)).not.toBeInTheDocument();
+			expect(screen.queryByLabelText("Start Time")).not.toBeInTheDocument();
+			expect(screen.queryByLabelText("End Time")).not.toBeInTheDocument();
+			expect(
+				screen.queryByLabelText("Break Time (min)")
+			).not.toBeInTheDocument();
+		});
+
+		it("hides cash-game detail fields (variant, blinds, ante, table size)", async () => {
+			const user = userEvent.setup();
+			renderLiveLinkedCash();
+			await user.click(screen.getByRole("button", { name: "Detail" }));
+			expect(document.getElementById("blind1")).not.toBeInTheDocument();
+			expect(document.getElementById("blind2")).not.toBeInTheDocument();
+			expect(document.getElementById("blind3")).not.toBeInTheDocument();
+			expect(document.getElementById("ante")).not.toBeInTheDocument();
+			expect(document.getElementById("anteType")).not.toBeInTheDocument();
+			expect(document.getElementById("tableSize")).not.toBeInTheDocument();
+			expect(document.getElementById("variant")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("isLiveLinked tournament session", () => {
+		const renderLiveLinkedTournament = () =>
+			render(
+				<SessionForm
+					defaultValues={{
+						type: "tournament",
+						tournamentBuyIn: 10_000,
+						entryFee: 1000,
+						prizeMoney: 25_000,
+						placement: 3,
+						totalEntries: 50,
+						rebuyCount: 1,
+						rebuyCost: 5000,
+						addonCost: 2000,
+						bountyPrizes: 0,
+					}}
+					isLiveLinked
+					onSubmit={vi.fn()}
+				/>
+			);
+
+		it("shows the live-linked informational banner", () => {
+			renderLiveLinkedTournament();
+			expect(screen.getByTestId("live-linked-banner")).toBeInTheDocument();
+		});
+
+		it("hides primary tournament fields derived from events", () => {
+			renderLiveLinkedTournament();
+			expect(
+				document.getElementById("tournamentBuyIn")
+			).not.toBeInTheDocument();
+			expect(document.getElementById("entryFee")).not.toBeInTheDocument();
+			expect(document.getElementById("prizeMoney")).not.toBeInTheDocument();
+			expect(document.getElementById("placement")).not.toBeInTheDocument();
+			expect(document.getElementById("totalEntries")).not.toBeInTheDocument();
+			expect(document.getElementById("beforeDeadline")).not.toBeInTheDocument();
+		});
+
+		it("hides legacy / event-derived detail fields (rebuy, addon, bounty)", async () => {
+			const user = userEvent.setup();
+			renderLiveLinkedTournament();
+			await user.click(
+				screen.getByRole("button", { name: "Tournament Details" })
+			);
+			expect(document.getElementById("rebuyCount")).not.toBeInTheDocument();
+			expect(document.getElementById("rebuyCost")).not.toBeInTheDocument();
+			expect(document.getElementById("addonCost")).not.toBeInTheDocument();
+			expect(document.getElementById("bountyPrizes")).not.toBeInTheDocument();
 		});
 	});
 

--- a/apps/web/src/features/sessions/components/session-form/session-form.tsx
+++ b/apps/web/src/features/sessions/components/session-form/session-form.tsx
@@ -139,95 +139,95 @@ export function SessionForm({
 			{isLiveLinked && (
 				<Alert data-testid="live-linked-banner">
 					<AlertDescription>
-						This session is generated from a live session. Items calculated from
-						event history cannot be edited. To modify, edit the events in the
-						live session.
+						This session was generated from a live session. Fields derived from
+						event history — timing, buy-ins, payouts, placement, chip purchases,
+						and blinds — are managed there and are not shown here. Edit the
+						events in the live session to update them. Store, currency, tags,
+						and memo can still be edited below.
 					</AlertDescription>
 				</Alert>
 			)}
-			<Field label="Session Type">
-				<Tabs
-					onValueChange={(value) =>
-						setSessionType(value as "cash_game" | "tournament")
-					}
-					value={sessionType}
-				>
-					<TabsList className="grid w-full grid-cols-2">
-						<TabsTrigger disabled={isLiveLinked} value="cash_game">
-							Cash Game
-						</TabsTrigger>
-						<TabsTrigger disabled={isLiveLinked} value="tournament">
-							Tournament
-						</TabsTrigger>
-					</TabsList>
-				</Tabs>
-			</Field>
+			{!isLiveLinked && (
+				<Field label="Session Type">
+					<Tabs
+						onValueChange={(value) =>
+							setSessionType(value as "cash_game" | "tournament")
+						}
+						value={sessionType}
+					>
+						<TabsList className="grid w-full grid-cols-2">
+							<TabsTrigger value="cash_game">Cash Game</TabsTrigger>
+							<TabsTrigger value="tournament">Tournament</TabsTrigger>
+						</TabsList>
+					</Tabs>
+				</Field>
+			)}
 
 			<div className="flex flex-col gap-4">
-				<form.Field name="sessionDate">
-					{(field) => (
-						<Field htmlFor={field.name} label="Session Date" required>
-							<Input
-								disabled={isLiveLinked}
-								id={field.name}
-								onBlur={field.handleBlur}
-								onChange={(e) => field.handleChange(e.target.value)}
-								type="date"
-								value={field.state.value}
-							/>
-						</Field>
-					)}
-				</form.Field>
+				{!isLiveLinked && (
+					<>
+						<form.Field name="sessionDate">
+							{(field) => (
+								<Field htmlFor={field.name} label="Session Date" required>
+									<Input
+										id={field.name}
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										type="date"
+										value={field.state.value}
+									/>
+								</Field>
+							)}
+						</form.Field>
 
-				<div className="grid grid-cols-2 gap-3">
-					<form.Field name="startTime">
-						{(field) => (
-							<Field htmlFor={field.name} label="Start Time">
-								<Input
-									disabled={isLiveLinked}
-									id={field.name}
-									onBlur={field.handleBlur}
-									onChange={(e) => field.handleChange(e.target.value)}
-									type="time"
-									value={field.state.value}
-								/>
-							</Field>
-						)}
-					</form.Field>
-					<form.Field name="endTime">
-						{(field) => (
-							<Field htmlFor={field.name} label="End Time">
-								<Input
-									disabled={isLiveLinked}
-									id={field.name}
-									onBlur={field.handleBlur}
-									onChange={(e) => field.handleChange(e.target.value)}
-									type="time"
-									value={field.state.value}
-								/>
-							</Field>
-						)}
-					</form.Field>
-				</div>
+						<div className="grid grid-cols-2 gap-3">
+							<form.Field name="startTime">
+								{(field) => (
+									<Field htmlFor={field.name} label="Start Time">
+										<Input
+											id={field.name}
+											onBlur={field.handleBlur}
+											onChange={(e) => field.handleChange(e.target.value)}
+											type="time"
+											value={field.state.value}
+										/>
+									</Field>
+								)}
+							</form.Field>
+							<form.Field name="endTime">
+								{(field) => (
+									<Field htmlFor={field.name} label="End Time">
+										<Input
+											id={field.name}
+											onBlur={field.handleBlur}
+											onChange={(e) => field.handleChange(e.target.value)}
+											type="time"
+											value={field.state.value}
+										/>
+									</Field>
+								)}
+							</form.Field>
+						</div>
 
-				<form.Field name="breakMinutes">
-					{(field) => (
-						<Field
-							error={field.state.meta.errors[0]?.message}
-							htmlFor={field.name}
-							label="Break Time (min)"
-						>
-							<Input
-								disabled={isLiveLinked}
-								id={field.name}
-								inputMode="numeric"
-								onBlur={field.handleBlur}
-								onChange={(e) => field.handleChange(e.target.value)}
-								value={field.state.value}
-							/>
-						</Field>
-					)}
-				</form.Field>
+						<form.Field name="breakMinutes">
+							{(field) => (
+								<Field
+									error={field.state.meta.errors[0]?.message}
+									htmlFor={field.name}
+									label="Break Time (min)"
+								>
+									<Input
+										id={field.name}
+										inputMode="numeric"
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										value={field.state.value}
+									/>
+								</Field>
+							)}
+						</form.Field>
+					</>
+				)}
 
 				<StoreGameSelectors
 					gameLabel={gameLabel}
@@ -240,7 +240,7 @@ export function SessionForm({
 					stores={stores}
 				/>
 
-				{isCashGame && (
+				{!isLiveLinked && isCashGame && (
 					<>
 						<div className="grid grid-cols-2 gap-3">
 							<form.Field name="buyIn">
@@ -252,7 +252,6 @@ export function SessionForm({
 										required
 									>
 										<Input
-											disabled={isLiveLinked}
 											id={field.name}
 											inputMode="numeric"
 											onBlur={field.handleBlur}
@@ -271,7 +270,6 @@ export function SessionForm({
 										required
 									>
 										<Input
-											disabled={isLiveLinked}
 											id={field.name}
 											inputMode="numeric"
 											onBlur={field.handleBlur}
@@ -286,7 +284,6 @@ export function SessionForm({
 							{(field) => (
 								<Field htmlFor={field.name} label="EV Cash-out">
 									<Input
-										disabled={isLiveLinked}
 										id={field.name}
 										inputMode="numeric"
 										onBlur={field.handleBlur}
@@ -299,10 +296,9 @@ export function SessionForm({
 					</>
 				)}
 
-				{!isCashGame && (
+				{!(isLiveLinked || isCashGame) && (
 					<TournamentPrimaryFields
 						form={form}
-						isLiveLinked={isLiveLinked}
 						key={`tourney-primary-${selectedGameId ?? "none"}`}
 					/>
 				)}

--- a/apps/web/src/features/sessions/components/tournament-fields/tournament-fields.tsx
+++ b/apps/web/src/features/sessions/components/tournament-fields/tournament-fields.tsx
@@ -30,19 +30,16 @@ type AnyForm = ReactFormExtendedApi<
 
 interface TournamentFieldsProps {
 	form: AnyForm;
-	isLiveLinked?: boolean;
 }
 
 interface TournamentDetailFieldsProps extends TournamentFieldsProps {
 	currencies?: Array<{ id: string; name: string }>;
+	isLiveLinked?: boolean;
 	onCurrencyChange?: (id: string | undefined) => void;
 	selectedCurrencyId?: string;
 }
 
-export function TournamentPrimaryFields({
-	form,
-	isLiveLinked = false,
-}: TournamentFieldsProps) {
+export function TournamentPrimaryFields({ form }: TournamentFieldsProps) {
 	return (
 		<>
 			<div className="grid grid-cols-2 gap-3">
@@ -55,7 +52,6 @@ export function TournamentPrimaryFields({
 							required
 						>
 							<Input
-								disabled={isLiveLinked}
 								id={field.name}
 								inputMode="numeric"
 								onBlur={field.handleBlur}
@@ -73,7 +69,6 @@ export function TournamentPrimaryFields({
 							label="Entry Fee"
 						>
 							<Input
-								disabled={isLiveLinked}
 								id={field.name}
 								inputMode="numeric"
 								onBlur={field.handleBlur}
@@ -93,7 +88,6 @@ export function TournamentPrimaryFields({
 						label="Prize Money"
 					>
 						<Input
-							disabled={isLiveLinked}
 							id={field.name}
 							inputMode="numeric"
 							onBlur={field.handleBlur}
@@ -110,7 +104,6 @@ export function TournamentPrimaryFields({
 						<>
 							<Checkbox
 								checked={field.state.value === true}
-								disabled={isLiveLinked}
 								id={field.name}
 								onCheckedChange={(checked) =>
 									field.handleChange(checked === true)
@@ -136,7 +129,6 @@ export function TournamentPrimaryFields({
 										label="Placement"
 									>
 										<Input
-											disabled={isLiveLinked}
 											id={field.name}
 											inputMode="numeric"
 											onBlur={field.handleBlur}
@@ -154,7 +146,6 @@ export function TournamentPrimaryFields({
 										label="Total Entries"
 									>
 										<Input
-											disabled={isLiveLinked}
 											id={field.name}
 											inputMode="numeric"
 											onBlur={field.handleBlur}
@@ -204,83 +195,83 @@ export function TournamentDetailFields({
 				</Field>
 			)}
 
-			<div className="grid grid-cols-2 gap-3">
-				<form.Field name="rebuyCount">
-					{(field) => (
-						<Field
-							error={field.state.meta.errors[0]?.message}
-							htmlFor={field.name}
-							label="Rebuy Count"
-						>
-							<Input
-								disabled={isLiveLinked}
-								id={field.name}
-								inputMode="numeric"
-								onBlur={field.handleBlur}
-								onChange={(e) => field.handleChange(e.target.value)}
-								value={field.state.value}
-							/>
-						</Field>
-					)}
-				</form.Field>
-				<form.Field name="rebuyCost">
-					{(field) => (
-						<Field
-							error={field.state.meta.errors[0]?.message}
-							htmlFor={field.name}
-							label="Rebuy Cost"
-						>
-							<Input
-								disabled={isLiveLinked}
-								id={field.name}
-								inputMode="numeric"
-								onBlur={field.handleBlur}
-								onChange={(e) => field.handleChange(e.target.value)}
-								value={field.state.value}
-							/>
-						</Field>
-					)}
-				</form.Field>
-			</div>
+			{!isLiveLinked && (
+				<>
+					<div className="grid grid-cols-2 gap-3">
+						<form.Field name="rebuyCount">
+							{(field) => (
+								<Field
+									error={field.state.meta.errors[0]?.message}
+									htmlFor={field.name}
+									label="Rebuy Count"
+								>
+									<Input
+										id={field.name}
+										inputMode="numeric"
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										value={field.state.value}
+									/>
+								</Field>
+							)}
+						</form.Field>
+						<form.Field name="rebuyCost">
+							{(field) => (
+								<Field
+									error={field.state.meta.errors[0]?.message}
+									htmlFor={field.name}
+									label="Rebuy Cost"
+								>
+									<Input
+										id={field.name}
+										inputMode="numeric"
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										value={field.state.value}
+									/>
+								</Field>
+							)}
+						</form.Field>
+					</div>
 
-			<div className="grid grid-cols-2 gap-3">
-				<form.Field name="addonCost">
-					{(field) => (
-						<Field
-							error={field.state.meta.errors[0]?.message}
-							htmlFor={field.name}
-							label="Addon Cost"
-						>
-							<Input
-								disabled={isLiveLinked}
-								id={field.name}
-								inputMode="numeric"
-								onBlur={field.handleBlur}
-								onChange={(e) => field.handleChange(e.target.value)}
-								value={field.state.value}
-							/>
-						</Field>
-					)}
-				</form.Field>
-				<form.Field name="bountyPrizes">
-					{(field) => (
-						<Field
-							error={field.state.meta.errors[0]?.message}
-							htmlFor={field.name}
-							label="Bounty Prizes"
-						>
-							<Input
-								disabled={isLiveLinked}
-								id={field.name}
-								inputMode="numeric"
-								onBlur={field.handleBlur}
-								onChange={(e) => field.handleChange(e.target.value)}
-								value={field.state.value}
-							/>
-						</Field>
-					)}
-				</form.Field>
-			</div>
+					<div className="grid grid-cols-2 gap-3">
+						<form.Field name="addonCost">
+							{(field) => (
+								<Field
+									error={field.state.meta.errors[0]?.message}
+									htmlFor={field.name}
+									label="Addon Cost"
+								>
+									<Input
+										id={field.name}
+										inputMode="numeric"
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										value={field.state.value}
+									/>
+								</Field>
+							)}
+						</form.Field>
+						<form.Field name="bountyPrizes">
+							{(field) => (
+								<Field
+									error={field.state.meta.errors[0]?.message}
+									htmlFor={field.name}
+									label="Bounty Prizes"
+								>
+									<Input
+										id={field.name}
+										inputMode="numeric"
+										onBlur={field.handleBlur}
+										onChange={(e) => field.handleChange(e.target.value)}
+										value={field.state.value}
+									/>
+								</Field>
+							)}
+						</form.Field>
+					</div>
+				</>
+			)}
 		</>
 	);
 }


### PR DESCRIPTION
Closes SA2-11 / #237.

## Summary

トーナメント一覧画面のセッション編集モーダルで、ライブセッションから生成されたセッションを編集するときに、イベント履歴から算出されるフィールド (Rebuy Cost、Buy-in、Prize Money、Placement、Blinds など) が大量にグレーアウト表示されていた。Rebuy Cost / Addon Cost のような旧データ構造のフィールドも残ったままで、UX がよくなかった。

ライブリンク済みセッションの編集モーダルでは、イベント由来のフィールドを **非表示** にして、上部のバナーで「これらの項目はライブセッションのイベントから派生しているため、ここでは編集できない」ことを説明する形に変更。編集可能なのは Store / Currency / Tags / Memo のみ。

## Changes

- `session-form.tsx`: `isLiveLinked` のときは Session Type タブ・Session Date・Start/End Time・Break Time・Cash 用 Buy-in/Cash-out/EV Cash-out・`TournamentPrimaryFields` を全部レンダリングしない。バナー文言も「何が編集可能か」を明示するように更新。
- `tournament-fields.tsx`: `TournamentDetailFields` で `isLiveLinked` のときは Rebuy Count / Rebuy Cost / Addon Cost / Bounty Prizes を非表示。Currency のみ残す。`TournamentPrimaryFields` は live-linked 経路で呼ばれなくなったので `isLiveLinked` プロップを削除 (`disabled` 制御も不要に)。
- `cash-game-fields.tsx`: 同様に live-linked では Variant / Blinds / Ante / Table Size を非表示、Currency のみ残す。
- `link-selectors.tsx`: live-linked のときは Game セレクタ (tournament/ring game) を非表示 (`tournamentId` / `ringGameId` は restricted フィールド)。Store はライブセッションでも編集可能なので残す。
- 既存 `disabled={isLiveLinked}` は不要になったので除去。
- テストを更新: 既存の "disables ..." アサーションを "hides ..." (`not.toBeInTheDocument`) に書き換え、新規にトーナメント live-linked のテストを追加。

## Test plan

- [x] `bunx vitest run --project web-dom apps/web/src/features/sessions apps/web/src/routes/sessions` → 172/172 passed
- [x] `bun run check-types` → clean
- [x] `bun run lint` (ultracite) → clean
- [ ] 動作確認: ライブセッション由来のトーナメントセッションを編集モーダルで開き、計算系フィールドが非表示になっていてバナーが説明文を出していること、Currency / Tags / Memo / Store が編集できることを確認
- [ ] 動作確認: 通常 (manual) のトーナメント / キャッシュゲームセッションでは従来通り全フィールドが表示・編集できること

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHoVxmLZjLzDTZi573CRQH)_