### PR TITLE
fix: SA2-14 redirect home page, SA2-16 pre-populate stack modal from last event

### DIFF
--- a/apps/web/src/features/live-sessions/components/live-stack-form-sheet/__tests__/use-live-stack-form-sheet.test.ts
+++ b/apps/web/src/features/live-sessions/components/live-stack-form-sheet/__tests__/use-live-stack-form-sheet.test.ts
@@ -9,20 +9,90 @@ import { StackSheetProvider } from "@/features/live-sessions/hooks/use-stack-she
 
 const STACK_SHEET_PROVIDER_RE = /StackSheetProvider/;
 
+const mocks = vi.hoisted(() => ({
+	setStackAmount: vi.fn(),
+	setRemainingPlayers: vi.fn(),
+	setTotalEntries: vi.fn(),
+	cashSummary: undefined as Record<string, unknown> | undefined,
+	tournamentSummary: undefined as Record<string, unknown> | undefined,
+}));
+
+vi.mock("@/features/live-sessions/hooks/use-session-form", () => ({
+	useStackFormContext: () => ({
+		state: { stackAmount: "", allIns: [] },
+		setStackAmount: mocks.setStackAmount,
+		setAllIns: vi.fn(),
+	}),
+	useTournamentFormContext: () => ({
+		state: {
+			stackAmount: "",
+			remainingPlayers: "",
+			totalEntries: "",
+			chipPurchaseCounts: [],
+		},
+		setStackAmount: mocks.setStackAmount,
+		setRemainingPlayers: mocks.setRemainingPlayers,
+		setTotalEntries: mocks.setTotalEntries,
+		setChipPurchaseCounts: vi.fn(),
+	}),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+	useQuery: (options: { queryKey?: unknown[] }) => {
+		const key = options.queryKey?.[0];
+		if (key === "liveCashGameSession.getById") {
+			return {
+				data: mocks.cashSummary ? { summary: mocks.cashSummary } : undefined,
+			};
+		}
+		if (key === "liveTournamentSession.getById") {
+			return {
+				data: mocks.tournamentSummary
+					? { summary: mocks.tournamentSummary }
+					: undefined,
+			};
+		}
+		return { data: undefined };
+	},
+}));
+
+vi.mock("@/utils/trpc", () => ({
+	trpc: {
+		liveCashGameSession: {
+			getById: {
+				queryOptions: ({ id }: { id: string }) => ({
+					queryKey: ["liveCashGameSession.getById", id],
+				}),
+			},
+		},
+		liveTournamentSession: {
+			getById: {
+				queryOptions: ({ id }: { id: string }) => ({
+					queryKey: ["liveTournamentSession.getById", id],
+				}),
+			},
+		},
+	},
+}));
+
 function wrapper({ children }: { children: ReactNode }) {
 	return createElement(StackSheetProvider, null, children);
 }
 
 describe("useCashGameStackSheet", () => {
 	it("initialises isCompleteOpen=false and defaultFinalStack=undefined, exposes StackSheet from context", () => {
-		const { result } = renderHook(() => useCashGameStackSheet(), { wrapper });
+		const { result } = renderHook(() => useCashGameStackSheet("s1"), {
+			wrapper,
+		});
 		expect(result.current.isCompleteOpen).toBe(false);
 		expect(result.current.defaultFinalStack).toBeUndefined();
 		expect(result.current.stackSheet.isOpen).toBe(false);
 	});
 
 	it("setIsCompleteOpen toggles independently of the stack sheet", () => {
-		const { result } = renderHook(() => useCashGameStackSheet(), { wrapper });
+		const { result } = renderHook(() => useCashGameStackSheet("s1"), {
+			wrapper,
+		});
 		act(() => {
 			result.current.setIsCompleteOpen(true);
 		});
@@ -31,7 +101,9 @@ describe("useCashGameStackSheet", () => {
 	});
 
 	it("setDefaultFinalStack updates the default value", () => {
-		const { result } = renderHook(() => useCashGameStackSheet(), { wrapper });
+		const { result } = renderHook(() => useCashGameStackSheet("s1"), {
+			wrapper,
+		});
 		act(() => {
 			result.current.setDefaultFinalStack(5000);
 		});
@@ -39,7 +111,9 @@ describe("useCashGameStackSheet", () => {
 	});
 
 	it("stackSheet.open / close flips isOpen on the underlying sheet", () => {
-		const { result } = renderHook(() => useCashGameStackSheet(), { wrapper });
+		const { result } = renderHook(() => useCashGameStackSheet("s1"), {
+			wrapper,
+		});
 		act(() => {
 			result.current.stackSheet.open();
 		});
@@ -51,20 +125,108 @@ describe("useCashGameStackSheet", () => {
 	});
 
 	it("throws outside of StackSheetProvider", () => {
-		// Suppress the expected error being logged.
 		const spy = vi.spyOn(console, "error").mockImplementation(() => {
 			/* noop */
 		});
-		expect(() => renderHook(() => useCashGameStackSheet())).toThrow(
+		expect(() => renderHook(() => useCashGameStackSheet("s1"))).toThrow(
 			STACK_SHEET_PROVIDER_RE
 		);
 		spy.mockRestore();
+	});
+
+	describe("pre-population on open", () => {
+		it("sets stackAmount from currentStack when sheet opens", () => {
+			mocks.cashSummary = { currentStack: 3000 };
+			mocks.setStackAmount.mockReset();
+			const { result } = renderHook(() => useCashGameStackSheet("s1"), {
+				wrapper,
+			});
+			act(() => {
+				result.current.stackSheet.open();
+			});
+			expect(mocks.setStackAmount).toHaveBeenCalledOnce();
+			expect(mocks.setStackAmount).toHaveBeenCalledWith("3000");
+		});
+
+		it("falls back to totalBuyIn when currentStack is null", () => {
+			mocks.cashSummary = { currentStack: null, totalBuyIn: 5000 };
+			mocks.setStackAmount.mockReset();
+			const { result } = renderHook(() => useCashGameStackSheet("s1"), {
+				wrapper,
+			});
+			act(() => {
+				result.current.stackSheet.open();
+			});
+			expect(mocks.setStackAmount).toHaveBeenCalledOnce();
+			expect(mocks.setStackAmount).toHaveBeenCalledWith("5000");
+		});
+
+		it("does not call setStackAmount when summary is empty", () => {
+			mocks.cashSummary = {};
+			mocks.setStackAmount.mockReset();
+			const { result } = renderHook(() => useCashGameStackSheet("s1"), {
+				wrapper,
+			});
+			act(() => {
+				result.current.stackSheet.open();
+			});
+			expect(mocks.setStackAmount).not.toHaveBeenCalled();
+		});
+
+		it("does not call setStackAmount when session data is undefined", () => {
+			mocks.cashSummary = undefined;
+			mocks.setStackAmount.mockReset();
+			const { result } = renderHook(() => useCashGameStackSheet("s1"), {
+				wrapper,
+			});
+			act(() => {
+				result.current.stackSheet.open();
+			});
+			expect(mocks.setStackAmount).not.toHaveBeenCalled();
+		});
+
+		it("does not re-populate while sheet remains open", () => {
+			mocks.cashSummary = { currentStack: 3000 };
+			mocks.setStackAmount.mockReset();
+			const { result } = renderHook(() => useCashGameStackSheet("s1"), {
+				wrapper,
+			});
+			act(() => {
+				result.current.stackSheet.open();
+			});
+			expect(mocks.setStackAmount).toHaveBeenCalledOnce();
+			// Simulate another render without closing: setIsOpen(true) again
+			act(() => {
+				result.current.stackSheet.setIsOpen(true);
+			});
+			expect(mocks.setStackAmount).toHaveBeenCalledOnce();
+		});
+
+		it("re-populates on second open after close", () => {
+			mocks.cashSummary = { currentStack: 3000 };
+			mocks.setStackAmount.mockReset();
+			const { result } = renderHook(() => useCashGameStackSheet("s1"), {
+				wrapper,
+			});
+			act(() => {
+				result.current.stackSheet.open();
+			});
+			act(() => {
+				result.current.stackSheet.close();
+			});
+			act(() => {
+				result.current.stackSheet.open();
+			});
+			expect(mocks.setStackAmount).toHaveBeenCalledTimes(2);
+			expect(mocks.setStackAmount).toHaveBeenNthCalledWith(1, "3000");
+			expect(mocks.setStackAmount).toHaveBeenNthCalledWith(2, "3000");
+		});
 	});
 });
 
 describe("useTournamentStackSheet", () => {
 	it("initialises isCompleteOpen=false and exposes the StackSheet context", () => {
-		const { result } = renderHook(() => useTournamentStackSheet(), {
+		const { result } = renderHook(() => useTournamentStackSheet("t1"), {
 			wrapper,
 		});
 		expect(result.current.isCompleteOpen).toBe(false);
@@ -72,12 +234,85 @@ describe("useTournamentStackSheet", () => {
 	});
 
 	it("setIsCompleteOpen toggles", () => {
-		const { result } = renderHook(() => useTournamentStackSheet(), {
+		const { result } = renderHook(() => useTournamentStackSheet("t1"), {
 			wrapper,
 		});
 		act(() => {
 			result.current.setIsCompleteOpen(true);
 		});
 		expect(result.current.isCompleteOpen).toBe(true);
+	});
+
+	describe("pre-population on open", () => {
+		it("sets all tournament fields from summary when sheet opens", () => {
+			mocks.tournamentSummary = {
+				currentStack: 8000,
+				remainingPlayers: 42,
+				totalEntries: 100,
+			};
+			mocks.setStackAmount.mockReset();
+			mocks.setRemainingPlayers.mockReset();
+			mocks.setTotalEntries.mockReset();
+			const { result } = renderHook(() => useTournamentStackSheet("t1"), {
+				wrapper,
+			});
+			act(() => {
+				result.current.stackSheet.open();
+			});
+			expect(mocks.setStackAmount).toHaveBeenCalledOnce();
+			expect(mocks.setStackAmount).toHaveBeenCalledWith("8000");
+			expect(mocks.setRemainingPlayers).toHaveBeenCalledOnce();
+			expect(mocks.setRemainingPlayers).toHaveBeenCalledWith("42");
+			expect(mocks.setTotalEntries).toHaveBeenCalledOnce();
+			expect(mocks.setTotalEntries).toHaveBeenCalledWith("100");
+		});
+
+		it("only sets fields where values are numbers", () => {
+			mocks.tournamentSummary = { currentStack: 5000 };
+			mocks.setStackAmount.mockReset();
+			mocks.setRemainingPlayers.mockReset();
+			mocks.setTotalEntries.mockReset();
+			const { result } = renderHook(() => useTournamentStackSheet("t1"), {
+				wrapper,
+			});
+			act(() => {
+				result.current.stackSheet.open();
+			});
+			expect(mocks.setStackAmount).toHaveBeenCalledOnce();
+			expect(mocks.setRemainingPlayers).not.toHaveBeenCalled();
+			expect(mocks.setTotalEntries).not.toHaveBeenCalled();
+		});
+
+		it("does not populate when summary is undefined", () => {
+			mocks.tournamentSummary = undefined;
+			mocks.setStackAmount.mockReset();
+			mocks.setRemainingPlayers.mockReset();
+			mocks.setTotalEntries.mockReset();
+			const { result } = renderHook(() => useTournamentStackSheet("t1"), {
+				wrapper,
+			});
+			act(() => {
+				result.current.stackSheet.open();
+			});
+			expect(mocks.setStackAmount).not.toHaveBeenCalled();
+			expect(mocks.setRemainingPlayers).not.toHaveBeenCalled();
+			expect(mocks.setTotalEntries).not.toHaveBeenCalled();
+		});
+
+		it("does not re-populate while sheet remains open", () => {
+			mocks.tournamentSummary = { currentStack: 8000 };
+			mocks.setStackAmount.mockReset();
+			const { result } = renderHook(() => useTournamentStackSheet("t1"), {
+				wrapper,
+			});
+			act(() => {
+				result.current.stackSheet.open();
+			});
+			expect(mocks.setStackAmount).toHaveBeenCalledOnce();
+			act(() => {
+				result.current.stackSheet.setIsOpen(true);
+			});
+			expect(mocks.setStackAmount).toHaveBeenCalledOnce();
+		});
 	});
 });

--- a/apps/web/src/features/live-sessions/components/live-stack-form-sheet/live-stack-form-sheet.test.tsx
+++ b/apps/web/src/features/live-sessions/components/live-stack-form-sheet/live-stack-form-sheet.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
 	},
 	chipPurchaseTypes: [] as Array<{ chips: number; cost: number; name: string }>,
 	sessionData: null as null | { tournamentId: string | null },
+	cashSessionData: null as null | { summary: Record<string, unknown> },
 	stackSheet: {
 		close: vi.fn(),
 		isOpen: true,
@@ -30,6 +31,9 @@ vi.mock("@tanstack/react-query", () => ({
 	}),
 	useQuery: (options: { queryKey?: unknown[] }) => {
 		const scope = options.queryKey?.[0];
+		if (scope === "liveCashGameSession.getById") {
+			return { data: mocks.cashSessionData };
+		}
 		if (scope === "liveTournamentSession.getById") {
 			return { data: mocks.sessionData };
 		}
@@ -40,6 +44,26 @@ vi.mock("@tanstack/react-query", () => ({
 	},
 	useQueryClient: () => ({
 		invalidateQueries: vi.fn(),
+	}),
+}));
+
+vi.mock("@/features/live-sessions/hooks/use-session-form", () => ({
+	useStackFormContext: () => ({
+		state: { stackAmount: "", allIns: [] },
+		setStackAmount: vi.fn(),
+		setAllIns: vi.fn(),
+	}),
+	useTournamentFormContext: () => ({
+		state: {
+			stackAmount: "",
+			remainingPlayers: "",
+			totalEntries: "",
+			chipPurchaseCounts: [],
+		},
+		setStackAmount: vi.fn(),
+		setRemainingPlayers: vi.fn(),
+		setTotalEntries: vi.fn(),
+		setChipPurchaseCounts: vi.fn(),
 	}),
 }));
 

--- a/apps/web/src/features/live-sessions/components/live-stack-form-sheet/live-stack-form-sheet.tsx
+++ b/apps/web/src/features/live-sessions/components/live-stack-form-sheet/live-stack-form-sheet.tsx
@@ -18,7 +18,7 @@ function CashGameStackSheet({ sessionId }: { sessionId: string }) {
 		setIsCompleteOpen,
 		defaultFinalStack,
 		setDefaultFinalStack,
-	} = useCashGameStackSheet();
+	} = useCashGameStackSheet(sessionId);
 
 	const {
 		recordStack,
@@ -81,7 +81,7 @@ function CashGameStackSheet({ sessionId }: { sessionId: string }) {
 
 function TournamentStackSheet({ sessionId }: { sessionId: string }) {
 	const { stackSheet, isCompleteOpen, setIsCompleteOpen } =
-		useTournamentStackSheet();
+		useTournamentStackSheet(sessionId);
 
 	const {
 		chipPurchaseTypes,

--- a/apps/web/src/features/live-sessions/components/live-stack-form-sheet/use-live-stack-form-sheet.ts
+++ b/apps/web/src/features/live-sessions/components/live-stack-form-sheet/use-live-stack-form-sheet.ts
@@ -1,12 +1,44 @@
-import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+import {
+	useStackFormContext,
+	useTournamentFormContext,
+} from "@/features/live-sessions/hooks/use-session-form";
 import { useStackSheet } from "@/features/live-sessions/hooks/use-stack-sheet";
+import { trpc } from "@/utils/trpc";
 
-export function useCashGameStackSheet() {
+export function useCashGameStackSheet(sessionId: string) {
 	const stackSheet = useStackSheet();
 	const [isCompleteOpen, setIsCompleteOpen] = useState(false);
 	const [defaultFinalStack, setDefaultFinalStack] = useState<
 		number | undefined
 	>(undefined);
+
+	const { setStackAmount } = useStackFormContext();
+
+	const sessionQuery = useQuery({
+		...trpc.liveCashGameSession.getById.queryOptions({ id: sessionId }),
+		enabled: !!sessionId,
+	});
+	const summary = sessionQuery.data?.summary as
+		| Record<string, unknown>
+		| undefined;
+
+	const prevIsOpen = useRef(false);
+	useEffect(() => {
+		const justOpened = stackSheet.isOpen && !prevIsOpen.current;
+		prevIsOpen.current = stackSheet.isOpen;
+		if (!justOpened) {
+			return;
+		}
+		const currentStack = summary?.currentStack;
+		const totalBuyIn = summary?.totalBuyIn;
+		if (typeof currentStack === "number") {
+			setStackAmount(String(currentStack));
+		} else if (typeof totalBuyIn === "number") {
+			setStackAmount(String(totalBuyIn));
+		}
+	}, [stackSheet.isOpen, summary, setStackAmount]);
 
 	return {
 		stackSheet,
@@ -17,9 +49,44 @@ export function useCashGameStackSheet() {
 	};
 }
 
-export function useTournamentStackSheet() {
+export function useTournamentStackSheet(sessionId: string) {
 	const stackSheet = useStackSheet();
 	const [isCompleteOpen, setIsCompleteOpen] = useState(false);
+
+	const { setStackAmount, setRemainingPlayers, setTotalEntries } =
+		useTournamentFormContext();
+
+	const sessionQuery = useQuery({
+		...trpc.liveTournamentSession.getById.queryOptions({ id: sessionId }),
+		enabled: !!sessionId,
+	});
+	const summary = sessionQuery.data?.summary as
+		| Record<string, unknown>
+		| undefined;
+
+	const prevIsOpen = useRef(false);
+	useEffect(() => {
+		const justOpened = stackSheet.isOpen && !prevIsOpen.current;
+		prevIsOpen.current = stackSheet.isOpen;
+		if (!justOpened) {
+			return;
+		}
+		if (typeof summary?.currentStack === "number") {
+			setStackAmount(String(summary.currentStack));
+		}
+		if (typeof summary?.remainingPlayers === "number") {
+			setRemainingPlayers(String(summary.remainingPlayers));
+		}
+		if (typeof summary?.totalEntries === "number") {
+			setTotalEntries(String(summary.totalEntries));
+		}
+	}, [
+		stackSheet.isOpen,
+		summary,
+		setStackAmount,
+		setRemainingPlayers,
+		setTotalEntries,
+	]);
 
 	return {
 		stackSheet,

--- a/apps/web/src/routes/-use-home-page.ts
+++ b/apps/web/src/routes/-use-home-page.ts
@@ -1,20 +1,52 @@
 import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
 import { authClient } from "@/lib/auth-client";
 import { trpc } from "@/utils/trpc";
 
 export function useHomePage() {
-	const healthCheck = useQuery(trpc.healthCheck.queryOptions());
-	const { data: session } = authClient.useSession();
+	const { data: authSession, isPending: isAuthPending } =
+		authClient.useSession();
+	const navigate = useNavigate();
+	const isSignedIn = Boolean(authSession);
 
-	const isConnected = Boolean(healthCheck.data);
-	const isSignedIn = Boolean(session);
-	const isLoading = healthCheck.isLoading;
-	const userName = session?.user.name ?? null;
+	const cashActiveQuery = useQuery({
+		...trpc.liveCashGameSession.list.queryOptions({
+			status: "active",
+			limit: 1,
+		}),
+		enabled: isSignedIn,
+	});
+	const tournamentActiveQuery = useQuery({
+		...trpc.liveTournamentSession.list.queryOptions({
+			status: "active",
+			limit: 1,
+		}),
+		enabled: isSignedIn,
+	});
 
-	return {
-		isConnected,
-		isSignedIn,
-		isLoading,
-		userName,
-	};
+	const hasActiveSession = Boolean(
+		cashActiveQuery.data?.items?.[0] || tournamentActiveQuery.data?.items?.[0]
+	);
+	const isSessionLoading =
+		isSignedIn &&
+		(cashActiveQuery.isLoading || tournamentActiveQuery.isLoading);
+	const isLoading = isAuthPending || isSessionLoading;
+
+	useEffect(() => {
+		if (isLoading) {
+			return;
+		}
+		if (!isSignedIn) {
+			navigate({ to: "/login" });
+			return;
+		}
+		if (hasActiveSession) {
+			navigate({ to: "/active-session" });
+		} else {
+			navigate({ to: "/dashboard" });
+		}
+	}, [isLoading, isSignedIn, hasActiveSession, navigate]);
+
+	return { isLoading };
 }

--- a/apps/web/src/routes/__tests__/use-home-page.test.ts
+++ b/apps/web/src/routes/__tests__/use-home-page.test.ts
@@ -2,27 +2,59 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-	healthCheck: {
-		data: null as null | { ok: boolean },
-		isLoading: false,
-	},
+	navigate: vi.fn(),
+	isAuthPending: false,
 	session: null as null | { user: { email: string; name: string } },
+	cashItems: [] as Array<{ id: string }>,
+	cashIsLoading: false,
+	tournamentItems: [] as Array<{ id: string }>,
+	tournamentIsLoading: false,
 }));
 
-vi.mock("@tanstack/react-query", () => ({
-	useQuery: () => mocks.healthCheck,
+vi.mock("@tanstack/react-router", () => ({
+	useNavigate: () => mocks.navigate,
 }));
 
 vi.mock("@/lib/auth-client", () => ({
 	authClient: {
-		useSession: () => ({ data: mocks.session }),
+		useSession: () => ({ data: mocks.session, isPending: mocks.isAuthPending }),
+	},
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+	useQuery: (options: { queryKey?: unknown[]; enabled?: boolean }) => {
+		const key = options.queryKey?.[0];
+		if (key === "liveCashGameSession.list") {
+			return {
+				data: { items: mocks.cashItems },
+				isLoading: mocks.cashIsLoading,
+			};
+		}
+		if (key === "liveTournamentSession.list") {
+			return {
+				data: { items: mocks.tournamentItems },
+				isLoading: mocks.tournamentIsLoading,
+			};
+		}
+		return { data: undefined, isLoading: false };
 	},
 }));
 
 vi.mock("@/utils/trpc", () => ({
 	trpc: {
-		healthCheck: {
-			queryOptions: () => ({ queryKey: ["health-check"] }),
+		liveCashGameSession: {
+			list: {
+				queryOptions: (input: unknown) => ({
+					queryKey: ["liveCashGameSession.list", input],
+				}),
+			},
+		},
+		liveTournamentSession: {
+			list: {
+				queryOptions: (input: unknown) => ({
+					queryKey: ["liveTournamentSession.list", input],
+				}),
+			},
 		},
 	},
 }));
@@ -31,84 +63,97 @@ import { useHomePage } from "@/routes/-use-home-page";
 
 describe("useHomePage", () => {
 	beforeEach(() => {
-		mocks.healthCheck.data = null;
-		mocks.healthCheck.isLoading = false;
+		mocks.navigate.mockReset();
+		mocks.isAuthPending = false;
 		mocks.session = null;
-	});
-
-	describe("isConnected", () => {
-		it("is false when healthCheck.data is null", () => {
-			mocks.healthCheck.data = null;
-			const { result } = renderHook(() => useHomePage());
-			expect(result.current.isConnected).toBe(false);
-		});
-
-		it("is true when healthCheck.data is a non-null object", () => {
-			mocks.healthCheck.data = { ok: true };
-			const { result } = renderHook(() => useHomePage());
-			expect(result.current.isConnected).toBe(true);
-		});
-
-		it("is false while the health check is loading", () => {
-			mocks.healthCheck.isLoading = true;
-			mocks.healthCheck.data = null;
-			const { result } = renderHook(() => useHomePage());
-			expect(result.current.isConnected).toBe(false);
-			expect(result.current.isLoading).toBe(true);
-		});
-	});
-
-	describe("isSignedIn", () => {
-		it("is false when session is null", () => {
-			mocks.session = null;
-			const { result } = renderHook(() => useHomePage());
-			expect(result.current.isSignedIn).toBe(false);
-		});
-
-		it("is true when session is present", () => {
-			mocks.session = { user: { email: "a@b.c", name: "Alice" } };
-			const { result } = renderHook(() => useHomePage());
-			expect(result.current.isSignedIn).toBe(true);
-		});
-	});
-
-	describe("userName", () => {
-		it("is null when the session has no user", () => {
-			mocks.session = null;
-			const { result } = renderHook(() => useHomePage());
-			expect(result.current.userName).toBeNull();
-		});
-
-		it("returns the user name when signed in", () => {
-			mocks.session = { user: { email: "hiro@b.c", name: "Hiro" } };
-			const { result } = renderHook(() => useHomePage());
-			expect(result.current.userName).toBe("Hiro");
-		});
+		mocks.cashItems = [];
+		mocks.cashIsLoading = false;
+		mocks.tournamentItems = [];
+		mocks.tournamentIsLoading = false;
 	});
 
 	describe("isLoading", () => {
-		it("mirrors healthCheck.isLoading", () => {
-			mocks.healthCheck.isLoading = true;
-			const r1 = renderHook(() => useHomePage());
-			expect(r1.result.current.isLoading).toBe(true);
+		it("is true when auth is pending", () => {
+			mocks.isAuthPending = true;
+			const { result } = renderHook(() => useHomePage());
+			expect(result.current.isLoading).toBe(true);
+		});
 
-			mocks.healthCheck.isLoading = false;
-			const r2 = renderHook(() => useHomePage());
-			expect(r2.result.current.isLoading).toBe(false);
+		it("is true when signed in and cash session query is loading", () => {
+			mocks.session = { user: { email: "a@b.c", name: "Alice" } };
+			mocks.cashIsLoading = true;
+			const { result } = renderHook(() => useHomePage());
+			expect(result.current.isLoading).toBe(true);
+		});
+
+		it("is true when signed in and tournament session query is loading", () => {
+			mocks.session = { user: { email: "a@b.c", name: "Alice" } };
+			mocks.tournamentIsLoading = true;
+			const { result } = renderHook(() => useHomePage());
+			expect(result.current.isLoading).toBe(true);
+		});
+
+		it("is false when not signed in and not pending", () => {
+			mocks.session = null;
+			mocks.isAuthPending = false;
+			const { result } = renderHook(() => useHomePage());
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		it("is false when signed in and session queries are done", () => {
+			mocks.session = { user: { email: "a@b.c", name: "Alice" } };
+			mocks.cashIsLoading = false;
+			mocks.tournamentIsLoading = false;
+			const { result } = renderHook(() => useHomePage());
+			expect(result.current.isLoading).toBe(false);
 		});
 	});
 
-	describe("combined state", () => {
-		it("reports connected + signed in with user name", () => {
-			mocks.healthCheck.data = { ok: true };
-			mocks.session = { user: { email: "h@s.c", name: "Hiro" } };
-			const { result } = renderHook(() => useHomePage());
-			expect(result.current).toEqual({
-				isConnected: true,
-				isSignedIn: true,
-				isLoading: false,
-				userName: "Hiro",
-			});
+	describe("redirect behaviour", () => {
+		it("redirects to /login when not signed in and not loading", () => {
+			mocks.session = null;
+			renderHook(() => useHomePage());
+			expect(mocks.navigate).toHaveBeenCalledOnce();
+			expect(mocks.navigate).toHaveBeenCalledWith({ to: "/login" });
+		});
+
+		it("redirects to /active-session when signed in and a cash session is active", () => {
+			mocks.session = { user: { email: "a@b.c", name: "Alice" } };
+			mocks.cashItems = [{ id: "cash-1" }];
+			renderHook(() => useHomePage());
+			expect(mocks.navigate).toHaveBeenCalledOnce();
+			expect(mocks.navigate).toHaveBeenCalledWith({ to: "/active-session" });
+		});
+
+		it("redirects to /active-session when signed in and a tournament session is active", () => {
+			mocks.session = { user: { email: "a@b.c", name: "Alice" } };
+			mocks.tournamentItems = [{ id: "tour-1" }];
+			renderHook(() => useHomePage());
+			expect(mocks.navigate).toHaveBeenCalledOnce();
+			expect(mocks.navigate).toHaveBeenCalledWith({ to: "/active-session" });
+		});
+
+		it("redirects to /dashboard when signed in and no active session", () => {
+			mocks.session = { user: { email: "a@b.c", name: "Alice" } };
+			mocks.cashItems = [];
+			mocks.tournamentItems = [];
+			renderHook(() => useHomePage());
+			expect(mocks.navigate).toHaveBeenCalledOnce();
+			expect(mocks.navigate).toHaveBeenCalledWith({ to: "/dashboard" });
+		});
+
+		it("does not navigate while auth is pending", () => {
+			mocks.isAuthPending = true;
+			mocks.session = null;
+			renderHook(() => useHomePage());
+			expect(mocks.navigate).not.toHaveBeenCalled();
+		});
+
+		it("does not navigate while session queries are loading", () => {
+			mocks.session = { user: { email: "a@b.c", name: "Alice" } };
+			mocks.cashIsLoading = true;
+			renderHook(() => useHomePage());
+			expect(mocks.navigate).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,102 +1,11 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { PageSection } from "@/shared/components/page-section";
-import { PublicPageShell } from "@/shared/components/public-page-shell";
-import { Button } from "@/shared/components/ui/button";
+import { createFileRoute } from "@tanstack/react-router";
 import { useHomePage } from "./-use-home-page";
 
 export const Route = createFileRoute("/")({
-	component: HomeComponent,
+	component: HomeRedirect,
 });
 
-function getStatusText(isLoading: boolean, isConnected: boolean) {
-	if (isLoading) {
-		return "Checking...";
-	}
-	return isConnected ? "Connected" : "Disconnected";
-}
-
-function getStatusDescription(isLoading: boolean, isConnected: boolean) {
-	if (isLoading) {
-		return "Checking server connectivity before you continue.";
-	}
-	if (isConnected) {
-		return "Everything looks ready.";
-	}
-	return "Server connection is unavailable right now.";
-}
-
-function HomeComponent() {
-	const { isConnected, isSignedIn, isLoading, userName } = useHomePage();
-	const healthStatusDescription = getStatusDescription(isLoading, isConnected);
-
-	return (
-		<PublicPageShell
-			actions={
-				<>
-					<Button asChild>
-						<Link to={isSignedIn ? "/dashboard" : "/login"}>
-							{isSignedIn ? "Open Dashboard" : "Get Started"}
-						</Link>
-					</Button>
-					{isSignedIn ? null : (
-						<Button asChild variant="outline">
-							<Link to="/login">Sign In</Link>
-						</Button>
-					)}
-				</>
-			}
-			aside={
-				<PageSection
-					description="The same shared UI system now powers public entry, auth, and the authenticated app."
-					heading="What you can do"
-				>
-					<ul className="space-y-2 text-muted-foreground text-sm">
-						<li>Track live and historical sessions in one place.</li>
-						<li>Manage stores, currencies, players, and shared tags.</li>
-						<li>Jump straight into live session tools after sign in.</li>
-					</ul>
-				</PageSection>
-			}
-			description="A lightweight public entry point for session tracking, store management, and live play workflows."
-			eyebrow="Session Tracking"
-			title="sapphire2 keeps your poker operations in sync."
-		>
-			<div className="space-y-4">
-				<PageSection
-					description="Public routes stay lightweight while still reflecting the current app health."
-					heading="API Status"
-				>
-					<div className="flex items-center gap-3">
-						<div
-							className={`size-3 rounded-full ${isConnected ? "bg-green-500" : "bg-red-500"}`}
-						/>
-						<div className="space-y-1">
-							<p className="font-medium">
-								API: {getStatusText(isLoading, isConnected)}
-							</p>
-							<p className="text-muted-foreground text-sm">
-								{healthStatusDescription}
-							</p>
-						</div>
-					</div>
-				</PageSection>
-				<PageSection
-					description={
-						isSignedIn
-							? `Signed in as ${userName ?? "your account"}. Continue where you left off.`
-							: "Sign in to access dashboard, settings, sessions, and live tools."
-					}
-					heading={isSignedIn ? "Ready to continue" : "Start with your account"}
-				>
-					<div className="flex flex-wrap gap-3">
-						<Button asChild variant={isSignedIn ? "default" : "outline"}>
-							<Link to={isSignedIn ? "/dashboard" : "/login"}>
-								{isSignedIn ? "Go to Dashboard" : "Open Sign In"}
-							</Link>
-						</Button>
-					</div>
-				</PageSection>
-			</div>
-		</PublicPageShell>
-	);
+function HomeRedirect() {
+	useHomePage();
+	return null;
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **SA2-14**: `/` は不要なので、リダイレクト専用ルートに変更。認証済み＋アクティブなライブセッションあり → `/active-session`、認証済み＋セッションなし → `/dashboard`、未認証 → `/login` にリダイレクト。旧ランディングページUIは削除。
- **SA2-16**: スタック記録シートを開いた際に、最後のUpdateイベント（`update_stack`）またはSessionStartイベントの値をフォームに引き継ぐ。キャッシュゲームは `currentStack`（なければ `totalBuyIn`）を `stackAmount` にセット。トーナメントは `currentStack` / `remainingPlayers` / `totalEntries` をセット。シートが閉じた状態から開いた時のみ反映（開いている間は再セットしない）。

## Changes

- `apps/web/src/routes/index.tsx` — ランディングUIを削除、`useHomePage()` 呼び出しのみのリダイレクトコンポーネントに変更
- `apps/web/src/routes/-use-home-page.ts` — 認証状態・アクティブセッションを確認して `useNavigate` でリダイレクトするロジックに書き換え
- `apps/web/src/features/live-sessions/components/live-stack-form-sheet/use-live-stack-form-sheet.ts` — `useCashGameStackSheet` / `useTournamentStackSheet` に `sessionId` パラメータを追加。シートopen時にセッションsummaryからフォームコンテキストを事前設定
- `apps/web/src/features/live-sessions/components/live-stack-form-sheet/live-stack-form-sheet.tsx` — `sessionId` をhookへ渡すよう更新

## Test plan

- [ ] `bun x vitest run --project web-dom apps/web/src/routes/__tests__/use-home-page.test.ts` — 11テスト全通過
- [ ] `bun x vitest run --project web-dom apps/web/src/features/live-sessions/components/live-stack-form-sheet` — 19テスト全通過
- [ ] `bun run lint` — エラーなし
- [ ] `bun run check-types` — エラーなし

https://claude.ai/code/session_01ENGRtdcZzcPNTCzsb1n3iu
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENGRtdcZzcPNTCzsb1n3iu)_