### PR TITLE
refactor(dashboard): share session filter structure across widgets

### DIFF
--- a/apps/web/src/features/dashboard/components/dashboard-grid/__tests__/use-dashboard-grid.test.ts
+++ b/apps/web/src/features/dashboard/components/dashboard-grid/__tests__/use-dashboard-grid.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/utils/trpc", () => ({
@@ -13,6 +13,9 @@ vi.mock("@/utils/trpc", () => ({
 		currency: {
 			list: { queryOptions: () => ({ queryKey: ["currency-list"] }) },
 		},
+		store: {
+			list: { queryOptions: () => ({ queryKey: ["store-list"] }) },
+		},
 	},
 	trpcClient: {},
 }));
@@ -23,6 +26,7 @@ import {
 	useDashboardGrid,
 } from "@/features/dashboard/components/dashboard-grid/use-dashboard-grid";
 import type { DashboardWidget } from "@/features/dashboard/hooks/use-dashboard-widgets";
+import { DEFAULT_GLOBAL_FILTER_VALUES } from "@/features/dashboard/hooks/use-global-filter";
 
 function widget(partial: Partial<DashboardWidget>): DashboardWidget {
 	return {
@@ -120,5 +124,106 @@ describe("useDashboardGrid", () => {
 		const first = result.current.layout;
 		rerender({ ws: widgets });
 		expect(result.current.layout).toBe(first);
+	});
+});
+
+describe("useDashboardGrid — globalFilter", () => {
+	it("exposes default values when no global_filter widget is present", () => {
+		const { result } = renderHook(() => useDashboardGrid([], "desktop"));
+		expect(result.current.globalFilter.values).toEqual(
+			DEFAULT_GLOBAL_FILTER_VALUES
+		);
+	});
+
+	it("seeds runtime values from global_filter widget config initialValues", () => {
+		const widgets: DashboardWidget[] = [
+			widget({
+				id: "gf",
+				type: "global_filter",
+				config: {
+					type: { initialValue: "cash_game", visible: true },
+					storeId: { initialValue: "store-1", visible: true },
+					dateRangeDays: { initialValue: 7, visible: true },
+				},
+			}),
+		];
+		const { result } = renderHook(() => useDashboardGrid(widgets, "desktop"));
+		expect(result.current.globalFilter.values.type).toBe("cash_game");
+		expect(result.current.globalFilter.values.storeId).toBe("store-1");
+		expect(result.current.globalFilter.values.dateRangeDays).toBe(7);
+	});
+
+	it("setValue updates a single key", () => {
+		const { result } = renderHook(() => useDashboardGrid([], "desktop"));
+		act(() => {
+			result.current.globalFilter.setValue("type", "tournament");
+		});
+		expect(result.current.globalFilter.values.type).toBe("tournament");
+		expect(result.current.globalFilter.values.storeId).toBeNull();
+	});
+
+	it("reset restores values to the config initialValues", () => {
+		const widgets: DashboardWidget[] = [
+			widget({
+				id: "gf",
+				type: "global_filter",
+				config: {
+					type: { initialValue: "cash_game", visible: true },
+				},
+			}),
+		];
+		const { result } = renderHook(() => useDashboardGrid(widgets, "desktop"));
+		act(() => {
+			result.current.globalFilter.setValue("type", "tournament");
+		});
+		expect(result.current.globalFilter.values.type).toBe("tournament");
+		act(() => {
+			result.current.globalFilter.reset();
+		});
+		expect(result.current.globalFilter.values.type).toBe("cash_game");
+	});
+
+	it("resets runtime values when widget config changes", () => {
+		const initial: DashboardWidget[] = [
+			widget({
+				id: "gf",
+				type: "global_filter",
+				config: { type: { initialValue: "cash_game", visible: true } },
+			}),
+		];
+		const next: DashboardWidget[] = [
+			widget({
+				id: "gf",
+				type: "global_filter",
+				config: { type: { initialValue: "tournament", visible: true } },
+			}),
+		];
+		const { result, rerender } = renderHook(
+			({ ws }: { ws: DashboardWidget[] }) => useDashboardGrid(ws, "desktop"),
+			{ initialProps: { ws: initial } }
+		);
+		expect(result.current.globalFilter.values.type).toBe("cash_game");
+		rerender({ ws: next });
+		expect(result.current.globalFilter.values.type).toBe("tournament");
+	});
+
+	it("preserves user-set runtime values when widgets array reference changes but config doesn't", () => {
+		const widgets: DashboardWidget[] = [
+			widget({
+				id: "gf",
+				type: "global_filter",
+				config: { type: { initialValue: null, visible: true } },
+			}),
+		];
+		const { result, rerender } = renderHook(
+			({ ws }: { ws: DashboardWidget[] }) => useDashboardGrid(ws, "desktop"),
+			{ initialProps: { ws: widgets } }
+		);
+		act(() => {
+			result.current.globalFilter.setValue("type", "tournament");
+		});
+		// Same content but new array reference (e.g. query refetch).
+		rerender({ ws: [...widgets] });
+		expect(result.current.globalFilter.values.type).toBe("tournament");
 	});
 });

--- a/apps/web/src/features/dashboard/components/dashboard-grid/dashboard-grid.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-grid/dashboard-grid.tsx
@@ -8,6 +8,7 @@ import {
 import { WidgetRenderer } from "@/features/dashboard/components/widget-renderer";
 import type { Device } from "@/features/dashboard/hooks/use-current-device";
 import type { DashboardWidget as DashboardWidgetRow } from "@/features/dashboard/hooks/use-dashboard-widgets";
+import { GlobalFilterProvider } from "@/features/dashboard/hooks/use-global-filter";
 import { GRID_COLS, useDashboardGrid } from "./use-dashboard-grid";
 
 const ROW_HEIGHT = 40;
@@ -31,39 +32,43 @@ export function DashboardGrid({
 	onEditWidget,
 	onDeleteWidget,
 }: DashboardGridProps) {
-	const { layout } = useDashboardGrid(widgets, device);
+	const { layout, globalFilter } = useDashboardGrid(widgets, device);
 
 	return (
-		<GridLayout
-			cols={GRID_COLS[device]}
-			containerPadding={[0, 0]}
-			draggableHandle={`.${WIDGET_DRAG_HANDLE_CLASS}`}
-			isDraggable={isEditing}
-			isResizable={isEditing}
-			layout={layout}
-			margin={[8, 8]}
-			onDragStop={(current) => onLayoutChange?.(current)}
-			onResizeStop={(current) => onLayoutChange?.(current)}
-			rowHeight={ROW_HEIGHT}
-			width={containerWidth}
-		>
-			{widgets.map((widget) => (
-				<div key={widget.id}>
-					<DashboardWidget
-						id={widget.id}
-						isEditing={isEditing}
-						onDelete={onDeleteWidget ? () => onDeleteWidget(widget) : undefined}
-						onEdit={onEditWidget ? () => onEditWidget(widget) : undefined}
-						type={widget.type}
-					>
-						<WidgetRenderer
-							config={widget.config}
+		<GlobalFilterProvider value={globalFilter}>
+			<GridLayout
+				cols={GRID_COLS[device]}
+				containerPadding={[0, 0]}
+				draggableHandle={`.${WIDGET_DRAG_HANDLE_CLASS}`}
+				isDraggable={isEditing}
+				isResizable={isEditing}
+				layout={layout}
+				margin={[8, 8]}
+				onDragStop={(current) => onLayoutChange?.(current)}
+				onResizeStop={(current) => onLayoutChange?.(current)}
+				rowHeight={ROW_HEIGHT}
+				width={containerWidth}
+			>
+				{widgets.map((widget) => (
+					<div key={widget.id}>
+						<DashboardWidget
+							id={widget.id}
+							isEditing={isEditing}
+							onDelete={
+								onDeleteWidget ? () => onDeleteWidget(widget) : undefined
+							}
+							onEdit={onEditWidget ? () => onEditWidget(widget) : undefined}
 							type={widget.type}
-							widgetId={widget.id}
-						/>
-					</DashboardWidget>
-				</div>
-			))}
-		</GridLayout>
+						>
+							<WidgetRenderer
+								config={widget.config}
+								type={widget.type}
+								widgetId={widget.id}
+							/>
+						</DashboardWidget>
+					</div>
+				))}
+			</GridLayout>
+		</GlobalFilterProvider>
 	);
 }

--- a/apps/web/src/features/dashboard/components/dashboard-grid/use-dashboard-grid.ts
+++ b/apps/web/src/features/dashboard/components/dashboard-grid/use-dashboard-grid.ts
@@ -2,6 +2,10 @@ import { useMemo } from "react";
 import type { Layout } from "react-grid-layout";
 import type { Device } from "@/features/dashboard/hooks/use-current-device";
 import type { DashboardWidget } from "@/features/dashboard/hooks/use-dashboard-widgets";
+import {
+	type GlobalFilterValues,
+	resolveGlobalFilterFromWidgets,
+} from "@/features/dashboard/hooks/use-global-filter";
 import { getWidgetEntry } from "@/features/dashboard/widgets/registry";
 
 export const GRID_COLS: Record<Device, number> = {
@@ -30,5 +34,10 @@ export function useDashboardGrid(widgets: DashboardWidget[], device: Device) {
 		[widgets, device]
 	);
 
-	return { layout, gridCols: GRID_COLS[device] };
+	const globalFilter = useMemo<GlobalFilterValues>(
+		() => resolveGlobalFilterFromWidgets(widgets),
+		[widgets]
+	);
+
+	return { layout, gridCols: GRID_COLS[device], globalFilter };
 }

--- a/apps/web/src/features/dashboard/components/dashboard-grid/use-dashboard-grid.ts
+++ b/apps/web/src/features/dashboard/components/dashboard-grid/use-dashboard-grid.ts
@@ -1,8 +1,10 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Layout } from "react-grid-layout";
 import type { Device } from "@/features/dashboard/hooks/use-current-device";
 import type { DashboardWidget } from "@/features/dashboard/hooks/use-dashboard-widgets";
 import {
+	configToInitialValues,
+	type GlobalFilterKey,
 	type GlobalFilterValues,
 	resolveGlobalFilterFromWidgets,
 } from "@/features/dashboard/hooks/use-global-filter";
@@ -34,10 +36,44 @@ export function useDashboardGrid(widgets: DashboardWidget[], device: Device) {
 		[widgets, device]
 	);
 
-	const globalFilter = useMemo<GlobalFilterValues>(
+	const fieldsConfig = useMemo(
 		() => resolveGlobalFilterFromWidgets(widgets),
 		[widgets]
 	);
+	const initialValues = useMemo<GlobalFilterValues>(
+		() => configToInitialValues(fieldsConfig),
+		[fieldsConfig]
+	);
 
-	return { layout, gridCols: GRID_COLS[device], globalFilter };
+	const [values, setValues] = useState<GlobalFilterValues>(initialValues);
+	const initialValuesKey = JSON.stringify(initialValues);
+	const lastInitialKey = useRef(initialValuesKey);
+	useEffect(() => {
+		if (lastInitialKey.current !== initialValuesKey) {
+			lastInitialKey.current = initialValuesKey;
+			setValues(initialValues);
+		}
+	}, [initialValuesKey, initialValues]);
+
+	const setValue = useCallback(
+		<K extends GlobalFilterKey>(key: K, value: GlobalFilterValues[K]) => {
+			setValues((prev) => ({ ...prev, [key]: value }));
+		},
+		[]
+	);
+
+	const reset = useCallback(() => {
+		setValues(initialValues);
+	}, [initialValues]);
+
+	const globalFilter = useMemo(
+		() => ({ values, setValue, reset }),
+		[values, setValue, reset]
+	);
+
+	return {
+		layout,
+		gridCols: GRID_COLS[device],
+		globalFilter,
+	};
 }

--- a/apps/web/src/features/dashboard/hooks/__tests__/use-global-filter.test.ts
+++ b/apps/web/src/features/dashboard/hooks/__tests__/use-global-filter.test.ts
@@ -1,188 +1,396 @@
 import { renderHook } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
-	DEFAULT_GLOBAL_FILTER,
+	configToInitialValues,
+	DEFAULT_GLOBAL_FILTER_FIELDS_CONFIG,
+	DEFAULT_GLOBAL_FILTER_VALUES,
+	findGlobalFilterWidget,
 	GlobalFilterProvider,
-	type GlobalFilterValues,
-	resolveDateRangeDaysFilter,
+	isoDateToEpochSeconds,
+	parseGlobalFilterConfig,
+	resolveDateFromEpoch,
+	resolveDateToEpoch,
 	resolveGlobalFilterFromWidgets,
-	resolveSessionTypeFilter,
+	resolveSessionType,
 	useGlobalFilter,
+	useGlobalFilterControl,
 } from "@/features/dashboard/hooks/use-global-filter";
 
-describe("DEFAULT_GLOBAL_FILTER", () => {
-	it("is a no-op filter (type='all', dateRangeDays=null)", () => {
-		expect(DEFAULT_GLOBAL_FILTER).toEqual({
-			type: "all",
+describe("DEFAULT_GLOBAL_FILTER_VALUES", () => {
+	it("is a no-op filter (every key null)", () => {
+		expect(DEFAULT_GLOBAL_FILTER_VALUES).toEqual({
+			type: null,
+			storeId: null,
+			currencyId: null,
+			dateFrom: null,
+			dateTo: null,
 			dateRangeDays: null,
 		});
 	});
 });
 
-describe("useGlobalFilter", () => {
-	it("returns DEFAULT_GLOBAL_FILTER when no provider wraps", () => {
+describe("DEFAULT_GLOBAL_FILTER_FIELDS_CONFIG", () => {
+	it("marks every field visible with null initialValue", () => {
+		for (const key of [
+			"type",
+			"storeId",
+			"currencyId",
+			"dateFrom",
+			"dateTo",
+			"dateRangeDays",
+		] as const) {
+			expect(DEFAULT_GLOBAL_FILTER_FIELDS_CONFIG[key]).toEqual({
+				initialValue: null,
+				visible: true,
+			});
+		}
+	});
+});
+
+describe("useGlobalFilter / useGlobalFilterControl", () => {
+	it("useGlobalFilter returns DEFAULT values without provider", () => {
 		const { result } = renderHook(() => useGlobalFilter());
-		expect(result.current).toEqual(DEFAULT_GLOBAL_FILTER);
+		expect(result.current).toEqual(DEFAULT_GLOBAL_FILTER_VALUES);
 	});
 
-	it("returns the provided value through GlobalFilterProvider", () => {
-		const value: GlobalFilterValues = { type: "cash_game", dateRangeDays: 7 };
+	it("useGlobalFilterControl returns no-op handlers without provider", () => {
+		const { result } = renderHook(() => useGlobalFilterControl());
+		expect(result.current.values).toEqual(DEFAULT_GLOBAL_FILTER_VALUES);
+		expect(typeof result.current.setValue).toBe("function");
+		expect(typeof result.current.reset).toBe("function");
+		expect(() => result.current.setValue("type", "cash_game")).not.toThrow();
+		expect(() => result.current.reset()).not.toThrow();
+	});
+
+	it("useGlobalFilter reads provided values", () => {
+		const setValue = vi.fn();
+		const reset = vi.fn();
+		const values = {
+			...DEFAULT_GLOBAL_FILTER_VALUES,
+			type: "tournament" as const,
+			dateRangeDays: 30,
+		};
 		function wrapper({ children }: { children: ReactNode }) {
-			return createElement(GlobalFilterProvider, { value }, children);
+			return createElement(
+				GlobalFilterProvider,
+				{ value: { values, setValue, reset } },
+				children
+			);
 		}
 		const { result } = renderHook(() => useGlobalFilter(), { wrapper });
-		expect(result.current).toEqual(value);
+		expect(result.current).toBe(values);
+	});
+
+	it("useGlobalFilterControl exposes provided handlers", () => {
+		const setValue = vi.fn();
+		const reset = vi.fn();
+		const values = DEFAULT_GLOBAL_FILTER_VALUES;
+		function wrapper({ children }: { children: ReactNode }) {
+			return createElement(
+				GlobalFilterProvider,
+				{ value: { values, setValue, reset } },
+				children
+			);
+		}
+		const { result } = renderHook(() => useGlobalFilterControl(), {
+			wrapper,
+		});
+		result.current.setValue("storeId", "store-1");
+		result.current.reset();
+		expect(setValue).toHaveBeenCalledTimes(1);
+		expect(setValue).toHaveBeenCalledWith("storeId", "store-1");
+		expect(reset).toHaveBeenCalledTimes(1);
 	});
 });
 
-describe("resolveGlobalFilterFromWidgets", () => {
-	it("returns defaults when no global_filter widget is present", () => {
-		expect(
-			resolveGlobalFilterFromWidgets([
-				{ type: "summary_stats", config: { type: "cash_game" } },
-			])
-		).toEqual(DEFAULT_GLOBAL_FILTER);
+describe("parseGlobalFilterConfig", () => {
+	it("returns defaults for an empty config", () => {
+		expect(parseGlobalFilterConfig({})).toEqual(
+			DEFAULT_GLOBAL_FILTER_FIELDS_CONFIG
+		);
 	});
 
-	it("returns defaults when widgets array is empty", () => {
-		expect(resolveGlobalFilterFromWidgets([])).toEqual(DEFAULT_GLOBAL_FILTER);
+	it("parses type field with valid values", () => {
+		expect(
+			parseGlobalFilterConfig({
+				type: { initialValue: "cash_game", visible: false },
+			}).type
+		).toEqual({ initialValue: "cash_game", visible: false });
+		expect(
+			parseGlobalFilterConfig({
+				type: { initialValue: "tournament", visible: true },
+			}).type
+		).toEqual({ initialValue: "tournament", visible: true });
 	});
 
-	it("returns the global_filter widget's parsed values", () => {
+	it("rejects unknown type initialValue", () => {
 		expect(
-			resolveGlobalFilterFromWidgets([
-				{
-					type: "global_filter",
-					config: { type: "tournament", dateRangeDays: 30 },
-				},
-			])
-		).toEqual({ type: "tournament", dateRangeDays: 30 });
-	});
-
-	it("uses the first global_filter widget when multiple exist", () => {
-		expect(
-			resolveGlobalFilterFromWidgets([
-				{
-					type: "global_filter",
-					config: { type: "cash_game", dateRangeDays: 7 },
-				},
-				{
-					type: "global_filter",
-					config: { type: "tournament", dateRangeDays: 90 },
-				},
-			])
-		).toEqual({ type: "cash_game", dateRangeDays: 7 });
-	});
-
-	it("coerces unknown type to 'all'", () => {
-		expect(
-			resolveGlobalFilterFromWidgets([
-				{ type: "global_filter", config: { type: "weird" } },
-			]).type
-		).toBe("all");
-	});
-
-	it("coerces non-numeric dateRangeDays to null", () => {
-		expect(
-			resolveGlobalFilterFromWidgets([
-				{ type: "global_filter", config: { dateRangeDays: "30" } },
-			]).dateRangeDays
+			parseGlobalFilterConfig({
+				type: { initialValue: "weird", visible: true },
+			}).type.initialValue
 		).toBeNull();
 	});
 
-	it("coerces dateRangeDays < 1 to null", () => {
-		expect(
-			resolveGlobalFilterFromWidgets([
-				{ type: "global_filter", config: { dateRangeDays: 0 } },
-			]).dateRangeDays
-		).toBeNull();
-		expect(
-			resolveGlobalFilterFromWidgets([
-				{ type: "global_filter", config: { dateRangeDays: -10 } },
-			]).dateRangeDays
-		).toBeNull();
+	it("parses string fields (storeId / currencyId / dateFrom / dateTo)", () => {
+		const parsed = parseGlobalFilterConfig({
+			storeId: { initialValue: "store-1", visible: true },
+			currencyId: { initialValue: "currency-1", visible: false },
+			dateFrom: { initialValue: "2026-01-01", visible: true },
+			dateTo: { initialValue: "2026-12-31", visible: true },
+		});
+		expect(parsed.storeId.initialValue).toBe("store-1");
+		expect(parsed.currencyId).toEqual({
+			initialValue: "currency-1",
+			visible: false,
+		});
+		expect(parsed.dateFrom.initialValue).toBe("2026-01-01");
+		expect(parsed.dateTo.initialValue).toBe("2026-12-31");
 	});
 
-	it("coerces NaN dateRangeDays to null", () => {
+	it("rejects non-string initialValue for string fields", () => {
 		expect(
-			resolveGlobalFilterFromWidgets([
-				{ type: "global_filter", config: { dateRangeDays: Number.NaN } },
-			]).dateRangeDays
-		).toBeNull();
-	});
-
-	it("coerces Infinity dateRangeDays to null", () => {
-		expect(
-			resolveGlobalFilterFromWidgets([
-				{
-					type: "global_filter",
-					config: { dateRangeDays: Number.POSITIVE_INFINITY },
-				},
-			]).dateRangeDays
+			parseGlobalFilterConfig({
+				storeId: { initialValue: 123, visible: true },
+			}).storeId.initialValue
 		).toBeNull();
 	});
 
-	it("floors fractional dateRangeDays", () => {
+	it("parses dateRangeDays as a positive integer", () => {
 		expect(
-			resolveGlobalFilterFromWidgets([
-				{ type: "global_filter", config: { dateRangeDays: 7.9 } },
-			]).dateRangeDays
-		).toBe(7);
-	});
-});
-
-describe("resolveSessionTypeFilter", () => {
-	it("returns local when global type is 'all'", () => {
-		expect(
-			resolveSessionTypeFilter("cash_game", {
-				type: "all",
-				dateRangeDays: null,
-			})
-		).toBe("cash_game");
-	});
-
-	it("returns global when global type is 'cash_game'", () => {
-		expect(
-			resolveSessionTypeFilter("tournament", {
-				type: "cash_game",
-				dateRangeDays: null,
-			})
-		).toBe("cash_game");
-	});
-
-	it("returns global when global type is 'tournament'", () => {
-		expect(
-			resolveSessionTypeFilter("all", {
-				type: "tournament",
-				dateRangeDays: null,
-			})
-		).toBe("tournament");
-	});
-});
-
-describe("resolveDateRangeDaysFilter", () => {
-	it("returns local when global is null", () => {
-		expect(
-			resolveDateRangeDaysFilter(30, { type: "all", dateRangeDays: null })
+			parseGlobalFilterConfig({
+				dateRangeDays: { initialValue: 30, visible: true },
+			}).dateRangeDays.initialValue
 		).toBe(30);
 	});
 
-	it("returns global when global is set", () => {
+	it("floors fractional dateRangeDays initialValue", () => {
 		expect(
-			resolveDateRangeDaysFilter(30, { type: "all", dateRangeDays: 7 })
+			parseGlobalFilterConfig({
+				dateRangeDays: { initialValue: 7.9, visible: true },
+			}).dateRangeDays.initialValue
 		).toBe(7);
 	});
 
-	it("returns null when both local and global are null", () => {
+	it("rejects dateRangeDays < 1", () => {
 		expect(
-			resolveDateRangeDaysFilter(null, { type: "all", dateRangeDays: null })
+			parseGlobalFilterConfig({
+				dateRangeDays: { initialValue: 0, visible: true },
+			}).dateRangeDays.initialValue
+		).toBeNull();
+		expect(
+			parseGlobalFilterConfig({
+				dateRangeDays: { initialValue: -3, visible: true },
+			}).dateRangeDays.initialValue
 		).toBeNull();
 	});
 
-	it("returns global=1 (boundary) over local", () => {
+	it("rejects NaN / Infinity dateRangeDays", () => {
 		expect(
-			resolveDateRangeDaysFilter(30, { type: "all", dateRangeDays: 1 })
-		).toBe(1);
+			parseGlobalFilterConfig({
+				dateRangeDays: { initialValue: Number.NaN, visible: true },
+			}).dateRangeDays.initialValue
+		).toBeNull();
+		expect(
+			parseGlobalFilterConfig({
+				dateRangeDays: {
+					initialValue: Number.POSITIVE_INFINITY,
+					visible: true,
+				},
+			}).dateRangeDays.initialValue
+		).toBeNull();
+	});
+
+	it("defaults visible to true when not specified or non-boolean", () => {
+		expect(
+			parseGlobalFilterConfig({ type: { initialValue: "cash_game" } }).type
+				.visible
+		).toBe(true);
+		expect(
+			parseGlobalFilterConfig({
+				type: { initialValue: "cash_game", visible: "yes" as unknown },
+			}).type.visible
+		).toBe(true);
+	});
+
+	it("respects visible: false explicitly", () => {
+		expect(
+			parseGlobalFilterConfig({
+				storeId: { initialValue: "s1", visible: false },
+			}).storeId.visible
+		).toBe(false);
+	});
+
+	it("treats non-object raw fields as defaults", () => {
+		expect(parseGlobalFilterConfig({ type: null }).type).toEqual({
+			initialValue: null,
+			visible: true,
+		});
+		expect(parseGlobalFilterConfig({ type: 123 }).type).toEqual({
+			initialValue: null,
+			visible: true,
+		});
+	});
+});
+
+describe("findGlobalFilterWidget / resolveGlobalFilterFromWidgets", () => {
+	it("returns undefined when no global_filter widget exists", () => {
+		expect(
+			findGlobalFilterWidget([
+				{ type: "summary_stats", config: {} },
+				{ type: "recent_sessions", config: {} },
+			])
+		).toBeUndefined();
+	});
+
+	it("returns DEFAULT fields config when no global_filter widget exists", () => {
+		expect(resolveGlobalFilterFromWidgets([])).toBe(
+			DEFAULT_GLOBAL_FILTER_FIELDS_CONFIG
+		);
+	});
+
+	it("returns the first global_filter widget's parsed config", () => {
+		expect(
+			resolveGlobalFilterFromWidgets([
+				{
+					type: "global_filter",
+					config: { type: { initialValue: "cash_game", visible: false } },
+				},
+				{
+					type: "global_filter",
+					config: { type: { initialValue: "tournament", visible: true } },
+				},
+			]).type
+		).toEqual({ initialValue: "cash_game", visible: false });
+	});
+});
+
+describe("configToInitialValues", () => {
+	it("flattens fields config into runtime values", () => {
+		const config = {
+			...DEFAULT_GLOBAL_FILTER_FIELDS_CONFIG,
+			type: { initialValue: "cash_game" as const, visible: true },
+			storeId: { initialValue: "store-1", visible: true },
+			dateRangeDays: { initialValue: 7, visible: true },
+		};
+		expect(configToInitialValues(config)).toEqual({
+			...DEFAULT_GLOBAL_FILTER_VALUES,
+			type: "cash_game",
+			storeId: "store-1",
+			dateRangeDays: 7,
+		});
+	});
+
+	it("returns all-null when config has only defaults", () => {
+		expect(configToInitialValues(DEFAULT_GLOBAL_FILTER_FIELDS_CONFIG)).toEqual(
+			DEFAULT_GLOBAL_FILTER_VALUES
+		);
+	});
+});
+
+describe("isoDateToEpochSeconds", () => {
+	it("returns undefined for null", () => {
+		expect(isoDateToEpochSeconds(null)).toBeUndefined();
+	});
+
+	it("returns undefined for empty string", () => {
+		expect(isoDateToEpochSeconds("")).toBeUndefined();
+	});
+
+	it("returns undefined for invalid date string", () => {
+		expect(isoDateToEpochSeconds("not-a-date")).toBeUndefined();
+	});
+
+	it("returns start-of-day epoch by default", () => {
+		const epoch = isoDateToEpochSeconds("2026-04-01");
+		expect(typeof epoch).toBe("number");
+		expect(epoch).toBe(
+			Math.floor(new Date("2026-04-01T00:00:00").getTime() / 1000)
+		);
+	});
+
+	it("returns end-of-day epoch when endOfDay=true", () => {
+		const epoch = isoDateToEpochSeconds("2026-04-01", true);
+		expect(epoch).toBe(
+			Math.floor(new Date("2026-04-01T23:59:59").getTime() / 1000)
+		);
+	});
+});
+
+describe("resolveDateFromEpoch", () => {
+	it("prefers values.dateFrom over dateRangeDays", () => {
+		const epoch = resolveDateFromEpoch({
+			...DEFAULT_GLOBAL_FILTER_VALUES,
+			dateFrom: "2026-01-01",
+			dateRangeDays: 30,
+		});
+		expect(epoch).toBe(
+			Math.floor(new Date("2026-01-01T00:00:00").getTime() / 1000)
+		);
+	});
+
+	it("uses dateRangeDays when dateFrom is null", () => {
+		const before = Math.floor(Date.now() / 1000) - 7 * 86_400 - 5;
+		const after = Math.floor(Date.now() / 1000) - 7 * 86_400 + 5;
+		const epoch = resolveDateFromEpoch({
+			...DEFAULT_GLOBAL_FILTER_VALUES,
+			dateRangeDays: 7,
+		}) as number;
+		expect(epoch).toBeGreaterThanOrEqual(before);
+		expect(epoch).toBeLessThanOrEqual(after);
+	});
+
+	it("falls back to localDateRangeDays when both global values are null", () => {
+		const epoch = resolveDateFromEpoch(
+			DEFAULT_GLOBAL_FILTER_VALUES,
+			14
+		) as number;
+		const expected = Math.floor(Date.now() / 1000) - 14 * 86_400;
+		expect(epoch).toBeGreaterThanOrEqual(expected - 5);
+		expect(epoch).toBeLessThanOrEqual(expected + 5);
+	});
+
+	it("returns undefined when nothing is set", () => {
+		expect(resolveDateFromEpoch(DEFAULT_GLOBAL_FILTER_VALUES)).toBeUndefined();
+	});
+});
+
+describe("resolveDateToEpoch", () => {
+	it("returns end-of-day epoch when dateTo is set", () => {
+		const epoch = resolveDateToEpoch({
+			...DEFAULT_GLOBAL_FILTER_VALUES,
+			dateTo: "2026-04-30",
+		});
+		expect(epoch).toBe(
+			Math.floor(new Date("2026-04-30T23:59:59").getTime() / 1000)
+		);
+	});
+
+	it("returns undefined when dateTo is null", () => {
+		expect(resolveDateToEpoch(DEFAULT_GLOBAL_FILTER_VALUES)).toBeUndefined();
+	});
+});
+
+describe("resolveSessionType", () => {
+	it("uses global type when set", () => {
+		expect(
+			resolveSessionType("all", {
+				...DEFAULT_GLOBAL_FILTER_VALUES,
+				type: "cash_game",
+			})
+		).toBe("cash_game");
+		expect(
+			resolveSessionType("tournament", {
+				...DEFAULT_GLOBAL_FILTER_VALUES,
+				type: "cash_game",
+			})
+		).toBe("cash_game");
+	});
+
+	it("uses local when global type is null", () => {
+		expect(resolveSessionType("cash_game", DEFAULT_GLOBAL_FILTER_VALUES)).toBe(
+			"cash_game"
+		);
+		expect(resolveSessionType("all", DEFAULT_GLOBAL_FILTER_VALUES)).toBe("all");
 	});
 });

--- a/apps/web/src/features/dashboard/hooks/__tests__/use-global-filter.test.ts
+++ b/apps/web/src/features/dashboard/hooks/__tests__/use-global-filter.test.ts
@@ -1,0 +1,188 @@
+import { renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_GLOBAL_FILTER,
+	GlobalFilterProvider,
+	type GlobalFilterValues,
+	resolveDateRangeDaysFilter,
+	resolveGlobalFilterFromWidgets,
+	resolveSessionTypeFilter,
+	useGlobalFilter,
+} from "@/features/dashboard/hooks/use-global-filter";
+
+describe("DEFAULT_GLOBAL_FILTER", () => {
+	it("is a no-op filter (type='all', dateRangeDays=null)", () => {
+		expect(DEFAULT_GLOBAL_FILTER).toEqual({
+			type: "all",
+			dateRangeDays: null,
+		});
+	});
+});
+
+describe("useGlobalFilter", () => {
+	it("returns DEFAULT_GLOBAL_FILTER when no provider wraps", () => {
+		const { result } = renderHook(() => useGlobalFilter());
+		expect(result.current).toEqual(DEFAULT_GLOBAL_FILTER);
+	});
+
+	it("returns the provided value through GlobalFilterProvider", () => {
+		const value: GlobalFilterValues = { type: "cash_game", dateRangeDays: 7 };
+		function wrapper({ children }: { children: ReactNode }) {
+			return createElement(GlobalFilterProvider, { value }, children);
+		}
+		const { result } = renderHook(() => useGlobalFilter(), { wrapper });
+		expect(result.current).toEqual(value);
+	});
+});
+
+describe("resolveGlobalFilterFromWidgets", () => {
+	it("returns defaults when no global_filter widget is present", () => {
+		expect(
+			resolveGlobalFilterFromWidgets([
+				{ type: "summary_stats", config: { type: "cash_game" } },
+			])
+		).toEqual(DEFAULT_GLOBAL_FILTER);
+	});
+
+	it("returns defaults when widgets array is empty", () => {
+		expect(resolveGlobalFilterFromWidgets([])).toEqual(DEFAULT_GLOBAL_FILTER);
+	});
+
+	it("returns the global_filter widget's parsed values", () => {
+		expect(
+			resolveGlobalFilterFromWidgets([
+				{
+					type: "global_filter",
+					config: { type: "tournament", dateRangeDays: 30 },
+				},
+			])
+		).toEqual({ type: "tournament", dateRangeDays: 30 });
+	});
+
+	it("uses the first global_filter widget when multiple exist", () => {
+		expect(
+			resolveGlobalFilterFromWidgets([
+				{
+					type: "global_filter",
+					config: { type: "cash_game", dateRangeDays: 7 },
+				},
+				{
+					type: "global_filter",
+					config: { type: "tournament", dateRangeDays: 90 },
+				},
+			])
+		).toEqual({ type: "cash_game", dateRangeDays: 7 });
+	});
+
+	it("coerces unknown type to 'all'", () => {
+		expect(
+			resolveGlobalFilterFromWidgets([
+				{ type: "global_filter", config: { type: "weird" } },
+			]).type
+		).toBe("all");
+	});
+
+	it("coerces non-numeric dateRangeDays to null", () => {
+		expect(
+			resolveGlobalFilterFromWidgets([
+				{ type: "global_filter", config: { dateRangeDays: "30" } },
+			]).dateRangeDays
+		).toBeNull();
+	});
+
+	it("coerces dateRangeDays < 1 to null", () => {
+		expect(
+			resolveGlobalFilterFromWidgets([
+				{ type: "global_filter", config: { dateRangeDays: 0 } },
+			]).dateRangeDays
+		).toBeNull();
+		expect(
+			resolveGlobalFilterFromWidgets([
+				{ type: "global_filter", config: { dateRangeDays: -10 } },
+			]).dateRangeDays
+		).toBeNull();
+	});
+
+	it("coerces NaN dateRangeDays to null", () => {
+		expect(
+			resolveGlobalFilterFromWidgets([
+				{ type: "global_filter", config: { dateRangeDays: Number.NaN } },
+			]).dateRangeDays
+		).toBeNull();
+	});
+
+	it("coerces Infinity dateRangeDays to null", () => {
+		expect(
+			resolveGlobalFilterFromWidgets([
+				{
+					type: "global_filter",
+					config: { dateRangeDays: Number.POSITIVE_INFINITY },
+				},
+			]).dateRangeDays
+		).toBeNull();
+	});
+
+	it("floors fractional dateRangeDays", () => {
+		expect(
+			resolveGlobalFilterFromWidgets([
+				{ type: "global_filter", config: { dateRangeDays: 7.9 } },
+			]).dateRangeDays
+		).toBe(7);
+	});
+});
+
+describe("resolveSessionTypeFilter", () => {
+	it("returns local when global type is 'all'", () => {
+		expect(
+			resolveSessionTypeFilter("cash_game", {
+				type: "all",
+				dateRangeDays: null,
+			})
+		).toBe("cash_game");
+	});
+
+	it("returns global when global type is 'cash_game'", () => {
+		expect(
+			resolveSessionTypeFilter("tournament", {
+				type: "cash_game",
+				dateRangeDays: null,
+			})
+		).toBe("cash_game");
+	});
+
+	it("returns global when global type is 'tournament'", () => {
+		expect(
+			resolveSessionTypeFilter("all", {
+				type: "tournament",
+				dateRangeDays: null,
+			})
+		).toBe("tournament");
+	});
+});
+
+describe("resolveDateRangeDaysFilter", () => {
+	it("returns local when global is null", () => {
+		expect(
+			resolveDateRangeDaysFilter(30, { type: "all", dateRangeDays: null })
+		).toBe(30);
+	});
+
+	it("returns global when global is set", () => {
+		expect(
+			resolveDateRangeDaysFilter(30, { type: "all", dateRangeDays: 7 })
+		).toBe(7);
+	});
+
+	it("returns null when both local and global are null", () => {
+		expect(
+			resolveDateRangeDaysFilter(null, { type: "all", dateRangeDays: null })
+		).toBeNull();
+	});
+
+	it("returns global=1 (boundary) over local", () => {
+		expect(
+			resolveDateRangeDaysFilter(30, { type: "all", dateRangeDays: 1 })
+		).toBe(1);
+	});
+});

--- a/apps/web/src/features/dashboard/hooks/use-dashboard-widgets.ts
+++ b/apps/web/src/features/dashboard/hooks/use-dashboard-widgets.ts
@@ -13,7 +13,8 @@ export type WidgetType =
 	| "summary_stats"
 	| "recent_sessions"
 	| "active_session"
-	| "currency_balance";
+	| "currency_balance"
+	| "global_filter";
 
 export interface DashboardWidget {
 	config: Record<string, unknown>;

--- a/apps/web/src/features/dashboard/hooks/use-global-filter.ts
+++ b/apps/web/src/features/dashboard/hooks/use-global-filter.ts
@@ -1,0 +1,61 @@
+import { createContext, useContext } from "react";
+
+export type GlobalFilterSessionType = "all" | "cash_game" | "tournament";
+
+export interface GlobalFilterValues {
+	dateRangeDays: number | null;
+	type: GlobalFilterSessionType;
+}
+
+export const DEFAULT_GLOBAL_FILTER: GlobalFilterValues = {
+	type: "all",
+	dateRangeDays: null,
+};
+
+const GlobalFilterContext = createContext<GlobalFilterValues>(
+	DEFAULT_GLOBAL_FILTER
+);
+
+export const GlobalFilterProvider = GlobalFilterContext.Provider;
+
+export function useGlobalFilter(): GlobalFilterValues {
+	return useContext(GlobalFilterContext);
+}
+
+interface WidgetLike {
+	config: Record<string, unknown>;
+	type: string;
+}
+
+export function resolveGlobalFilterFromWidgets(
+	widgets: readonly WidgetLike[]
+): GlobalFilterValues {
+	const widget = widgets.find((w) => w.type === "global_filter");
+	if (!widget) {
+		return DEFAULT_GLOBAL_FILTER;
+	}
+	const raw = widget.config;
+	const type: GlobalFilterSessionType =
+		raw.type === "cash_game" || raw.type === "tournament" ? raw.type : "all";
+	const dateRangeDays =
+		typeof raw.dateRangeDays === "number" &&
+		Number.isFinite(raw.dateRangeDays) &&
+		raw.dateRangeDays >= 1
+			? Math.floor(raw.dateRangeDays)
+			: null;
+	return { type, dateRangeDays };
+}
+
+export function resolveSessionTypeFilter<T extends GlobalFilterSessionType>(
+	local: T,
+	global: GlobalFilterValues
+): T {
+	return global.type === "all" ? local : (global.type as T);
+}
+
+export function resolveDateRangeDaysFilter(
+	local: number | null,
+	global: GlobalFilterValues
+): number | null {
+	return global.dateRangeDays ?? local;
+}

--- a/apps/web/src/features/dashboard/hooks/use-global-filter.ts
+++ b/apps/web/src/features/dashboard/hooks/use-global-filter.ts
@@ -1,25 +1,147 @@
 import { createContext, useContext } from "react";
 
-export type GlobalFilterSessionType = "all" | "cash_game" | "tournament";
+export type GlobalFilterSessionType = "cash_game" | "tournament";
 
 export interface GlobalFilterValues {
+	currencyId: string | null;
+	dateFrom: string | null;
 	dateRangeDays: number | null;
-	type: GlobalFilterSessionType;
+	dateTo: string | null;
+	storeId: string | null;
+	type: GlobalFilterSessionType | null;
 }
 
-export const DEFAULT_GLOBAL_FILTER: GlobalFilterValues = {
-	type: "all",
+export const DEFAULT_GLOBAL_FILTER_VALUES: GlobalFilterValues = {
+	type: null,
+	storeId: null,
+	currencyId: null,
+	dateFrom: null,
+	dateTo: null,
 	dateRangeDays: null,
 };
 
-const GlobalFilterContext = createContext<GlobalFilterValues>(
-	DEFAULT_GLOBAL_FILTER
-);
+export const GLOBAL_FILTER_KEYS = [
+	"type",
+	"storeId",
+	"currencyId",
+	"dateFrom",
+	"dateTo",
+	"dateRangeDays",
+] as const;
+
+export type GlobalFilterKey = (typeof GLOBAL_FILTER_KEYS)[number];
+
+export interface GlobalFilterFieldConfig<T> {
+	initialValue: T | null;
+	visible: boolean;
+}
+
+export interface GlobalFilterFieldsConfig {
+	currencyId: GlobalFilterFieldConfig<string>;
+	dateFrom: GlobalFilterFieldConfig<string>;
+	dateRangeDays: GlobalFilterFieldConfig<number>;
+	dateTo: GlobalFilterFieldConfig<string>;
+	storeId: GlobalFilterFieldConfig<string>;
+	type: GlobalFilterFieldConfig<GlobalFilterSessionType>;
+}
+
+const DEFAULT_FIELD: GlobalFilterFieldConfig<never> = {
+	initialValue: null,
+	visible: true,
+};
+
+export const DEFAULT_GLOBAL_FILTER_FIELDS_CONFIG: GlobalFilterFieldsConfig = {
+	type: DEFAULT_FIELD as GlobalFilterFieldConfig<GlobalFilterSessionType>,
+	storeId: DEFAULT_FIELD as GlobalFilterFieldConfig<string>,
+	currencyId: DEFAULT_FIELD as GlobalFilterFieldConfig<string>,
+	dateFrom: DEFAULT_FIELD as GlobalFilterFieldConfig<string>,
+	dateTo: DEFAULT_FIELD as GlobalFilterFieldConfig<string>,
+	dateRangeDays: DEFAULT_FIELD as GlobalFilterFieldConfig<number>,
+};
+
+interface GlobalFilterContextValue {
+	reset: () => void;
+	setValue: <K extends GlobalFilterKey>(
+		key: K,
+		value: GlobalFilterValues[K]
+	) => void;
+	values: GlobalFilterValues;
+}
+
+const noop = () => {
+	// no-op default for tests / outside-of-provider usage
+};
+
+const GlobalFilterContext = createContext<GlobalFilterContextValue>({
+	values: DEFAULT_GLOBAL_FILTER_VALUES,
+	setValue: noop,
+	reset: noop,
+});
 
 export const GlobalFilterProvider = GlobalFilterContext.Provider;
 
 export function useGlobalFilter(): GlobalFilterValues {
+	return useContext(GlobalFilterContext).values;
+}
+
+export function useGlobalFilterControl(): GlobalFilterContextValue {
 	return useContext(GlobalFilterContext);
+}
+
+interface RawFieldShape {
+	initialValue?: unknown;
+	visible?: unknown;
+}
+
+function asField(raw: unknown): RawFieldShape {
+	return typeof raw === "object" && raw !== null ? (raw as RawFieldShape) : {};
+}
+
+function parseStringField(raw: unknown): GlobalFilterFieldConfig<string> {
+	const f = asField(raw);
+	return {
+		initialValue: typeof f.initialValue === "string" ? f.initialValue : null,
+		visible: f.visible !== false,
+	};
+}
+
+function parseTypeField(
+	raw: unknown
+): GlobalFilterFieldConfig<GlobalFilterSessionType> {
+	const f = asField(raw);
+	const initialValue =
+		f.initialValue === "cash_game" || f.initialValue === "tournament"
+			? f.initialValue
+			: null;
+	return {
+		initialValue,
+		visible: f.visible !== false,
+	};
+}
+
+function parsePositiveIntField(raw: unknown): GlobalFilterFieldConfig<number> {
+	const f = asField(raw);
+	const isValidInt =
+		typeof f.initialValue === "number" &&
+		Number.isFinite(f.initialValue) &&
+		f.initialValue >= 1;
+	return {
+		initialValue: isValidInt ? Math.floor(f.initialValue as number) : null,
+		visible: f.visible !== false,
+	};
+}
+
+export function parseGlobalFilterConfig(
+	raw: Record<string, unknown>
+): GlobalFilterFieldsConfig {
+	return {
+		type: parseTypeField(raw.type),
+		storeId: parseStringField(raw.storeId),
+		currencyId: parseStringField(raw.currencyId),
+		dateFrom: parseStringField(raw.dateFrom),
+		dateTo: parseStringField(raw.dateTo),
+		dateRangeDays: parsePositiveIntField(raw.dateRangeDays),
+	};
 }
 
 interface WidgetLike {
@@ -27,35 +149,78 @@ interface WidgetLike {
 	type: string;
 }
 
+export function findGlobalFilterWidget(
+	widgets: readonly WidgetLike[]
+): WidgetLike | undefined {
+	return widgets.find((w) => w.type === "global_filter");
+}
+
 export function resolveGlobalFilterFromWidgets(
 	widgets: readonly WidgetLike[]
-): GlobalFilterValues {
-	const widget = widgets.find((w) => w.type === "global_filter");
+): GlobalFilterFieldsConfig {
+	const widget = findGlobalFilterWidget(widgets);
 	if (!widget) {
-		return DEFAULT_GLOBAL_FILTER;
+		return DEFAULT_GLOBAL_FILTER_FIELDS_CONFIG;
 	}
-	const raw = widget.config;
-	const type: GlobalFilterSessionType =
-		raw.type === "cash_game" || raw.type === "tournament" ? raw.type : "all";
-	const dateRangeDays =
-		typeof raw.dateRangeDays === "number" &&
-		Number.isFinite(raw.dateRangeDays) &&
-		raw.dateRangeDays >= 1
-			? Math.floor(raw.dateRangeDays)
-			: null;
-	return { type, dateRangeDays };
+	return parseGlobalFilterConfig(widget.config);
 }
 
-export function resolveSessionTypeFilter<T extends GlobalFilterSessionType>(
+export function configToInitialValues(
+	config: GlobalFilterFieldsConfig
+): GlobalFilterValues {
+	return {
+		type: config.type.initialValue,
+		storeId: config.storeId.initialValue,
+		currencyId: config.currencyId.initialValue,
+		dateFrom: config.dateFrom.initialValue,
+		dateTo: config.dateTo.initialValue,
+		dateRangeDays: config.dateRangeDays.initialValue,
+	};
+}
+
+export function isoDateToEpochSeconds(
+	value: string | null,
+	endOfDay = false
+): number | undefined {
+	if (!value) {
+		return undefined;
+	}
+	const suffix = endOfDay ? "T23:59:59" : "T00:00:00";
+	const parsed = new Date(`${value}${suffix}`).getTime();
+	if (!Number.isFinite(parsed)) {
+		return undefined;
+	}
+	return Math.floor(parsed / 1000);
+}
+
+export function resolveDateFromEpoch(
+	values: GlobalFilterValues,
+	localDateRangeDays: number | null = null
+): number | undefined {
+	if (values.dateFrom) {
+		return isoDateToEpochSeconds(values.dateFrom);
+	}
+	if (values.dateRangeDays !== null) {
+		return Math.floor(Date.now() / 1000) - values.dateRangeDays * 86_400;
+	}
+	if (localDateRangeDays !== null) {
+		return Math.floor(Date.now() / 1000) - localDateRangeDays * 86_400;
+	}
+	return undefined;
+}
+
+export function resolveDateToEpoch(
+	values: GlobalFilterValues
+): number | undefined {
+	return isoDateToEpochSeconds(values.dateTo, true);
+}
+
+export function resolveSessionType<T extends GlobalFilterSessionType | "all">(
 	local: T,
-	global: GlobalFilterValues
-): T {
-	return global.type === "all" ? local : (global.type as T);
-}
-
-export function resolveDateRangeDaysFilter(
-	local: number | null,
-	global: GlobalFilterValues
-): number | null {
-	return global.dateRangeDays ?? local;
+	values: GlobalFilterValues
+): T | GlobalFilterSessionType {
+	if (values.type !== null) {
+		return values.type;
+	}
+	return local;
 }

--- a/apps/web/src/features/dashboard/utils/__tests__/session-filter.test.ts
+++ b/apps/web/src/features/dashboard/utils/__tests__/session-filter.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_GLOBAL_FILTER_VALUES } from "@/features/dashboard/hooks/use-global-filter";
+import {
+	parseDateRangeDays,
+	parseSessionFilterWidgetConfig,
+	parseSessionType,
+	resolveSessionListQueryInput,
+	SESSION_TYPE_OPTIONS,
+	SESSION_TYPE_VALUES,
+} from "@/features/dashboard/utils/session-filter";
+
+describe("SESSION_TYPE_VALUES", () => {
+	it("contains exactly 'all', 'cash_game', 'tournament'", () => {
+		expect([...SESSION_TYPE_VALUES]).toEqual([
+			"all",
+			"cash_game",
+			"tournament",
+		]);
+	});
+});
+
+describe("SESSION_TYPE_OPTIONS", () => {
+	it("matches the canonical type values in order", () => {
+		expect(SESSION_TYPE_OPTIONS.map((o) => o.value)).toEqual([
+			"all",
+			"cash_game",
+			"tournament",
+		]);
+	});
+
+	it("provides a label for every option", () => {
+		expect(SESSION_TYPE_OPTIONS).toEqual([
+			{ value: "all", label: "All" },
+			{ value: "cash_game", label: "Cash Game" },
+			{ value: "tournament", label: "Tournament" },
+		]);
+	});
+});
+
+describe("parseSessionType", () => {
+	it("returns 'cash_game' / 'tournament' as-is", () => {
+		expect(parseSessionType("cash_game")).toBe("cash_game");
+		expect(parseSessionType("tournament")).toBe("tournament");
+	});
+
+	it("falls back to 'all' for any other value", () => {
+		expect(parseSessionType("all")).toBe("all");
+		expect(parseSessionType(undefined)).toBe("all");
+		expect(parseSessionType(null)).toBe("all");
+		expect(parseSessionType("")).toBe("all");
+		expect(parseSessionType("garbage")).toBe("all");
+		expect(parseSessionType(0)).toBe("all");
+		expect(parseSessionType({})).toBe("all");
+	});
+});
+
+describe("parseDateRangeDays", () => {
+	it("keeps positive integers as-is", () => {
+		expect(parseDateRangeDays(1)).toBe(1);
+		expect(parseDateRangeDays(7)).toBe(7);
+		expect(parseDateRangeDays(365)).toBe(365);
+	});
+
+	it("floors fractional positive numbers", () => {
+		expect(parseDateRangeDays(7.9)).toBe(7);
+		expect(parseDateRangeDays(1.0001)).toBe(1);
+	});
+
+	it("rejects values < 1", () => {
+		expect(parseDateRangeDays(0)).toBeNull();
+		expect(parseDateRangeDays(0.999)).toBeNull();
+		expect(parseDateRangeDays(-1)).toBeNull();
+	});
+
+	it("rejects NaN / Infinity", () => {
+		expect(parseDateRangeDays(Number.NaN)).toBeNull();
+		expect(parseDateRangeDays(Number.POSITIVE_INFINITY)).toBeNull();
+		expect(parseDateRangeDays(Number.NEGATIVE_INFINITY)).toBeNull();
+	});
+
+	it("rejects non-number values", () => {
+		expect(parseDateRangeDays(undefined)).toBeNull();
+		expect(parseDateRangeDays(null)).toBeNull();
+		expect(parseDateRangeDays("7")).toBeNull();
+		expect(parseDateRangeDays({})).toBeNull();
+	});
+});
+
+describe("parseSessionFilterWidgetConfig", () => {
+	it("returns canonical defaults for an empty object", () => {
+		expect(parseSessionFilterWidgetConfig({})).toEqual({
+			type: "all",
+			dateRangeDays: null,
+		});
+	});
+
+	it("parses type and dateRangeDays together", () => {
+		expect(
+			parseSessionFilterWidgetConfig({ type: "cash_game", dateRangeDays: 30 })
+		).toEqual({ type: "cash_game", dateRangeDays: 30 });
+	});
+
+	it("ignores unknown keys", () => {
+		expect(
+			parseSessionFilterWidgetConfig({
+				type: "tournament",
+				something: "else",
+			})
+		).toEqual({ type: "tournament", dateRangeDays: null });
+	});
+
+	it("normalizes invalid type to 'all' and invalid dateRangeDays to null", () => {
+		expect(
+			parseSessionFilterWidgetConfig({ type: "weird", dateRangeDays: -3 })
+		).toEqual({ type: "all", dateRangeDays: null });
+	});
+});
+
+describe("resolveSessionListQueryInput", () => {
+	const baseLocal = { type: "all", dateRangeDays: null } as const;
+
+	it("returns all-undefined when local and global are defaults", () => {
+		expect(
+			resolveSessionListQueryInput(baseLocal, DEFAULT_GLOBAL_FILTER_VALUES)
+		).toEqual({
+			type: undefined,
+			storeId: undefined,
+			currencyId: undefined,
+			dateFrom: undefined,
+			dateTo: undefined,
+		});
+	});
+
+	it("uses local type when global type is null", () => {
+		expect(
+			resolveSessionListQueryInput(
+				{ type: "cash_game", dateRangeDays: null },
+				DEFAULT_GLOBAL_FILTER_VALUES
+			).type
+		).toBe("cash_game");
+	});
+
+	it("global type overrides local type", () => {
+		expect(
+			resolveSessionListQueryInput(
+				{ type: "cash_game", dateRangeDays: null },
+				{ ...DEFAULT_GLOBAL_FILTER_VALUES, type: "tournament" }
+			).type
+		).toBe("tournament");
+	});
+
+	it("emits 'all' as undefined for the query", () => {
+		expect(
+			resolveSessionListQueryInput(baseLocal, DEFAULT_GLOBAL_FILTER_VALUES).type
+		).toBeUndefined();
+	});
+
+	it("forwards global storeId / currencyId", () => {
+		const out = resolveSessionListQueryInput(baseLocal, {
+			...DEFAULT_GLOBAL_FILTER_VALUES,
+			storeId: "store-1",
+			currencyId: "currency-1",
+		});
+		expect(out.storeId).toBe("store-1");
+		expect(out.currencyId).toBe("currency-1");
+	});
+
+	it("converts global dateFrom into start-of-day epoch seconds", () => {
+		const out = resolveSessionListQueryInput(baseLocal, {
+			...DEFAULT_GLOBAL_FILTER_VALUES,
+			dateFrom: "2026-01-01",
+		});
+		expect(out.dateFrom).toBe(
+			Math.floor(new Date("2026-01-01T00:00:00").getTime() / 1000)
+		);
+	});
+
+	it("converts global dateTo into end-of-day epoch seconds", () => {
+		const out = resolveSessionListQueryInput(baseLocal, {
+			...DEFAULT_GLOBAL_FILTER_VALUES,
+			dateTo: "2026-12-31",
+		});
+		expect(out.dateTo).toBe(
+			Math.floor(new Date("2026-12-31T23:59:59").getTime() / 1000)
+		);
+	});
+
+	it("global dateRangeDays takes precedence over local dateRangeDays", () => {
+		const out = resolveSessionListQueryInput(
+			{ type: "all", dateRangeDays: 30 },
+			{ ...DEFAULT_GLOBAL_FILTER_VALUES, dateRangeDays: 3 }
+		);
+		const expected = Math.floor(Date.now() / 1000) - 3 * 86_400;
+		expect(out.dateFrom).toBeGreaterThanOrEqual(expected - 5);
+		expect(out.dateFrom).toBeLessThanOrEqual(expected + 5);
+	});
+
+	it("falls back to local dateRangeDays when global is fully default", () => {
+		const out = resolveSessionListQueryInput(
+			{ type: "all", dateRangeDays: 14 },
+			DEFAULT_GLOBAL_FILTER_VALUES
+		);
+		const expected = Math.floor(Date.now() / 1000) - 14 * 86_400;
+		expect(out.dateFrom).toBeGreaterThanOrEqual(expected - 5);
+		expect(out.dateFrom).toBeLessThanOrEqual(expected + 5);
+	});
+
+	it("global dateFrom takes precedence over both dateRangeDays sources", () => {
+		const out = resolveSessionListQueryInput(
+			{ type: "all", dateRangeDays: 14 },
+			{
+				...DEFAULT_GLOBAL_FILTER_VALUES,
+				dateFrom: "2026-01-01",
+				dateRangeDays: 7,
+			}
+		);
+		expect(out.dateFrom).toBe(
+			Math.floor(new Date("2026-01-01T00:00:00").getTime() / 1000)
+		);
+	});
+});

--- a/apps/web/src/features/dashboard/utils/session-filter.ts
+++ b/apps/web/src/features/dashboard/utils/session-filter.ts
@@ -1,0 +1,65 @@
+import {
+	type GlobalFilterValues,
+	resolveDateFromEpoch,
+	resolveDateToEpoch,
+	resolveSessionType,
+} from "@/features/dashboard/hooks/use-global-filter";
+
+export const SESSION_TYPE_VALUES = ["all", "cash_game", "tournament"] as const;
+export type SessionTypeFilter = (typeof SESSION_TYPE_VALUES)[number];
+
+export const SESSION_TYPE_OPTIONS: ReadonlyArray<{
+	label: string;
+	value: SessionTypeFilter;
+}> = [
+	{ value: "all", label: "All" },
+	{ value: "cash_game", label: "Cash Game" },
+	{ value: "tournament", label: "Tournament" },
+];
+
+export interface SessionFilterWidgetConfig {
+	dateRangeDays: number | null;
+	type: SessionTypeFilter;
+}
+
+export function parseSessionType(raw: unknown): SessionTypeFilter {
+	return raw === "cash_game" || raw === "tournament" ? raw : "all";
+}
+
+export function parseDateRangeDays(raw: unknown): number | null {
+	if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 1) {
+		return null;
+	}
+	return Math.floor(raw);
+}
+
+export function parseSessionFilterWidgetConfig(
+	raw: Record<string, unknown>
+): SessionFilterWidgetConfig {
+	return {
+		type: parseSessionType(raw.type),
+		dateRangeDays: parseDateRangeDays(raw.dateRangeDays),
+	};
+}
+
+export interface SessionListQueryInput {
+	currencyId: string | undefined;
+	dateFrom: number | undefined;
+	dateTo: number | undefined;
+	storeId: string | undefined;
+	type: "cash_game" | "tournament" | undefined;
+}
+
+export function resolveSessionListQueryInput(
+	local: SessionFilterWidgetConfig,
+	globalFilter: GlobalFilterValues
+): SessionListQueryInput {
+	const effectiveType = resolveSessionType(local.type, globalFilter);
+	return {
+		type: effectiveType === "all" ? undefined : effectiveType,
+		storeId: globalFilter.storeId ?? undefined,
+		currencyId: globalFilter.currencyId ?? undefined,
+		dateFrom: resolveDateFromEpoch(globalFilter, local.dateRangeDays),
+		dateTo: resolveDateToEpoch(globalFilter),
+	};
+}

--- a/apps/web/src/features/dashboard/widgets/active-session-widget/__tests__/use-active-session-edit-form.test.ts
+++ b/apps/web/src/features/dashboard/widgets/active-session-widget/__tests__/use-active-session-edit-form.test.ts
@@ -16,47 +16,70 @@ vi.mock("@/utils/trpc", () => ({
 import { useActiveSessionEditForm } from "@/features/dashboard/widgets/active-session-widget/use-active-session-edit-form";
 
 describe("useActiveSessionEditForm", () => {
-	it("defaults sessionType to 'all' when config is empty", () => {
+	it("defaults type to 'all' when config is empty", () => {
 		const onSave = vi.fn().mockResolvedValue(undefined);
 		const { result } = renderHook(() =>
 			useActiveSessionEditForm({ config: {}, onSave })
 		);
-		expect(result.current.form.state.values.sessionType).toBe("all");
+		expect(result.current.form.state.values.type).toBe("all");
 	});
 
-	it("seeds sessionType from a valid config value", () => {
+	it("seeds type from a valid config value", () => {
 		const onSave = vi.fn().mockResolvedValue(undefined);
 		const { result } = renderHook(() =>
 			useActiveSessionEditForm({
-				config: { sessionType: "cash_game" },
+				config: { type: "cash_game" },
 				onSave,
 			})
 		);
-		expect(result.current.form.state.values.sessionType).toBe("cash_game");
+		expect(result.current.form.state.values.type).toBe("cash_game");
 	});
 
-	it("falls back to 'all' when config.sessionType is not a known value", () => {
+	it("seeds type from a legacy sessionType key for backward compat", () => {
 		const onSave = vi.fn().mockResolvedValue(undefined);
 		const { result } = renderHook(() =>
 			useActiveSessionEditForm({
-				config: { sessionType: "garbage" },
+				config: { sessionType: "tournament" },
 				onSave,
 			})
 		);
-		expect(result.current.form.state.values.sessionType).toBe("all");
+		expect(result.current.form.state.values.type).toBe("tournament");
 	});
 
-	it("submits by calling onSave with the current sessionType", async () => {
+	it("prefers `type` over legacy `sessionType` when both are present", () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useActiveSessionEditForm({
+				config: { type: "cash_game", sessionType: "tournament" },
+				onSave,
+			})
+		);
+		expect(result.current.form.state.values.type).toBe("cash_game");
+	});
+
+	it("falls back to 'all' when config.type is not a known value", () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useActiveSessionEditForm({
+				config: { type: "garbage" },
+				onSave,
+			})
+		);
+		expect(result.current.form.state.values.type).toBe("all");
+	});
+
+	it("submits by calling onSave with the current type", async () => {
 		const onSave = vi.fn().mockResolvedValue(undefined);
 		const { result } = renderHook(() =>
 			useActiveSessionEditForm({ config: {}, onSave })
 		);
 		act(() => {
-			result.current.form.setFieldValue("sessionType", "tournament");
+			result.current.form.setFieldValue("type", "tournament");
 		});
 		await act(async () => {
 			await result.current.form.handleSubmit();
 		});
-		expect(onSave).toHaveBeenCalledWith({ sessionType: "tournament" });
+		expect(onSave).toHaveBeenCalledTimes(1);
+		expect(onSave).toHaveBeenCalledWith({ type: "tournament" });
 	});
 });

--- a/apps/web/src/features/dashboard/widgets/active-session-widget/__tests__/use-active-session-widget.test.ts
+++ b/apps/web/src/features/dashboard/widgets/active-session-widget/__tests__/use-active-session-widget.test.ts
@@ -31,6 +31,7 @@ vi.mock("@/utils/trpc", () => ({
 }));
 
 import {
+	DEFAULT_GLOBAL_FILTER_VALUES,
 	GlobalFilterProvider,
 	type GlobalFilterValues,
 } from "@/features/dashboard/hooks/use-global-filter";
@@ -67,13 +68,19 @@ function wrapper(client: QueryClient) {
 
 function wrapperWithGlobalFilter(
 	client: QueryClient,
-	globalFilter: GlobalFilterValues
+	values: GlobalFilterValues
 ) {
+	const setValue = vi.fn();
+	const reset = vi.fn();
 	return function Wrapper({ children }: { children: ReactNode }) {
 		return createElement(
 			QueryClientProvider,
 			{ client },
-			createElement(GlobalFilterProvider, { value: globalFilter }, children)
+			createElement(
+				GlobalFilterProvider,
+				{ value: { values, setValue, reset } },
+				children
+			)
 		);
 	};
 }
@@ -154,8 +161,8 @@ describe("useActiveSessionWidget — global filter integration", () => {
 		qc.setQueryData(TOURNAMENT_KEY, { items: [{ id: "t1" }] });
 		const { result } = renderHook(() => useActiveSessionWidget({}), {
 			wrapper: wrapperWithGlobalFilter(qc, {
+				...DEFAULT_GLOBAL_FILTER_VALUES,
 				type: "cash_game",
-				dateRangeDays: null,
 			}),
 		});
 		await waitFor(() => expect(result.current.cashItems).toHaveLength(1));
@@ -170,8 +177,8 @@ describe("useActiveSessionWidget — global filter integration", () => {
 			() => useActiveSessionWidget({ sessionType: "cash_game" }),
 			{
 				wrapper: wrapperWithGlobalFilter(qc, {
+					...DEFAULT_GLOBAL_FILTER_VALUES,
 					type: "tournament",
-					dateRangeDays: null,
 				}),
 			}
 		);
@@ -179,17 +186,14 @@ describe("useActiveSessionWidget — global filter integration", () => {
 		expect(result.current.cashItems).toEqual([]);
 	});
 
-	it("falls back to local when global type is 'all'", async () => {
+	it("falls back to local when global type is null (no override)", async () => {
 		const qc = createClient();
 		qc.setQueryData(CASH_KEY, { items: [{ id: "c1" }] });
 		qc.setQueryData(TOURNAMENT_KEY, { items: [{ id: "t1" }] });
 		const { result } = renderHook(
 			() => useActiveSessionWidget({ sessionType: "tournament" }),
 			{
-				wrapper: wrapperWithGlobalFilter(qc, {
-					type: "all",
-					dateRangeDays: null,
-				}),
+				wrapper: wrapperWithGlobalFilter(qc, DEFAULT_GLOBAL_FILTER_VALUES),
 			}
 		);
 		await waitFor(() => expect(result.current.tournamentItems).toHaveLength(1));

--- a/apps/web/src/features/dashboard/widgets/active-session-widget/__tests__/use-active-session-widget.test.ts
+++ b/apps/web/src/features/dashboard/widgets/active-session-widget/__tests__/use-active-session-widget.test.ts
@@ -31,6 +31,10 @@ vi.mock("@/utils/trpc", () => ({
 }));
 
 import {
+	GlobalFilterProvider,
+	type GlobalFilterValues,
+} from "@/features/dashboard/hooks/use-global-filter";
+import {
 	parseActiveSessionWidgetConfig,
 	useActiveSessionWidget,
 } from "@/features/dashboard/widgets/active-session-widget/use-active-session-widget";
@@ -58,6 +62,19 @@ function createClient(): QueryClient {
 function wrapper(client: QueryClient) {
 	return function Wrapper({ children }: { children: ReactNode }) {
 		return createElement(QueryClientProvider, { client }, children);
+	};
+}
+
+function wrapperWithGlobalFilter(
+	client: QueryClient,
+	globalFilter: GlobalFilterValues
+) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(
+			QueryClientProvider,
+			{ client },
+			createElement(GlobalFilterProvider, { value: globalFilter }, children)
+		);
 	};
 }
 
@@ -127,5 +144,55 @@ describe("useActiveSessionWidget", () => {
 		});
 		expect(result.current.cashItems).toEqual([]);
 		expect(result.current.tournamentItems).toEqual([]);
+	});
+});
+
+describe("useActiveSessionWidget — global filter integration", () => {
+	it("global filter type='cash_game' overrides local 'all'", async () => {
+		const qc = createClient();
+		qc.setQueryData(CASH_KEY, { items: [{ id: "c1" }] });
+		qc.setQueryData(TOURNAMENT_KEY, { items: [{ id: "t1" }] });
+		const { result } = renderHook(() => useActiveSessionWidget({}), {
+			wrapper: wrapperWithGlobalFilter(qc, {
+				type: "cash_game",
+				dateRangeDays: null,
+			}),
+		});
+		await waitFor(() => expect(result.current.cashItems).toHaveLength(1));
+		expect(result.current.tournamentItems).toEqual([]);
+	});
+
+	it("global filter type='tournament' overrides local 'cash_game'", async () => {
+		const qc = createClient();
+		qc.setQueryData(CASH_KEY, { items: [{ id: "c1" }] });
+		qc.setQueryData(TOURNAMENT_KEY, { items: [{ id: "t1" }] });
+		const { result } = renderHook(
+			() => useActiveSessionWidget({ sessionType: "cash_game" }),
+			{
+				wrapper: wrapperWithGlobalFilter(qc, {
+					type: "tournament",
+					dateRangeDays: null,
+				}),
+			}
+		);
+		await waitFor(() => expect(result.current.tournamentItems).toHaveLength(1));
+		expect(result.current.cashItems).toEqual([]);
+	});
+
+	it("falls back to local when global type is 'all'", async () => {
+		const qc = createClient();
+		qc.setQueryData(CASH_KEY, { items: [{ id: "c1" }] });
+		qc.setQueryData(TOURNAMENT_KEY, { items: [{ id: "t1" }] });
+		const { result } = renderHook(
+			() => useActiveSessionWidget({ sessionType: "tournament" }),
+			{
+				wrapper: wrapperWithGlobalFilter(qc, {
+					type: "all",
+					dateRangeDays: null,
+				}),
+			}
+		);
+		await waitFor(() => expect(result.current.tournamentItems).toHaveLength(1));
+		expect(result.current.cashItems).toEqual([]);
 	});
 });

--- a/apps/web/src/features/dashboard/widgets/active-session-widget/__tests__/use-active-session-widget.test.ts
+++ b/apps/web/src/features/dashboard/widgets/active-session-widget/__tests__/use-active-session-widget.test.ts
@@ -86,28 +86,47 @@ function wrapperWithGlobalFilter(
 }
 
 describe("parseActiveSessionWidgetConfig", () => {
-	it("defaults sessionType to 'all' when raw has no value", () => {
-		expect(parseActiveSessionWidgetConfig({})).toEqual({ sessionType: "all" });
+	it("defaults type to 'all' when raw has no value", () => {
+		expect(parseActiveSessionWidgetConfig({})).toEqual({ type: "all" });
 	});
 
-	it("keeps cash_game and tournament values", () => {
+	it("keeps cash_game and tournament values from `type`", () => {
+		expect(parseActiveSessionWidgetConfig({ type: "cash_game" }).type).toBe(
+			"cash_game"
+		);
+		expect(parseActiveSessionWidgetConfig({ type: "tournament" }).type).toBe(
+			"tournament"
+		);
+	});
+
+	it("reads legacy `sessionType` key when `type` is missing", () => {
 		expect(
-			parseActiveSessionWidgetConfig({ sessionType: "cash_game" }).sessionType
+			parseActiveSessionWidgetConfig({ sessionType: "cash_game" }).type
 		).toBe("cash_game");
 		expect(
-			parseActiveSessionWidgetConfig({ sessionType: "tournament" }).sessionType
+			parseActiveSessionWidgetConfig({ sessionType: "tournament" }).type
 		).toBe("tournament");
 	});
 
-	it("coerces unknown sessionType to 'all'", () => {
+	it("prefers `type` over legacy `sessionType`", () => {
 		expect(
-			parseActiveSessionWidgetConfig({ sessionType: "weird" }).sessionType
-		).toBe("all");
+			parseActiveSessionWidgetConfig({
+				type: "cash_game",
+				sessionType: "tournament",
+			}).type
+		).toBe("cash_game");
+	});
+
+	it("coerces unknown type to 'all'", () => {
+		expect(parseActiveSessionWidgetConfig({ type: "weird" }).type).toBe("all");
+		expect(parseActiveSessionWidgetConfig({ sessionType: "weird" }).type).toBe(
+			"all"
+		);
 	});
 });
 
 describe("useActiveSessionWidget", () => {
-	it("returns both cash and tournament items for sessionType 'all'", async () => {
+	it("returns both cash and tournament items for type 'all'", async () => {
 		const qc = createClient();
 		qc.setQueryData(CASH_KEY, { items: [{ id: "c1" }] });
 		qc.setQueryData(TOURNAMENT_KEY, { items: [{ id: "t1" }] });
@@ -120,7 +139,31 @@ describe("useActiveSessionWidget", () => {
 		});
 	});
 
-	it("returns only cash items when sessionType is 'cash_game'", async () => {
+	it("returns only cash items when type is 'cash_game'", async () => {
+		const qc = createClient();
+		qc.setQueryData(CASH_KEY, { items: [{ id: "c1" }] });
+		qc.setQueryData(TOURNAMENT_KEY, { items: [{ id: "t1" }] });
+		const { result } = renderHook(
+			() => useActiveSessionWidget({ type: "cash_game" }),
+			{ wrapper: wrapper(qc) }
+		);
+		await waitFor(() => expect(result.current.cashItems).toHaveLength(1));
+		expect(result.current.tournamentItems).toEqual([]);
+	});
+
+	it("returns only tournament items when type is 'tournament'", async () => {
+		const qc = createClient();
+		qc.setQueryData(CASH_KEY, { items: [{ id: "c1" }] });
+		qc.setQueryData(TOURNAMENT_KEY, { items: [{ id: "t1" }] });
+		const { result } = renderHook(
+			() => useActiveSessionWidget({ type: "tournament" }),
+			{ wrapper: wrapper(qc) }
+		);
+		await waitFor(() => expect(result.current.tournamentItems).toHaveLength(1));
+		expect(result.current.cashItems).toEqual([]);
+	});
+
+	it("honors legacy `sessionType` config when filtering", async () => {
 		const qc = createClient();
 		qc.setQueryData(CASH_KEY, { items: [{ id: "c1" }] });
 		qc.setQueryData(TOURNAMENT_KEY, { items: [{ id: "t1" }] });
@@ -130,18 +173,6 @@ describe("useActiveSessionWidget", () => {
 		);
 		await waitFor(() => expect(result.current.cashItems).toHaveLength(1));
 		expect(result.current.tournamentItems).toEqual([]);
-	});
-
-	it("returns only tournament items when sessionType is 'tournament'", async () => {
-		const qc = createClient();
-		qc.setQueryData(CASH_KEY, { items: [{ id: "c1" }] });
-		qc.setQueryData(TOURNAMENT_KEY, { items: [{ id: "t1" }] });
-		const { result } = renderHook(
-			() => useActiveSessionWidget({ sessionType: "tournament" }),
-			{ wrapper: wrapper(qc) }
-		);
-		await waitFor(() => expect(result.current.tournamentItems).toHaveLength(1));
-		expect(result.current.cashItems).toEqual([]);
 	});
 
 	it("returns empty arrays when queries have no data", () => {
@@ -174,7 +205,7 @@ describe("useActiveSessionWidget — global filter integration", () => {
 		qc.setQueryData(CASH_KEY, { items: [{ id: "c1" }] });
 		qc.setQueryData(TOURNAMENT_KEY, { items: [{ id: "t1" }] });
 		const { result } = renderHook(
-			() => useActiveSessionWidget({ sessionType: "cash_game" }),
+			() => useActiveSessionWidget({ type: "cash_game" }),
 			{
 				wrapper: wrapperWithGlobalFilter(qc, {
 					...DEFAULT_GLOBAL_FILTER_VALUES,
@@ -191,7 +222,7 @@ describe("useActiveSessionWidget — global filter integration", () => {
 		qc.setQueryData(CASH_KEY, { items: [{ id: "c1" }] });
 		qc.setQueryData(TOURNAMENT_KEY, { items: [{ id: "t1" }] });
 		const { result } = renderHook(
-			() => useActiveSessionWidget({ sessionType: "tournament" }),
+			() => useActiveSessionWidget({ type: "tournament" }),
 			{
 				wrapper: wrapperWithGlobalFilter(qc, DEFAULT_GLOBAL_FILTER_VALUES),
 			}

--- a/apps/web/src/features/dashboard/widgets/active-session-widget/active-session-widget.tsx
+++ b/apps/web/src/features/dashboard/widgets/active-session-widget/active-session-widget.tsx
@@ -132,7 +132,7 @@ export function ActiveSessionEditForm({
 				form.handleSubmit();
 			}}
 		>
-			<form.Field name="sessionType">
+			<form.Field name="type">
 				{(field) => (
 					<Field htmlFor={field.name} label="Session Type">
 						<Select

--- a/apps/web/src/features/dashboard/widgets/active-session-widget/use-active-session-edit-form.ts
+++ b/apps/web/src/features/dashboard/widgets/active-session-widget/use-active-session-edit-form.ts
@@ -1,15 +1,14 @@
 import { useForm } from "@tanstack/react-form";
 import z from "zod";
+import { SESSION_TYPE_VALUES } from "@/features/dashboard/utils/session-filter";
 import type { WidgetEditProps } from "@/features/dashboard/widgets/registry";
 import {
 	type ActiveSessionWidgetSessionType,
 	parseActiveSessionWidgetConfig,
 } from "./use-active-session-widget";
 
-const SESSION_TYPE_VALUES = ["all", "cash_game", "tournament"] as const;
-
 const editFormSchema = z.object({
-	sessionType: z.enum(SESSION_TYPE_VALUES),
+	type: z.enum(SESSION_TYPE_VALUES),
 });
 
 interface UseActiveSessionEditFormOptions {
@@ -24,10 +23,10 @@ export function useActiveSessionEditForm({
 	const parsed = parseActiveSessionWidgetConfig(config);
 	const form = useForm({
 		defaultValues: {
-			sessionType: parsed.sessionType as ActiveSessionWidgetSessionType,
+			type: parsed.type as ActiveSessionWidgetSessionType,
 		},
 		onSubmit: async ({ value }) => {
-			await onSave({ sessionType: value.sessionType });
+			await onSave({ type: value.type });
 		},
 		validators: {
 			onSubmit: editFormSchema,

--- a/apps/web/src/features/dashboard/widgets/active-session-widget/use-active-session-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/active-session-widget/use-active-session-widget.ts
@@ -3,22 +3,24 @@ import {
 	resolveSessionType,
 	useGlobalFilter,
 } from "@/features/dashboard/hooks/use-global-filter";
+import {
+	parseSessionType,
+	type SessionTypeFilter,
+} from "@/features/dashboard/utils/session-filter";
 import { trpc } from "@/utils/trpc";
 
-export type ActiveSessionWidgetSessionType = "all" | "cash_game" | "tournament";
+export type ActiveSessionWidgetSessionType = SessionTypeFilter;
 
 interface ParsedConfig {
-	sessionType: ActiveSessionWidgetSessionType;
+	type: ActiveSessionWidgetSessionType;
 }
 
 export function parseActiveSessionWidgetConfig(
 	raw: Record<string, unknown>
 ): ParsedConfig {
-	const sessionType =
-		raw.sessionType === "cash_game" || raw.sessionType === "tournament"
-			? (raw.sessionType as ActiveSessionWidgetSessionType)
-			: ("all" as ActiveSessionWidgetSessionType);
-	return { sessionType };
+	// Legacy configs persisted the field as `sessionType`; read it as a fallback
+	// so existing dashboards keep their selection after the rename.
+	return { type: parseSessionType(raw.type ?? raw.sessionType) };
 }
 
 interface CashItem {
@@ -46,10 +48,7 @@ export function useActiveSessionWidget(
 ): UseActiveSessionWidgetResult {
 	const parsed = parseActiveSessionWidgetConfig(config);
 	const globalFilter = useGlobalFilter();
-	const effectiveSessionType = resolveSessionType(
-		parsed.sessionType,
-		globalFilter
-	);
+	const effectiveType = resolveSessionType(parsed.type, globalFilter);
 
 	const cashQuery = useQuery({
 		...trpc.liveCashGameSession.list.queryOptions({
@@ -58,7 +57,7 @@ export function useActiveSessionWidget(
 		}),
 		refetchInterval: 5000,
 		refetchIntervalInBackground: false,
-		enabled: effectiveSessionType !== "tournament",
+		enabled: effectiveType !== "tournament",
 	});
 
 	const tournamentQuery = useQuery({
@@ -68,16 +67,14 @@ export function useActiveSessionWidget(
 		}),
 		refetchInterval: 5000,
 		refetchIntervalInBackground: false,
-		enabled: effectiveSessionType !== "cash_game",
+		enabled: effectiveType !== "cash_game",
 	});
 
 	const isLoading = cashQuery.isLoading || tournamentQuery.isLoading;
 	const cashItems: CashItem[] =
-		effectiveSessionType === "tournament" ? [] : (cashQuery.data?.items ?? []);
+		effectiveType === "tournament" ? [] : (cashQuery.data?.items ?? []);
 	const tournamentItems: TournamentItem[] =
-		effectiveSessionType === "cash_game"
-			? []
-			: (tournamentQuery.data?.items ?? []);
+		effectiveType === "cash_game" ? [] : (tournamentQuery.data?.items ?? []);
 
 	return { isLoading, cashItems, tournamentItems };
 }

--- a/apps/web/src/features/dashboard/widgets/active-session-widget/use-active-session-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/active-session-widget/use-active-session-widget.ts
@@ -1,4 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
+import {
+	resolveSessionTypeFilter,
+	useGlobalFilter,
+} from "@/features/dashboard/hooks/use-global-filter";
 import { trpc } from "@/utils/trpc";
 
 export type ActiveSessionWidgetSessionType = "all" | "cash_game" | "tournament";
@@ -41,6 +45,11 @@ export function useActiveSessionWidget(
 	config: Record<string, unknown>
 ): UseActiveSessionWidgetResult {
 	const parsed = parseActiveSessionWidgetConfig(config);
+	const globalFilter = useGlobalFilter();
+	const effectiveSessionType = resolveSessionTypeFilter(
+		parsed.sessionType,
+		globalFilter
+	);
 
 	const cashQuery = useQuery({
 		...trpc.liveCashGameSession.list.queryOptions({
@@ -49,7 +58,7 @@ export function useActiveSessionWidget(
 		}),
 		refetchInterval: 5000,
 		refetchIntervalInBackground: false,
-		enabled: parsed.sessionType !== "tournament",
+		enabled: effectiveSessionType !== "tournament",
 	});
 
 	const tournamentQuery = useQuery({
@@ -59,14 +68,14 @@ export function useActiveSessionWidget(
 		}),
 		refetchInterval: 5000,
 		refetchIntervalInBackground: false,
-		enabled: parsed.sessionType !== "cash_game",
+		enabled: effectiveSessionType !== "cash_game",
 	});
 
 	const isLoading = cashQuery.isLoading || tournamentQuery.isLoading;
 	const cashItems: CashItem[] =
-		parsed.sessionType === "tournament" ? [] : (cashQuery.data?.items ?? []);
+		effectiveSessionType === "tournament" ? [] : (cashQuery.data?.items ?? []);
 	const tournamentItems: TournamentItem[] =
-		parsed.sessionType === "cash_game"
+		effectiveSessionType === "cash_game"
 			? []
 			: (tournamentQuery.data?.items ?? []);
 

--- a/apps/web/src/features/dashboard/widgets/active-session-widget/use-active-session-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/active-session-widget/use-active-session-widget.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import {
-	resolveSessionTypeFilter,
+	resolveSessionType,
 	useGlobalFilter,
 } from "@/features/dashboard/hooks/use-global-filter";
 import { trpc } from "@/utils/trpc";
@@ -46,7 +46,7 @@ export function useActiveSessionWidget(
 ): UseActiveSessionWidgetResult {
 	const parsed = parseActiveSessionWidgetConfig(config);
 	const globalFilter = useGlobalFilter();
-	const effectiveSessionType = resolveSessionTypeFilter(
+	const effectiveSessionType = resolveSessionType(
 		parsed.sessionType,
 		globalFilter
 	);

--- a/apps/web/src/features/dashboard/widgets/global-filter-widget/__tests__/use-global-filter-edit-form.test.ts
+++ b/apps/web/src/features/dashboard/widgets/global-filter-widget/__tests__/use-global-filter-edit-form.test.ts
@@ -1,88 +1,135 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/trpc", () => ({
+	trpc: {
+		store: { list: { queryOptions: () => ({ queryKey: ["store-list"] }) } },
+		currency: {
+			list: { queryOptions: () => ({ queryKey: ["currency-list"] }) },
+		},
+	},
+}));
+
 import { useGlobalFilterEditForm } from "@/features/dashboard/widgets/global-filter-widget/use-global-filter-edit-form";
 
+function wrapper() {
+	const qc = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0, staleTime: Number.POSITIVE_INFINITY },
+			mutations: { retry: false },
+		},
+	});
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(QueryClientProvider, { client: qc }, children);
+	};
+}
+
 describe("useGlobalFilterEditForm", () => {
-	it("defaults from empty config: type='all', dateRangeDays=''", () => {
+	it("defaults from empty config: every field visible, every initial empty", () => {
 		const onSave = vi.fn().mockResolvedValue(undefined);
-		const { result } = renderHook(() =>
-			useGlobalFilterEditForm({ config: {}, onSave })
+		const { result } = renderHook(
+			() => useGlobalFilterEditForm({ config: {}, onSave }),
+			{ wrapper: wrapper() }
 		);
-		expect(result.current.form.state.values.type).toBe("all");
-		expect(result.current.form.state.values.dateRangeDays).toBe("");
+		const v = result.current.form.state.values;
+		expect(v.typeVisible).toBe(true);
+		expect(v.storeIdVisible).toBe(true);
+		expect(v.currencyIdVisible).toBe(true);
+		expect(v.dateFromVisible).toBe(true);
+		expect(v.dateToVisible).toBe(true);
+		expect(v.dateRangeDaysVisible).toBe(true);
+		expect(v.typeInitial).toBe("");
+		expect(v.storeIdInitial).toBe("");
+		expect(v.currencyIdInitial).toBe("");
+		expect(v.dateFromInitial).toBe("");
+		expect(v.dateToInitial).toBe("");
+		expect(v.dateRangeDaysInitial).toBe("");
 	});
 
-	it("seeds dateRangeDays as string when config provides a number", () => {
+	it("seeds initial values from existing config", () => {
 		const onSave = vi.fn().mockResolvedValue(undefined);
-		const { result } = renderHook(() =>
-			useGlobalFilterEditForm({
-				config: { type: "tournament", dateRangeDays: 14 },
-				onSave,
-			})
+		const { result } = renderHook(
+			() =>
+				useGlobalFilterEditForm({
+					config: {
+						type: { initialValue: "cash_game", visible: true },
+						storeId: { initialValue: "store-1", visible: false },
+						dateRangeDays: { initialValue: 30, visible: true },
+					},
+					onSave,
+				}),
+			{ wrapper: wrapper() }
 		);
-		expect(result.current.form.state.values.type).toBe("tournament");
-		expect(result.current.form.state.values.dateRangeDays).toBe("14");
+		const v = result.current.form.state.values;
+		expect(v.typeInitial).toBe("cash_game");
+		expect(v.storeIdInitial).toBe("store-1");
+		expect(v.storeIdVisible).toBe(false);
+		expect(v.dateRangeDaysInitial).toBe("30");
 	});
 
-	it("submits type and dateRangeDays as a number", async () => {
+	it("submits a complete config object back to onSave", async () => {
 		const onSave = vi.fn().mockResolvedValue(undefined);
-		const { result } = renderHook(() =>
-			useGlobalFilterEditForm({ config: {}, onSave })
+		const { result } = renderHook(
+			() => useGlobalFilterEditForm({ config: {}, onSave }),
+			{ wrapper: wrapper() }
 		);
 		act(() => {
-			result.current.form.setFieldValue("type", "cash_game");
-			result.current.form.setFieldValue("dateRangeDays", "30");
+			result.current.form.setFieldValue("typeVisible", true);
+			result.current.form.setFieldValue("typeInitial", "cash_game");
+			result.current.form.setFieldValue("storeIdVisible", false);
+			result.current.form.setFieldValue("storeIdInitial", "store-1");
+			result.current.form.setFieldValue("currencyIdVisible", true);
+			result.current.form.setFieldValue("currencyIdInitial", "currency-1");
+			result.current.form.setFieldValue("dateFromVisible", true);
+			result.current.form.setFieldValue("dateFromInitial", "2026-01-01");
+			result.current.form.setFieldValue("dateToVisible", false);
+			result.current.form.setFieldValue("dateToInitial", "2026-12-31");
+			result.current.form.setFieldValue("dateRangeDaysVisible", true);
+			result.current.form.setFieldValue("dateRangeDaysInitial", "14");
 		});
 		await act(async () => {
 			await result.current.form.handleSubmit();
 		});
 		expect(onSave).toHaveBeenCalledTimes(1);
 		expect(onSave).toHaveBeenCalledWith({
-			type: "cash_game",
-			dateRangeDays: 30,
+			type: { initialValue: "cash_game", visible: true },
+			storeId: { initialValue: "store-1", visible: false },
+			currencyId: { initialValue: "currency-1", visible: true },
+			dateFrom: { initialValue: "2026-01-01", visible: true },
+			dateTo: { initialValue: "2026-12-31", visible: false },
+			dateRangeDays: { initialValue: 14, visible: true },
 		});
 	});
 
-	it("submits dateRangeDays as null when blank", async () => {
+	it("submits nulls when text fields are empty", async () => {
 		const onSave = vi.fn().mockResolvedValue(undefined);
-		const { result } = renderHook(() =>
-			useGlobalFilterEditForm({ config: {}, onSave })
+		const { result } = renderHook(
+			() => useGlobalFilterEditForm({ config: {}, onSave }),
+			{ wrapper: wrapper() }
 		);
-		act(() => {
-			result.current.form.setFieldValue("type", "tournament");
-		});
 		await act(async () => {
 			await result.current.form.handleSubmit();
 		});
 		expect(onSave).toHaveBeenCalledWith({
-			type: "tournament",
-			dateRangeDays: null,
+			type: { initialValue: null, visible: true },
+			storeId: { initialValue: null, visible: true },
+			currencyId: { initialValue: null, visible: true },
+			dateFrom: { initialValue: null, visible: true },
+			dateTo: { initialValue: null, visible: true },
+			dateRangeDays: { initialValue: null, visible: true },
 		});
 	});
 
-	it("submits dateRangeDays as null when whitespace only", async () => {
+	it("rejects dateRangeDays below 1", async () => {
 		const onSave = vi.fn().mockResolvedValue(undefined);
-		const { result } = renderHook(() =>
-			useGlobalFilterEditForm({ config: {}, onSave })
+		const { result } = renderHook(
+			() => useGlobalFilterEditForm({ config: {}, onSave }),
+			{ wrapper: wrapper() }
 		);
 		act(() => {
-			result.current.form.setFieldValue("dateRangeDays", "   ");
-		});
-		await act(async () => {
-			await result.current.form.handleSubmit();
-		});
-		expect(onSave).toHaveBeenCalledWith(
-			expect.objectContaining({ dateRangeDays: null })
-		);
-	});
-
-	it("rejects dateRangeDays below 1 (validation)", async () => {
-		const onSave = vi.fn().mockResolvedValue(undefined);
-		const { result } = renderHook(() =>
-			useGlobalFilterEditForm({ config: {}, onSave })
-		);
-		act(() => {
-			result.current.form.setFieldValue("dateRangeDays", "0");
+			result.current.form.setFieldValue("dateRangeDaysInitial", "0");
 		});
 		await act(async () => {
 			await result.current.form.handleSubmit();
@@ -90,13 +137,14 @@ describe("useGlobalFilterEditForm", () => {
 		expect(onSave).not.toHaveBeenCalled();
 	});
 
-	it("rejects dateRangeDays above 3650 (validation)", async () => {
+	it("rejects dateRangeDays above 3650", async () => {
 		const onSave = vi.fn().mockResolvedValue(undefined);
-		const { result } = renderHook(() =>
-			useGlobalFilterEditForm({ config: {}, onSave })
+		const { result } = renderHook(
+			() => useGlobalFilterEditForm({ config: {}, onSave }),
+			{ wrapper: wrapper() }
 		);
 		act(() => {
-			result.current.form.setFieldValue("dateRangeDays", "9999");
+			result.current.form.setFieldValue("dateRangeDaysInitial", "9999");
 		});
 		await act(async () => {
 			await result.current.form.handleSubmit();

--- a/apps/web/src/features/dashboard/widgets/global-filter-widget/__tests__/use-global-filter-edit-form.test.ts
+++ b/apps/web/src/features/dashboard/widgets/global-filter-widget/__tests__/use-global-filter-edit-form.test.ts
@@ -1,0 +1,106 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useGlobalFilterEditForm } from "@/features/dashboard/widgets/global-filter-widget/use-global-filter-edit-form";
+
+describe("useGlobalFilterEditForm", () => {
+	it("defaults from empty config: type='all', dateRangeDays=''", () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useGlobalFilterEditForm({ config: {}, onSave })
+		);
+		expect(result.current.form.state.values.type).toBe("all");
+		expect(result.current.form.state.values.dateRangeDays).toBe("");
+	});
+
+	it("seeds dateRangeDays as string when config provides a number", () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useGlobalFilterEditForm({
+				config: { type: "tournament", dateRangeDays: 14 },
+				onSave,
+			})
+		);
+		expect(result.current.form.state.values.type).toBe("tournament");
+		expect(result.current.form.state.values.dateRangeDays).toBe("14");
+	});
+
+	it("submits type and dateRangeDays as a number", async () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useGlobalFilterEditForm({ config: {}, onSave })
+		);
+		act(() => {
+			result.current.form.setFieldValue("type", "cash_game");
+			result.current.form.setFieldValue("dateRangeDays", "30");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSave).toHaveBeenCalledTimes(1);
+		expect(onSave).toHaveBeenCalledWith({
+			type: "cash_game",
+			dateRangeDays: 30,
+		});
+	});
+
+	it("submits dateRangeDays as null when blank", async () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useGlobalFilterEditForm({ config: {}, onSave })
+		);
+		act(() => {
+			result.current.form.setFieldValue("type", "tournament");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSave).toHaveBeenCalledWith({
+			type: "tournament",
+			dateRangeDays: null,
+		});
+	});
+
+	it("submits dateRangeDays as null when whitespace only", async () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useGlobalFilterEditForm({ config: {}, onSave })
+		);
+		act(() => {
+			result.current.form.setFieldValue("dateRangeDays", "   ");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSave).toHaveBeenCalledWith(
+			expect.objectContaining({ dateRangeDays: null })
+		);
+	});
+
+	it("rejects dateRangeDays below 1 (validation)", async () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useGlobalFilterEditForm({ config: {}, onSave })
+		);
+		act(() => {
+			result.current.form.setFieldValue("dateRangeDays", "0");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSave).not.toHaveBeenCalled();
+	});
+
+	it("rejects dateRangeDays above 3650 (validation)", async () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(() =>
+			useGlobalFilterEditForm({ config: {}, onSave })
+		);
+		act(() => {
+			result.current.form.setFieldValue("dateRangeDays", "9999");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSave).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/features/dashboard/widgets/global-filter-widget/__tests__/use-global-filter-widget.test.ts
+++ b/apps/web/src/features/dashboard/widgets/global-filter-widget/__tests__/use-global-filter-widget.test.ts
@@ -1,0 +1,108 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+	GLOBAL_FILTER_TYPE_LABELS,
+	parseGlobalFilterWidgetConfig,
+	useGlobalFilterWidget,
+} from "@/features/dashboard/widgets/global-filter-widget/use-global-filter-widget";
+
+describe("parseGlobalFilterWidgetConfig", () => {
+	it("returns defaults when raw is empty", () => {
+		expect(parseGlobalFilterWidgetConfig({})).toEqual({
+			type: "all",
+			dateRangeDays: null,
+		});
+	});
+
+	it("preserves cash_game type", () => {
+		expect(parseGlobalFilterWidgetConfig({ type: "cash_game" }).type).toBe(
+			"cash_game"
+		);
+	});
+
+	it("preserves tournament type", () => {
+		expect(parseGlobalFilterWidgetConfig({ type: "tournament" }).type).toBe(
+			"tournament"
+		);
+	});
+
+	it("coerces unknown type to 'all'", () => {
+		expect(parseGlobalFilterWidgetConfig({ type: "weird" }).type).toBe("all");
+	});
+
+	it("preserves numeric dateRangeDays", () => {
+		expect(
+			parseGlobalFilterWidgetConfig({ dateRangeDays: 30 }).dateRangeDays
+		).toBe(30);
+	});
+
+	it("coerces non-number dateRangeDays to null", () => {
+		expect(
+			parseGlobalFilterWidgetConfig({ dateRangeDays: "30" }).dateRangeDays
+		).toBeNull();
+	});
+
+	it("coerces dateRangeDays < 1 to null", () => {
+		expect(
+			parseGlobalFilterWidgetConfig({ dateRangeDays: 0 }).dateRangeDays
+		).toBeNull();
+		expect(
+			parseGlobalFilterWidgetConfig({ dateRangeDays: -1 }).dateRangeDays
+		).toBeNull();
+	});
+
+	it("coerces NaN dateRangeDays to null", () => {
+		expect(
+			parseGlobalFilterWidgetConfig({ dateRangeDays: Number.NaN }).dateRangeDays
+		).toBeNull();
+	});
+
+	it("coerces Infinity dateRangeDays to null", () => {
+		expect(
+			parseGlobalFilterWidgetConfig({
+				dateRangeDays: Number.POSITIVE_INFINITY,
+			}).dateRangeDays
+		).toBeNull();
+	});
+
+	it("floors fractional dateRangeDays", () => {
+		expect(
+			parseGlobalFilterWidgetConfig({ dateRangeDays: 7.9 }).dateRangeDays
+		).toBe(7);
+	});
+});
+
+describe("useGlobalFilterWidget", () => {
+	it("reports hasActiveFilter=false when both are defaults", () => {
+		const { result } = renderHook(() => useGlobalFilterWidget({}));
+		expect(result.current.hasActiveFilter).toBe(false);
+		expect(result.current.type).toBe("all");
+		expect(result.current.typeLabel).toBe("All");
+		expect(result.current.dateRangeDays).toBeNull();
+	});
+
+	it("reports hasActiveFilter=true when type is set", () => {
+		const { result } = renderHook(() =>
+			useGlobalFilterWidget({ type: "cash_game" })
+		);
+		expect(result.current.hasActiveFilter).toBe(true);
+		expect(result.current.type).toBe("cash_game");
+		expect(result.current.typeLabel).toBe("Cash Game");
+	});
+
+	it("reports hasActiveFilter=true when dateRangeDays is set", () => {
+		const { result } = renderHook(() =>
+			useGlobalFilterWidget({ dateRangeDays: 7 })
+		);
+		expect(result.current.hasActiveFilter).toBe(true);
+		expect(result.current.dateRangeDays).toBe(7);
+	});
+
+	it("uses friendly labels from GLOBAL_FILTER_TYPE_LABELS", () => {
+		expect(GLOBAL_FILTER_TYPE_LABELS).toEqual({
+			all: "All",
+			cash_game: "Cash Game",
+			tournament: "Tournament",
+		});
+	});
+});

--- a/apps/web/src/features/dashboard/widgets/global-filter-widget/__tests__/use-global-filter-widget.test.ts
+++ b/apps/web/src/features/dashboard/widgets/global-filter-widget/__tests__/use-global-filter-widget.test.ts
@@ -1,108 +1,189 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/trpc", () => ({
+	trpc: {
+		store: { list: { queryOptions: () => ({ queryKey: ["store-list"] }) } },
+		currency: {
+			list: { queryOptions: () => ({ queryKey: ["currency-list"] }) },
+		},
+	},
+}));
+
 import {
-	GLOBAL_FILTER_TYPE_LABELS,
-	parseGlobalFilterWidgetConfig,
-	useGlobalFilterWidget,
-} from "@/features/dashboard/widgets/global-filter-widget/use-global-filter-widget";
+	DEFAULT_GLOBAL_FILTER_VALUES,
+	GlobalFilterProvider,
+	type GlobalFilterValues,
+} from "@/features/dashboard/hooks/use-global-filter";
+import { useGlobalFilterWidget } from "@/features/dashboard/widgets/global-filter-widget/use-global-filter-widget";
 
-describe("parseGlobalFilterWidgetConfig", () => {
-	it("returns defaults when raw is empty", () => {
-		expect(parseGlobalFilterWidgetConfig({})).toEqual({
-			type: "all",
-			dateRangeDays: null,
-		});
+function createClient() {
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0, staleTime: Number.POSITIVE_INFINITY },
+			mutations: { retry: false },
+		},
 	});
+}
 
-	it("preserves cash_game type", () => {
-		expect(parseGlobalFilterWidgetConfig({ type: "cash_game" }).type).toBe(
-			"cash_game"
+function wrapperWith({
+	values = DEFAULT_GLOBAL_FILTER_VALUES,
+	stores = [] as Array<{ id: string; name: string }>,
+	currencies = [] as Array<{ id: string; name: string }>,
+	setValue = vi.fn(),
+	reset = vi.fn(),
+}: {
+	currencies?: Array<{ id: string; name: string }>;
+	reset?: () => void;
+	setValue?: <K extends keyof GlobalFilterValues>(
+		key: K,
+		value: GlobalFilterValues[K]
+	) => void;
+	stores?: Array<{ id: string; name: string }>;
+	values?: GlobalFilterValues;
+}) {
+	const qc = createClient();
+	qc.setQueryData(["store-list"], stores);
+	qc.setQueryData(["currency-list"], currencies);
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(
+			QueryClientProvider,
+			{ client: qc },
+			createElement(
+				GlobalFilterProvider,
+				{ value: { values, setValue, reset } },
+				children
+			)
 		);
-	});
-
-	it("preserves tournament type", () => {
-		expect(parseGlobalFilterWidgetConfig({ type: "tournament" }).type).toBe(
-			"tournament"
-		);
-	});
-
-	it("coerces unknown type to 'all'", () => {
-		expect(parseGlobalFilterWidgetConfig({ type: "weird" }).type).toBe("all");
-	});
-
-	it("preserves numeric dateRangeDays", () => {
-		expect(
-			parseGlobalFilterWidgetConfig({ dateRangeDays: 30 }).dateRangeDays
-		).toBe(30);
-	});
-
-	it("coerces non-number dateRangeDays to null", () => {
-		expect(
-			parseGlobalFilterWidgetConfig({ dateRangeDays: "30" }).dateRangeDays
-		).toBeNull();
-	});
-
-	it("coerces dateRangeDays < 1 to null", () => {
-		expect(
-			parseGlobalFilterWidgetConfig({ dateRangeDays: 0 }).dateRangeDays
-		).toBeNull();
-		expect(
-			parseGlobalFilterWidgetConfig({ dateRangeDays: -1 }).dateRangeDays
-		).toBeNull();
-	});
-
-	it("coerces NaN dateRangeDays to null", () => {
-		expect(
-			parseGlobalFilterWidgetConfig({ dateRangeDays: Number.NaN }).dateRangeDays
-		).toBeNull();
-	});
-
-	it("coerces Infinity dateRangeDays to null", () => {
-		expect(
-			parseGlobalFilterWidgetConfig({
-				dateRangeDays: Number.POSITIVE_INFINITY,
-			}).dateRangeDays
-		).toBeNull();
-	});
-
-	it("floors fractional dateRangeDays", () => {
-		expect(
-			parseGlobalFilterWidgetConfig({ dateRangeDays: 7.9 }).dateRangeDays
-		).toBe(7);
-	});
-});
+	};
+}
 
 describe("useGlobalFilterWidget", () => {
-	it("reports hasActiveFilter=false when both are defaults", () => {
-		const { result } = renderHook(() => useGlobalFilterWidget({}));
-		expect(result.current.hasActiveFilter).toBe(false);
-		expect(result.current.type).toBe("all");
-		expect(result.current.typeLabel).toBe("All");
-		expect(result.current.dateRangeDays).toBeNull();
-	});
-
-	it("reports hasActiveFilter=true when type is set", () => {
-		const { result } = renderHook(() =>
-			useGlobalFilterWidget({ type: "cash_game" })
+	it("hasAnyVisible=false when every field is hidden", () => {
+		const { result } = renderHook(
+			() =>
+				useGlobalFilterWidget({
+					type: { initialValue: null, visible: false },
+					storeId: { initialValue: null, visible: false },
+					currencyId: { initialValue: null, visible: false },
+					dateFrom: { initialValue: null, visible: false },
+					dateTo: { initialValue: null, visible: false },
+					dateRangeDays: { initialValue: null, visible: false },
+				}),
+			{ wrapper: wrapperWith({}) }
 		);
-		expect(result.current.hasActiveFilter).toBe(true);
-		expect(result.current.type).toBe("cash_game");
-		expect(result.current.typeLabel).toBe("Cash Game");
+		expect(result.current.hasAnyVisible).toBe(false);
+		expect(result.current.visibleFields).toEqual([]);
 	});
 
-	it("reports hasActiveFilter=true when dateRangeDays is set", () => {
-		const { result } = renderHook(() =>
-			useGlobalFilterWidget({ dateRangeDays: 7 })
+	it("returns visible fields in canonical order", () => {
+		const { result } = renderHook(
+			() =>
+				useGlobalFilterWidget({
+					storeId: { initialValue: null, visible: false },
+					dateRangeDays: { initialValue: null, visible: true },
+					type: { initialValue: null, visible: true },
+				}),
+			{ wrapper: wrapperWith({}) }
 		);
-		expect(result.current.hasActiveFilter).toBe(true);
-		expect(result.current.dateRangeDays).toBe(7);
+		expect(result.current.visibleFields.map((f) => f.key)).toEqual([
+			"type",
+			"currencyId",
+			"dateFrom",
+			"dateTo",
+			"dateRangeDays",
+		]);
 	});
 
-	it("uses friendly labels from GLOBAL_FILTER_TYPE_LABELS", () => {
-		expect(GLOBAL_FILTER_TYPE_LABELS).toEqual({
-			all: "All",
-			cash_game: "Cash Game",
-			tournament: "Tournament",
-		});
+	it("hasDirtyValues is false when runtime values match config initialValues", () => {
+		const { result } = renderHook(
+			() =>
+				useGlobalFilterWidget({
+					type: { initialValue: "cash_game", visible: true },
+				}),
+			{
+				wrapper: wrapperWith({
+					values: {
+						...DEFAULT_GLOBAL_FILTER_VALUES,
+						type: "cash_game",
+					},
+				}),
+			}
+		);
+		expect(result.current.hasDirtyValues).toBe(false);
+	});
+
+	it("hasDirtyValues is true when runtime differs from initial", () => {
+		const { result } = renderHook(
+			() =>
+				useGlobalFilterWidget({
+					type: { initialValue: "cash_game", visible: true },
+				}),
+			{
+				wrapper: wrapperWith({
+					values: {
+						...DEFAULT_GLOBAL_FILTER_VALUES,
+						type: "tournament",
+					},
+				}),
+			}
+		);
+		expect(result.current.hasDirtyValues).toBe(true);
+	});
+
+	it("hasDirtyValues only considers visible fields", () => {
+		const { result } = renderHook(
+			() =>
+				useGlobalFilterWidget({
+					type: { initialValue: null, visible: true },
+					storeId: { initialValue: "store-A", visible: false },
+				}),
+			{
+				wrapper: wrapperWith({
+					values: {
+						...DEFAULT_GLOBAL_FILTER_VALUES,
+						storeId: "store-Z",
+					},
+				}),
+			}
+		);
+		expect(result.current.hasDirtyValues).toBe(false);
+	});
+
+	it("forwards onValueChange and onReset to context handlers", () => {
+		const setValue = vi.fn();
+		const reset = vi.fn();
+		const { result } = renderHook(
+			() =>
+				useGlobalFilterWidget({
+					type: { initialValue: null, visible: true },
+				}),
+			{ wrapper: wrapperWith({ setValue, reset }) }
+		);
+		result.current.onValueChange("type", "cash_game");
+		result.current.onReset();
+		expect(setValue).toHaveBeenCalledTimes(1);
+		expect(setValue).toHaveBeenCalledWith("type", "cash_game");
+		expect(reset).toHaveBeenCalledTimes(1);
+	});
+
+	it("exposes stores and currencies from cache", () => {
+		const { result } = renderHook(
+			() =>
+				useGlobalFilterWidget({
+					storeId: { initialValue: null, visible: true },
+					currencyId: { initialValue: null, visible: true },
+				}),
+			{
+				wrapper: wrapperWith({
+					stores: [{ id: "s1", name: "Store 1" }],
+					currencies: [{ id: "c1", name: "USD" }],
+				}),
+			}
+		);
+		expect(result.current.stores).toEqual([{ id: "s1", name: "Store 1" }]);
+		expect(result.current.currencies).toEqual([{ id: "c1", name: "USD" }]);
 	});
 });

--- a/apps/web/src/features/dashboard/widgets/global-filter-widget/global-filter-widget.tsx
+++ b/apps/web/src/features/dashboard/widgets/global-filter-widget/global-filter-widget.tsx
@@ -1,0 +1,121 @@
+import { IconCalendar, IconFilter } from "@tabler/icons-react";
+import type {
+	WidgetEditProps,
+	WidgetRenderProps,
+} from "@/features/dashboard/widgets/registry";
+import { Badge } from "@/shared/components/ui/badge";
+import { Button } from "@/shared/components/ui/button";
+import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
+import { Field } from "@/shared/components/ui/field";
+import { Input } from "@/shared/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/shared/components/ui/select";
+import { useGlobalFilterEditForm } from "./use-global-filter-edit-form";
+import { useGlobalFilterWidget } from "./use-global-filter-widget";
+
+export function GlobalFilterWidget({ config }: WidgetRenderProps) {
+	const { type, typeLabel, dateRangeDays, hasActiveFilter } =
+		useGlobalFilterWidget(config);
+
+	if (!hasActiveFilter) {
+		return (
+			<div className="flex h-full items-center gap-2 px-3 text-muted-foreground text-sm">
+				<IconFilter size={14} />
+				<span>No active filters — showing all data</span>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex h-full flex-wrap items-center gap-2 px-3">
+			<IconFilter className="shrink-0 text-muted-foreground" size={14} />
+			{type === "all" ? null : (
+				<Badge variant="secondary">Type: {typeLabel}</Badge>
+			)}
+			{dateRangeDays === null ? null : (
+				<Badge variant="secondary">
+					<IconCalendar size={12} />
+					Last {dateRangeDays} {dateRangeDays === 1 ? "day" : "days"}
+				</Badge>
+			)}
+		</div>
+	);
+}
+
+export function GlobalFilterEditForm({
+	config,
+	onSave,
+	onCancel,
+}: WidgetEditProps) {
+	const { form } = useGlobalFilterEditForm({ config, onSave });
+
+	return (
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="type">
+				{(field) => (
+					<Field htmlFor={field.name} label="Session Type">
+						<Select
+							onValueChange={(value) =>
+								field.handleChange(value as typeof field.state.value)
+							}
+							value={field.state.value}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">All</SelectItem>
+								<SelectItem value="cash_game">Cash Game</SelectItem>
+								<SelectItem value="tournament">Tournament</SelectItem>
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
+			<form.Field name="dateRangeDays">
+				{(field) => (
+					<Field
+						description="Leave empty to use all-time data."
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Date Range (days)"
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
+			<DialogActionRow>
+				<Button onClick={onCancel} type="button" variant="outline">
+					Cancel
+				</Button>
+				<form.Subscribe
+					selector={(state) => [state.canSubmit, state.isSubmitting]}
+				>
+					{([canSubmit, isSubmitting]) => (
+						<Button disabled={!canSubmit || isSubmitting} type="submit">
+							{isSubmitting ? "Saving..." : "Save"}
+						</Button>
+					)}
+				</form.Subscribe>
+			</DialogActionRow>
+		</form>
+	);
+}

--- a/apps/web/src/features/dashboard/widgets/global-filter-widget/global-filter-widget.tsx
+++ b/apps/web/src/features/dashboard/widgets/global-filter-widget/global-filter-widget.tsx
@@ -1,48 +1,187 @@
-import { IconCalendar, IconFilter } from "@tabler/icons-react";
+import { IconFilter, IconRotateClockwise } from "@tabler/icons-react";
 import type {
 	WidgetEditProps,
 	WidgetRenderProps,
 } from "@/features/dashboard/widgets/registry";
-import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
+import { Label } from "@/shared/components/ui/label";
 import {
-	Select,
 	SelectContent,
 	SelectItem,
 	SelectTrigger,
 	SelectValue,
+	SelectWithClear,
 } from "@/shared/components/ui/select";
+import { Switch } from "@/shared/components/ui/switch";
 import { useGlobalFilterEditForm } from "./use-global-filter-edit-form";
-import { useGlobalFilterWidget } from "./use-global-filter-widget";
+import {
+	GLOBAL_FILTER_FIELD_LABELS,
+	GLOBAL_FILTER_TYPE_OPTIONS,
+	useGlobalFilterWidget,
+} from "./use-global-filter-widget";
 
 export function GlobalFilterWidget({ config }: WidgetRenderProps) {
-	const { type, typeLabel, dateRangeDays, hasActiveFilter } =
-		useGlobalFilterWidget(config);
+	const {
+		visibleFields,
+		hasAnyVisible,
+		hasDirtyValues,
+		values,
+		onValueChange,
+		onReset,
+		stores,
+		currencies,
+	} = useGlobalFilterWidget(config);
 
-	if (!hasActiveFilter) {
+	if (!hasAnyVisible) {
 		return (
 			<div className="flex h-full items-center gap-2 px-3 text-muted-foreground text-sm">
 				<IconFilter size={14} />
-				<span>No active filters — showing all data</span>
+				<span>No filters configured</span>
 			</div>
 		);
 	}
 
 	return (
-		<div className="flex h-full flex-wrap items-center gap-2 px-3">
-			<IconFilter className="shrink-0 text-muted-foreground" size={14} />
-			{type === "all" ? null : (
-				<Badge variant="secondary">Type: {typeLabel}</Badge>
-			)}
-			{dateRangeDays === null ? null : (
-				<Badge variant="secondary">
-					<IconCalendar size={12} />
-					Last {dateRangeDays} {dateRangeDays === 1 ? "day" : "days"}
-				</Badge>
-			)}
+		<div className="flex h-full flex-wrap items-center gap-2 overflow-auto px-3 py-2">
+			<div className="flex shrink-0 items-center gap-1 text-muted-foreground">
+				<IconFilter size={14} />
+				<span className="font-medium text-xs">Filters</span>
+			</div>
+			{visibleFields.map((field) => {
+				if (field.key === "type") {
+					return (
+						<div className="min-w-32" key={field.key}>
+							<SelectWithClear
+								onValueChange={(value) =>
+									onValueChange(
+										"type",
+										(value as "cash_game" | "tournament" | undefined) ?? null
+									)
+								}
+								value={values.type ?? ""}
+							>
+								<SelectTrigger
+									aria-label={GLOBAL_FILTER_FIELD_LABELS.type}
+									className="h-8 text-xs"
+								>
+									<SelectValue placeholder="Type" />
+								</SelectTrigger>
+								<SelectContent>
+									{GLOBAL_FILTER_TYPE_OPTIONS.map((opt) => (
+										<SelectItem key={opt.value} value={opt.value}>
+											{opt.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</SelectWithClear>
+						</div>
+					);
+				}
+				if (field.key === "storeId") {
+					return (
+						<div className="min-w-32" key={field.key}>
+							<SelectWithClear
+								onValueChange={(value) =>
+									onValueChange("storeId", value ?? null)
+								}
+								value={values.storeId ?? ""}
+							>
+								<SelectTrigger
+									aria-label={GLOBAL_FILTER_FIELD_LABELS.storeId}
+									className="h-8 text-xs"
+								>
+									<SelectValue placeholder="Store" />
+								</SelectTrigger>
+								<SelectContent>
+									{stores.map((s) => (
+										<SelectItem key={s.id} value={s.id}>
+											{s.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</SelectWithClear>
+						</div>
+					);
+				}
+				if (field.key === "currencyId") {
+					return (
+						<div className="min-w-32" key={field.key}>
+							<SelectWithClear
+								onValueChange={(value) =>
+									onValueChange("currencyId", value ?? null)
+								}
+								value={values.currencyId ?? ""}
+							>
+								<SelectTrigger
+									aria-label={GLOBAL_FILTER_FIELD_LABELS.currencyId}
+									className="h-8 text-xs"
+								>
+									<SelectValue placeholder="Currency" />
+								</SelectTrigger>
+								<SelectContent>
+									{currencies.map((c) => (
+										<SelectItem key={c.id} value={c.id}>
+											{c.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</SelectWithClear>
+						</div>
+					);
+				}
+				if (field.key === "dateFrom" || field.key === "dateTo") {
+					const value = values[field.key] ?? "";
+					return (
+						<Input
+							aria-label={GLOBAL_FILTER_FIELD_LABELS[field.key]}
+							className="h-8 w-36 text-xs"
+							key={field.key}
+							onChange={(e) => onValueChange(field.key, e.target.value || null)}
+							type="date"
+							value={value}
+						/>
+					);
+				}
+				if (field.key === "dateRangeDays") {
+					const value = values.dateRangeDays;
+					return (
+						<Input
+							aria-label={GLOBAL_FILTER_FIELD_LABELS.dateRangeDays}
+							className="h-8 w-24 text-xs"
+							inputMode="numeric"
+							key={field.key}
+							onChange={(e) => {
+								const trimmed = e.target.value.trim();
+								if (trimmed === "") {
+									onValueChange("dateRangeDays", null);
+									return;
+								}
+								const parsed = Number.parseInt(trimmed, 10);
+								onValueChange(
+									"dateRangeDays",
+									Number.isFinite(parsed) ? parsed : null
+								);
+							}}
+							value={value === null ? "" : String(value)}
+						/>
+					);
+				}
+				return null;
+			})}
+			<Button
+				aria-label="Reset filters"
+				className="ml-auto h-8 shrink-0"
+				disabled={!hasDirtyValues}
+				onClick={onReset}
+				size="sm"
+				variant="ghost"
+			>
+				<IconRotateClockwise size={14} />
+				Reset
+			</Button>
 		</div>
 	);
 }
@@ -52,7 +191,10 @@ export function GlobalFilterEditForm({
 	onSave,
 	onCancel,
 }: WidgetEditProps) {
-	const { form } = useGlobalFilterEditForm({ config, onSave });
+	const { form, stores, currencies } = useGlobalFilterEditForm({
+		config,
+		onSave,
+	});
 
 	return (
 		<form
@@ -63,45 +205,184 @@ export function GlobalFilterEditForm({
 				form.handleSubmit();
 			}}
 		>
-			<form.Field name="type">
-				{(field) => (
-					<Field htmlFor={field.name} label="Session Type">
-						<Select
-							onValueChange={(value) =>
-								field.handleChange(value as typeof field.state.value)
-							}
-							value={field.state.value}
-						>
-							<SelectTrigger className="w-full" id={field.name}>
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value="all">All</SelectItem>
-								<SelectItem value="cash_game">Cash Game</SelectItem>
-								<SelectItem value="tournament">Tournament</SelectItem>
-							</SelectContent>
-						</Select>
-					</Field>
+			<p className="text-muted-foreground text-sm">
+				Toggle a filter on to expose it as a dropdown on the dashboard. Initial
+				values are applied when the widget loads or after a reset.
+			</p>
+
+			<form.Field name="typeVisible">
+				{(visibleField) => (
+					<form.Field name="typeInitial">
+						{(valueField) => (
+							<EditRow
+								label={GLOBAL_FILTER_FIELD_LABELS.type}
+								onVisibleChange={visibleField.handleChange}
+								visible={visibleField.state.value}
+							>
+								<SelectWithClear
+									onValueChange={(value) =>
+										valueField.handleChange(
+											(value ?? "") as typeof valueField.state.value
+										)
+									}
+									value={valueField.state.value}
+								>
+									<SelectTrigger
+										aria-label={GLOBAL_FILTER_FIELD_LABELS.type}
+										className="w-full"
+									>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{GLOBAL_FILTER_TYPE_OPTIONS.map((opt) => (
+											<SelectItem key={opt.value} value={opt.value}>
+												{opt.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</SelectWithClear>
+							</EditRow>
+						)}
+					</form.Field>
 				)}
 			</form.Field>
-			<form.Field name="dateRangeDays">
-				{(field) => (
-					<Field
-						description="Leave empty to use all-time data."
-						error={field.state.meta.errors[0]?.message}
-						htmlFor={field.name}
-						label="Date Range (days)"
-					>
-						<Input
-							id={field.name}
-							inputMode="numeric"
-							onBlur={field.handleBlur}
-							onChange={(e) => field.handleChange(e.target.value)}
-							value={field.state.value}
-						/>
-					</Field>
+
+			<form.Field name="storeIdVisible">
+				{(visibleField) => (
+					<form.Field name="storeIdInitial">
+						{(valueField) => (
+							<EditRow
+								label={GLOBAL_FILTER_FIELD_LABELS.storeId}
+								onVisibleChange={visibleField.handleChange}
+								visible={visibleField.state.value}
+							>
+								<SelectWithClear
+									onValueChange={(value) =>
+										valueField.handleChange(value ?? "")
+									}
+									value={valueField.state.value}
+								>
+									<SelectTrigger
+										aria-label={GLOBAL_FILTER_FIELD_LABELS.storeId}
+										className="w-full"
+									>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{stores.map((s) => (
+											<SelectItem key={s.id} value={s.id}>
+												{s.name}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</SelectWithClear>
+							</EditRow>
+						)}
+					</form.Field>
 				)}
 			</form.Field>
+
+			<form.Field name="currencyIdVisible">
+				{(visibleField) => (
+					<form.Field name="currencyIdInitial">
+						{(valueField) => (
+							<EditRow
+								label={GLOBAL_FILTER_FIELD_LABELS.currencyId}
+								onVisibleChange={visibleField.handleChange}
+								visible={visibleField.state.value}
+							>
+								<SelectWithClear
+									onValueChange={(value) =>
+										valueField.handleChange(value ?? "")
+									}
+									value={valueField.state.value}
+								>
+									<SelectTrigger
+										aria-label={GLOBAL_FILTER_FIELD_LABELS.currencyId}
+										className="w-full"
+									>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{currencies.map((c) => (
+											<SelectItem key={c.id} value={c.id}>
+												{c.name}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</SelectWithClear>
+							</EditRow>
+						)}
+					</form.Field>
+				)}
+			</form.Field>
+
+			<form.Field name="dateFromVisible">
+				{(visibleField) => (
+					<form.Field name="dateFromInitial">
+						{(valueField) => (
+							<EditRow
+								label={GLOBAL_FILTER_FIELD_LABELS.dateFrom}
+								onVisibleChange={visibleField.handleChange}
+								visible={visibleField.state.value}
+							>
+								<Input
+									aria-label={GLOBAL_FILTER_FIELD_LABELS.dateFrom}
+									onChange={(e) => valueField.handleChange(e.target.value)}
+									type="date"
+									value={valueField.state.value}
+								/>
+							</EditRow>
+						)}
+					</form.Field>
+				)}
+			</form.Field>
+
+			<form.Field name="dateToVisible">
+				{(visibleField) => (
+					<form.Field name="dateToInitial">
+						{(valueField) => (
+							<EditRow
+								label={GLOBAL_FILTER_FIELD_LABELS.dateTo}
+								onVisibleChange={visibleField.handleChange}
+								visible={visibleField.state.value}
+							>
+								<Input
+									aria-label={GLOBAL_FILTER_FIELD_LABELS.dateTo}
+									onChange={(e) => valueField.handleChange(e.target.value)}
+									type="date"
+									value={valueField.state.value}
+								/>
+							</EditRow>
+						)}
+					</form.Field>
+				)}
+			</form.Field>
+
+			<form.Field name="dateRangeDaysVisible">
+				{(visibleField) => (
+					<form.Field name="dateRangeDaysInitial">
+						{(valueField) => (
+							<EditRow
+								description="Filter to the last N days from today."
+								error={valueField.state.meta.errors[0]?.message}
+								label={GLOBAL_FILTER_FIELD_LABELS.dateRangeDays}
+								onVisibleChange={visibleField.handleChange}
+								visible={visibleField.state.value}
+							>
+								<Input
+									aria-label={GLOBAL_FILTER_FIELD_LABELS.dateRangeDays}
+									inputMode="numeric"
+									onBlur={valueField.handleBlur}
+									onChange={(e) => valueField.handleChange(e.target.value)}
+									value={valueField.state.value}
+								/>
+							</EditRow>
+						)}
+					</form.Field>
+				)}
+			</form.Field>
+
 			<DialogActionRow>
 				<Button onClick={onCancel} type="button" variant="outline">
 					Cancel
@@ -117,5 +398,42 @@ export function GlobalFilterEditForm({
 				</form.Subscribe>
 			</DialogActionRow>
 		</form>
+	);
+}
+
+interface EditRowProps {
+	children: React.ReactNode;
+	description?: string;
+	error?: string;
+	label: string;
+	onVisibleChange: (next: boolean) => void;
+	visible: boolean;
+}
+
+function EditRow({
+	label,
+	visible,
+	onVisibleChange,
+	children,
+	description,
+	error,
+}: EditRowProps) {
+	const switchId = `global-filter-${label.replaceAll(/\s+/g, "-").toLowerCase()}-visible`;
+	return (
+		<div className="flex flex-col gap-2 rounded-md border p-3">
+			<div className="flex items-center justify-between gap-2">
+				<Label className="font-medium text-sm" htmlFor={switchId}>
+					{label}
+				</Label>
+				<Switch
+					checked={visible}
+					id={switchId}
+					onCheckedChange={onVisibleChange}
+				/>
+			</div>
+			<Field description={description} error={error} label="Initial value">
+				{children}
+			</Field>
+		</div>
 	);
 }

--- a/apps/web/src/features/dashboard/widgets/global-filter-widget/index.ts
+++ b/apps/web/src/features/dashboard/widgets/global-filter-widget/index.ts
@@ -1,0 +1,10 @@
+export {
+	GlobalFilterEditForm,
+	GlobalFilterWidget,
+} from "./global-filter-widget";
+export type { GlobalFilterWidgetSessionType } from "./use-global-filter-widget";
+export {
+	GLOBAL_FILTER_TYPE_LABELS,
+	parseGlobalFilterWidgetConfig,
+	useGlobalFilterWidget,
+} from "./use-global-filter-widget";

--- a/apps/web/src/features/dashboard/widgets/global-filter-widget/index.ts
+++ b/apps/web/src/features/dashboard/widgets/global-filter-widget/index.ts
@@ -2,9 +2,8 @@ export {
 	GlobalFilterEditForm,
 	GlobalFilterWidget,
 } from "./global-filter-widget";
-export type { GlobalFilterWidgetSessionType } from "./use-global-filter-widget";
 export {
-	GLOBAL_FILTER_TYPE_LABELS,
-	parseGlobalFilterWidgetConfig,
+	GLOBAL_FILTER_FIELD_LABELS,
+	GLOBAL_FILTER_TYPE_OPTIONS,
 	useGlobalFilterWidget,
 } from "./use-global-filter-widget";

--- a/apps/web/src/features/dashboard/widgets/global-filter-widget/use-global-filter-edit-form.ts
+++ b/apps/web/src/features/dashboard/widgets/global-filter-widget/use-global-filter-edit-form.ts
@@ -1,0 +1,46 @@
+import { useForm } from "@tanstack/react-form";
+import z from "zod";
+import type { WidgetEditProps } from "@/features/dashboard/widgets/registry";
+import { optionalNumericString } from "@/shared/lib/form-fields";
+import {
+	type GlobalFilterWidgetSessionType,
+	parseGlobalFilterWidgetConfig,
+} from "./use-global-filter-widget";
+
+const TYPE_VALUES = ["all", "cash_game", "tournament"] as const;
+
+const editFormSchema = z.object({
+	type: z.enum(TYPE_VALUES),
+	dateRangeDays: optionalNumericString({ integer: true, min: 1, max: 3650 }),
+});
+
+interface UseGlobalFilterEditFormOptions {
+	config: WidgetEditProps["config"];
+	onSave: WidgetEditProps["onSave"];
+}
+
+export function useGlobalFilterEditForm({
+	config,
+	onSave,
+}: UseGlobalFilterEditFormOptions) {
+	const parsed = parseGlobalFilterWidgetConfig(config);
+	const form = useForm({
+		defaultValues: {
+			type: parsed.type as GlobalFilterWidgetSessionType,
+			dateRangeDays:
+				parsed.dateRangeDays === null ? "" : String(parsed.dateRangeDays),
+		},
+		onSubmit: async ({ value }) => {
+			const trimmed = value.dateRangeDays.trim();
+			await onSave({
+				type: value.type,
+				dateRangeDays: trimmed === "" ? null : Number.parseInt(trimmed, 10),
+			});
+		},
+		validators: {
+			onSubmit: editFormSchema,
+		},
+	});
+
+	return { form };
+}

--- a/apps/web/src/features/dashboard/widgets/global-filter-widget/use-global-filter-edit-form.ts
+++ b/apps/web/src/features/dashboard/widgets/global-filter-widget/use-global-filter-edit-form.ts
@@ -1,17 +1,30 @@
 import { useForm } from "@tanstack/react-form";
+import { useQuery } from "@tanstack/react-query";
 import z from "zod";
+import { parseGlobalFilterConfig } from "@/features/dashboard/hooks/use-global-filter";
 import type { WidgetEditProps } from "@/features/dashboard/widgets/registry";
 import { optionalNumericString } from "@/shared/lib/form-fields";
-import {
-	type GlobalFilterWidgetSessionType,
-	parseGlobalFilterWidgetConfig,
-} from "./use-global-filter-widget";
+import { trpc } from "@/utils/trpc";
 
-const TYPE_VALUES = ["all", "cash_game", "tournament"] as const;
+const TYPE_VALUES = ["cash_game", "tournament"] as const;
 
 const editFormSchema = z.object({
-	type: z.enum(TYPE_VALUES),
-	dateRangeDays: optionalNumericString({ integer: true, min: 1, max: 3650 }),
+	typeVisible: z.boolean(),
+	typeInitial: z.enum(["", ...TYPE_VALUES]),
+	storeIdVisible: z.boolean(),
+	storeIdInitial: z.string(),
+	currencyIdVisible: z.boolean(),
+	currencyIdInitial: z.string(),
+	dateFromVisible: z.boolean(),
+	dateFromInitial: z.string(),
+	dateToVisible: z.boolean(),
+	dateToInitial: z.string(),
+	dateRangeDaysVisible: z.boolean(),
+	dateRangeDaysInitial: optionalNumericString({
+		integer: true,
+		min: 1,
+		max: 3650,
+	}),
 });
 
 interface UseGlobalFilterEditFormOptions {
@@ -19,22 +32,76 @@ interface UseGlobalFilterEditFormOptions {
 	onSave: WidgetEditProps["onSave"];
 }
 
+interface CurrencyOption {
+	id: string;
+	name: string;
+}
+interface StoreOption {
+	id: string;
+	name: string;
+}
+
 export function useGlobalFilterEditForm({
 	config,
 	onSave,
 }: UseGlobalFilterEditFormOptions) {
-	const parsed = parseGlobalFilterWidgetConfig(config);
+	const parsed = parseGlobalFilterConfig(config);
+	const storesQuery = useQuery(trpc.store.list.queryOptions());
+	const currenciesQuery = useQuery(trpc.currency.list.queryOptions());
+
 	const form = useForm({
 		defaultValues: {
-			type: parsed.type as GlobalFilterWidgetSessionType,
-			dateRangeDays:
-				parsed.dateRangeDays === null ? "" : String(parsed.dateRangeDays),
+			typeVisible: parsed.type.visible,
+			typeInitial: (parsed.type.initialValue ?? "") as
+				| ""
+				| (typeof TYPE_VALUES)[number],
+			storeIdVisible: parsed.storeId.visible,
+			storeIdInitial: parsed.storeId.initialValue ?? "",
+			currencyIdVisible: parsed.currencyId.visible,
+			currencyIdInitial: parsed.currencyId.initialValue ?? "",
+			dateFromVisible: parsed.dateFrom.visible,
+			dateFromInitial: parsed.dateFrom.initialValue ?? "",
+			dateToVisible: parsed.dateTo.visible,
+			dateToInitial: parsed.dateTo.initialValue ?? "",
+			dateRangeDaysVisible: parsed.dateRangeDays.visible,
+			dateRangeDaysInitial:
+				parsed.dateRangeDays.initialValue === null
+					? ""
+					: String(parsed.dateRangeDays.initialValue),
 		},
 		onSubmit: async ({ value }) => {
-			const trimmed = value.dateRangeDays.trim();
+			const dateRangeDaysTrimmed = value.dateRangeDaysInitial.trim();
 			await onSave({
-				type: value.type,
-				dateRangeDays: trimmed === "" ? null : Number.parseInt(trimmed, 10),
+				type: {
+					initialValue: value.typeInitial === "" ? null : value.typeInitial,
+					visible: value.typeVisible,
+				},
+				storeId: {
+					initialValue:
+						value.storeIdInitial === "" ? null : value.storeIdInitial,
+					visible: value.storeIdVisible,
+				},
+				currencyId: {
+					initialValue:
+						value.currencyIdInitial === "" ? null : value.currencyIdInitial,
+					visible: value.currencyIdVisible,
+				},
+				dateFrom: {
+					initialValue:
+						value.dateFromInitial === "" ? null : value.dateFromInitial,
+					visible: value.dateFromVisible,
+				},
+				dateTo: {
+					initialValue: value.dateToInitial === "" ? null : value.dateToInitial,
+					visible: value.dateToVisible,
+				},
+				dateRangeDays: {
+					initialValue:
+						dateRangeDaysTrimmed === ""
+							? null
+							: Number.parseInt(dateRangeDaysTrimmed, 10),
+					visible: value.dateRangeDaysVisible,
+				},
 			});
 		},
 		validators: {
@@ -42,5 +109,9 @@ export function useGlobalFilterEditForm({
 		},
 	});
 
-	return { form };
+	return {
+		form,
+		stores: (storesQuery.data ?? []) as StoreOption[],
+		currencies: (currenciesQuery.data ?? []) as CurrencyOption[],
+	};
 }

--- a/apps/web/src/features/dashboard/widgets/global-filter-widget/use-global-filter-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/global-filter-widget/use-global-filter-widget.ts
@@ -1,52 +1,106 @@
-import type { GlobalFilterSessionType } from "@/features/dashboard/hooks/use-global-filter";
+import { useQuery } from "@tanstack/react-query";
+import {
+	type GlobalFilterFieldsConfig,
+	type GlobalFilterKey,
+	type GlobalFilterValues,
+	parseGlobalFilterConfig,
+	useGlobalFilterControl,
+} from "@/features/dashboard/hooks/use-global-filter";
+import { trpc } from "@/utils/trpc";
 
-export type GlobalFilterWidgetSessionType = GlobalFilterSessionType;
-
-interface ParsedConfig {
-	dateRangeDays: number | null;
-	type: GlobalFilterWidgetSessionType;
+interface CurrencyOption {
+	id: string;
+	name: string;
+}
+interface StoreOption {
+	id: string;
+	name: string;
 }
 
-export function parseGlobalFilterWidgetConfig(
-	raw: Record<string, unknown>
-): ParsedConfig {
-	const type: GlobalFilterWidgetSessionType =
-		raw.type === "cash_game" || raw.type === "tournament" ? raw.type : "all";
-	const dateRangeDays =
-		typeof raw.dateRangeDays === "number" &&
-		Number.isFinite(raw.dateRangeDays) &&
-		raw.dateRangeDays >= 1
-			? Math.floor(raw.dateRangeDays)
-			: null;
-	return { type, dateRangeDays };
-}
+export const GLOBAL_FILTER_TYPE_OPTIONS: ReadonlyArray<{
+	label: string;
+	value: "cash_game" | "tournament";
+}> = [
+	{ value: "cash_game", label: "Cash Game" },
+	{ value: "tournament", label: "Tournament" },
+];
 
-export const GLOBAL_FILTER_TYPE_LABELS: Record<
-	GlobalFilterWidgetSessionType,
-	string
-> = {
-	all: "All",
-	cash_game: "Cash Game",
-	tournament: "Tournament",
+export const GLOBAL_FILTER_FIELD_LABELS: Record<GlobalFilterKey, string> = {
+	type: "Type",
+	storeId: "Store",
+	currencyId: "Currency",
+	dateFrom: "Date From",
+	dateTo: "Date To",
+	dateRangeDays: "Last N Days",
 };
 
-interface UseGlobalFilterWidgetResult {
-	dateRangeDays: number | null;
-	hasActiveFilter: boolean;
-	type: GlobalFilterWidgetSessionType;
-	typeLabel: string;
+export interface VisibleField {
+	initialValue: GlobalFilterValues[GlobalFilterKey];
+	key: GlobalFilterKey;
+	label: string;
 }
+
+interface UseGlobalFilterWidgetResult {
+	currencies: CurrencyOption[];
+	fieldsConfig: GlobalFilterFieldsConfig;
+	hasAnyVisible: boolean;
+	hasDirtyValues: boolean;
+	onReset: () => void;
+	onValueChange: <K extends GlobalFilterKey>(
+		key: K,
+		value: GlobalFilterValues[K]
+	) => void;
+	stores: StoreOption[];
+	values: GlobalFilterValues;
+	visibleFields: VisibleField[];
+}
+
+const FIELD_ORDER: readonly GlobalFilterKey[] = [
+	"type",
+	"storeId",
+	"currencyId",
+	"dateFrom",
+	"dateTo",
+	"dateRangeDays",
+];
 
 export function useGlobalFilterWidget(
 	config: Record<string, unknown>
 ): UseGlobalFilterWidgetResult {
-	const parsed = parseGlobalFilterWidgetConfig(config);
-	const hasActiveFilter =
-		parsed.type !== "all" || parsed.dateRangeDays !== null;
+	const fieldsConfig = parseGlobalFilterConfig(config);
+	const { values, setValue, reset } = useGlobalFilterControl();
+
+	const visibleFields: VisibleField[] = FIELD_ORDER.filter(
+		(key) => fieldsConfig[key].visible
+	).map((key) => ({
+		key,
+		label: GLOBAL_FILTER_FIELD_LABELS[key],
+		initialValue: fieldsConfig[key]
+			.initialValue as GlobalFilterValues[typeof key],
+	}));
+
+	const hasDirtyValues = visibleFields.some(
+		(f) => values[f.key] !== fieldsConfig[f.key].initialValue
+	);
+
+	const storesQuery = useQuery({
+		...trpc.store.list.queryOptions(),
+		enabled: fieldsConfig.storeId.visible,
+	});
+	const currenciesQuery = useQuery({
+		...trpc.currency.list.queryOptions(),
+		enabled: fieldsConfig.currencyId.visible,
+	});
+
 	return {
-		type: parsed.type,
-		typeLabel: GLOBAL_FILTER_TYPE_LABELS[parsed.type],
-		dateRangeDays: parsed.dateRangeDays,
-		hasActiveFilter,
+		fieldsConfig,
+		hasAnyVisible: visibleFields.length > 0,
+		hasDirtyValues,
+		onReset: reset,
+		onValueChange: setValue,
+		stores: (storesQuery.data ?? []) as StoreOption[],
+		currencies: (currenciesQuery.data ?? []) as CurrencyOption[],
+		values,
+		visibleFields,
 	};
 }

--- a/apps/web/src/features/dashboard/widgets/global-filter-widget/use-global-filter-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/global-filter-widget/use-global-filter-widget.ts
@@ -1,0 +1,52 @@
+import type { GlobalFilterSessionType } from "@/features/dashboard/hooks/use-global-filter";
+
+export type GlobalFilterWidgetSessionType = GlobalFilterSessionType;
+
+interface ParsedConfig {
+	dateRangeDays: number | null;
+	type: GlobalFilterWidgetSessionType;
+}
+
+export function parseGlobalFilterWidgetConfig(
+	raw: Record<string, unknown>
+): ParsedConfig {
+	const type: GlobalFilterWidgetSessionType =
+		raw.type === "cash_game" || raw.type === "tournament" ? raw.type : "all";
+	const dateRangeDays =
+		typeof raw.dateRangeDays === "number" &&
+		Number.isFinite(raw.dateRangeDays) &&
+		raw.dateRangeDays >= 1
+			? Math.floor(raw.dateRangeDays)
+			: null;
+	return { type, dateRangeDays };
+}
+
+export const GLOBAL_FILTER_TYPE_LABELS: Record<
+	GlobalFilterWidgetSessionType,
+	string
+> = {
+	all: "All",
+	cash_game: "Cash Game",
+	tournament: "Tournament",
+};
+
+interface UseGlobalFilterWidgetResult {
+	dateRangeDays: number | null;
+	hasActiveFilter: boolean;
+	type: GlobalFilterWidgetSessionType;
+	typeLabel: string;
+}
+
+export function useGlobalFilterWidget(
+	config: Record<string, unknown>
+): UseGlobalFilterWidgetResult {
+	const parsed = parseGlobalFilterWidgetConfig(config);
+	const hasActiveFilter =
+		parsed.type !== "all" || parsed.dateRangeDays !== null;
+	return {
+		type: parsed.type,
+		typeLabel: GLOBAL_FILTER_TYPE_LABELS[parsed.type],
+		dateRangeDays: parsed.dateRangeDays,
+		hasActiveFilter,
+	};
+}

--- a/apps/web/src/features/dashboard/widgets/recent-sessions-widget/__tests__/use-recent-sessions-widget.test.ts
+++ b/apps/web/src/features/dashboard/widgets/recent-sessions-widget/__tests__/use-recent-sessions-widget.test.ts
@@ -23,6 +23,10 @@ vi.mock("@/utils/trpc", () => ({
 }));
 
 import {
+	GlobalFilterProvider,
+	type GlobalFilterValues,
+} from "@/features/dashboard/hooks/use-global-filter";
+import {
 	parseRecentSessionsWidgetConfig,
 	useRecentSessionsWidget,
 } from "@/features/dashboard/widgets/recent-sessions-widget/use-recent-sessions-widget";
@@ -39,6 +43,19 @@ function createClient(): QueryClient {
 function wrapper(client: QueryClient) {
 	return function Wrapper({ children }: { children: ReactNode }) {
 		return createElement(QueryClientProvider, { client }, children);
+	};
+}
+
+function wrapperWithGlobalFilter(
+	client: QueryClient,
+	globalFilter: GlobalFilterValues
+) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(
+			QueryClientProvider,
+			{ client },
+			createElement(GlobalFilterProvider, { value: globalFilter }, children)
+		);
 	};
 }
 
@@ -107,5 +124,55 @@ describe("useRecentSessionsWidget", () => {
 			wrapper: wrapper(qc),
 		});
 		expect(result.current.items).toEqual([]);
+	});
+});
+
+describe("useRecentSessionsWidget — global filter integration", () => {
+	it("global filter type overrides local 'all'", async () => {
+		const qc = createClient();
+		qc.setQueryData(["session", "list", { type: "cash_game" }], {
+			items: [{ id: "x1" }, { id: "x2" }],
+		});
+		const { result } = renderHook(() => useRecentSessionsWidget({}), {
+			wrapper: wrapperWithGlobalFilter(qc, {
+				type: "cash_game",
+				dateRangeDays: null,
+			}),
+		});
+		await waitFor(() => expect(result.current.items).toHaveLength(2));
+	});
+
+	it("global filter type overrides a non-'all' local type", async () => {
+		const qc = createClient();
+		qc.setQueryData(["session", "list", { type: "tournament" }], {
+			items: [{ id: "t1" }],
+		});
+		const { result } = renderHook(
+			() => useRecentSessionsWidget({ type: "cash_game" }),
+			{
+				wrapper: wrapperWithGlobalFilter(qc, {
+					type: "tournament",
+					dateRangeDays: null,
+				}),
+			}
+		);
+		await waitFor(() => expect(result.current.items).toHaveLength(1));
+	});
+
+	it("falls back to local when global type is 'all'", async () => {
+		const qc = createClient();
+		qc.setQueryData(["session", "list", { type: "cash_game" }], {
+			items: [{ id: "c1" }],
+		});
+		const { result } = renderHook(
+			() => useRecentSessionsWidget({ type: "cash_game" }),
+			{
+				wrapper: wrapperWithGlobalFilter(qc, {
+					type: "all",
+					dateRangeDays: null,
+				}),
+			}
+		);
+		await waitFor(() => expect(result.current.items).toHaveLength(1));
 	});
 });

--- a/apps/web/src/features/dashboard/widgets/recent-sessions-widget/__tests__/use-recent-sessions-widget.test.ts
+++ b/apps/web/src/features/dashboard/widgets/recent-sessions-widget/__tests__/use-recent-sessions-widget.test.ts
@@ -13,7 +13,13 @@ vi.mock("@/utils/trpc", () => ({
 	trpc: {
 		session: {
 			list: {
-				queryOptions: (input: { type?: string }) => ({
+				queryOptions: (input: {
+					currencyId?: string;
+					dateFrom?: number;
+					dateTo?: number;
+					storeId?: string;
+					type?: string;
+				}) => ({
 					queryKey: buildKey("session", "list", input),
 					queryFn: () => Promise.resolve({ items: [] }),
 				}),
@@ -23,6 +29,7 @@ vi.mock("@/utils/trpc", () => ({
 }));
 
 import {
+	DEFAULT_GLOBAL_FILTER_VALUES,
 	GlobalFilterProvider,
 	type GlobalFilterValues,
 } from "@/features/dashboard/hooks/use-global-filter";
@@ -48,16 +55,30 @@ function wrapper(client: QueryClient) {
 
 function wrapperWithGlobalFilter(
 	client: QueryClient,
-	globalFilter: GlobalFilterValues
+	values: GlobalFilterValues
 ) {
+	const setValue = vi.fn();
+	const reset = vi.fn();
 	return function Wrapper({ children }: { children: ReactNode }) {
 		return createElement(
 			QueryClientProvider,
 			{ client },
-			createElement(GlobalFilterProvider, { value: globalFilter }, children)
+			createElement(
+				GlobalFilterProvider,
+				{ value: { values, setValue, reset } },
+				children
+			)
 		);
 	};
 }
+
+const DEFAULT_QUERY_INPUT = {
+	type: undefined,
+	storeId: undefined,
+	currencyId: undefined,
+	dateFrom: undefined,
+	dateTo: undefined,
+};
 
 describe("parseRecentSessionsWidgetConfig", () => {
 	it("defaults limit to 5 when not a valid number", () => {
@@ -89,7 +110,7 @@ describe("parseRecentSessionsWidgetConfig", () => {
 describe("useRecentSessionsWidget", () => {
 	it("slices items down to the configured limit", async () => {
 		const qc = createClient();
-		qc.setQueryData(["session", "list", { type: undefined }], {
+		qc.setQueryData(["session", "list", DEFAULT_QUERY_INPUT], {
 			items: [
 				{ id: "s1" },
 				{ id: "s2" },
@@ -108,9 +129,10 @@ describe("useRecentSessionsWidget", () => {
 
 	it("passes the type through to the query when filtering", async () => {
 		const qc = createClient();
-		qc.setQueryData(["session", "list", { type: "tournament" }], {
-			items: [{ id: "t1" }],
-		});
+		qc.setQueryData(
+			["session", "list", { ...DEFAULT_QUERY_INPUT, type: "tournament" }],
+			{ items: [{ id: "t1" }] }
+		);
 		const { result } = renderHook(
 			() => useRecentSessionsWidget({ type: "tournament" }),
 			{ wrapper: wrapper(qc) }
@@ -130,13 +152,14 @@ describe("useRecentSessionsWidget", () => {
 describe("useRecentSessionsWidget — global filter integration", () => {
 	it("global filter type overrides local 'all'", async () => {
 		const qc = createClient();
-		qc.setQueryData(["session", "list", { type: "cash_game" }], {
-			items: [{ id: "x1" }, { id: "x2" }],
-		});
+		qc.setQueryData(
+			["session", "list", { ...DEFAULT_QUERY_INPUT, type: "cash_game" }],
+			{ items: [{ id: "x1" }, { id: "x2" }] }
+		);
 		const { result } = renderHook(() => useRecentSessionsWidget({}), {
 			wrapper: wrapperWithGlobalFilter(qc, {
+				...DEFAULT_GLOBAL_FILTER_VALUES,
 				type: "cash_game",
-				dateRangeDays: null,
 			}),
 		});
 		await waitFor(() => expect(result.current.items).toHaveLength(2));
@@ -144,35 +167,51 @@ describe("useRecentSessionsWidget — global filter integration", () => {
 
 	it("global filter type overrides a non-'all' local type", async () => {
 		const qc = createClient();
-		qc.setQueryData(["session", "list", { type: "tournament" }], {
-			items: [{ id: "t1" }],
-		});
+		qc.setQueryData(
+			["session", "list", { ...DEFAULT_QUERY_INPUT, type: "tournament" }],
+			{ items: [{ id: "t1" }] }
+		);
 		const { result } = renderHook(
 			() => useRecentSessionsWidget({ type: "cash_game" }),
 			{
 				wrapper: wrapperWithGlobalFilter(qc, {
+					...DEFAULT_GLOBAL_FILTER_VALUES,
 					type: "tournament",
-					dateRangeDays: null,
 				}),
 			}
 		);
 		await waitFor(() => expect(result.current.items).toHaveLength(1));
 	});
 
-	it("falls back to local when global type is 'all'", async () => {
+	it("global storeId / currencyId / dateFrom / dateTo are forwarded", async () => {
 		const qc = createClient();
-		qc.setQueryData(["session", "list", { type: "cash_game" }], {
-			items: [{ id: "c1" }],
-		});
-		const { result } = renderHook(
-			() => useRecentSessionsWidget({ type: "cash_game" }),
-			{
-				wrapper: wrapperWithGlobalFilter(qc, {
-					type: "all",
-					dateRangeDays: null,
-				}),
-			}
+		const dateFrom = Math.floor(
+			new Date("2026-01-01T00:00:00").getTime() / 1000
 		);
+		const dateTo = Math.floor(new Date("2026-04-30T23:59:59").getTime() / 1000);
+		qc.setQueryData(
+			[
+				"session",
+				"list",
+				{
+					type: undefined,
+					storeId: "store-A",
+					currencyId: "currency-X",
+					dateFrom,
+					dateTo,
+				},
+			],
+			{ items: [{ id: "z1" }] }
+		);
+		const { result } = renderHook(() => useRecentSessionsWidget({}), {
+			wrapper: wrapperWithGlobalFilter(qc, {
+				...DEFAULT_GLOBAL_FILTER_VALUES,
+				storeId: "store-A",
+				currencyId: "currency-X",
+				dateFrom: "2026-01-01",
+				dateTo: "2026-04-30",
+			}),
+		});
 		await waitFor(() => expect(result.current.items).toHaveLength(1));
 	});
 });

--- a/apps/web/src/features/dashboard/widgets/recent-sessions-widget/use-recent-sessions-edit-form.ts
+++ b/apps/web/src/features/dashboard/widgets/recent-sessions-widget/use-recent-sessions-edit-form.ts
@@ -1,5 +1,6 @@
 import { useForm } from "@tanstack/react-form";
 import z from "zod";
+import { SESSION_TYPE_VALUES } from "@/features/dashboard/utils/session-filter";
 import type { WidgetEditProps } from "@/features/dashboard/widgets/registry";
 import { requiredNumericString } from "@/shared/lib/form-fields";
 import {
@@ -7,11 +8,9 @@ import {
 	type RecentSessionsWidgetTypeFilter,
 } from "./use-recent-sessions-widget";
 
-const TYPE_VALUES = ["all", "cash_game", "tournament"] as const;
-
 const editFormSchema = z.object({
 	limit: requiredNumericString({ integer: true, min: 1, max: 20 }),
-	type: z.enum(TYPE_VALUES),
+	type: z.enum(SESSION_TYPE_VALUES),
 });
 
 interface UseRecentSessionsEditFormOptions {

--- a/apps/web/src/features/dashboard/widgets/recent-sessions-widget/use-recent-sessions-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/recent-sessions-widget/use-recent-sessions-widget.ts
@@ -1,4 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
+import {
+	resolveSessionTypeFilter,
+	useGlobalFilter,
+} from "@/features/dashboard/hooks/use-global-filter";
 import { trpc } from "@/utils/trpc";
 
 export type RecentSessionsWidgetTypeFilter = "all" | "cash_game" | "tournament";
@@ -41,9 +45,11 @@ export function useRecentSessionsWidget(
 	config: Record<string, unknown>
 ): UseRecentSessionsWidgetResult {
 	const parsed = parseRecentSessionsWidgetConfig(config);
+	const globalFilter = useGlobalFilter();
+	const effectiveType = resolveSessionTypeFilter(parsed.type, globalFilter);
 	const query = useQuery(
 		trpc.session.list.queryOptions({
-			type: parsed.type === "all" ? undefined : parsed.type,
+			type: effectiveType === "all" ? undefined : effectiveType,
 		})
 	);
 

--- a/apps/web/src/features/dashboard/widgets/recent-sessions-widget/use-recent-sessions-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/recent-sessions-widget/use-recent-sessions-widget.ts
@@ -1,31 +1,28 @@
 import { useQuery } from "@tanstack/react-query";
+import { useGlobalFilter } from "@/features/dashboard/hooks/use-global-filter";
 import {
-	resolveDateFromEpoch,
-	resolveDateToEpoch,
-	resolveSessionType,
-	useGlobalFilter,
-} from "@/features/dashboard/hooks/use-global-filter";
+	parseSessionFilterWidgetConfig,
+	resolveSessionListQueryInput,
+	type SessionFilterWidgetConfig,
+	type SessionTypeFilter,
+} from "@/features/dashboard/utils/session-filter";
 import { trpc } from "@/utils/trpc";
 
-export type RecentSessionsWidgetTypeFilter = "all" | "cash_game" | "tournament";
+export type RecentSessionsWidgetTypeFilter = SessionTypeFilter;
 
-interface ParsedConfig {
+interface ParsedConfig extends SessionFilterWidgetConfig {
 	limit: number;
-	type: RecentSessionsWidgetTypeFilter;
 }
 
 export function parseRecentSessionsWidgetConfig(
 	raw: Record<string, unknown>
 ): ParsedConfig {
+	const sessionFilter = parseSessionFilterWidgetConfig(raw);
 	const limit =
 		typeof raw.limit === "number" && raw.limit > 0 && raw.limit <= 20
 			? Math.floor(raw.limit)
 			: 5;
-	const type =
-		raw.type === "cash_game" || raw.type === "tournament"
-			? (raw.type as RecentSessionsWidgetTypeFilter)
-			: ("all" as RecentSessionsWidgetTypeFilter);
-	return { limit, type };
+	return { ...sessionFilter, limit };
 }
 
 interface SessionItem {
@@ -48,18 +45,8 @@ export function useRecentSessionsWidget(
 ): UseRecentSessionsWidgetResult {
 	const parsed = parseRecentSessionsWidgetConfig(config);
 	const globalFilter = useGlobalFilter();
-	const effectiveType = resolveSessionType(parsed.type, globalFilter);
-	const dateFrom = resolveDateFromEpoch(globalFilter);
-	const dateTo = resolveDateToEpoch(globalFilter);
-	const query = useQuery(
-		trpc.session.list.queryOptions({
-			type: effectiveType === "all" ? undefined : effectiveType,
-			storeId: globalFilter.storeId ?? undefined,
-			currencyId: globalFilter.currencyId ?? undefined,
-			dateFrom,
-			dateTo,
-		})
-	);
+	const queryInput = resolveSessionListQueryInput(parsed, globalFilter);
+	const query = useQuery(trpc.session.list.queryOptions(queryInput));
 
 	const items = ((query.data?.items ?? []) as SessionItem[]).slice(
 		0,

--- a/apps/web/src/features/dashboard/widgets/recent-sessions-widget/use-recent-sessions-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/recent-sessions-widget/use-recent-sessions-widget.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import {
-	resolveSessionTypeFilter,
+	resolveDateFromEpoch,
+	resolveDateToEpoch,
+	resolveSessionType,
 	useGlobalFilter,
 } from "@/features/dashboard/hooks/use-global-filter";
 import { trpc } from "@/utils/trpc";
@@ -46,10 +48,16 @@ export function useRecentSessionsWidget(
 ): UseRecentSessionsWidgetResult {
 	const parsed = parseRecentSessionsWidgetConfig(config);
 	const globalFilter = useGlobalFilter();
-	const effectiveType = resolveSessionTypeFilter(parsed.type, globalFilter);
+	const effectiveType = resolveSessionType(parsed.type, globalFilter);
+	const dateFrom = resolveDateFromEpoch(globalFilter);
+	const dateTo = resolveDateToEpoch(globalFilter);
 	const query = useQuery(
 		trpc.session.list.queryOptions({
 			type: effectiveType === "all" ? undefined : effectiveType,
+			storeId: globalFilter.storeId ?? undefined,
+			currencyId: globalFilter.currencyId ?? undefined,
+			dateFrom,
+			dateTo,
 		})
 	);
 

--- a/apps/web/src/features/dashboard/widgets/registry/registry.test.ts
+++ b/apps/web/src/features/dashboard/widgets/registry/registry.test.ts
@@ -14,6 +14,9 @@ vi.mock("@/utils/trpc", () => ({
 		currency: {
 			list: { queryOptions: () => ({ queryKey: ["currency-list"] }) },
 		},
+		store: {
+			list: { queryOptions: () => ({ queryKey: ["store-list"] }) },
+		},
 		dashboardWidget: {
 			list: { queryOptions: () => ({ queryKey: ["widget-list"] }) },
 		},

--- a/apps/web/src/features/dashboard/widgets/registry/registry.test.ts
+++ b/apps/web/src/features/dashboard/widgets/registry/registry.test.ts
@@ -26,11 +26,12 @@ const { getWidgetEntry, listWidgetTypes, widgetRegistry } = await import(
 );
 
 describe("widget registry", () => {
-	it("has entries for all 4 MVP widget types", () => {
+	it("has entries for all 5 widget types", () => {
 		expect(Object.keys(widgetRegistry).sort()).toEqual(
 			[
 				"active_session",
 				"currency_balance",
+				"global_filter",
 				"recent_sessions",
 				"summary_stats",
 			].sort()
@@ -39,7 +40,7 @@ describe("widget registry", () => {
 
 	it("lists all widget entries", () => {
 		const entries = listWidgetTypes();
-		expect(entries).toHaveLength(4);
+		expect(entries).toHaveLength(5);
 		for (const entry of entries) {
 			expect(entry.label).toBeTruthy();
 			expect(entry.Render).toBeTruthy();
@@ -52,5 +53,10 @@ describe("widget registry", () => {
 	it("returns entry by type", () => {
 		expect(getWidgetEntry("summary_stats").type).toBe("summary_stats");
 		expect(getWidgetEntry("active_session").type).toBe("active_session");
+		expect(getWidgetEntry("global_filter").type).toBe("global_filter");
+	});
+
+	it("global_filter has an EditForm", () => {
+		expect(getWidgetEntry("global_filter").EditForm).toBeTruthy();
 	});
 });

--- a/apps/web/src/features/dashboard/widgets/registry/registry.ts
+++ b/apps/web/src/features/dashboard/widgets/registry/registry.ts
@@ -2,6 +2,7 @@ import type { TablerIcon } from "@tabler/icons-react";
 import {
 	IconBolt,
 	IconCoin,
+	IconFilter,
 	IconListDetails,
 	IconReportAnalytics,
 } from "@tabler/icons-react";
@@ -44,6 +45,10 @@ import {
 	CurrencyBalanceEditForm,
 	CurrencyBalanceWidget,
 } from "../currency-balance-widget";
+import {
+	GlobalFilterEditForm,
+	GlobalFilterWidget,
+} from "../global-filter-widget";
 import {
 	RecentSessionsEditForm,
 	RecentSessionsWidget,
@@ -105,6 +110,19 @@ export const widgetRegistry: Record<WidgetType, WidgetRegistryEntry> = {
 			mobile: { w: 3, h: 2 },
 		},
 		minSize: { w: 2, h: 2 },
+	},
+	global_filter: {
+		type: "global_filter",
+		label: "Global Filter",
+		description: "Filters all other widgets on this dashboard",
+		icon: IconFilter,
+		Render: GlobalFilterWidget,
+		EditForm: GlobalFilterEditForm,
+		defaultSize: {
+			desktop: { w: 12, h: 1 },
+			mobile: { w: 4, h: 1 },
+		},
+		minSize: { w: 2, h: 1 },
 	},
 };
 

--- a/apps/web/src/features/dashboard/widgets/summary-stats-widget/__tests__/use-summary-stats-widget.test.ts
+++ b/apps/web/src/features/dashboard/widgets/summary-stats-widget/__tests__/use-summary-stats-widget.test.ts
@@ -23,6 +23,10 @@ vi.mock("@/utils/trpc", () => ({
 }));
 
 import {
+	GlobalFilterProvider,
+	type GlobalFilterValues,
+} from "@/features/dashboard/hooks/use-global-filter";
+import {
 	parseSummaryStatsWidgetConfig,
 	SUMMARY_STATS_DEFAULT_METRICS,
 	useSummaryStatsWidget,
@@ -40,6 +44,19 @@ function createClient(): QueryClient {
 function wrapper(client: QueryClient) {
 	return function Wrapper({ children }: { children: ReactNode }) {
 		return createElement(QueryClientProvider, { client }, children);
+	};
+}
+
+function wrapperWithGlobalFilter(
+	client: QueryClient,
+	globalFilter: GlobalFilterValues
+) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(
+			QueryClientProvider,
+			{ client },
+			createElement(GlobalFilterProvider, { value: globalFilter }, children)
+		);
 	};
 }
 
@@ -123,5 +140,95 @@ describe("useSummaryStatsWidget", () => {
 			wrapper: wrapper(qc),
 		});
 		expect(result.current.summary).toBeUndefined();
+	});
+});
+
+describe("useSummaryStatsWidget — global filter integration", () => {
+	it("uses global filter type when local is 'all'", async () => {
+		const qc = createClient();
+		qc.setQueryData(
+			["session", "list", { type: "tournament", dateFrom: undefined }],
+			{ summary: { totalSessions: 9 } }
+		);
+		const { result } = renderHook(() => useSummaryStatsWidget({}), {
+			wrapper: wrapperWithGlobalFilter(qc, {
+				type: "tournament",
+				dateRangeDays: null,
+			}),
+		});
+		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(9));
+	});
+
+	it("global filter type overrides a non-'all' local type", async () => {
+		const qc = createClient();
+		qc.setQueryData(
+			["session", "list", { type: "cash_game", dateFrom: undefined }],
+			{ summary: { totalSessions: 11 } }
+		);
+		const { result } = renderHook(
+			() => useSummaryStatsWidget({ type: "tournament" }),
+			{
+				wrapper: wrapperWithGlobalFilter(qc, {
+					type: "cash_game",
+					dateRangeDays: null,
+				}),
+			}
+		);
+		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(11));
+	});
+
+	it("uses global filter dateRangeDays when local is null", async () => {
+		const qc = createClient();
+		const dateFrom = Math.floor(Date.now() / 1000) - 7 * 86_400;
+		// Match within ~2 seconds tolerance by using a custom selector
+		const expectedKey = [
+			"session",
+			"list",
+			{ type: undefined, dateFrom },
+		] as const;
+		qc.setQueryData(expectedKey, { summary: { totalSessions: 22 } });
+		const { result } = renderHook(() => useSummaryStatsWidget({}), {
+			wrapper: wrapperWithGlobalFilter(qc, {
+				type: "all",
+				dateRangeDays: 7,
+			}),
+		});
+		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(22));
+	});
+
+	it("global dateRangeDays overrides local dateRangeDays", async () => {
+		const qc = createClient();
+		const dateFrom = Math.floor(Date.now() / 1000) - 3 * 86_400;
+		qc.setQueryData(["session", "list", { type: undefined, dateFrom }], {
+			summary: { totalSessions: 33 },
+		});
+		const { result } = renderHook(
+			() => useSummaryStatsWidget({ dateRangeDays: 30 }),
+			{
+				wrapper: wrapperWithGlobalFilter(qc, {
+					type: "all",
+					dateRangeDays: 3,
+				}),
+			}
+		);
+		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(33));
+	});
+
+	it("falls back to local when global is fully default", async () => {
+		const qc = createClient();
+		qc.setQueryData(
+			["session", "list", { type: "cash_game", dateFrom: undefined }],
+			{ summary: { totalSessions: 44 } }
+		);
+		const { result } = renderHook(
+			() => useSummaryStatsWidget({ type: "cash_game" }),
+			{
+				wrapper: wrapperWithGlobalFilter(qc, {
+					type: "all",
+					dateRangeDays: null,
+				}),
+			}
+		);
+		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(44));
 	});
 });

--- a/apps/web/src/features/dashboard/widgets/summary-stats-widget/__tests__/use-summary-stats-widget.test.ts
+++ b/apps/web/src/features/dashboard/widgets/summary-stats-widget/__tests__/use-summary-stats-widget.test.ts
@@ -13,7 +13,13 @@ vi.mock("@/utils/trpc", () => ({
 	trpc: {
 		session: {
 			list: {
-				queryOptions: (input: { type?: string; dateFrom?: number }) => ({
+				queryOptions: (input: {
+					currencyId?: string;
+					dateFrom?: number;
+					dateTo?: number;
+					storeId?: string;
+					type?: string;
+				}) => ({
 					queryKey: buildKey("session", "list", input),
 					queryFn: () => Promise.resolve({ items: [], summary: undefined }),
 				}),
@@ -23,6 +29,7 @@ vi.mock("@/utils/trpc", () => ({
 }));
 
 import {
+	DEFAULT_GLOBAL_FILTER_VALUES,
 	GlobalFilterProvider,
 	type GlobalFilterValues,
 } from "@/features/dashboard/hooks/use-global-filter";
@@ -49,16 +56,30 @@ function wrapper(client: QueryClient) {
 
 function wrapperWithGlobalFilter(
 	client: QueryClient,
-	globalFilter: GlobalFilterValues
+	values: GlobalFilterValues
 ) {
+	const setValue = vi.fn();
+	const reset = vi.fn();
 	return function Wrapper({ children }: { children: ReactNode }) {
 		return createElement(
 			QueryClientProvider,
 			{ client },
-			createElement(GlobalFilterProvider, { value: globalFilter }, children)
+			createElement(
+				GlobalFilterProvider,
+				{ value: { values, setValue, reset } },
+				children
+			)
 		);
 	};
 }
+
+const DEFAULT_QUERY_INPUT = {
+	type: undefined,
+	storeId: undefined,
+	currencyId: undefined,
+	dateFrom: undefined,
+	dateTo: undefined,
+};
 
 describe("parseSummaryStatsWidgetConfig", () => {
 	it("returns defaults when raw is empty", () => {
@@ -99,21 +120,18 @@ describe("parseSummaryStatsWidgetConfig", () => {
 });
 
 describe("useSummaryStatsWidget", () => {
-	it("exposes the summary from a matching query key", async () => {
+	it("exposes the summary from a default-input query key", async () => {
 		const qc = createClient();
-		qc.setQueryData(
-			["session", "list", { type: undefined, dateFrom: undefined }],
-			{
-				summary: {
-					totalSessions: 3,
-					totalProfitLoss: 100,
-					winRate: 0.5,
-					avgProfitLoss: 33,
-					totalEvProfitLoss: 50,
-					totalEvDiff: -10,
-				},
-			}
-		);
+		qc.setQueryData(["session", "list", DEFAULT_QUERY_INPUT], {
+			summary: {
+				totalSessions: 3,
+				totalProfitLoss: 100,
+				winRate: 0.5,
+				avgProfitLoss: 33,
+				totalEvProfitLoss: 50,
+				totalEvDiff: -10,
+			},
+		});
 		const { result } = renderHook(() => useSummaryStatsWidget({}), {
 			wrapper: wrapper(qc),
 		});
@@ -124,7 +142,7 @@ describe("useSummaryStatsWidget", () => {
 	it("passes type filter to query when type is not 'all'", async () => {
 		const qc = createClient();
 		qc.setQueryData(
-			["session", "list", { type: "cash_game", dateFrom: undefined }],
+			["session", "list", { ...DEFAULT_QUERY_INPUT, type: "cash_game" }],
 			{ summary: { totalSessions: 1 } }
 		);
 		const { result } = renderHook(
@@ -147,13 +165,13 @@ describe("useSummaryStatsWidget — global filter integration", () => {
 	it("uses global filter type when local is 'all'", async () => {
 		const qc = createClient();
 		qc.setQueryData(
-			["session", "list", { type: "tournament", dateFrom: undefined }],
+			["session", "list", { ...DEFAULT_QUERY_INPUT, type: "tournament" }],
 			{ summary: { totalSessions: 9 } }
 		);
 		const { result } = renderHook(() => useSummaryStatsWidget({}), {
 			wrapper: wrapperWithGlobalFilter(qc, {
+				...DEFAULT_GLOBAL_FILTER_VALUES,
 				type: "tournament",
-				dateRangeDays: null,
 			}),
 		});
 		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(9));
@@ -162,51 +180,117 @@ describe("useSummaryStatsWidget — global filter integration", () => {
 	it("global filter type overrides a non-'all' local type", async () => {
 		const qc = createClient();
 		qc.setQueryData(
-			["session", "list", { type: "cash_game", dateFrom: undefined }],
+			["session", "list", { ...DEFAULT_QUERY_INPUT, type: "cash_game" }],
 			{ summary: { totalSessions: 11 } }
 		);
 		const { result } = renderHook(
 			() => useSummaryStatsWidget({ type: "tournament" }),
 			{
 				wrapper: wrapperWithGlobalFilter(qc, {
+					...DEFAULT_GLOBAL_FILTER_VALUES,
 					type: "cash_game",
-					dateRangeDays: null,
 				}),
 			}
 		);
 		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(11));
 	});
 
-	it("uses global filter dateRangeDays when local is null", async () => {
+	it("global filter storeId is forwarded to query", async () => {
 		const qc = createClient();
-		const dateFrom = Math.floor(Date.now() / 1000) - 7 * 86_400;
-		// Match within ~2 seconds tolerance by using a custom selector
-		const expectedKey = [
-			"session",
-			"list",
-			{ type: undefined, dateFrom },
-		] as const;
-		qc.setQueryData(expectedKey, { summary: { totalSessions: 22 } });
+		qc.setQueryData(
+			["session", "list", { ...DEFAULT_QUERY_INPUT, storeId: "store-7" }],
+			{ summary: { totalSessions: 55 } }
+		);
 		const { result } = renderHook(() => useSummaryStatsWidget({}), {
 			wrapper: wrapperWithGlobalFilter(qc, {
-				type: "all",
+				...DEFAULT_GLOBAL_FILTER_VALUES,
+				storeId: "store-7",
+			}),
+		});
+		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(55));
+	});
+
+	it("global filter currencyId is forwarded to query", async () => {
+		const qc = createClient();
+		qc.setQueryData(
+			["session", "list", { ...DEFAULT_QUERY_INPUT, currencyId: "currency-1" }],
+			{ summary: { totalSessions: 66 } }
+		);
+		const { result } = renderHook(() => useSummaryStatsWidget({}), {
+			wrapper: wrapperWithGlobalFilter(qc, {
+				...DEFAULT_GLOBAL_FILTER_VALUES,
+				currencyId: "currency-1",
+			}),
+		});
+		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(66));
+	});
+
+	it("global filter dateFrom is converted to start-of-day epoch", async () => {
+		const qc = createClient();
+		const expectedDateFrom = Math.floor(
+			new Date("2026-01-01T00:00:00").getTime() / 1000
+		);
+		qc.setQueryData(
+			[
+				"session",
+				"list",
+				{ ...DEFAULT_QUERY_INPUT, dateFrom: expectedDateFrom },
+			],
+			{ summary: { totalSessions: 7 } }
+		);
+		const { result } = renderHook(() => useSummaryStatsWidget({}), {
+			wrapper: wrapperWithGlobalFilter(qc, {
+				...DEFAULT_GLOBAL_FILTER_VALUES,
+				dateFrom: "2026-01-01",
+			}),
+		});
+		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(7));
+	});
+
+	it("global filter dateTo is converted to end-of-day epoch", async () => {
+		const qc = createClient();
+		const expectedDateTo = Math.floor(
+			new Date("2026-12-31T23:59:59").getTime() / 1000
+		);
+		qc.setQueryData(
+			["session", "list", { ...DEFAULT_QUERY_INPUT, dateTo: expectedDateTo }],
+			{ summary: { totalSessions: 8 } }
+		);
+		const { result } = renderHook(() => useSummaryStatsWidget({}), {
+			wrapper: wrapperWithGlobalFilter(qc, {
+				...DEFAULT_GLOBAL_FILTER_VALUES,
+				dateTo: "2026-12-31",
+			}),
+		});
+		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(8));
+	});
+
+	it("global dateRangeDays converts to dateFrom (now - N*86400)", async () => {
+		const qc = createClient();
+		const dateFrom = Math.floor(Date.now() / 1000) - 7 * 86_400;
+		qc.setQueryData(["session", "list", { ...DEFAULT_QUERY_INPUT, dateFrom }], {
+			summary: { totalSessions: 22 },
+		});
+		const { result } = renderHook(() => useSummaryStatsWidget({}), {
+			wrapper: wrapperWithGlobalFilter(qc, {
+				...DEFAULT_GLOBAL_FILTER_VALUES,
 				dateRangeDays: 7,
 			}),
 		});
 		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(22));
 	});
 
-	it("global dateRangeDays overrides local dateRangeDays", async () => {
+	it("global dateRangeDays takes precedence over local dateRangeDays", async () => {
 		const qc = createClient();
 		const dateFrom = Math.floor(Date.now() / 1000) - 3 * 86_400;
-		qc.setQueryData(["session", "list", { type: undefined, dateFrom }], {
+		qc.setQueryData(["session", "list", { ...DEFAULT_QUERY_INPUT, dateFrom }], {
 			summary: { totalSessions: 33 },
 		});
 		const { result } = renderHook(
 			() => useSummaryStatsWidget({ dateRangeDays: 30 }),
 			{
 				wrapper: wrapperWithGlobalFilter(qc, {
-					type: "all",
+					...DEFAULT_GLOBAL_FILTER_VALUES,
 					dateRangeDays: 3,
 				}),
 			}
@@ -214,20 +298,15 @@ describe("useSummaryStatsWidget — global filter integration", () => {
 		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(33));
 	});
 
-	it("falls back to local when global is fully default", async () => {
+	it("falls back to local dateRangeDays when global is fully default", async () => {
 		const qc = createClient();
-		qc.setQueryData(
-			["session", "list", { type: "cash_game", dateFrom: undefined }],
-			{ summary: { totalSessions: 44 } }
-		);
+		const dateFrom = Math.floor(Date.now() / 1000) - 14 * 86_400;
+		qc.setQueryData(["session", "list", { ...DEFAULT_QUERY_INPUT, dateFrom }], {
+			summary: { totalSessions: 44 },
+		});
 		const { result } = renderHook(
-			() => useSummaryStatsWidget({ type: "cash_game" }),
-			{
-				wrapper: wrapperWithGlobalFilter(qc, {
-					type: "all",
-					dateRangeDays: null,
-				}),
-			}
+			() => useSummaryStatsWidget({ dateRangeDays: 14 }),
+			{ wrapper: wrapper(qc) }
 		);
 		await waitFor(() => expect(result.current.summary?.totalSessions).toBe(44));
 	});

--- a/apps/web/src/features/dashboard/widgets/summary-stats-widget/use-summary-stats-edit-form.ts
+++ b/apps/web/src/features/dashboard/widgets/summary-stats-widget/use-summary-stats-edit-form.ts
@@ -1,5 +1,6 @@
 import { useForm } from "@tanstack/react-form";
 import z from "zod";
+import { SESSION_TYPE_VALUES } from "@/features/dashboard/utils/session-filter";
 import type { WidgetEditProps } from "@/features/dashboard/widgets/registry";
 import { optionalNumericString } from "@/shared/lib/form-fields";
 import {
@@ -8,8 +9,6 @@ import {
 	type SummaryStatsMetricKey,
 	type SummaryStatsWidgetType,
 } from "./use-summary-stats-widget";
-
-const TYPE_VALUES = ["all", "cash_game", "tournament"] as const;
 
 const METRIC_VALUES: readonly SummaryStatsMetricKey[] = [
 	"totalSessions",
@@ -22,7 +21,7 @@ const METRIC_VALUES: readonly SummaryStatsMetricKey[] = [
 
 const editFormSchema = z.object({
 	metrics: z.array(z.enum(METRIC_VALUES)),
-	type: z.enum(TYPE_VALUES),
+	type: z.enum(SESSION_TYPE_VALUES),
 	dateRangeDays: optionalNumericString({ integer: true, min: 1 }),
 });
 

--- a/apps/web/src/features/dashboard/widgets/summary-stats-widget/use-summary-stats-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/summary-stats-widget/use-summary-stats-widget.ts
@@ -1,13 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
+import { useGlobalFilter } from "@/features/dashboard/hooks/use-global-filter";
 import {
-	resolveDateFromEpoch,
-	resolveDateToEpoch,
-	resolveSessionType,
-	useGlobalFilter,
-} from "@/features/dashboard/hooks/use-global-filter";
+	parseSessionFilterWidgetConfig,
+	resolveSessionListQueryInput,
+	type SessionFilterWidgetConfig,
+	type SessionTypeFilter,
+} from "@/features/dashboard/utils/session-filter";
 import { trpc } from "@/utils/trpc";
 
-export type SummaryStatsWidgetType = "all" | "cash_game" | "tournament";
+export type SummaryStatsWidgetType = SessionTypeFilter;
 
 export type SummaryStatsMetricKey =
 	| "totalSessions"
@@ -36,29 +37,21 @@ export const SUMMARY_STATS_DEFAULT_METRICS: SummaryStatsMetricKey[] = [
 	"avgProfitLoss",
 ];
 
-interface ParsedConfig {
-	dateRangeDays: number | null;
+interface ParsedConfig extends SessionFilterWidgetConfig {
 	metrics: SummaryStatsMetricKey[];
-	type: SummaryStatsWidgetType;
 }
 
 export function parseSummaryStatsWidgetConfig(
 	raw: Record<string, unknown>
 ): ParsedConfig {
+	const sessionFilter = parseSessionFilterWidgetConfig(raw);
 	const metricsRaw = Array.isArray(raw.metrics) ? raw.metrics : [];
 	const metrics = metricsRaw.filter((m): m is SummaryStatsMetricKey =>
 		SUMMARY_STATS_ALL_METRICS.some((am) => am.key === m)
 	);
-	const type =
-		raw.type === "cash_game" || raw.type === "tournament"
-			? (raw.type as SummaryStatsWidgetType)
-			: ("all" as SummaryStatsWidgetType);
-	const dateRangeDays =
-		typeof raw.dateRangeDays === "number" ? raw.dateRangeDays : null;
 	return {
+		...sessionFilter,
 		metrics: metrics.length > 0 ? metrics : SUMMARY_STATS_DEFAULT_METRICS,
-		type,
-		dateRangeDays,
 	};
 }
 
@@ -82,19 +75,9 @@ export function useSummaryStatsWidget(
 ): UseSummaryStatsWidgetResult {
 	const parsed = parseSummaryStatsWidgetConfig(config);
 	const globalFilter = useGlobalFilter();
-	const effectiveType = resolveSessionType(parsed.type, globalFilter);
-	const dateFrom = resolveDateFromEpoch(globalFilter, parsed.dateRangeDays);
-	const dateTo = resolveDateToEpoch(globalFilter);
+	const queryInput = resolveSessionListQueryInput(parsed, globalFilter);
 
-	const query = useQuery(
-		trpc.session.list.queryOptions({
-			type: effectiveType === "all" ? undefined : effectiveType,
-			storeId: globalFilter.storeId ?? undefined,
-			currencyId: globalFilter.currencyId ?? undefined,
-			dateFrom,
-			dateTo,
-		})
-	);
+	const query = useQuery(trpc.session.list.queryOptions(queryInput));
 
 	return {
 		isLoading: query.isLoading,

--- a/apps/web/src/features/dashboard/widgets/summary-stats-widget/use-summary-stats-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/summary-stats-widget/use-summary-stats-widget.ts
@@ -1,4 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
+import {
+	resolveDateRangeDaysFilter,
+	resolveSessionTypeFilter,
+	useGlobalFilter,
+} from "@/features/dashboard/hooks/use-global-filter";
 import { trpc } from "@/utils/trpc";
 
 export type SummaryStatsWidgetType = "all" | "cash_game" | "tournament";
@@ -75,14 +80,20 @@ export function useSummaryStatsWidget(
 	config: Record<string, unknown>
 ): UseSummaryStatsWidgetResult {
 	const parsed = parseSummaryStatsWidgetConfig(config);
+	const globalFilter = useGlobalFilter();
+	const effectiveType = resolveSessionTypeFilter(parsed.type, globalFilter);
+	const effectiveDateRangeDays = resolveDateRangeDaysFilter(
+		parsed.dateRangeDays,
+		globalFilter
+	);
 	const dateFrom =
-		parsed.dateRangeDays === null
+		effectiveDateRangeDays === null
 			? undefined
-			: Math.floor(Date.now() / 1000) - parsed.dateRangeDays * 86_400;
+			: Math.floor(Date.now() / 1000) - effectiveDateRangeDays * 86_400;
 
 	const query = useQuery(
 		trpc.session.list.queryOptions({
-			type: parsed.type === "all" ? undefined : parsed.type,
+			type: effectiveType === "all" ? undefined : effectiveType,
 			dateFrom,
 		})
 	);

--- a/apps/web/src/features/dashboard/widgets/summary-stats-widget/use-summary-stats-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/summary-stats-widget/use-summary-stats-widget.ts
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import {
-	resolveDateRangeDaysFilter,
-	resolveSessionTypeFilter,
+	resolveDateFromEpoch,
+	resolveDateToEpoch,
+	resolveSessionType,
 	useGlobalFilter,
 } from "@/features/dashboard/hooks/use-global-filter";
 import { trpc } from "@/utils/trpc";
@@ -81,20 +82,17 @@ export function useSummaryStatsWidget(
 ): UseSummaryStatsWidgetResult {
 	const parsed = parseSummaryStatsWidgetConfig(config);
 	const globalFilter = useGlobalFilter();
-	const effectiveType = resolveSessionTypeFilter(parsed.type, globalFilter);
-	const effectiveDateRangeDays = resolveDateRangeDaysFilter(
-		parsed.dateRangeDays,
-		globalFilter
-	);
-	const dateFrom =
-		effectiveDateRangeDays === null
-			? undefined
-			: Math.floor(Date.now() / 1000) - effectiveDateRangeDays * 86_400;
+	const effectiveType = resolveSessionType(parsed.type, globalFilter);
+	const dateFrom = resolveDateFromEpoch(globalFilter, parsed.dateRangeDays);
+	const dateTo = resolveDateToEpoch(globalFilter);
 
 	const query = useQuery(
 		trpc.session.list.queryOptions({
 			type: effectiveType === "all" ? undefined : effectiveType,
+			storeId: globalFilter.storeId ?? undefined,
+			currencyId: globalFilter.currencyId ?? undefined,
 			dateFrom,
+			dateTo,
 		})
 	);
 

--- a/apps/web/vitest.node.config.ts
+++ b/apps/web/vitest.node.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
 			"src/utils/__tests__/*.test.ts",
 			"src/shared/lib/**/__tests__/*.test.ts",
 			"src/features/currencies/utils/__tests__/*.test.ts",
+			"src/features/dashboard/utils/__tests__/*.test.ts",
 			"src/features/live-sessions/utils/__tests__/*.test.ts",
 			"src/features/sessions/utils/__tests__/session-filters-helpers.test.ts",
 			"src/features/sessions/utils/__tests__/session-form-helpers.test.ts",

--- a/packages/api/src/__tests__/dashboard-widget.test.ts
+++ b/packages/api/src/__tests__/dashboard-widget.test.ts
@@ -215,31 +215,88 @@ describe("widget config parsing", () => {
 		expect(stringifyWidgetConfig(undefined)).toBe("{}");
 	});
 
-	it("returns defaults for global_filter when config is empty", () => {
-		const parsed = parseWidgetConfig("global_filter", "{}") as {
-			type: string;
-			dateRangeDays: number | null;
-		};
-		expect(parsed.type).toBe("all");
-		expect(parsed.dateRangeDays).toBeNull();
+	it("returns per-field defaults for global_filter when config is empty", () => {
+		const parsed = parseWidgetConfig("global_filter", "{}") as Record<
+			string,
+			{ initialValue: unknown; visible: boolean }
+		>;
+		for (const key of [
+			"type",
+			"storeId",
+			"currencyId",
+			"dateFrom",
+			"dateTo",
+			"dateRangeDays",
+		]) {
+			expect(parsed[key]).toEqual({ initialValue: null, visible: true });
+		}
 	});
 
-	it("preserves valid global_filter values", () => {
+	it("preserves valid global_filter values across all fields", () => {
 		const parsed = parseWidgetConfig(
 			"global_filter",
-			JSON.stringify({ type: "cash_game", dateRangeDays: 14 })
-		) as { type: string; dateRangeDays: number | null };
-		expect(parsed.type).toBe("cash_game");
-		expect(parsed.dateRangeDays).toBe(14);
+			JSON.stringify({
+				type: { initialValue: "cash_game", visible: true },
+				storeId: { initialValue: "store-1", visible: false },
+				currencyId: { initialValue: "currency-1", visible: true },
+				dateFrom: { initialValue: "2026-01-01", visible: true },
+				dateTo: { initialValue: "2026-12-31", visible: false },
+				dateRangeDays: { initialValue: 30, visible: true },
+			})
+		) as Record<string, { initialValue: unknown; visible: boolean }>;
+		expect(parsed.type).toEqual({ initialValue: "cash_game", visible: true });
+		expect(parsed.storeId).toEqual({
+			initialValue: "store-1",
+			visible: false,
+		});
+		expect(parsed.currencyId).toEqual({
+			initialValue: "currency-1",
+			visible: true,
+		});
+		expect(parsed.dateFrom).toEqual({
+			initialValue: "2026-01-01",
+			visible: true,
+		});
+		expect(parsed.dateTo).toEqual({
+			initialValue: "2026-12-31",
+			visible: false,
+		});
+		expect(parsed.dateRangeDays).toEqual({
+			initialValue: 30,
+			visible: true,
+		});
 	});
 
 	it("falls back to defaults for global_filter when values are invalid", () => {
 		const parsed = parseWidgetConfig(
 			"global_filter",
-			JSON.stringify({ type: "weird", dateRangeDays: -5 })
-		) as { type: string; dateRangeDays: number | null };
-		expect(parsed.type).toBe("all");
-		expect(parsed.dateRangeDays).toBeNull();
+			JSON.stringify({
+				type: { initialValue: "weird", visible: true },
+				dateRangeDays: { initialValue: -5, visible: true },
+			})
+		) as Record<string, { initialValue: unknown; visible: boolean }>;
+		expect(parsed.type).toEqual({ initialValue: null, visible: true });
+		expect(parsed.dateRangeDays).toEqual({
+			initialValue: null,
+			visible: true,
+		});
+	});
+
+	it("respects visible=false on global_filter fields", () => {
+		const parsed = parseWidgetConfig(
+			"global_filter",
+			JSON.stringify({ type: { initialValue: null, visible: false } })
+		) as Record<string, { initialValue: unknown; visible: boolean }>;
+		expect(parsed.type.visible).toBe(false);
+	});
+
+	it("preserves null initialValue on global_filter fields", () => {
+		const parsed = parseWidgetConfig(
+			"global_filter",
+			JSON.stringify({ storeId: { initialValue: null, visible: true } })
+		) as Record<string, { initialValue: unknown; visible: boolean }>;
+		expect(parsed.storeId.initialValue).toBeNull();
+		expect(parsed.storeId.visible).toBe(true);
 	});
 });
 

--- a/packages/api/src/__tests__/dashboard-widget.test.ts
+++ b/packages/api/src/__tests__/dashboard-widget.test.ts
@@ -214,4 +214,37 @@ describe("widget config parsing", () => {
 		expect(stringifyWidgetConfig(null)).toBe("{}");
 		expect(stringifyWidgetConfig(undefined)).toBe("{}");
 	});
+
+	it("returns defaults for global_filter when config is empty", () => {
+		const parsed = parseWidgetConfig("global_filter", "{}") as {
+			type: string;
+			dateRangeDays: number | null;
+		};
+		expect(parsed.type).toBe("all");
+		expect(parsed.dateRangeDays).toBeNull();
+	});
+
+	it("preserves valid global_filter values", () => {
+		const parsed = parseWidgetConfig(
+			"global_filter",
+			JSON.stringify({ type: "cash_game", dateRangeDays: 14 })
+		) as { type: string; dateRangeDays: number | null };
+		expect(parsed.type).toBe("cash_game");
+		expect(parsed.dateRangeDays).toBe(14);
+	});
+
+	it("falls back to defaults for global_filter when values are invalid", () => {
+		const parsed = parseWidgetConfig(
+			"global_filter",
+			JSON.stringify({ type: "weird", dateRangeDays: -5 })
+		) as { type: string; dateRangeDays: number | null };
+		expect(parsed.type).toBe("all");
+		expect(parsed.dateRangeDays).toBeNull();
+	});
+});
+
+describe("widget type schema", () => {
+	it("includes global_filter as a valid type", () => {
+		expect(widgetTypeSchema.options).toContain("global_filter");
+	});
 });

--- a/packages/api/src/types/dashboard-widget.ts
+++ b/packages/api/src/types/dashboard-widget.ts
@@ -8,6 +8,7 @@ export const widgetTypeSchema = z.enum([
 	"recent_sessions",
 	"active_session",
 	"currency_balance",
+	"global_filter",
 ]);
 export type WidgetType = z.infer<typeof widgetTypeSchema>;
 
@@ -53,11 +54,18 @@ export const currencyBalanceConfigSchema = z.object({
 });
 export type CurrencyBalanceConfig = z.infer<typeof currencyBalanceConfigSchema>;
 
+export const globalFilterConfigSchema = z.object({
+	type: z.enum(["all", "cash_game", "tournament"]).default("all"),
+	dateRangeDays: z.number().int().min(1).max(3650).nullable().default(null),
+});
+export type GlobalFilterConfig = z.infer<typeof globalFilterConfigSchema>;
+
 export const widgetConfigSchema = z.union([
 	summaryStatsConfigSchema,
 	recentSessionsConfigSchema,
 	activeSessionConfigSchema,
 	currencyBalanceConfigSchema,
+	globalFilterConfigSchema,
 ]);
 
 const configSchemaByType = {
@@ -65,6 +73,7 @@ const configSchemaByType = {
 	recent_sessions: recentSessionsConfigSchema,
 	active_session: activeSessionConfigSchema,
 	currency_balance: currencyBalanceConfigSchema,
+	global_filter: globalFilterConfigSchema,
 } as const;
 
 export function parseWidgetConfig(

--- a/packages/api/src/types/dashboard-widget.ts
+++ b/packages/api/src/types/dashboard-widget.ts
@@ -54,9 +54,24 @@ export const currencyBalanceConfigSchema = z.object({
 });
 export type CurrencyBalanceConfig = z.infer<typeof currencyBalanceConfigSchema>;
 
+const FILTER_FIELD_DEFAULT = { initialValue: null, visible: true } as const;
+
+function filterField<T extends z.ZodTypeAny>(value: T) {
+	return z
+		.object({
+			initialValue: value.nullable().default(null),
+			visible: z.boolean().default(true),
+		})
+		.default(FILTER_FIELD_DEFAULT);
+}
+
 export const globalFilterConfigSchema = z.object({
-	type: z.enum(["all", "cash_game", "tournament"]).default("all"),
-	dateRangeDays: z.number().int().min(1).max(3650).nullable().default(null),
+	type: filterField(z.enum(["cash_game", "tournament"])),
+	storeId: filterField(z.string()),
+	currencyId: filterField(z.string()),
+	dateFrom: filterField(z.string()),
+	dateTo: filterField(z.string()),
+	dateRangeDays: filterField(z.number().int().min(1).max(3650)),
 });
 export type GlobalFilterConfig = z.infer<typeof globalFilterConfigSchema>;
 


### PR DESCRIPTION
Closed in favor of a broader redesign tracked at SA2-17.

Scope of this PR was too narrow (only `type` + `dateRangeDays`); the new branch generalizes the spec to `{type, storeId, currencyId, tagIds, period}` with `{initialValue, visible}` per field, mode-exclusive period (rolling units / bucket presets), and threads `tagIds` through `session.list`. Plan: `/root/.claude/plans/parsed-wishing-rossum.md`.