### PR TITLE
fix(events): floor table-player join/leave occurredAt and use session-wide sortOrder

### DIFF
--- a/packages/api/src/__tests__/session-table-player.test.ts
+++ b/packages/api/src/__tests__/session-table-player.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { appRouter } from "../routers";
+import {
+	insertPlayerJoinEvent,
+	insertPlayerLeaveEvent,
+} from "../routers/session-table-player";
 import {
 	expectAccepts,
 	expectProtected,
@@ -237,6 +241,151 @@ describe("sessionTablePlayer.addTemporary input validation", () => {
 		expectRejects(appRouter.sessionTablePlayer.addTemporary, {
 			liveCashGameSessionId: "lcg1",
 			seatPosition: 9,
+		});
+	});
+});
+
+function makeInsertEventDb(maxSortOrder: number | null) {
+	const valuesSpy = vi.fn().mockResolvedValue(undefined);
+	const insertSpy = vi.fn().mockReturnValue({ values: valuesSpy });
+	const whereSpy = vi.fn().mockResolvedValue([{ maxSortOrder }]);
+	const fromSpy = vi.fn().mockReturnValue({ where: whereSpy });
+	const selectSpy = vi.fn().mockReturnValue({ from: fromSpy });
+	return {
+		db: { select: selectSpy, insert: insertSpy },
+		valuesSpy,
+		insertSpy,
+		whereSpy,
+		fromSpy,
+		selectSpy,
+	};
+}
+
+function firstInsertedRow(valuesSpy: ReturnType<typeof vi.fn>) {
+	const calls = valuesSpy.mock.calls;
+	if (calls.length === 0 || !calls[0] || calls[0].length === 0) {
+		throw new Error("expected values() to have been called at least once");
+	}
+	return calls[0][0] as Record<string, unknown>;
+}
+
+describe("insertPlayerJoinEvent (write-side ordering contract)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-24T17:30:45.123Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("floors occurredAt to the minute (no leaked seconds or ms)", async () => {
+		const { db, valuesSpy } = makeInsertEventDb(null);
+		await insertPlayerJoinEvent(
+			db as unknown as Parameters<typeof insertPlayerJoinEvent>[0],
+			"session-1",
+			"player-1"
+		);
+
+		expect(valuesSpy).toHaveBeenCalledTimes(1);
+		const inserted = firstInsertedRow(valuesSpy);
+		expect(inserted.eventType).toBe("player_join");
+		expect((inserted.occurredAt as Date).toISOString()).toBe(
+			"2026-04-24T17:30:00.000Z"
+		);
+	});
+
+	it("returns sortOrder = 0 only when the session has no events", async () => {
+		const { db, valuesSpy } = makeInsertEventDb(null);
+		await insertPlayerJoinEvent(
+			db as unknown as Parameters<typeof insertPlayerJoinEvent>[0],
+			"session-1",
+			"player-1"
+		);
+		expect(firstInsertedRow(valuesSpy).sortOrder).toBe(0);
+	});
+
+	it("uses session-wide max(sortOrder) + 1, not a per-second scope", async () => {
+		// Pre-existing event with sortOrder=5 at a different second.
+		// The bug it guards against: scoping max(sortOrder) by `unixepoch(occurredAt) = nowUnix`
+		// returned 0 here, colliding with the real session_start at sortOrder=0.
+		const { db, valuesSpy } = makeInsertEventDb(5);
+		await insertPlayerJoinEvent(
+			db as unknown as Parameters<typeof insertPlayerJoinEvent>[0],
+			"session-1",
+			"player-1"
+		);
+		expect(firstInsertedRow(valuesSpy).sortOrder).toBe(6);
+	});
+
+	it("treats max(sortOrder) = 0 as a real value (returns 1)", async () => {
+		const { db, valuesSpy } = makeInsertEventDb(0);
+		await insertPlayerJoinEvent(
+			db as unknown as Parameters<typeof insertPlayerJoinEvent>[0],
+			"session-1",
+			"player-1"
+		);
+		expect(firstInsertedRow(valuesSpy).sortOrder).toBe(1);
+	});
+
+	it("serializes the playerId into the payload", async () => {
+		const { db, valuesSpy } = makeInsertEventDb(2);
+		await insertPlayerJoinEvent(
+			db as unknown as Parameters<typeof insertPlayerJoinEvent>[0],
+			"session-1",
+			"player-xyz"
+		);
+		const inserted = firstInsertedRow(valuesSpy);
+		expect(JSON.parse(inserted.payload as string)).toEqual({
+			playerId: "player-xyz",
+		});
+	});
+});
+
+describe("insertPlayerLeaveEvent (write-side ordering contract)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-24T23:59:59.999Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("floors occurredAt to the minute even at the end-of-day boundary", async () => {
+		const { db, valuesSpy } = makeInsertEventDb(3);
+		await insertPlayerLeaveEvent(
+			db as unknown as Parameters<typeof insertPlayerLeaveEvent>[0],
+			"session-1",
+			"player-1"
+		);
+		const inserted = firstInsertedRow(valuesSpy);
+		expect(inserted.eventType).toBe("player_leave");
+		expect((inserted.occurredAt as Date).toISOString()).toBe(
+			"2026-04-24T23:59:00.000Z"
+		);
+	});
+
+	it("appends with session-wide max(sortOrder) + 1", async () => {
+		const { db, valuesSpy } = makeInsertEventDb(9);
+		await insertPlayerLeaveEvent(
+			db as unknown as Parameters<typeof insertPlayerLeaveEvent>[0],
+			"session-1",
+			"player-1"
+		);
+		expect(firstInsertedRow(valuesSpy).sortOrder).toBe(10);
+	});
+
+	it("serializes the playerId into the payload", async () => {
+		const { db, valuesSpy } = makeInsertEventDb(0);
+		await insertPlayerLeaveEvent(
+			db as unknown as Parameters<typeof insertPlayerLeaveEvent>[0],
+			"session-1",
+			"player-abc"
+		);
+		const inserted = firstInsertedRow(valuesSpy);
+		expect(JSON.parse(inserted.payload as string)).toEqual({
+			playerId: "player-abc",
 		});
 	});
 });

--- a/packages/api/src/routers/session-event.ts
+++ b/packages/api/src/routers/session-event.ts
@@ -15,7 +15,7 @@ import { sessionEvent } from "@sapphire2/db/schema/session-event";
 import { sessionTablePlayer } from "@sapphire2/db/schema/session-table-player";
 import { sessionTournamentDetail } from "@sapphire2/db/schema/session-tournament-detail";
 import { TRPCError } from "@trpc/server";
-import { and, asc, eq, max } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
 import {
@@ -25,6 +25,7 @@ import {
 import {
 	assertOccurredAtOrdering,
 	floorToMinute,
+	nextAppendSortOrder,
 } from "../utils/session-event-time";
 
 type DbInstance = Parameters<
@@ -73,18 +74,6 @@ async function resolveSessionOwnership(
 		status: session.status,
 		sessionDate: session.sessionDate,
 	};
-}
-
-async function nextAppendSortOrder(
-	db: DbInstance,
-	sessionId: string
-): Promise<number> {
-	const [row] = await db
-		.select({ maxSortOrder: max(sessionEvent.sortOrder) })
-		.from(sessionEvent)
-		.where(eq(sessionEvent.sessionId, sessionId));
-
-	return row?.maxSortOrder == null ? 0 : row.maxSortOrder + 1;
 }
 
 async function handlePlayerJoinSideEffect(

--- a/packages/api/src/routers/session-table-player.ts
+++ b/packages/api/src/routers/session-table-player.ts
@@ -12,9 +12,13 @@ import { sessionTournamentDetail } from "@sapphire2/db/schema/session-tournament
 import { store } from "@sapphire2/db/schema/store";
 import { tournament } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
-import { and, asc, eq, max, sql } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
+import {
+	floorToMinute,
+	nextAppendSortOrder,
+} from "../utils/session-event-time";
 
 type DbInstance = Parameters<
 	Parameters<typeof protectedProcedure.query>[0]
@@ -113,64 +117,38 @@ async function fetchSessionContext(
 	return { storeName, gameName };
 }
 
-async function insertPlayerJoinEvent(
+export async function insertPlayerJoinEvent(
 	db: DbInstance,
 	sessionId: string,
 	playerId: string
 ) {
 	const now = new Date();
-	const nowUnix = Math.floor(now.getTime() / 1000);
-
-	const [maxResult] = await db
-		.select({ maxSortOrder: max(sessionEvent.sortOrder) })
-		.from(sessionEvent)
-		.where(
-			and(
-				eq(sessionEvent.sessionId, sessionId),
-				sql`(unixepoch(${sessionEvent.occurredAt})) = ${nowUnix}`
-			)
-		);
-
-	const sortOrder =
-		maxResult?.maxSortOrder == null ? 0 : maxResult.maxSortOrder + 1;
+	const sortOrder = await nextAppendSortOrder(db, sessionId);
 
 	await db.insert(sessionEvent).values({
 		id: crypto.randomUUID(),
 		sessionId,
 		eventType: "player_join",
-		occurredAt: now,
+		occurredAt: floorToMinute(now),
 		sortOrder,
 		payload: JSON.stringify({ playerId }),
 		updatedAt: now,
 	});
 }
 
-async function insertPlayerLeaveEvent(
+export async function insertPlayerLeaveEvent(
 	db: DbInstance,
 	sessionId: string,
 	playerId: string
 ) {
 	const now = new Date();
-	const nowUnix = Math.floor(now.getTime() / 1000);
-
-	const [maxResult] = await db
-		.select({ maxSortOrder: max(sessionEvent.sortOrder) })
-		.from(sessionEvent)
-		.where(
-			and(
-				eq(sessionEvent.sessionId, sessionId),
-				sql`(unixepoch(${sessionEvent.occurredAt})) = ${nowUnix}`
-			)
-		);
-
-	const sortOrder =
-		maxResult?.maxSortOrder == null ? 0 : maxResult.maxSortOrder + 1;
+	const sortOrder = await nextAppendSortOrder(db, sessionId);
 
 	await db.insert(sessionEvent).values({
 		id: crypto.randomUUID(),
 		sessionId,
 		eventType: "player_leave",
-		occurredAt: now,
+		occurredAt: floorToMinute(now),
 		sortOrder,
 		payload: JSON.stringify({ playerId }),
 		updatedAt: now,

--- a/packages/api/src/utils/__tests__/session-event-time.test.ts
+++ b/packages/api/src/utils/__tests__/session-event-time.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { floorToMinute } from "../session-event-time";
+import { describe, expect, it, vi } from "vitest";
+import { floorToMinute, nextAppendSortOrder } from "../session-event-time";
 
 describe("floorToMinute", () => {
 	it("zeroes out seconds and milliseconds", () => {
@@ -31,5 +31,68 @@ describe("floorToMinute", () => {
 		const a = floorToMinute(new Date("2026-04-24T10:30:05.000Z"));
 		const b = floorToMinute(new Date("2026-04-24T10:30:55.000Z"));
 		expect(a.getTime()).toBe(b.getTime());
+	});
+});
+
+function makeMaxSortOrderDb(rows: { maxSortOrder: number | null }[]) {
+	const whereSpy = vi.fn().mockResolvedValue(rows);
+	const fromSpy = vi.fn().mockReturnValue({ where: whereSpy });
+	const selectSpy = vi.fn().mockReturnValue({ from: fromSpy });
+	return {
+		db: { select: selectSpy },
+		whereSpy,
+		fromSpy,
+		selectSpy,
+	};
+}
+
+describe("nextAppendSortOrder", () => {
+	it("returns 0 when the session has no events", async () => {
+		const { db } = makeMaxSortOrderDb([{ maxSortOrder: null }]);
+		const result = await nextAppendSortOrder(
+			db as unknown as Parameters<typeof nextAppendSortOrder>[0],
+			"session-1"
+		);
+		expect(result).toBe(0);
+	});
+
+	it("returns 0 when select returns an empty array", async () => {
+		const { db } = makeMaxSortOrderDb([]);
+		const result = await nextAppendSortOrder(
+			db as unknown as Parameters<typeof nextAppendSortOrder>[0],
+			"session-1"
+		);
+		expect(result).toBe(0);
+	});
+
+	it("returns max(sortOrder) + 1 when events exist", async () => {
+		const { db } = makeMaxSortOrderDb([{ maxSortOrder: 7 }]);
+		const result = await nextAppendSortOrder(
+			db as unknown as Parameters<typeof nextAppendSortOrder>[0],
+			"session-1"
+		);
+		expect(result).toBe(8);
+	});
+
+	it("treats sortOrder = 0 as a real value (returns 1, not 0)", async () => {
+		const { db } = makeMaxSortOrderDb([{ maxSortOrder: 0 }]);
+		const result = await nextAppendSortOrder(
+			db as unknown as Parameters<typeof nextAppendSortOrder>[0],
+			"session-1"
+		);
+		expect(result).toBe(1);
+	});
+
+	it("calls select().from() exactly once and where() exactly once", async () => {
+		const { db, fromSpy, whereSpy, selectSpy } = makeMaxSortOrderDb([
+			{ maxSortOrder: 3 },
+		]);
+		await nextAppendSortOrder(
+			db as unknown as Parameters<typeof nextAppendSortOrder>[0],
+			"session-1"
+		);
+		expect(selectSpy).toHaveBeenCalledTimes(1);
+		expect(fromSpy).toHaveBeenCalledTimes(1);
+		expect(whereSpy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/api/src/utils/session-event-time.ts
+++ b/packages/api/src/utils/session-event-time.ts
@@ -1,6 +1,6 @@
 import { sessionEvent } from "@sapphire2/db/schema/session-event";
 import { TRPCError } from "@trpc/server";
-import { and, asc, desc, eq, gt, lt } from "drizzle-orm";
+import { and, asc, desc, eq, gt, lt, max } from "drizzle-orm";
 import type { protectedProcedure } from "../index";
 
 type DbInstance = Parameters<
@@ -11,6 +11,18 @@ export function floorToMinute(date: Date): Date {
 	const copy = new Date(date);
 	copy.setSeconds(0, 0);
 	return copy;
+}
+
+export async function nextAppendSortOrder(
+	db: DbInstance,
+	sessionId: string
+): Promise<number> {
+	const [row] = await db
+		.select({ maxSortOrder: max(sessionEvent.sortOrder) })
+		.from(sessionEvent)
+		.where(eq(sessionEvent.sessionId, sessionId));
+
+	return row?.maxSortOrder == null ? 0 : row.maxSortOrder + 1;
 }
 
 function minuteEpoch(date: Date): number {


### PR DESCRIPTION
## Summary

`packages/api/src/routers/session-table-player.ts` was the only event writer never migrated when commit `db100c4` ("make sortOrder the sole event ordering key, floor occurredAt to minute") changed the conventions. Its `insertPlayerJoinEvent` / `insertPlayerLeaveEvent` were still running the pre-migration logic:

- `occurredAt: now` was persisted with seconds + milliseconds intact, while every other writer floors to the minute.
- `max(sortOrder)` was scoped by `unixepoch(occurredAt) = nowUnix`, so a fresh table-player join landed at sortOrder=0 and collided with the `session_start` that already owns sortOrder=0.

## Why the recording order looked wrong

Read paths order events by `(occurredAt ASC, sortOrder ASC)` (see `session-event.ts:189`, `live-cash-game-session.ts:248/287/708`, `live-tournament-session.ts:525/573/858`, `live-session-pl.ts:295/410`, `session-table-player.ts:196`).

Mixing one floored timestamp with one non-floored timestamp at the same minute breaks that ordering:

```
17:30:00 (floored) sortOrder=N   ← chips_add_remove (created later)
17:30:30 (raw)     sortOrder=0   ← player_join (created earlier)
```

The chips event sorts before the player_join even though the user pressed "Add player" first. P&L recalculation walks the same order, so cashed/active state can swap. Worse, multiple table-player joins in close succession could each collide on sortOrder=0, making the order non-deterministic.

## Fix

- Promote `nextAppendSortOrder` to `utils/session-event-time.ts` so every writer shares one append convention; drop the duplicate from `session-event.ts`.
- Rewrite both helpers in `session-table-player.ts` to floor `now` via `floorToMinute` and to use the session-wide `nextAppendSortOrder`.
- Export the helpers so the contract can be locked in by unit tests.

## Tests

New tests in `packages/api/src/utils/__tests__/session-event-time.test.ts` and `packages/api/src/__tests__/session-table-player.test.ts` cover:

- `nextAppendSortOrder`: empty-session → 0, sortOrder=0 → 1, max=N → N+1, single-query shape.
- `insertPlayerJoinEvent` / `insertPlayerLeaveEvent`: occurredAt floored to the minute (incl. day boundary), session-wide max(sortOrder)+1 (the regression: pre-fix returned 0 here), payload shape, eventType.

## Test plan

- [x] `bunx vitest run --project api` — 542 passed
- [x] `bunx ultracite check packages/api` — clean
- [x] `bunx tsc --noEmit` — only the two pre-existing errors remain (`live-session-pl.test.ts:786`, `db/src/index.ts:4`); both are unrelated to this change

https://claude.ai/code/session_01KYA2XRDF4JMMCKYHrEnJ7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYA2XRDF4JMMCKYHrEnJ7J)_