### PR TITLE
feat: セッションがゲーム定義を完全に保持するデータ構造への再設計 (SA2-22)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(bunx vitest *)",
-      "mcp__7d3661ac-8fa2-4e4c-b904-cddf640bd4ac__get_issue"
+      "mcp__7d3661ac-8fa2-4e4c-b904-cddf640bd4ac__get_issue",
+      "mcp__7d3661ac-8fa2-4e4c-b904-cddf640bd4ac__list_comments"
     ]
   },
   "enabledPlugins": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-grid-layout": "^1.5.2",
+    "recharts": "^3.8.1",
     "shadcn": "^4.1.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@sapphire2/api": "workspace:*",
     "@sapphire2/auth": "workspace:*",
+    "@sapphire2/db": "workspace:*",
     "@sapphire2/env": "workspace:*",
     "@tabler/icons-react": "^3.41.1",
     "@tailwindcss/typography": "^0.5.19",

--- a/apps/web/src/__tests__/mobile-nav.test.tsx
+++ b/apps/web/src/__tests__/mobile-nav.test.tsx
@@ -186,12 +186,12 @@ describe("MobileNav - Paused Session Mode", () => {
 		expect(screen.getByText("Resume")).toBeInTheDocument();
 	});
 
-	it("does not display live session nav items (Events, Game, Overview)", async () => {
+	it("does not display live session nav items (Timeline, Game, Overview)", async () => {
 		const router = createTestRouter("/sessions");
 		render(<RouterProvider router={router} />);
 
 		await screen.findByText("Dashboard");
-		expect(screen.queryByText("Events")).not.toBeInTheDocument();
+		expect(screen.queryByText("Timeline")).not.toBeInTheDocument();
 		expect(screen.queryByText("Game")).not.toBeInTheDocument();
 		expect(screen.queryByText("Overview")).not.toBeInTheDocument();
 	});
@@ -225,7 +225,7 @@ describe("MobileNav - Live Session Mode (active session)", () => {
 		);
 		render(<RouterProvider router={router} />);
 
-		await screen.findByText("Events");
+		await screen.findByText("Timeline");
 		expect(screen.getByText("Game")).toBeInTheDocument();
 		expect(screen.getByText("Overview")).toBeInTheDocument();
 		expect(screen.getByText("Settings")).toBeInTheDocument();

--- a/apps/web/src/__tests__/sessions-route.test.tsx
+++ b/apps/web/src/__tests__/sessions-route.test.tsx
@@ -212,7 +212,7 @@ describe("SessionsPage", () => {
 
 		render(<Component />);
 
-		await user.click(screen.getAllByRole("button", { name: "New Session" })[0]);
+		await user.click(screen.getAllByRole("button", { name: "New" })[0]);
 
 		expect(
 			screen.getByRole("heading", { name: "New Session" })
@@ -226,7 +226,7 @@ describe("SessionsPage", () => {
 
 		render(<Component />);
 
-		await user.click(screen.getByRole("button", { name: "Manage Tags" }));
+		await user.click(screen.getByRole("button", { name: "Tags" }));
 
 		expect(
 			screen.getByRole("heading", { name: "Manage Tags" })

--- a/apps/web/src/__tests__/tournament-lifecycle.test.tsx
+++ b/apps/web/src/__tests__/tournament-lifecycle.test.tsx
@@ -603,11 +603,11 @@ describe("ActiveSessionEventsPage — tournament events display", () => {
 		});
 	});
 
-	it("renders Events heading", async () => {
+	it("renders Timeline heading", async () => {
 		const router = createEventsRouter();
 		renderWithProviders(router);
 
-		await screen.findByRole("heading", { name: "Events" });
+		await screen.findByRole("heading", { name: "Timeline" });
 	});
 
 	it("renders update_stack events with 'Stack Update' label", async () => {

--- a/apps/web/src/features/dashboard/hooks/use-dashboard-widgets.ts
+++ b/apps/web/src/features/dashboard/hooks/use-dashboard-widgets.ts
@@ -13,7 +13,8 @@ export type WidgetType =
 	| "summary_stats"
 	| "recent_sessions"
 	| "active_session"
-	| "currency_balance";
+	| "currency_balance"
+	| "pnl_graph";
 
 export interface DashboardWidget {
 	config: Record<string, unknown>;

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/aggregate-pnl-points.test.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/aggregate-pnl-points.test.ts
@@ -23,7 +23,7 @@ function point(
 describe("aggregatePnlPoints", () => {
 	describe("xAxis = 'date'", () => {
 		it("returns empty result when no points are provided", () => {
-			const result = aggregatePnlPoints([], "date", "currency");
+			const result = aggregatePnlPoints([], "date", "currency", "all");
 			expect(result.points).toEqual([]);
 			expect(result.skippedCount).toBe(0);
 		});
@@ -45,7 +45,8 @@ describe("aggregatePnlPoints", () => {
 					point({ id: "c", profitLoss: 50, sessionDate: nextDay }),
 				],
 				"date",
-				"currency"
+				"currency",
+				"all"
 			);
 			expect(result.points).toHaveLength(2);
 			expect(result.points[0]?.cumulative).toBe(70);
@@ -61,7 +62,8 @@ describe("aggregatePnlPoints", () => {
 					point({ id: "earlier", profitLoss: 10, sessionDate: a }),
 				],
 				"date",
-				"currency"
+				"currency",
+				"all"
 			);
 			expect(result.points[0]?.cumulative).toBe(10);
 			expect(result.points[1]?.cumulative).toBe(60);
@@ -75,7 +77,8 @@ describe("aggregatePnlPoints", () => {
 					point({ id: "a", profitLoss: 10, sessionDate: t }),
 				],
 				"sessionCount",
-				"currency"
+				"currency",
+				"all"
 			);
 			expect(result.points.map((p) => p.cumulative)).toEqual([10, 15]);
 		});
@@ -91,7 +94,8 @@ describe("aggregatePnlPoints", () => {
 					point({ id: "c", profitLoss: -5, sessionDate: t0 + 2 }),
 				],
 				"sessionCount",
-				"currency"
+				"currency",
+				"all"
 			);
 			expect(result.points).toEqual([
 				{ x: 1, cumulative: 10 },
@@ -102,7 +106,7 @@ describe("aggregatePnlPoints", () => {
 	});
 
 	describe("xAxis = 'playTime'", () => {
-		it("uses cumulative play minutes as the x value, treating null as 0", () => {
+		it("uses cumulative play hours (minutes / 60) as the x value, treating null as 0", () => {
 			const result = aggregatePnlPoints(
 				[
 					point({
@@ -125,17 +129,18 @@ describe("aggregatePnlPoints", () => {
 					}),
 				],
 				"playTime",
-				"currency"
+				"currency",
+				"all"
 			);
 			expect(result.points).toEqual([
-				{ x: 60, cumulative: 100 },
-				{ x: 60, cumulative: 50 },
-				{ x: 90, cumulative: 75 },
+				{ x: 1, cumulative: 100 },
+				{ x: 1, cumulative: 50 },
+				{ x: 1.5, cumulative: 75 },
 			]);
 		});
 	});
 
-	describe("unit = 'bb'", () => {
+	describe("unit = 'normalized', sessionType = 'cash_game'", () => {
 		it("divides cash_game profit by bigBlind and skips other rows", () => {
 			const result = aggregatePnlPoints(
 				[
@@ -160,7 +165,8 @@ describe("aggregatePnlPoints", () => {
 					}),
 				],
 				"sessionCount",
-				"bb"
+				"normalized",
+				"cash_game"
 			);
 			expect(result.points).toEqual([
 				{ x: 1, cumulative: 4 },
@@ -176,14 +182,15 @@ describe("aggregatePnlPoints", () => {
 					point({ id: "b", profitLoss: 200, sessionDate: 2, bigBlind: 0 }),
 				],
 				"sessionCount",
-				"bb"
+				"normalized",
+				"cash_game"
 			);
 			expect(result.points).toEqual([]);
 			expect(result.skippedCount).toBe(2);
 		});
 	});
 
-	describe("unit = 'bi'", () => {
+	describe("unit = 'normalized', sessionType = 'tournament'", () => {
 		it("divides tournament profit by buyInTotal and skips other rows", () => {
 			const result = aggregatePnlPoints(
 				[
@@ -202,7 +209,8 @@ describe("aggregatePnlPoints", () => {
 					}),
 				],
 				"sessionCount",
-				"bi"
+				"normalized",
+				"tournament"
 			);
 			expect(result.points).toEqual([{ x: 1, cumulative: 3 }]);
 			expect(result.skippedCount).toBe(1);
@@ -227,10 +235,110 @@ describe("aggregatePnlPoints", () => {
 					}),
 				],
 				"sessionCount",
-				"bi"
+				"normalized",
+				"tournament"
 			);
 			expect(result.points).toEqual([]);
 			expect(result.skippedCount).toBe(2);
+		});
+	});
+
+	describe("unit = 'normalized', sessionType = 'all' (dual series)", () => {
+		it("emits both cashCumulative and tournamentCumulative on every point", () => {
+			const result = aggregatePnlPoints(
+				[
+					point({
+						id: "a",
+						profitLoss: 200,
+						sessionDate: 1,
+						bigBlind: 50,
+					}),
+					point({
+						id: "b",
+						profitLoss: 300,
+						sessionDate: 2,
+						type: "tournament",
+						buyInTotal: 100,
+					}),
+					point({
+						id: "c",
+						profitLoss: 100,
+						sessionDate: 3,
+						bigBlind: 25,
+					}),
+				],
+				"sessionCount",
+				"normalized",
+				"all"
+			);
+			expect(result.points).toEqual([
+				{ x: 1, cashCumulative: 4, tournamentCumulative: 0 },
+				{ x: 2, cashCumulative: 4, tournamentCumulative: 3 },
+				{ x: 3, cashCumulative: 8, tournamentCumulative: 3 },
+			]);
+			expect(result.skippedCount).toBe(0);
+		});
+
+		it("skips sessions with no usable normalization base in either series", () => {
+			const result = aggregatePnlPoints(
+				[
+					point({
+						id: "a",
+						profitLoss: 100,
+						sessionDate: 1,
+						bigBlind: null,
+					}),
+					point({
+						id: "b",
+						profitLoss: 200,
+						sessionDate: 2,
+						type: "tournament",
+						buyInTotal: null,
+					}),
+					point({
+						id: "c",
+						profitLoss: 50,
+						sessionDate: 3,
+						bigBlind: 25,
+					}),
+				],
+				"sessionCount",
+				"normalized",
+				"all"
+			);
+			expect(result.points).toEqual([
+				{ x: 1, cashCumulative: 2, tournamentCumulative: 0 },
+			]);
+			expect(result.skippedCount).toBe(2);
+		});
+
+		it("buckets dual-series points by UTC day for date axis", () => {
+			const day1 = Math.floor(
+				new Date("2026-04-01T03:00:00Z").getTime() / 1000
+			);
+			const day2 = Math.floor(
+				new Date("2026-04-02T03:00:00Z").getTime() / 1000
+			);
+			const result = aggregatePnlPoints(
+				[
+					point({ id: "a", profitLoss: 200, sessionDate: day1, bigBlind: 50 }),
+					point({
+						id: "b",
+						profitLoss: 300,
+						sessionDate: day2,
+						type: "tournament",
+						buyInTotal: 100,
+					}),
+				],
+				"date",
+				"normalized",
+				"all"
+			);
+			expect(result.points).toHaveLength(2);
+			expect(result.points[0]?.cashCumulative).toBe(4);
+			expect(result.points[0]?.tournamentCumulative).toBe(0);
+			expect(result.points[1]?.cashCumulative).toBe(4);
+			expect(result.points[1]?.tournamentCumulative).toBe(3);
 		});
 	});
 });

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/aggregate-pnl-points.test.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/aggregate-pnl-points.test.ts
@@ -14,18 +14,43 @@ function point(
 	return {
 		bigBlind: null,
 		buyInTotal: null,
+		evProfitLoss: null,
 		playMinutes: null,
 		type: "cash_game",
 		...overrides,
 	};
 }
 
+const baseOptions = {
+	rawPoints: [] as PnlSeriesPoint[],
+	xAxis: "date" as const,
+	unit: "currency" as const,
+	sessionType: "all" as const,
+	showEvCash: false,
+};
+
 describe("aggregatePnlPoints", () => {
 	describe("xAxis = 'date'", () => {
 		it("returns empty result when no points are provided", () => {
-			const result = aggregatePnlPoints([], "date", "currency", "all");
+			const result = aggregatePnlPoints({ ...baseOptions, rawPoints: [] });
 			expect(result.points).toEqual([]);
 			expect(result.skippedCount).toBe(0);
+		});
+
+		it("prepends an origin point one day before the earliest session", () => {
+			const day1 = Math.floor(
+				new Date("2026-04-01T03:00:00Z").getTime() / 1000
+			);
+			const result = aggregatePnlPoints({
+				...baseOptions,
+				rawPoints: [point({ id: "a", profitLoss: 100, sessionDate: day1 })],
+			});
+			expect(result.points).toHaveLength(2);
+			expect(result.points[0]?.cumulative).toBe(0);
+			expect(result.points[0]?.x).toBe(
+				new Date("2026-03-31T00:00:00Z").getTime()
+			);
+			expect(result.points[1]?.cumulative).toBe(100);
 		});
 
 		it("buckets points on the same UTC day to the cumulative end-of-day value", () => {
@@ -38,66 +63,35 @@ describe("aggregatePnlPoints", () => {
 			const nextDay = Math.floor(
 				new Date("2026-04-02T10:00:00Z").getTime() / 1000
 			);
-			const result = aggregatePnlPoints(
-				[
+			const result = aggregatePnlPoints({
+				...baseOptions,
+				rawPoints: [
 					point({ id: "a", profitLoss: 100, sessionDate: morning }),
 					point({ id: "b", profitLoss: -30, sessionDate: evening }),
 					point({ id: "c", profitLoss: 50, sessionDate: nextDay }),
 				],
-				"date",
-				"currency",
-				"all"
-			);
-			expect(result.points).toHaveLength(2);
-			expect(result.points[0]?.cumulative).toBe(70);
-			expect(result.points[1]?.cumulative).toBe(120);
-		});
-
-		it("sorts unsorted input by sessionDate ascending", () => {
-			const a = Math.floor(new Date("2026-04-01T00:00:00Z").getTime() / 1000);
-			const b = Math.floor(new Date("2026-04-05T00:00:00Z").getTime() / 1000);
-			const result = aggregatePnlPoints(
-				[
-					point({ id: "later", profitLoss: 50, sessionDate: b }),
-					point({ id: "earlier", profitLoss: 10, sessionDate: a }),
-				],
-				"date",
-				"currency",
-				"all"
-			);
-			expect(result.points[0]?.cumulative).toBe(10);
-			expect(result.points[1]?.cumulative).toBe(60);
-		});
-
-		it("breaks sessionDate ties by id ascending for deterministic ordering", () => {
-			const t = Math.floor(new Date("2026-04-01T00:00:00Z").getTime() / 1000);
-			const result = aggregatePnlPoints(
-				[
-					point({ id: "b", profitLoss: 5, sessionDate: t }),
-					point({ id: "a", profitLoss: 10, sessionDate: t }),
-				],
-				"sessionCount",
-				"currency",
-				"all"
-			);
-			expect(result.points.map((p) => p.cumulative)).toEqual([10, 15]);
+			});
+			expect(result.points).toHaveLength(3);
+			expect(result.points[0]?.cumulative).toBe(0);
+			expect(result.points[1]?.cumulative).toBe(70);
+			expect(result.points[2]?.cumulative).toBe(120);
 		});
 	});
 
 	describe("xAxis = 'sessionCount'", () => {
-		it("emits one point per included session, x = 1..N", () => {
+		it("emits one point per included session, x = 1..N, prefixed by origin (0, 0)", () => {
 			const t0 = 1;
-			const result = aggregatePnlPoints(
-				[
+			const result = aggregatePnlPoints({
+				...baseOptions,
+				xAxis: "sessionCount",
+				rawPoints: [
 					point({ id: "a", profitLoss: 10, sessionDate: t0 }),
 					point({ id: "b", profitLoss: 20, sessionDate: t0 + 1 }),
 					point({ id: "c", profitLoss: -5, sessionDate: t0 + 2 }),
 				],
-				"sessionCount",
-				"currency",
-				"all"
-			);
+			});
 			expect(result.points).toEqual([
+				{ x: 0, cumulative: 0 },
 				{ x: 1, cumulative: 10 },
 				{ x: 2, cumulative: 30 },
 				{ x: 3, cumulative: 25 },
@@ -106,9 +100,11 @@ describe("aggregatePnlPoints", () => {
 	});
 
 	describe("xAxis = 'playTime'", () => {
-		it("uses cumulative play hours (minutes / 60) as the x value, treating null as 0", () => {
-			const result = aggregatePnlPoints(
-				[
+		it("uses cumulative play hours and prepends origin (0, 0)", () => {
+			const result = aggregatePnlPoints({
+				...baseOptions,
+				xAxis: "playTime",
+				rawPoints: [
 					point({
 						id: "a",
 						profitLoss: 100,
@@ -128,11 +124,9 @@ describe("aggregatePnlPoints", () => {
 						playMinutes: 30,
 					}),
 				],
-				"playTime",
-				"currency",
-				"all"
-			);
+			});
 			expect(result.points).toEqual([
+				{ x: 0, cumulative: 0 },
 				{ x: 1, cumulative: 100 },
 				{ x: 1, cumulative: 50 },
 				{ x: 1.5, cumulative: 75 },
@@ -142,14 +136,13 @@ describe("aggregatePnlPoints", () => {
 
 	describe("unit = 'normalized', sessionType = 'cash_game'", () => {
 		it("divides cash_game profit by bigBlind and skips other rows", () => {
-			const result = aggregatePnlPoints(
-				[
-					point({
-						id: "a",
-						profitLoss: 200,
-						sessionDate: 1,
-						bigBlind: 50,
-					}),
+			const result = aggregatePnlPoints({
+				...baseOptions,
+				xAxis: "sessionCount",
+				unit: "normalized",
+				sessionType: "cash_game",
+				rawPoints: [
+					point({ id: "a", profitLoss: 200, sessionDate: 1, bigBlind: 50 }),
 					point({
 						id: "b",
 						profitLoss: 150,
@@ -157,43 +150,26 @@ describe("aggregatePnlPoints", () => {
 						type: "tournament",
 						buyInTotal: 100,
 					}),
-					point({
-						id: "c",
-						profitLoss: 100,
-						sessionDate: 3,
-						bigBlind: 25,
-					}),
+					point({ id: "c", profitLoss: 100, sessionDate: 3, bigBlind: 25 }),
 				],
-				"sessionCount",
-				"normalized",
-				"cash_game"
-			);
+			});
 			expect(result.points).toEqual([
+				{ x: 0, cumulative: 0 },
 				{ x: 1, cumulative: 4 },
 				{ x: 2, cumulative: 8 },
 			]);
 			expect(result.skippedCount).toBe(1);
 		});
-
-		it("skips cash sessions when bigBlind is null or zero", () => {
-			const result = aggregatePnlPoints(
-				[
-					point({ id: "a", profitLoss: 100, sessionDate: 1, bigBlind: null }),
-					point({ id: "b", profitLoss: 200, sessionDate: 2, bigBlind: 0 }),
-				],
-				"sessionCount",
-				"normalized",
-				"cash_game"
-			);
-			expect(result.points).toEqual([]);
-			expect(result.skippedCount).toBe(2);
-		});
 	});
 
 	describe("unit = 'normalized', sessionType = 'tournament'", () => {
 		it("divides tournament profit by buyInTotal and skips other rows", () => {
-			const result = aggregatePnlPoints(
-				[
+			const result = aggregatePnlPoints({
+				...baseOptions,
+				xAxis: "sessionCount",
+				unit: "normalized",
+				sessionType: "tournament",
+				rawPoints: [
 					point({
 						id: "a",
 						profitLoss: 300,
@@ -201,55 +177,57 @@ describe("aggregatePnlPoints", () => {
 						type: "tournament",
 						buyInTotal: 100,
 					}),
-					point({
-						id: "b",
-						profitLoss: 100,
-						sessionDate: 2,
-						bigBlind: 25,
-					}),
+					point({ id: "b", profitLoss: 100, sessionDate: 2, bigBlind: 25 }),
 				],
-				"sessionCount",
-				"normalized",
-				"tournament"
-			);
-			expect(result.points).toEqual([{ x: 1, cumulative: 3 }]);
+			});
+			expect(result.points).toEqual([
+				{ x: 0, cumulative: 0 },
+				{ x: 1, cumulative: 3 },
+			]);
 			expect(result.skippedCount).toBe(1);
-		});
-
-		it("skips tournament sessions when buyInTotal is null or zero", () => {
-			const result = aggregatePnlPoints(
-				[
-					point({
-						id: "a",
-						profitLoss: 100,
-						sessionDate: 1,
-						type: "tournament",
-						buyInTotal: null,
-					}),
-					point({
-						id: "b",
-						profitLoss: 100,
-						sessionDate: 2,
-						type: "tournament",
-						buyInTotal: 0,
-					}),
-				],
-				"sessionCount",
-				"normalized",
-				"tournament"
-			);
-			expect(result.points).toEqual([]);
-			expect(result.skippedCount).toBe(2);
 		});
 	});
 
 	describe("unit = 'normalized', sessionType = 'all' (dual series)", () => {
-		it("emits both cashCumulative and tournamentCumulative on every point", () => {
-			const result = aggregatePnlPoints(
-				[
+		it("emits both cashCumulative and tournamentCumulative on every point with shared origin", () => {
+			const result = aggregatePnlPoints({
+				...baseOptions,
+				xAxis: "sessionCount",
+				unit: "normalized",
+				sessionType: "all",
+				rawPoints: [
+					point({ id: "a", profitLoss: 200, sessionDate: 1, bigBlind: 50 }),
+					point({
+						id: "b",
+						profitLoss: 300,
+						sessionDate: 2,
+						type: "tournament",
+						buyInTotal: 100,
+					}),
+					point({ id: "c", profitLoss: 100, sessionDate: 3, bigBlind: 25 }),
+				],
+			});
+			expect(result.points).toEqual([
+				{ x: 0, cashCumulative: 0, tournamentCumulative: 0 },
+				{ x: 1, cashCumulative: 4, tournamentCumulative: 0 },
+				{ x: 2, cashCumulative: 4, tournamentCumulative: 3 },
+				{ x: 3, cashCumulative: 8, tournamentCumulative: 3 },
+			]);
+			expect(result.skippedCount).toBe(0);
+		});
+
+		it("includes evCashCumulative when showEvCash is enabled", () => {
+			const result = aggregatePnlPoints({
+				...baseOptions,
+				xAxis: "sessionCount",
+				unit: "normalized",
+				sessionType: "all",
+				showEvCash: true,
+				rawPoints: [
 					point({
 						id: "a",
 						profitLoss: 200,
+						evProfitLoss: 250,
 						sessionDate: 1,
 						bigBlind: 50,
 					}),
@@ -260,85 +238,88 @@ describe("aggregatePnlPoints", () => {
 						type: "tournament",
 						buyInTotal: 100,
 					}),
-					point({
-						id: "c",
-						profitLoss: 100,
-						sessionDate: 3,
-						bigBlind: 25,
-					}),
 				],
-				"sessionCount",
-				"normalized",
-				"all"
-			);
+			});
 			expect(result.points).toEqual([
-				{ x: 1, cashCumulative: 4, tournamentCumulative: 0 },
-				{ x: 2, cashCumulative: 4, tournamentCumulative: 3 },
-				{ x: 3, cashCumulative: 8, tournamentCumulative: 3 },
+				{
+					x: 0,
+					cashCumulative: 0,
+					tournamentCumulative: 0,
+					evCashCumulative: 0,
+				},
+				{
+					x: 1,
+					cashCumulative: 4,
+					tournamentCumulative: 0,
+					evCashCumulative: 5,
+				},
+				{
+					x: 2,
+					cashCumulative: 4,
+					tournamentCumulative: 3,
+					evCashCumulative: 5,
+				},
 			]);
-			expect(result.skippedCount).toBe(0);
 		});
+	});
 
-		it("skips sessions with no usable normalization base in either series", () => {
-			const result = aggregatePnlPoints(
-				[
+	describe("unit = 'currency', showEvCash = true", () => {
+		it("adds evCashCumulative alongside cumulative", () => {
+			const result = aggregatePnlPoints({
+				...baseOptions,
+				xAxis: "sessionCount",
+				unit: "currency",
+				sessionType: "all",
+				showEvCash: true,
+				rawPoints: [
 					point({
 						id: "a",
 						profitLoss: 100,
+						evProfitLoss: 150,
 						sessionDate: 1,
-						bigBlind: null,
 					}),
 					point({
 						id: "b",
-						profitLoss: 200,
+						profitLoss: 50,
 						sessionDate: 2,
 						type: "tournament",
-						buyInTotal: null,
+						buyInTotal: 25,
 					}),
 					point({
 						id: "c",
-						profitLoss: 50,
+						profitLoss: -20,
+						evProfitLoss: 10,
 						sessionDate: 3,
-						bigBlind: 25,
 					}),
 				],
-				"sessionCount",
-				"normalized",
-				"all"
-			);
+			});
 			expect(result.points).toEqual([
-				{ x: 1, cashCumulative: 2, tournamentCumulative: 0 },
+				{ x: 0, cumulative: 0, evCashCumulative: 0 },
+				{ x: 1, cumulative: 100, evCashCumulative: 150 },
+				{ x: 2, cumulative: 150, evCashCumulative: 150 },
+				{ x: 3, cumulative: 130, evCashCumulative: 160 },
 			]);
-			expect(result.skippedCount).toBe(2);
 		});
 
-		it("buckets dual-series points by UTC day for date axis", () => {
-			const day1 = Math.floor(
-				new Date("2026-04-01T03:00:00Z").getTime() / 1000
-			);
-			const day2 = Math.floor(
-				new Date("2026-04-02T03:00:00Z").getTime() / 1000
-			);
-			const result = aggregatePnlPoints(
-				[
-					point({ id: "a", profitLoss: 200, sessionDate: day1, bigBlind: 50 }),
+		it("skips EV contribution from tournament sessions", () => {
+			const result = aggregatePnlPoints({
+				...baseOptions,
+				xAxis: "sessionCount",
+				unit: "currency",
+				sessionType: "tournament",
+				showEvCash: true,
+				rawPoints: [
 					point({
-						id: "b",
-						profitLoss: 300,
-						sessionDate: day2,
+						id: "a",
+						profitLoss: 50,
+						sessionDate: 1,
 						type: "tournament",
-						buyInTotal: 100,
+						buyInTotal: 25,
 					}),
 				],
-				"date",
-				"normalized",
-				"all"
-			);
-			expect(result.points).toHaveLength(2);
-			expect(result.points[0]?.cashCumulative).toBe(4);
-			expect(result.points[0]?.tournamentCumulative).toBe(0);
-			expect(result.points[1]?.cashCumulative).toBe(4);
-			expect(result.points[1]?.tournamentCumulative).toBe(3);
+			});
+			expect(result.points[0]?.evCashCumulative).toBe(0);
+			expect(result.points[1]?.evCashCumulative).toBe(0);
 		});
 	});
 });

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/aggregate-pnl-points.test.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/aggregate-pnl-points.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+import {
+	aggregatePnlPoints,
+	type PnlSeriesPoint,
+} from "@/features/dashboard/widgets/pnl-graph-widget/aggregate-pnl-points";
+
+function point(
+	overrides: Partial<PnlSeriesPoint> & {
+		id: string;
+		profitLoss: number;
+		sessionDate: number;
+	}
+): PnlSeriesPoint {
+	return {
+		bigBlind: null,
+		buyInTotal: null,
+		playMinutes: null,
+		type: "cash_game",
+		...overrides,
+	};
+}
+
+describe("aggregatePnlPoints", () => {
+	describe("xAxis = 'date'", () => {
+		it("returns empty result when no points are provided", () => {
+			const result = aggregatePnlPoints([], "date", "currency");
+			expect(result.points).toEqual([]);
+			expect(result.skippedCount).toBe(0);
+		});
+
+		it("buckets points on the same UTC day to the cumulative end-of-day value", () => {
+			const morning = Math.floor(
+				new Date("2026-04-01T03:00:00Z").getTime() / 1000
+			);
+			const evening = Math.floor(
+				new Date("2026-04-01T22:00:00Z").getTime() / 1000
+			);
+			const nextDay = Math.floor(
+				new Date("2026-04-02T10:00:00Z").getTime() / 1000
+			);
+			const result = aggregatePnlPoints(
+				[
+					point({ id: "a", profitLoss: 100, sessionDate: morning }),
+					point({ id: "b", profitLoss: -30, sessionDate: evening }),
+					point({ id: "c", profitLoss: 50, sessionDate: nextDay }),
+				],
+				"date",
+				"currency"
+			);
+			expect(result.points).toHaveLength(2);
+			expect(result.points[0]?.cumulative).toBe(70);
+			expect(result.points[1]?.cumulative).toBe(120);
+		});
+
+		it("sorts unsorted input by sessionDate ascending", () => {
+			const a = Math.floor(new Date("2026-04-01T00:00:00Z").getTime() / 1000);
+			const b = Math.floor(new Date("2026-04-05T00:00:00Z").getTime() / 1000);
+			const result = aggregatePnlPoints(
+				[
+					point({ id: "later", profitLoss: 50, sessionDate: b }),
+					point({ id: "earlier", profitLoss: 10, sessionDate: a }),
+				],
+				"date",
+				"currency"
+			);
+			expect(result.points[0]?.cumulative).toBe(10);
+			expect(result.points[1]?.cumulative).toBe(60);
+		});
+
+		it("breaks sessionDate ties by id ascending for deterministic ordering", () => {
+			const t = Math.floor(new Date("2026-04-01T00:00:00Z").getTime() / 1000);
+			const result = aggregatePnlPoints(
+				[
+					point({ id: "b", profitLoss: 5, sessionDate: t }),
+					point({ id: "a", profitLoss: 10, sessionDate: t }),
+				],
+				"sessionCount",
+				"currency"
+			);
+			expect(result.points.map((p) => p.cumulative)).toEqual([10, 15]);
+		});
+	});
+
+	describe("xAxis = 'sessionCount'", () => {
+		it("emits one point per included session, x = 1..N", () => {
+			const t0 = 1;
+			const result = aggregatePnlPoints(
+				[
+					point({ id: "a", profitLoss: 10, sessionDate: t0 }),
+					point({ id: "b", profitLoss: 20, sessionDate: t0 + 1 }),
+					point({ id: "c", profitLoss: -5, sessionDate: t0 + 2 }),
+				],
+				"sessionCount",
+				"currency"
+			);
+			expect(result.points).toEqual([
+				{ x: 1, cumulative: 10 },
+				{ x: 2, cumulative: 30 },
+				{ x: 3, cumulative: 25 },
+			]);
+		});
+	});
+
+	describe("xAxis = 'playTime'", () => {
+		it("uses cumulative play minutes as the x value, treating null as 0", () => {
+			const result = aggregatePnlPoints(
+				[
+					point({
+						id: "a",
+						profitLoss: 100,
+						sessionDate: 1,
+						playMinutes: 60,
+					}),
+					point({
+						id: "b",
+						profitLoss: -50,
+						sessionDate: 2,
+						playMinutes: null,
+					}),
+					point({
+						id: "c",
+						profitLoss: 25,
+						sessionDate: 3,
+						playMinutes: 30,
+					}),
+				],
+				"playTime",
+				"currency"
+			);
+			expect(result.points).toEqual([
+				{ x: 60, cumulative: 100 },
+				{ x: 60, cumulative: 50 },
+				{ x: 90, cumulative: 75 },
+			]);
+		});
+	});
+
+	describe("unit = 'bb'", () => {
+		it("divides cash_game profit by bigBlind and skips other rows", () => {
+			const result = aggregatePnlPoints(
+				[
+					point({
+						id: "a",
+						profitLoss: 200,
+						sessionDate: 1,
+						bigBlind: 50,
+					}),
+					point({
+						id: "b",
+						profitLoss: 150,
+						sessionDate: 2,
+						type: "tournament",
+						buyInTotal: 100,
+					}),
+					point({
+						id: "c",
+						profitLoss: 100,
+						sessionDate: 3,
+						bigBlind: 25,
+					}),
+				],
+				"sessionCount",
+				"bb"
+			);
+			expect(result.points).toEqual([
+				{ x: 1, cumulative: 4 },
+				{ x: 2, cumulative: 8 },
+			]);
+			expect(result.skippedCount).toBe(1);
+		});
+
+		it("skips cash sessions when bigBlind is null or zero", () => {
+			const result = aggregatePnlPoints(
+				[
+					point({ id: "a", profitLoss: 100, sessionDate: 1, bigBlind: null }),
+					point({ id: "b", profitLoss: 200, sessionDate: 2, bigBlind: 0 }),
+				],
+				"sessionCount",
+				"bb"
+			);
+			expect(result.points).toEqual([]);
+			expect(result.skippedCount).toBe(2);
+		});
+	});
+
+	describe("unit = 'bi'", () => {
+		it("divides tournament profit by buyInTotal and skips other rows", () => {
+			const result = aggregatePnlPoints(
+				[
+					point({
+						id: "a",
+						profitLoss: 300,
+						sessionDate: 1,
+						type: "tournament",
+						buyInTotal: 100,
+					}),
+					point({
+						id: "b",
+						profitLoss: 100,
+						sessionDate: 2,
+						bigBlind: 25,
+					}),
+				],
+				"sessionCount",
+				"bi"
+			);
+			expect(result.points).toEqual([{ x: 1, cumulative: 3 }]);
+			expect(result.skippedCount).toBe(1);
+		});
+
+		it("skips tournament sessions when buyInTotal is null or zero", () => {
+			const result = aggregatePnlPoints(
+				[
+					point({
+						id: "a",
+						profitLoss: 100,
+						sessionDate: 1,
+						type: "tournament",
+						buyInTotal: null,
+					}),
+					point({
+						id: "b",
+						profitLoss: 100,
+						sessionDate: 2,
+						type: "tournament",
+						buyInTotal: 0,
+					}),
+				],
+				"sessionCount",
+				"bi"
+			);
+			expect(result.points).toEqual([]);
+			expect(result.skippedCount).toBe(2);
+		});
+	});
+});

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/use-pnl-graph-edit-form.test.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/use-pnl-graph-edit-form.test.ts
@@ -1,0 +1,176 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/trpc", () => ({
+	trpc: {
+		store: {
+			list: {
+				queryOptions: () => ({
+					queryKey: ["store", "list"],
+					queryFn: () => Promise.resolve([]),
+				}),
+			},
+		},
+		currency: {
+			list: {
+				queryOptions: () => ({
+					queryKey: ["currency", "list"],
+					queryFn: () => Promise.resolve([]),
+				}),
+			},
+		},
+		ringGame: {
+			listByStore: {
+				queryOptions: (input: { storeId: string }, opts?: unknown) => ({
+					queryKey: ["ringGame", "listByStore", input],
+					queryFn: () => Promise.resolve([]),
+					...((opts as object) ?? {}),
+				}),
+			},
+		},
+	},
+	trpcClient: {},
+}));
+
+import { usePnlGraphEditForm } from "@/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-edit-form";
+
+function createClient(): QueryClient {
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0, staleTime: Number.POSITIVE_INFINITY },
+			mutations: { retry: false },
+		},
+	});
+}
+
+function wrapper(client: QueryClient) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(QueryClientProvider, { client }, children);
+	};
+}
+
+describe("usePnlGraphEditForm", () => {
+	it("seeds form defaults from an empty config", () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(
+			() => usePnlGraphEditForm({ config: {}, onSave }),
+			{ wrapper: wrapper(createClient()) }
+		);
+		const v = result.current.form.state.values;
+		expect(v.xAxis).toBe("date");
+		expect(v.dateRangeDays).toBe("");
+		expect(v.sessionType).toBe("all");
+		expect(v.unit).toBe("currency");
+		expect(v.storeId).toBe("__none__");
+		expect(v.ringGameId).toBe("__none__");
+		expect(v.currencyId).toBe("__none__");
+		expect(v.showXAxis).toBe(false);
+		expect(v.showDateRange).toBe(false);
+	});
+
+	it("seeds form defaults from a populated config", () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(
+			() =>
+				usePnlGraphEditForm({
+					config: {
+						xAxis: "sessionCount",
+						dateRangeDays: 30,
+						sessionType: "tournament",
+						unit: "bi",
+						storeId: "s1",
+						ringGameId: "rg1",
+						currencyId: "c1",
+						showFilters: { xAxis: true, unit: true },
+					},
+					onSave,
+				}),
+			{ wrapper: wrapper(createClient()) }
+		);
+		const v = result.current.form.state.values;
+		expect(v.xAxis).toBe("sessionCount");
+		expect(v.dateRangeDays).toBe("30");
+		expect(v.sessionType).toBe("tournament");
+		expect(v.unit).toBe("bi");
+		expect(v.storeId).toBe("s1");
+		expect(v.ringGameId).toBe("rg1");
+		expect(v.currencyId).toBe("c1");
+		expect(v.showXAxis).toBe(true);
+		expect(v.showUnit).toBe(true);
+	});
+
+	it("submits the saved config with parsed values, mapping __none__ to null", async () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(
+			() => usePnlGraphEditForm({ config: {}, onSave }),
+			{ wrapper: wrapper(createClient()) }
+		);
+		act(() => {
+			result.current.form.setFieldValue("xAxis", "playTime");
+			result.current.form.setFieldValue("dateRangeDays", "14");
+			result.current.form.setFieldValue("sessionType", "cash_game");
+			result.current.form.setFieldValue("unit", "bb");
+			result.current.form.setFieldValue("storeId", "store-7");
+			result.current.form.setFieldValue("ringGameId", "rg-9");
+			result.current.form.setFieldValue("currencyId", "__none__");
+			result.current.form.setFieldValue("showXAxis", true);
+			result.current.form.setFieldValue("showUnit", true);
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSave).toHaveBeenCalledTimes(1);
+		expect(onSave).toHaveBeenCalledWith({
+			xAxis: "playTime",
+			dateRangeDays: 14,
+			sessionType: "cash_game",
+			unit: "bb",
+			storeId: "store-7",
+			ringGameId: "rg-9",
+			currencyId: null,
+			showFilters: {
+				xAxis: true,
+				dateRange: false,
+				sessionType: false,
+				unit: true,
+				store: false,
+				ringGame: false,
+				currency: false,
+			},
+		});
+	});
+
+	it("submits dateRangeDays as null when blank", async () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(
+			() => usePnlGraphEditForm({ config: { dateRangeDays: 5 }, onSave }),
+			{ wrapper: wrapper(createClient()) }
+		);
+		act(() => {
+			result.current.form.setFieldValue("dateRangeDays", "  ");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSave).toHaveBeenCalledWith(
+			expect.objectContaining({ dateRangeDays: null })
+		);
+	});
+
+	it("rejects non-positive dateRangeDays via the Zod validator", async () => {
+		const onSave = vi.fn().mockResolvedValue(undefined);
+		const { result } = renderHook(
+			() => usePnlGraphEditForm({ config: {}, onSave }),
+			{ wrapper: wrapper(createClient()) }
+		);
+		act(() => {
+			result.current.form.setFieldValue("dateRangeDays", "0");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSave).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/use-pnl-graph-edit-form.test.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/use-pnl-graph-edit-form.test.ts
@@ -68,6 +68,7 @@ describe("usePnlGraphEditForm", () => {
 		expect(v.currencyId).toBe("__none__");
 		expect(v.showXAxis).toBe(false);
 		expect(v.showDateRange).toBe(false);
+		expect(v.showEvCash).toBe(false);
 	});
 
 	it("seeds form defaults from a populated config", () => {
@@ -115,6 +116,7 @@ describe("usePnlGraphEditForm", () => {
 			result.current.form.setFieldValue("storeId", "store-7");
 			result.current.form.setFieldValue("ringGameId", "rg-9");
 			result.current.form.setFieldValue("currencyId", "__none__");
+			result.current.form.setFieldValue("showEvCash", true);
 			result.current.form.setFieldValue("showXAxis", true);
 			result.current.form.setFieldValue("showUnit", true);
 		});
@@ -130,6 +132,7 @@ describe("usePnlGraphEditForm", () => {
 			storeId: "store-7",
 			ringGameId: "rg-9",
 			currencyId: null,
+			showEvCash: true,
 			showFilters: {
 				xAxis: true,
 				dateRange: false,

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/use-pnl-graph-edit-form.test.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/use-pnl-graph-edit-form.test.ts
@@ -79,7 +79,7 @@ describe("usePnlGraphEditForm", () => {
 						xAxis: "sessionCount",
 						dateRangeDays: 30,
 						sessionType: "tournament",
-						unit: "bi",
+						unit: "normalized",
 						storeId: "s1",
 						ringGameId: "rg1",
 						currencyId: "c1",
@@ -93,7 +93,7 @@ describe("usePnlGraphEditForm", () => {
 		expect(v.xAxis).toBe("sessionCount");
 		expect(v.dateRangeDays).toBe("30");
 		expect(v.sessionType).toBe("tournament");
-		expect(v.unit).toBe("bi");
+		expect(v.unit).toBe("normalized");
 		expect(v.storeId).toBe("s1");
 		expect(v.ringGameId).toBe("rg1");
 		expect(v.currencyId).toBe("c1");
@@ -111,7 +111,7 @@ describe("usePnlGraphEditForm", () => {
 			result.current.form.setFieldValue("xAxis", "playTime");
 			result.current.form.setFieldValue("dateRangeDays", "14");
 			result.current.form.setFieldValue("sessionType", "cash_game");
-			result.current.form.setFieldValue("unit", "bb");
+			result.current.form.setFieldValue("unit", "normalized");
 			result.current.form.setFieldValue("storeId", "store-7");
 			result.current.form.setFieldValue("ringGameId", "rg-9");
 			result.current.form.setFieldValue("currencyId", "__none__");
@@ -126,7 +126,7 @@ describe("usePnlGraphEditForm", () => {
 			xAxis: "playTime",
 			dateRangeDays: 14,
 			sessionType: "cash_game",
-			unit: "bb",
+			unit: "normalized",
 			storeId: "store-7",
 			ringGameId: "rg-9",
 			currencyId: null,
@@ -136,7 +136,6 @@ describe("usePnlGraphEditForm", () => {
 				sessionType: false,
 				unit: true,
 				store: false,
-				ringGame: false,
 				currency: false,
 			},
 		});

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/use-pnl-graph-widget.test.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/use-pnl-graph-widget.test.ts
@@ -26,6 +26,24 @@ vi.mock("@/utils/trpc", () => ({
 				},
 			},
 		},
+		store: {
+			list: {
+				queryOptions: (_input?: undefined, opts?: { enabled?: boolean }) => ({
+					queryKey: ["store", "list"],
+					queryFn: () => Promise.resolve([]),
+					...(opts ?? {}),
+				}),
+			},
+		},
+		currency: {
+			list: {
+				queryOptions: (_input?: undefined, opts?: { enabled?: boolean }) => ({
+					queryKey: ["currency", "list"],
+					queryFn: () => Promise.resolve([]),
+					...(opts ?? {}),
+				}),
+			},
+		},
 	},
 }));
 
@@ -59,6 +77,7 @@ describe("parsePnlGraphWidgetConfig", () => {
 		expect(parsed.storeId).toBeNull();
 		expect(parsed.ringGameId).toBeNull();
 		expect(parsed.currencyId).toBeNull();
+		expect(parsed.showEvCash).toBe(false);
 		expect(parsed.showFilters).toEqual({
 			xAxis: false,
 			dateRange: false,
@@ -94,6 +113,16 @@ describe("parsePnlGraphWidgetConfig", () => {
 	it("rejects legacy 'bb' / 'bi' unit values", () => {
 		expect(parsePnlGraphWidgetConfig({ unit: "bb" }).unit).toBe("currency");
 		expect(parsePnlGraphWidgetConfig({ unit: "bi" }).unit).toBe("currency");
+	});
+
+	it("parses showEvCash as a strict boolean", () => {
+		expect(parsePnlGraphWidgetConfig({ showEvCash: true }).showEvCash).toBe(
+			true
+		);
+		expect(parsePnlGraphWidgetConfig({ showEvCash: 1 }).showEvCash).toBe(false);
+		expect(
+			parsePnlGraphWidgetConfig({ showEvCash: undefined }).showEvCash
+		).toBe(false);
 	});
 
 	it("treats non-positive or non-numeric dateRangeDays as null", () => {
@@ -225,6 +254,7 @@ describe("usePnlGraphWidget", () => {
 				type: "cash_game",
 				sessionDate: 1,
 				profitLoss: 50,
+				evProfitLoss: null,
 				playMinutes: null,
 				bigBlind: null,
 				buyInTotal: null,
@@ -234,6 +264,7 @@ describe("usePnlGraphWidget", () => {
 				type: "cash_game",
 				sessionDate: 2,
 				profitLoss: -10,
+				evProfitLoss: null,
 				playMinutes: null,
 				bigBlind: null,
 				buyInTotal: null,
@@ -257,9 +288,10 @@ describe("usePnlGraphWidget", () => {
 			() => usePnlGraphWidget({ xAxis: "sessionCount" }),
 			{ wrapper: wrapper(qc) }
 		);
-		await waitFor(() => expect(result.current.points).toHaveLength(2));
-		expect(result.current.points[0]?.cumulative).toBe(50);
-		expect(result.current.points[1]?.cumulative).toBe(40);
+		await waitFor(() => expect(result.current.points).toHaveLength(3));
+		expect(result.current.points[0]?.cumulative).toBe(0);
+		expect(result.current.points[1]?.cumulative).toBe(50);
+		expect(result.current.points[2]?.cumulative).toBe(40);
 	});
 
 	it("on*Handler setters update runtime state", () => {
@@ -288,6 +320,7 @@ describe("usePnlGraphWidget", () => {
 				type: "cash_game",
 				sessionDate: 1,
 				profitLoss: 200,
+				evProfitLoss: null,
 				playMinutes: null,
 				bigBlind: 50,
 				buyInTotal: null,
@@ -297,6 +330,7 @@ describe("usePnlGraphWidget", () => {
 				type: "tournament",
 				sessionDate: 2,
 				profitLoss: 300,
+				evProfitLoss: null,
 				playMinutes: null,
 				bigBlind: null,
 				buyInTotal: 100,
@@ -325,10 +359,12 @@ describe("usePnlGraphWidget", () => {
 				}),
 			{ wrapper: wrapper(qc) }
 		);
-		await waitFor(() => expect(result.current.points).toHaveLength(2));
-		expect(result.current.points[0]?.cashCumulative).toBe(4);
+		await waitFor(() => expect(result.current.points).toHaveLength(3));
+		expect(result.current.points[0]?.cashCumulative).toBe(0);
 		expect(result.current.points[0]?.tournamentCumulative).toBe(0);
 		expect(result.current.points[1]?.cashCumulative).toBe(4);
-		expect(result.current.points[1]?.tournamentCumulative).toBe(3);
+		expect(result.current.points[1]?.tournamentCumulative).toBe(0);
+		expect(result.current.points[2]?.cashCumulative).toBe(4);
+		expect(result.current.points[2]?.tournamentCumulative).toBe(3);
 	});
 });

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/use-pnl-graph-widget.test.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/use-pnl-graph-widget.test.ts
@@ -1,0 +1,281 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+interface CapturedInput {
+	currencyId?: string;
+	dateFrom?: number;
+	ringGameId?: string;
+	storeId?: string;
+	type?: string;
+}
+
+const captured: { lastInput: CapturedInput | null } = { lastInput: null };
+
+vi.mock("@/utils/trpc", () => ({
+	trpc: {
+		session: {
+			profitLossSeries: {
+				queryOptions: (input: CapturedInput) => {
+					captured.lastInput = input;
+					return {
+						queryKey: ["session", "profitLossSeries", input],
+						queryFn: () => Promise.resolve({ points: [] }),
+					};
+				},
+			},
+		},
+	},
+}));
+
+import {
+	parsePnlGraphWidgetConfig,
+	usePnlGraphWidget,
+} from "@/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-widget";
+
+function createClient(): QueryClient {
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0, staleTime: Number.POSITIVE_INFINITY },
+			mutations: { retry: false },
+		},
+	});
+}
+
+function wrapper(client: QueryClient) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(QueryClientProvider, { client }, children);
+	};
+}
+
+describe("parsePnlGraphWidgetConfig", () => {
+	it("returns defaults for an empty config", () => {
+		const parsed = parsePnlGraphWidgetConfig({});
+		expect(parsed.xAxis).toBe("date");
+		expect(parsed.dateRangeDays).toBeNull();
+		expect(parsed.sessionType).toBe("all");
+		expect(parsed.unit).toBe("currency");
+		expect(parsed.storeId).toBeNull();
+		expect(parsed.ringGameId).toBeNull();
+		expect(parsed.currencyId).toBeNull();
+		expect(parsed.showFilters).toEqual({
+			xAxis: false,
+			dateRange: false,
+			sessionType: false,
+			unit: false,
+			store: false,
+			ringGame: false,
+			currency: false,
+		});
+	});
+
+	it("coerces unknown enum values back to defaults", () => {
+		const parsed = parsePnlGraphWidgetConfig({
+			xAxis: "weird",
+			sessionType: "rotation",
+			unit: "satoshi",
+		});
+		expect(parsed.xAxis).toBe("date");
+		expect(parsed.sessionType).toBe("all");
+		expect(parsed.unit).toBe("currency");
+	});
+
+	it("keeps valid enum values", () => {
+		const parsed = parsePnlGraphWidgetConfig({
+			xAxis: "playTime",
+			sessionType: "cash_game",
+			unit: "bb",
+		});
+		expect(parsed.xAxis).toBe("playTime");
+		expect(parsed.sessionType).toBe("cash_game");
+		expect(parsed.unit).toBe("bb");
+	});
+
+	it("treats non-positive or non-numeric dateRangeDays as null", () => {
+		expect(
+			parsePnlGraphWidgetConfig({ dateRangeDays: 0 }).dateRangeDays
+		).toBeNull();
+		expect(
+			parsePnlGraphWidgetConfig({ dateRangeDays: -3 }).dateRangeDays
+		).toBeNull();
+		expect(
+			parsePnlGraphWidgetConfig({ dateRangeDays: "7" }).dateRangeDays
+		).toBeNull();
+		expect(parsePnlGraphWidgetConfig({ dateRangeDays: 7 }).dateRangeDays).toBe(
+			7
+		);
+	});
+
+	it("preserves string ids and treats empty string as null", () => {
+		expect(parsePnlGraphWidgetConfig({ storeId: "s1" }).storeId).toBe("s1");
+		expect(parsePnlGraphWidgetConfig({ storeId: "" }).storeId).toBeNull();
+		expect(parsePnlGraphWidgetConfig({ storeId: 5 }).storeId).toBeNull();
+	});
+
+	it("parses showFilters flags strictly via boolean equality", () => {
+		const parsed = parsePnlGraphWidgetConfig({
+			showFilters: {
+				xAxis: true,
+				dateRange: "yes",
+				sessionType: 1,
+				unit: false,
+				store: null,
+				ringGame: undefined,
+				currency: true,
+			},
+		});
+		expect(parsed.showFilters).toEqual({
+			xAxis: true,
+			dateRange: false,
+			sessionType: false,
+			unit: false,
+			store: false,
+			ringGame: false,
+			currency: true,
+		});
+	});
+
+	it("falls back to all-false flags when showFilters is not an object", () => {
+		expect(
+			parsePnlGraphWidgetConfig({ showFilters: null }).showFilters
+		).toEqual({
+			xAxis: false,
+			dateRange: false,
+			sessionType: false,
+			unit: false,
+			store: false,
+			ringGame: false,
+			currency: false,
+		});
+	});
+});
+
+describe("usePnlGraphWidget", () => {
+	function setup(config: Record<string, unknown> = {}) {
+		captured.lastInput = null;
+		const qc = createClient();
+		const view = renderHook(() => usePnlGraphWidget(config), {
+			wrapper: wrapper(qc),
+		});
+		return { qc, view };
+	}
+
+	it("seeds runtime state from parsed config defaults", () => {
+		const { view } = setup({
+			xAxis: "sessionCount",
+			sessionType: "tournament",
+			storeId: "store-1",
+			currencyId: "cur-1",
+		});
+		expect(view.result.current.state.xAxis).toBe("sessionCount");
+		expect(view.result.current.state.sessionType).toBe("tournament");
+		expect(view.result.current.state.storeId).toBe("store-1");
+		expect(view.result.current.state.currencyId).toBe("cur-1");
+	});
+
+	it("forces type=cash_game when unit is 'bb' regardless of sessionType setting", () => {
+		setup({ unit: "bb", sessionType: "tournament" });
+		expect(captured.lastInput?.type).toBe("cash_game");
+	});
+
+	it("forces type=tournament when unit is 'bi'", () => {
+		setup({ unit: "bi", sessionType: "all" });
+		expect(captured.lastInput?.type).toBe("tournament");
+	});
+
+	it("passes undefined type when unit=currency and sessionType=all", () => {
+		setup({});
+		expect(captured.lastInput?.type).toBeUndefined();
+	});
+
+	it("passes raw sessionType when unit=currency", () => {
+		setup({ sessionType: "tournament" });
+		expect(captured.lastInput?.type).toBe("tournament");
+	});
+
+	it("passes optional filters when set", () => {
+		setup({ storeId: "s1", ringGameId: "rg1", currencyId: "c1" });
+		expect(captured.lastInput?.storeId).toBe("s1");
+		expect(captured.lastInput?.ringGameId).toBe("rg1");
+		expect(captured.lastInput?.currencyId).toBe("c1");
+	});
+
+	it("computes dateFrom from dateRangeDays", () => {
+		const before = Math.floor(Date.now() / 1000);
+		setup({ dateRangeDays: 7 });
+		const after = Math.floor(Date.now() / 1000);
+		const expectedMin = before - 7 * 86_400;
+		const expectedMax = after - 7 * 86_400;
+		expect(captured.lastInput?.dateFrom).toBeGreaterThanOrEqual(expectedMin);
+		expect(captured.lastInput?.dateFrom).toBeLessThanOrEqual(expectedMax);
+	});
+
+	it("omits dateFrom when dateRangeDays is null", () => {
+		setup({});
+		expect(captured.lastInput?.dateFrom).toBeUndefined();
+	});
+
+	it("aggregates query data into chart points", async () => {
+		const qc = createClient();
+		const samplePoints = [
+			{
+				id: "a",
+				type: "cash_game",
+				sessionDate: 1,
+				profitLoss: 50,
+				playMinutes: null,
+				bigBlind: null,
+				buyInTotal: null,
+			},
+			{
+				id: "b",
+				type: "cash_game",
+				sessionDate: 2,
+				profitLoss: -10,
+				playMinutes: null,
+				bigBlind: null,
+				buyInTotal: null,
+			},
+		];
+		qc.setQueryData(
+			[
+				"session",
+				"profitLossSeries",
+				{
+					type: undefined,
+					storeId: undefined,
+					ringGameId: undefined,
+					currencyId: undefined,
+					dateFrom: undefined,
+				},
+			],
+			{ points: samplePoints }
+		);
+		const { result } = renderHook(
+			() => usePnlGraphWidget({ xAxis: "sessionCount" }),
+			{ wrapper: wrapper(qc) }
+		);
+		await waitFor(() => expect(result.current.points).toHaveLength(2));
+		expect(result.current.points[0]?.cumulative).toBe(50);
+		expect(result.current.points[1]?.cumulative).toBe(40);
+	});
+
+	it("on*Handler setters update runtime state", () => {
+		const { view } = setup({});
+		act(() => view.result.current.onChangeXAxis("playTime"));
+		expect(view.result.current.state.xAxis).toBe("playTime");
+		act(() => view.result.current.onChangeUnit("bi"));
+		expect(view.result.current.state.unit).toBe("bi");
+		act(() => view.result.current.onChangeSessionType("cash_game"));
+		expect(view.result.current.state.sessionType).toBe("cash_game");
+		act(() => view.result.current.onChangeStoreId("s2"));
+		expect(view.result.current.state.storeId).toBe("s2");
+		act(() => view.result.current.onChangeRingGameId("rg2"));
+		expect(view.result.current.state.ringGameId).toBe("rg2");
+		act(() => view.result.current.onChangeCurrencyId("c2"));
+		expect(view.result.current.state.currencyId).toBe("c2");
+		act(() => view.result.current.onChangeDateRangeDays(30));
+		expect(view.result.current.state.dateRangeDays).toBe(30);
+	});
+});

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/use-pnl-graph-widget.test.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/__tests__/use-pnl-graph-widget.test.ts
@@ -65,7 +65,6 @@ describe("parsePnlGraphWidgetConfig", () => {
 			sessionType: false,
 			unit: false,
 			store: false,
-			ringGame: false,
 			currency: false,
 		});
 	});
@@ -85,11 +84,16 @@ describe("parsePnlGraphWidgetConfig", () => {
 		const parsed = parsePnlGraphWidgetConfig({
 			xAxis: "playTime",
 			sessionType: "cash_game",
-			unit: "bb",
+			unit: "normalized",
 		});
 		expect(parsed.xAxis).toBe("playTime");
 		expect(parsed.sessionType).toBe("cash_game");
-		expect(parsed.unit).toBe("bb");
+		expect(parsed.unit).toBe("normalized");
+	});
+
+	it("rejects legacy 'bb' / 'bi' unit values", () => {
+		expect(parsePnlGraphWidgetConfig({ unit: "bb" }).unit).toBe("currency");
+		expect(parsePnlGraphWidgetConfig({ unit: "bi" }).unit).toBe("currency");
 	});
 
 	it("treats non-positive or non-numeric dateRangeDays as null", () => {
@@ -121,7 +125,6 @@ describe("parsePnlGraphWidgetConfig", () => {
 				sessionType: 1,
 				unit: false,
 				store: null,
-				ringGame: undefined,
 				currency: true,
 			},
 		});
@@ -131,7 +134,6 @@ describe("parsePnlGraphWidgetConfig", () => {
 			sessionType: false,
 			unit: false,
 			store: false,
-			ringGame: false,
 			currency: true,
 		});
 	});
@@ -145,7 +147,6 @@ describe("parsePnlGraphWidgetConfig", () => {
 			sessionType: false,
 			unit: false,
 			store: false,
-			ringGame: false,
 			currency: false,
 		});
 	});
@@ -174,14 +175,14 @@ describe("usePnlGraphWidget", () => {
 		expect(view.result.current.state.currencyId).toBe("cur-1");
 	});
 
-	it("forces type=cash_game when unit is 'bb' regardless of sessionType setting", () => {
-		setup({ unit: "bb", sessionType: "tournament" });
-		expect(captured.lastInput?.type).toBe("cash_game");
+	it("passes the raw sessionType filter regardless of unit selection", () => {
+		setup({ unit: "normalized", sessionType: "tournament" });
+		expect(captured.lastInput?.type).toBe("tournament");
 	});
 
-	it("forces type=tournament when unit is 'bi'", () => {
-		setup({ unit: "bi", sessionType: "all" });
-		expect(captured.lastInput?.type).toBe("tournament");
+	it("does not filter by type when sessionType=all even under normalized unit", () => {
+		setup({ unit: "normalized", sessionType: "all" });
+		expect(captured.lastInput?.type).toBeUndefined();
 	});
 
 	it("passes undefined type when unit=currency and sessionType=all", () => {
@@ -265,8 +266,8 @@ describe("usePnlGraphWidget", () => {
 		const { view } = setup({});
 		act(() => view.result.current.onChangeXAxis("playTime"));
 		expect(view.result.current.state.xAxis).toBe("playTime");
-		act(() => view.result.current.onChangeUnit("bi"));
-		expect(view.result.current.state.unit).toBe("bi");
+		act(() => view.result.current.onChangeUnit("normalized"));
+		expect(view.result.current.state.unit).toBe("normalized");
 		act(() => view.result.current.onChangeSessionType("cash_game"));
 		expect(view.result.current.state.sessionType).toBe("cash_game");
 		act(() => view.result.current.onChangeStoreId("s2"));
@@ -277,5 +278,57 @@ describe("usePnlGraphWidget", () => {
 		expect(view.result.current.state.currencyId).toBe("c2");
 		act(() => view.result.current.onChangeDateRangeDays(30));
 		expect(view.result.current.state.dateRangeDays).toBe(30);
+	});
+
+	it("emits dual-series points (cash + tournament cumulative) when unit=normalized + sessionType=all", async () => {
+		const qc = createClient();
+		const samplePoints = [
+			{
+				id: "a",
+				type: "cash_game",
+				sessionDate: 1,
+				profitLoss: 200,
+				playMinutes: null,
+				bigBlind: 50,
+				buyInTotal: null,
+			},
+			{
+				id: "b",
+				type: "tournament",
+				sessionDate: 2,
+				profitLoss: 300,
+				playMinutes: null,
+				bigBlind: null,
+				buyInTotal: 100,
+			},
+		];
+		qc.setQueryData(
+			[
+				"session",
+				"profitLossSeries",
+				{
+					type: undefined,
+					storeId: undefined,
+					ringGameId: undefined,
+					currencyId: undefined,
+					dateFrom: undefined,
+				},
+			],
+			{ points: samplePoints }
+		);
+		const { result } = renderHook(
+			() =>
+				usePnlGraphWidget({
+					xAxis: "sessionCount",
+					unit: "normalized",
+					sessionType: "all",
+				}),
+			{ wrapper: wrapper(qc) }
+		);
+		await waitFor(() => expect(result.current.points).toHaveLength(2));
+		expect(result.current.points[0]?.cashCumulative).toBe(4);
+		expect(result.current.points[0]?.tournamentCumulative).toBe(0);
+		expect(result.current.points[1]?.cashCumulative).toBe(4);
+		expect(result.current.points[1]?.tournamentCumulative).toBe(3);
 	});
 });

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/aggregate-pnl-points.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/aggregate-pnl-points.ts
@@ -1,0 +1,106 @@
+export type PnlGraphXAxis = "date" | "sessionCount" | "playTime";
+export type PnlGraphUnit = "currency" | "bb" | "bi";
+
+export interface PnlSeriesPoint {
+	bigBlind: number | null;
+	buyInTotal: number | null;
+	id: string;
+	playMinutes: number | null;
+	profitLoss: number;
+	sessionDate: number;
+	type: "cash_game" | "tournament";
+}
+
+export interface AggregatedPoint {
+	cumulative: number;
+	x: number;
+}
+
+export interface AggregateResult {
+	points: AggregatedPoint[];
+	skippedCount: number;
+}
+
+function convertProfitLoss(
+	point: PnlSeriesPoint,
+	unit: PnlGraphUnit
+): number | null {
+	if (unit === "currency") {
+		return point.profitLoss;
+	}
+	if (unit === "bb") {
+		if (
+			point.type !== "cash_game" ||
+			point.bigBlind === null ||
+			point.bigBlind <= 0
+		) {
+			return null;
+		}
+		return point.profitLoss / point.bigBlind;
+	}
+	if (
+		point.type !== "tournament" ||
+		point.buyInTotal === null ||
+		point.buyInTotal <= 0
+	) {
+		return null;
+	}
+	return point.profitLoss / point.buyInTotal;
+}
+
+function startOfDayMs(epochSec: number): number {
+	const d = new Date(epochSec * 1000);
+	d.setUTCHours(0, 0, 0, 0);
+	return d.getTime();
+}
+
+export function aggregatePnlPoints(
+	rawPoints: PnlSeriesPoint[],
+	xAxis: PnlGraphXAxis,
+	unit: PnlGraphUnit
+): AggregateResult {
+	const sorted = [...rawPoints].sort(
+		(a, b) => a.sessionDate - b.sessionDate || a.id.localeCompare(b.id)
+	);
+
+	const result: AggregatedPoint[] = [];
+	let cumulative = 0;
+	let sessionIndex = 0;
+	let cumulativeMinutes = 0;
+	let skippedCount = 0;
+
+	const dayBuckets = new Map<number, number>();
+
+	for (const point of sorted) {
+		const value = convertProfitLoss(point, unit);
+		if (value === null) {
+			skippedCount++;
+			continue;
+		}
+		cumulative += value;
+		sessionIndex++;
+
+		if (xAxis === "sessionCount") {
+			result.push({ x: sessionIndex, cumulative });
+			continue;
+		}
+
+		if (xAxis === "playTime") {
+			cumulativeMinutes += point.playMinutes ?? 0;
+			result.push({ x: cumulativeMinutes, cumulative });
+			continue;
+		}
+
+		const dayMs = startOfDayMs(point.sessionDate);
+		dayBuckets.set(dayMs, cumulative);
+	}
+
+	if (xAxis === "date") {
+		const sortedDays = [...dayBuckets.entries()].sort((a, b) => a[0] - b[0]);
+		for (const [dayMs, value] of sortedDays) {
+			result.push({ x: dayMs, cumulative: value });
+		}
+	}
+
+	return { points: result, skippedCount };
+}

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/aggregate-pnl-points.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/aggregate-pnl-points.ts
@@ -5,6 +5,7 @@ export type PnlGraphSessionType = "all" | "cash_game" | "tournament";
 export interface PnlSeriesPoint {
 	bigBlind: number | null;
 	buyInTotal: number | null;
+	evProfitLoss: number | null;
 	id: string;
 	playMinutes: number | null;
 	profitLoss: number;
@@ -15,6 +16,7 @@ export interface PnlSeriesPoint {
 export interface AggregatedPoint {
 	cashCumulative?: number;
 	cumulative?: number;
+	evCashCumulative?: number;
 	tournamentCumulative?: number;
 	x: number;
 }
@@ -22,6 +24,14 @@ export interface AggregatedPoint {
 export interface AggregateResult {
 	points: AggregatedPoint[];
 	skippedCount: number;
+}
+
+export interface AggregateOptions {
+	rawPoints: PnlSeriesPoint[];
+	sessionType: PnlGraphSessionType;
+	showEvCash: boolean;
+	unit: PnlGraphUnit;
+	xAxis: PnlGraphXAxis;
 }
 
 type SingleSeries = "currency" | "bb" | "bi";
@@ -48,6 +58,19 @@ function biValue(point: PnlSeriesPoint): number | null {
 	return point.profitLoss / point.buyInTotal;
 }
 
+function evCashValue(point: PnlSeriesPoint, unit: PnlGraphUnit): number | null {
+	if (point.type !== "cash_game" || point.evProfitLoss === null) {
+		return null;
+	}
+	if (unit === "currency") {
+		return point.evProfitLoss;
+	}
+	if (point.bigBlind === null || point.bigBlind <= 0) {
+		return null;
+	}
+	return point.evProfitLoss / point.bigBlind;
+}
+
 function singleSeriesValue(
 	point: PnlSeriesPoint,
 	series: SingleSeries
@@ -67,140 +90,250 @@ function startOfDayMs(epochSec: number): number {
 	return d.getTime();
 }
 
+function originX(
+	xAxis: PnlGraphXAxis,
+	firstSessionDateSec: number | null
+): number {
+	if (xAxis === "date") {
+		if (firstSessionDateSec === null) {
+			return 0;
+		}
+		return startOfDayMs(firstSessionDateSec) - 86_400_000;
+	}
+	return 0;
+}
+
 function sortPoints(points: PnlSeriesPoint[]): PnlSeriesPoint[] {
 	return [...points].sort(
 		(a, b) => a.sessionDate - b.sessionDate || a.id.localeCompare(b.id)
 	);
 }
 
+interface SingleAccumulator {
+	cumulative: number;
+	cumulativeMinutes: number;
+	evCashCumulative: number;
+	sessionIndex: number;
+}
+
+interface DualAccumulator {
+	cashCumulative: number;
+	cumulativeMinutes: number;
+	evCashCumulative: number;
+	sessionIndex: number;
+	tournamentCumulative: number;
+}
+
+function pickXValue(
+	xAxis: PnlGraphXAxis,
+	sessionDateSec: number,
+	sessionIndex: number,
+	cumulativeMinutes: number
+): number {
+	if (xAxis === "sessionCount") {
+		return sessionIndex;
+	}
+	if (xAxis === "playTime") {
+		return cumulativeMinutes / 60;
+	}
+	return startOfDayMs(sessionDateSec);
+}
+
+function makeSinglePoint(
+	x: number,
+	cumulative: number,
+	evCashCumulative: number,
+	showEvCash: boolean
+): AggregatedPoint {
+	if (showEvCash) {
+		return { x, cumulative, evCashCumulative };
+	}
+	return { x, cumulative };
+}
+
+function makeDualPoint(
+	x: number,
+	cashCumulative: number,
+	tournamentCumulative: number,
+	evCashCumulative: number,
+	showEvCash: boolean
+): AggregatedPoint {
+	if (showEvCash) {
+		return { x, cashCumulative, tournamentCumulative, evCashCumulative };
+	}
+	return { x, cashCumulative, tournamentCumulative };
+}
+
 function aggregateSingle(
 	rawPoints: PnlSeriesPoint[],
 	xAxis: PnlGraphXAxis,
-	series: SingleSeries
+	series: SingleSeries,
+	showEvCash: boolean,
+	unit: PnlGraphUnit
 ): AggregateResult {
 	const sorted = sortPoints(rawPoints);
+	const acc: SingleAccumulator = {
+		cumulative: 0,
+		cumulativeMinutes: 0,
+		evCashCumulative: 0,
+		sessionIndex: 0,
+	};
+	const dayBuckets = new Map<number, AggregatedPoint>();
 	const result: AggregatedPoint[] = [];
-	let cumulative = 0;
-	let sessionIndex = 0;
-	let cumulativeMinutes = 0;
 	let skippedCount = 0;
-	const dayBuckets = new Map<number, number>();
 
-	for (const point of sorted) {
-		const value = singleSeriesValue(point, series);
-		if (value === null) {
+	for (const p of sorted) {
+		const value = singleSeriesValue(p, series);
+		const evDelta = showEvCash ? evCashValue(p, unit) : null;
+		if (value === null && evDelta === null) {
 			skippedCount++;
 			continue;
 		}
-		cumulative += value;
-		sessionIndex++;
-
-		if (xAxis === "sessionCount") {
-			result.push({ x: sessionIndex, cumulative });
-			continue;
+		if (value !== null) {
+			acc.cumulative += value;
 		}
-		if (xAxis === "playTime") {
-			cumulativeMinutes += point.playMinutes ?? 0;
-			result.push({ x: cumulativeMinutes / 60, cumulative });
-			continue;
+		if (evDelta !== null) {
+			acc.evCashCumulative += evDelta;
 		}
-		dayBuckets.set(startOfDayMs(point.sessionDate), cumulative);
+		acc.sessionIndex++;
+		acc.cumulativeMinutes += p.playMinutes ?? 0;
+		const x = pickXValue(
+			xAxis,
+			p.sessionDate,
+			acc.sessionIndex,
+			acc.cumulativeMinutes
+		);
+		const point = makeSinglePoint(
+			x,
+			acc.cumulative,
+			acc.evCashCumulative,
+			showEvCash
+		);
+		if (xAxis === "date") {
+			dayBuckets.set(x, point);
+		} else {
+			result.push(point);
+		}
 	}
 
 	if (xAxis === "date") {
 		const sortedDays = [...dayBuckets.entries()].sort((a, b) => a[0] - b[0]);
-		for (const [dayMs, value] of sortedDays) {
-			result.push({ x: dayMs, cumulative: value });
+		for (const [, value] of sortedDays) {
+			result.push(value);
 		}
 	}
 
+	if (result.length > 0) {
+		const firstDate = sorted[0]?.sessionDate ?? null;
+		const oX = originX(xAxis, firstDate);
+		result.unshift(makeSinglePoint(oX, 0, 0, showEvCash));
+	}
 	return { points: result, skippedCount };
+}
+
+interface DualDeltas {
+	cashDelta: number | null;
+	evDelta: number | null;
+	tournamentDelta: number | null;
+}
+
+function dualDeltas(p: PnlSeriesPoint, showEvCash: boolean): DualDeltas {
+	return {
+		cashDelta: p.type === "cash_game" ? bbValue(p) : null,
+		tournamentDelta: p.type === "tournament" ? biValue(p) : null,
+		evDelta: showEvCash ? evCashValue(p, "normalized") : null,
+	};
+}
+
+function applyDualDeltas(acc: DualAccumulator, deltas: DualDeltas) {
+	if (deltas.cashDelta !== null) {
+		acc.cashCumulative += deltas.cashDelta;
+	}
+	if (deltas.tournamentDelta !== null) {
+		acc.tournamentCumulative += deltas.tournamentDelta;
+	}
+	if (deltas.evDelta !== null) {
+		acc.evCashCumulative += deltas.evDelta;
+	}
 }
 
 function aggregateDual(
 	rawPoints: PnlSeriesPoint[],
-	xAxis: PnlGraphXAxis
+	xAxis: PnlGraphXAxis,
+	showEvCash: boolean
 ): AggregateResult {
 	const sorted = sortPoints(rawPoints);
+	const acc: DualAccumulator = {
+		cashCumulative: 0,
+		cumulativeMinutes: 0,
+		evCashCumulative: 0,
+		sessionIndex: 0,
+		tournamentCumulative: 0,
+	};
+	const dayBuckets = new Map<number, AggregatedPoint>();
 	const result: AggregatedPoint[] = [];
-	let cashCumulative = 0;
-	let tournamentCumulative = 0;
-	let sessionIndex = 0;
-	let cumulativeMinutes = 0;
 	let skippedCount = 0;
-	const dayBuckets = new Map<
-		number,
-		{ cashCumulative: number; tournamentCumulative: number }
-	>();
 
-	for (const point of sorted) {
-		const cashDelta = point.type === "cash_game" ? bbValue(point) : null;
-		const tournamentDelta = point.type === "tournament" ? biValue(point) : null;
-
-		if (cashDelta === null && tournamentDelta === null) {
+	for (const p of sorted) {
+		const deltas = dualDeltas(p, showEvCash);
+		if (
+			deltas.cashDelta === null &&
+			deltas.tournamentDelta === null &&
+			deltas.evDelta === null
+		) {
 			skippedCount++;
 			continue;
 		}
-
-		if (cashDelta !== null) {
-			cashCumulative += cashDelta;
+		applyDualDeltas(acc, deltas);
+		acc.sessionIndex++;
+		acc.cumulativeMinutes += p.playMinutes ?? 0;
+		const x = pickXValue(
+			xAxis,
+			p.sessionDate,
+			acc.sessionIndex,
+			acc.cumulativeMinutes
+		);
+		const point = makeDualPoint(
+			x,
+			acc.cashCumulative,
+			acc.tournamentCumulative,
+			acc.evCashCumulative,
+			showEvCash
+		);
+		if (xAxis === "date") {
+			dayBuckets.set(x, point);
+		} else {
+			result.push(point);
 		}
-		if (tournamentDelta !== null) {
-			tournamentCumulative += tournamentDelta;
-		}
-		sessionIndex++;
-
-		if (xAxis === "sessionCount") {
-			result.push({
-				x: sessionIndex,
-				cashCumulative,
-				tournamentCumulative,
-			});
-			continue;
-		}
-		if (xAxis === "playTime") {
-			cumulativeMinutes += point.playMinutes ?? 0;
-			result.push({
-				x: cumulativeMinutes / 60,
-				cashCumulative,
-				tournamentCumulative,
-			});
-			continue;
-		}
-		dayBuckets.set(startOfDayMs(point.sessionDate), {
-			cashCumulative,
-			tournamentCumulative,
-		});
 	}
 
 	if (xAxis === "date") {
 		const sortedDays = [...dayBuckets.entries()].sort((a, b) => a[0] - b[0]);
-		for (const [dayMs, value] of sortedDays) {
-			result.push({
-				x: dayMs,
-				cashCumulative: value.cashCumulative,
-				tournamentCumulative: value.tournamentCumulative,
-			});
+		for (const [, value] of sortedDays) {
+			result.push(value);
 		}
 	}
 
+	if (result.length > 0) {
+		const firstDate = sorted[0]?.sessionDate ?? null;
+		const oX = originX(xAxis, firstDate);
+		result.unshift(makeDualPoint(oX, 0, 0, 0, showEvCash));
+	}
 	return { points: result, skippedCount };
 }
 
-export function aggregatePnlPoints(
-	rawPoints: PnlSeriesPoint[],
-	xAxis: PnlGraphXAxis,
-	unit: PnlGraphUnit,
-	sessionType: PnlGraphSessionType
-): AggregateResult {
+export function aggregatePnlPoints(options: AggregateOptions): AggregateResult {
+	const { rawPoints, xAxis, unit, sessionType, showEvCash } = options;
+	const evApplies =
+		showEvCash && (unit === "currency" || sessionType !== "tournament");
 	if (unit === "currency") {
-		return aggregateSingle(rawPoints, xAxis, "currency");
+		return aggregateSingle(rawPoints, xAxis, "currency", evApplies, "currency");
 	}
 	if (sessionType === "cash_game") {
-		return aggregateSingle(rawPoints, xAxis, "bb");
+		return aggregateSingle(rawPoints, xAxis, "bb", evApplies, "normalized");
 	}
 	if (sessionType === "tournament") {
-		return aggregateSingle(rawPoints, xAxis, "bi");
+		return aggregateSingle(rawPoints, xAxis, "bi", false, "normalized");
 	}
-	return aggregateDual(rawPoints, xAxis);
+	return aggregateDual(rawPoints, xAxis, evApplies);
 }

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/aggregate-pnl-points.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/aggregate-pnl-points.ts
@@ -1,5 +1,6 @@
 export type PnlGraphXAxis = "date" | "sessionCount" | "playTime";
-export type PnlGraphUnit = "currency" | "bb" | "bi";
+export type PnlGraphUnit = "currency" | "normalized";
+export type PnlGraphSessionType = "all" | "cash_game" | "tournament";
 
 export interface PnlSeriesPoint {
 	bigBlind: number | null;
@@ -12,7 +13,9 @@ export interface PnlSeriesPoint {
 }
 
 export interface AggregatedPoint {
-	cumulative: number;
+	cashCumulative?: number;
+	cumulative?: number;
+	tournamentCumulative?: number;
 	x: number;
 }
 
@@ -21,23 +24,20 @@ export interface AggregateResult {
 	skippedCount: number;
 }
 
-function convertProfitLoss(
-	point: PnlSeriesPoint,
-	unit: PnlGraphUnit
-): number | null {
-	if (unit === "currency") {
-		return point.profitLoss;
+type SingleSeries = "currency" | "bb" | "bi";
+
+function bbValue(point: PnlSeriesPoint): number | null {
+	if (
+		point.type !== "cash_game" ||
+		point.bigBlind === null ||
+		point.bigBlind <= 0
+	) {
+		return null;
 	}
-	if (unit === "bb") {
-		if (
-			point.type !== "cash_game" ||
-			point.bigBlind === null ||
-			point.bigBlind <= 0
-		) {
-			return null;
-		}
-		return point.profitLoss / point.bigBlind;
-	}
+	return point.profitLoss / point.bigBlind;
+}
+
+function biValue(point: PnlSeriesPoint): number | null {
 	if (
 		point.type !== "tournament" ||
 		point.buyInTotal === null ||
@@ -48,31 +48,46 @@ function convertProfitLoss(
 	return point.profitLoss / point.buyInTotal;
 }
 
+function singleSeriesValue(
+	point: PnlSeriesPoint,
+	series: SingleSeries
+): number | null {
+	if (series === "currency") {
+		return point.profitLoss;
+	}
+	if (series === "bb") {
+		return bbValue(point);
+	}
+	return biValue(point);
+}
+
 function startOfDayMs(epochSec: number): number {
 	const d = new Date(epochSec * 1000);
 	d.setUTCHours(0, 0, 0, 0);
 	return d.getTime();
 }
 
-export function aggregatePnlPoints(
-	rawPoints: PnlSeriesPoint[],
-	xAxis: PnlGraphXAxis,
-	unit: PnlGraphUnit
-): AggregateResult {
-	const sorted = [...rawPoints].sort(
+function sortPoints(points: PnlSeriesPoint[]): PnlSeriesPoint[] {
+	return [...points].sort(
 		(a, b) => a.sessionDate - b.sessionDate || a.id.localeCompare(b.id)
 	);
+}
 
+function aggregateSingle(
+	rawPoints: PnlSeriesPoint[],
+	xAxis: PnlGraphXAxis,
+	series: SingleSeries
+): AggregateResult {
+	const sorted = sortPoints(rawPoints);
 	const result: AggregatedPoint[] = [];
 	let cumulative = 0;
 	let sessionIndex = 0;
 	let cumulativeMinutes = 0;
 	let skippedCount = 0;
-
 	const dayBuckets = new Map<number, number>();
 
 	for (const point of sorted) {
-		const value = convertProfitLoss(point, unit);
+		const value = singleSeriesValue(point, series);
 		if (value === null) {
 			skippedCount++;
 			continue;
@@ -84,15 +99,12 @@ export function aggregatePnlPoints(
 			result.push({ x: sessionIndex, cumulative });
 			continue;
 		}
-
 		if (xAxis === "playTime") {
 			cumulativeMinutes += point.playMinutes ?? 0;
-			result.push({ x: cumulativeMinutes, cumulative });
+			result.push({ x: cumulativeMinutes / 60, cumulative });
 			continue;
 		}
-
-		const dayMs = startOfDayMs(point.sessionDate);
-		dayBuckets.set(dayMs, cumulative);
+		dayBuckets.set(startOfDayMs(point.sessionDate), cumulative);
 	}
 
 	if (xAxis === "date") {
@@ -103,4 +115,92 @@ export function aggregatePnlPoints(
 	}
 
 	return { points: result, skippedCount };
+}
+
+function aggregateDual(
+	rawPoints: PnlSeriesPoint[],
+	xAxis: PnlGraphXAxis
+): AggregateResult {
+	const sorted = sortPoints(rawPoints);
+	const result: AggregatedPoint[] = [];
+	let cashCumulative = 0;
+	let tournamentCumulative = 0;
+	let sessionIndex = 0;
+	let cumulativeMinutes = 0;
+	let skippedCount = 0;
+	const dayBuckets = new Map<
+		number,
+		{ cashCumulative: number; tournamentCumulative: number }
+	>();
+
+	for (const point of sorted) {
+		const cashDelta = point.type === "cash_game" ? bbValue(point) : null;
+		const tournamentDelta = point.type === "tournament" ? biValue(point) : null;
+
+		if (cashDelta === null && tournamentDelta === null) {
+			skippedCount++;
+			continue;
+		}
+
+		if (cashDelta !== null) {
+			cashCumulative += cashDelta;
+		}
+		if (tournamentDelta !== null) {
+			tournamentCumulative += tournamentDelta;
+		}
+		sessionIndex++;
+
+		if (xAxis === "sessionCount") {
+			result.push({
+				x: sessionIndex,
+				cashCumulative,
+				tournamentCumulative,
+			});
+			continue;
+		}
+		if (xAxis === "playTime") {
+			cumulativeMinutes += point.playMinutes ?? 0;
+			result.push({
+				x: cumulativeMinutes / 60,
+				cashCumulative,
+				tournamentCumulative,
+			});
+			continue;
+		}
+		dayBuckets.set(startOfDayMs(point.sessionDate), {
+			cashCumulative,
+			tournamentCumulative,
+		});
+	}
+
+	if (xAxis === "date") {
+		const sortedDays = [...dayBuckets.entries()].sort((a, b) => a[0] - b[0]);
+		for (const [dayMs, value] of sortedDays) {
+			result.push({
+				x: dayMs,
+				cashCumulative: value.cashCumulative,
+				tournamentCumulative: value.tournamentCumulative,
+			});
+		}
+	}
+
+	return { points: result, skippedCount };
+}
+
+export function aggregatePnlPoints(
+	rawPoints: PnlSeriesPoint[],
+	xAxis: PnlGraphXAxis,
+	unit: PnlGraphUnit,
+	sessionType: PnlGraphSessionType
+): AggregateResult {
+	if (unit === "currency") {
+		return aggregateSingle(rawPoints, xAxis, "currency");
+	}
+	if (sessionType === "cash_game") {
+		return aggregateSingle(rawPoints, xAxis, "bb");
+	}
+	if (sessionType === "tournament") {
+		return aggregateSingle(rawPoints, xAxis, "bi");
+	}
+	return aggregateDual(rawPoints, xAxis);
 }

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/index.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/index.ts
@@ -1,0 +1,18 @@
+export {
+	type AggregatedPoint,
+	aggregatePnlPoints,
+	type PnlSeriesPoint,
+} from "./aggregate-pnl-points";
+export { PnlGraphEditForm, PnlGraphWidget } from "./pnl-graph-widget";
+export {
+	PNL_GRAPH_SESSION_TYPE_VALUES,
+	PNL_GRAPH_UNIT_VALUES,
+	PNL_GRAPH_X_AXIS_VALUES,
+	type PnlGraphFilterFlags,
+	type PnlGraphParsedConfig,
+	type PnlGraphSessionType,
+	type PnlGraphUnit,
+	type PnlGraphXAxis,
+	parsePnlGraphWidgetConfig,
+	usePnlGraphWidget,
+} from "./use-pnl-graph-widget";

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-chart.tsx
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-chart.tsx
@@ -1,0 +1,82 @@
+import {
+	CartesianGrid,
+	Line,
+	LineChart,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { formatCompactNumber } from "@/utils/format-number";
+import type { PnlGraphXAxis } from "./aggregate-pnl-points";
+
+function formatXTick(value: number, xAxis: PnlGraphXAxis): string {
+	if (xAxis === "date") {
+		const d = new Date(value);
+		const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+		const day = String(d.getUTCDate()).padStart(2, "0");
+		return `${month}/${day}`;
+	}
+	return formatCompactNumber(value);
+}
+
+function formatTooltipLabel(value: number, xAxis: PnlGraphXAxis): string {
+	if (xAxis === "date") {
+		return new Date(value).toISOString().slice(0, 10);
+	}
+	if (xAxis === "playTime") {
+		return `${value.toFixed(0)} min`;
+	}
+	return `Session ${value}`;
+}
+
+interface PnlGraphChartProps {
+	points: { cumulative: number; x: number }[];
+	xAxisType: PnlGraphXAxis;
+}
+
+export default function PnlGraphChart({
+	points,
+	xAxisType,
+}: PnlGraphChartProps) {
+	return (
+		<ResponsiveContainer height="100%" width="100%">
+			<LineChart
+				data={points}
+				margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+			>
+				<CartesianGrid className="stroke-border" strokeDasharray="3 3" />
+				<XAxis
+					dataKey="x"
+					domain={["dataMin", "dataMax"]}
+					tick={{ fontSize: 10 }}
+					tickFormatter={(v: number) => formatXTick(v, xAxisType)}
+					type="number"
+				/>
+				<YAxis
+					tick={{ fontSize: 10 }}
+					tickFormatter={(v: number) => formatCompactNumber(v)}
+					width={50}
+				/>
+				<Tooltip
+					formatter={(value) =>
+						typeof value === "number" ? formatCompactNumber(value) : ""
+					}
+					labelFormatter={(label) =>
+						typeof label === "number"
+							? formatTooltipLabel(label, xAxisType)
+							: ""
+					}
+				/>
+				<Line
+					className="stroke-primary"
+					dataKey="cumulative"
+					dot={false}
+					isAnimationActive={false}
+					strokeWidth={2}
+					type="monotone"
+				/>
+			</LineChart>
+		</ResponsiveContainer>
+	);
+}

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-chart.tsx
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-chart.tsx
@@ -13,7 +13,6 @@ import type { PnlGraphXAxis } from "./aggregate-pnl-points";
 
 const COLOR_CASH = "oklch(0.62 0.21 250)";
 const COLOR_TOURNAMENT = "oklch(0.75 0.16 70)";
-const COLOR_EV_CASH = "oklch(0.7 0.17 162)";
 const COLOR_PRIMARY = "var(--color-primary)";
 
 function formatXTick(value: number, xAxis: PnlGraphXAxis): string {
@@ -95,6 +94,73 @@ function CustomTooltip({ active, label, payload, xAxis }: CustomTooltipProps) {
 	);
 }
 
+function computeAlignedDomain(
+	min: number,
+	max: number,
+	negFrac: number
+): [number, number] {
+	if (min === 0 && max === 0) {
+		return [-1, 1];
+	}
+	if (negFrac === 0) {
+		return [0, max || 1];
+	}
+	if (negFrac === 1) {
+		return [min || -1, 0];
+	}
+	const candidateMin = (-max * negFrac) / (1 - negFrac);
+	if (candidateMin <= min) {
+		return [candidateMin, max];
+	}
+	const newMax = (-min * (1 - negFrac)) / negFrac;
+	return [min, newMax];
+}
+
+interface ScanResult {
+	bbMax: number;
+	bbMin: number;
+	biMax: number;
+	biMin: number;
+}
+
+function scanDualValues(points: ChartPoint[]): ScanResult {
+	let bbMin = 0;
+	let bbMax = 0;
+	let biMin = 0;
+	let biMax = 0;
+	for (const p of points) {
+		if (typeof p.cashCumulative === "number") {
+			bbMin = Math.min(bbMin, p.cashCumulative);
+			bbMax = Math.max(bbMax, p.cashCumulative);
+		}
+		if (typeof p.evCashCumulative === "number") {
+			bbMin = Math.min(bbMin, p.evCashCumulative);
+			bbMax = Math.max(bbMax, p.evCashCumulative);
+		}
+		if (typeof p.tournamentCumulative === "number") {
+			biMin = Math.min(biMin, p.tournamentCumulative);
+			biMax = Math.max(biMax, p.tournamentCumulative);
+		}
+	}
+	return { bbMin, bbMax, biMin, biMax };
+}
+
+function alignedDualDomains(points: ChartPoint[]): {
+	bb: [number, number];
+	bi: [number, number];
+} {
+	const { bbMin, bbMax, biMin, biMax } = scanDualValues(points);
+	const bbRange = bbMax - bbMin || 1;
+	const biRange = biMax - biMin || 1;
+	const bbNegFrac = -bbMin / bbRange;
+	const biNegFrac = -biMin / biRange;
+	const negFrac = Math.max(bbNegFrac, biNegFrac);
+	return {
+		bb: computeAlignedDomain(bbMin, bbMax, negFrac),
+		bi: computeAlignedDomain(biMin, biMax, negFrac),
+	};
+}
+
 interface PnlGraphChartProps {
 	dual: boolean;
 	points: ChartPoint[];
@@ -109,8 +175,10 @@ export default function PnlGraphChart({
 	xAxisType,
 }: PnlGraphChartProps) {
 	const showLegend = dual || showEvCash;
+	const dualDomains = dual ? alignedDualDomains(points) : null;
+	const singleColor = dual ? COLOR_CASH : COLOR_PRIMARY;
 	return (
-		<div className="h-full w-full focus:outline-none [&_.recharts-surface]:focus:outline-none [&_.recharts-surface]:focus-visible:outline-none [&_.recharts-wrapper]:focus:outline-none [&_.recharts-wrapper]:focus-visible:outline-none">
+		<div className="h-full w-full">
 			<ResponsiveContainer height="100%" width="100%">
 				<LineChart
 					data={points}
@@ -124,15 +192,17 @@ export default function PnlGraphChart({
 						tickFormatter={(v: number) => formatXTick(v, xAxisType)}
 						type="number"
 					/>
-					{dual ? (
+					{dual && dualDomains ? (
 						<>
 							<YAxis
+								domain={dualDomains.bb}
 								tick={{ fontSize: 10 }}
 								tickFormatter={(v: number) => formatCompactNumber(v)}
 								width={50}
 								yAxisId="bb"
 							/>
 							<YAxis
+								domain={dualDomains.bi}
 								orientation="right"
 								tick={{ fontSize: 10 }}
 								tickFormatter={(v: number) => formatCompactNumber(v)}
@@ -181,6 +251,20 @@ export default function PnlGraphChart({
 								type="linear"
 								yAxisId="bb"
 							/>
+							{showEvCash ? (
+								<Line
+									connectNulls
+									dataKey="evCashCumulative"
+									dot={false}
+									isAnimationActive={false}
+									name="EV BB (cash)"
+									stroke={COLOR_CASH}
+									strokeDasharray="4 4"
+									strokeWidth={2}
+									type="linear"
+									yAxisId="bb"
+								/>
+							) : null}
 							<Line
 								connectNulls
 								dataKey="tournamentCumulative"
@@ -192,20 +276,6 @@ export default function PnlGraphChart({
 								type="linear"
 								yAxisId="bi"
 							/>
-							{showEvCash ? (
-								<Line
-									connectNulls
-									dataKey="evCashCumulative"
-									dot={false}
-									isAnimationActive={false}
-									name="EV BB (cash)"
-									stroke={COLOR_EV_CASH}
-									strokeDasharray="4 4"
-									strokeWidth={2}
-									type="linear"
-									yAxisId="bb"
-								/>
-							) : null}
 						</>
 					) : (
 						<>
@@ -214,7 +284,7 @@ export default function PnlGraphChart({
 								dot={false}
 								isAnimationActive={false}
 								name="Cumulative"
-								stroke={COLOR_PRIMARY}
+								stroke={singleColor}
 								strokeWidth={2}
 								type="linear"
 							/>
@@ -225,7 +295,7 @@ export default function PnlGraphChart({
 									dot={false}
 									isAnimationActive={false}
 									name="EV (cash)"
-									stroke={COLOR_EV_CASH}
+									stroke={singleColor}
 									strokeDasharray="4 4"
 									strokeWidth={2}
 									type="linear"

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-chart.tsx
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-chart.tsx
@@ -17,6 +17,9 @@ function formatXTick(value: number, xAxis: PnlGraphXAxis): string {
 		const day = String(d.getUTCDate()).padStart(2, "0");
 		return `${month}/${day}`;
 	}
+	if (xAxis === "playTime") {
+		return value.toFixed(1);
+	}
 	return formatCompactNumber(value);
 }
 
@@ -25,17 +28,74 @@ function formatTooltipLabel(value: number, xAxis: PnlGraphXAxis): string {
 		return new Date(value).toISOString().slice(0, 10);
 	}
 	if (xAxis === "playTime") {
-		return `${value.toFixed(0)} min`;
+		return `${value.toFixed(1)} h`;
 	}
 	return `Session ${value}`;
 }
 
+interface ChartPoint {
+	cashCumulative?: number;
+	cumulative?: number;
+	tournamentCumulative?: number;
+	x: number;
+}
+
+interface TooltipPayloadItem {
+	color?: string;
+	dataKey?: string | number;
+	name?: string | number;
+	value?: number | string | (number | string)[];
+}
+
+interface CustomTooltipProps {
+	active?: boolean;
+	label?: number | string;
+	payload?: readonly TooltipPayloadItem[];
+	xAxis: PnlGraphXAxis;
+}
+
+function CustomTooltip({ active, label, payload, xAxis }: CustomTooltipProps) {
+	if (!(active && payload) || payload.length === 0) {
+		return null;
+	}
+	return (
+		<div className="rounded-md border border-border bg-popover px-2 py-1 text-popover-foreground text-xs shadow-md">
+			{typeof label === "number" ? (
+				<div className="text-muted-foreground">
+					{formatTooltipLabel(label, xAxis)}
+				</div>
+			) : null}
+			{payload.map((item) => (
+				<div
+					className="flex items-center gap-2"
+					key={String(item.dataKey ?? item.name)}
+				>
+					<span
+						className="inline-block h-2 w-2 rounded-full"
+						style={{ backgroundColor: item.color }}
+					/>
+					<span className="text-muted-foreground">
+						{String(item.name ?? "")}
+					</span>
+					<span className="font-medium tabular-nums">
+						{typeof item.value === "number"
+							? formatCompactNumber(item.value)
+							: ""}
+					</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
 interface PnlGraphChartProps {
-	points: { cumulative: number; x: number }[];
+	dual: boolean;
+	points: ChartPoint[];
 	xAxisType: PnlGraphXAxis;
 }
 
 export default function PnlGraphChart({
+	dual,
 	points,
 	xAxisType,
 }: PnlGraphChartProps) {
@@ -53,29 +113,79 @@ export default function PnlGraphChart({
 					tickFormatter={(v: number) => formatXTick(v, xAxisType)}
 					type="number"
 				/>
-				<YAxis
-					tick={{ fontSize: 10 }}
-					tickFormatter={(v: number) => formatCompactNumber(v)}
-					width={50}
-				/>
+				{dual ? (
+					<>
+						<YAxis
+							tick={{ fontSize: 10 }}
+							tickFormatter={(v: number) => formatCompactNumber(v)}
+							width={50}
+							yAxisId="bb"
+						/>
+						<YAxis
+							orientation="right"
+							tick={{ fontSize: 10 }}
+							tickFormatter={(v: number) => formatCompactNumber(v)}
+							width={50}
+							yAxisId="bi"
+						/>
+					</>
+				) : (
+					<YAxis
+						tick={{ fontSize: 10 }}
+						tickFormatter={(v: number) => formatCompactNumber(v)}
+						width={50}
+					/>
+				)}
 				<Tooltip
-					formatter={(value) =>
-						typeof value === "number" ? formatCompactNumber(value) : ""
-					}
-					labelFormatter={(label) =>
-						typeof label === "number"
-							? formatTooltipLabel(label, xAxisType)
-							: ""
-					}
+					content={(props) => (
+						<CustomTooltip
+							active={props.active}
+							label={props.label as number | string | undefined}
+							payload={
+								props.payload as readonly TooltipPayloadItem[] | undefined
+							}
+							xAxis={xAxisType}
+						/>
+					)}
+					cursor={false}
+					wrapperStyle={{ outline: "none" }}
 				/>
-				<Line
-					className="stroke-primary"
-					dataKey="cumulative"
-					dot={false}
-					isAnimationActive={false}
-					strokeWidth={2}
-					type="monotone"
-				/>
+				{dual ? (
+					<>
+						<Line
+							className="stroke-chart-1"
+							connectNulls
+							dataKey="cashCumulative"
+							dot={false}
+							isAnimationActive={false}
+							name="BB (cash)"
+							strokeWidth={2}
+							type="linear"
+							yAxisId="bb"
+						/>
+						<Line
+							className="stroke-chart-2"
+							connectNulls
+							dataKey="tournamentCumulative"
+							dot={false}
+							isAnimationActive={false}
+							name="BI (tournament)"
+							strokeWidth={2}
+							type="linear"
+							yAxisId="bi"
+						/>
+					</>
+				) : (
+					<Line
+						className="stroke-primary"
+						dataKey="cumulative"
+						dot={false}
+						isAnimationActive={false}
+						name="Cumulative"
+						strokeWidth={2}
+						type="linear"
+					/>
+				)}
 			</LineChart>
 		</ResponsiveContainer>
 	);

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-chart.tsx
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-chart.tsx
@@ -168,6 +168,69 @@ interface PnlGraphChartProps {
 	xAxisType: PnlGraphXAxis;
 }
 
+interface LegendItem {
+	color: string;
+	dashed: boolean;
+	value: string;
+}
+
+function legendItemsFor(
+	dual: boolean,
+	showEvCash: boolean,
+	singleColor: string
+): LegendItem[] {
+	if (dual) {
+		const items: LegendItem[] = [
+			{ value: "BB (cash)", color: COLOR_CASH, dashed: false },
+		];
+		if (showEvCash) {
+			items.push({ value: "EV BB (cash)", color: COLOR_CASH, dashed: true });
+		}
+		items.push({
+			value: "BI (tournament)",
+			color: COLOR_TOURNAMENT,
+			dashed: false,
+		});
+		return items;
+	}
+	const items: LegendItem[] = [
+		{ value: "Cumulative", color: singleColor, dashed: false },
+	];
+	if (showEvCash) {
+		items.push({ value: "EV (cash)", color: singleColor, dashed: true });
+	}
+	return items;
+}
+
+function CustomLegend({ items }: { items: LegendItem[] }) {
+	return (
+		<div className="flex flex-wrap items-center justify-center gap-3 pt-1 text-[11px]">
+			{items.map((item) => (
+				<div className="flex items-center gap-1.5" key={item.value}>
+					<svg
+						aria-hidden="true"
+						className="shrink-0"
+						height={6}
+						viewBox="0 0 14 6"
+						width={14}
+					>
+						<line
+							stroke={item.color}
+							strokeDasharray={item.dashed ? "3 2" : undefined}
+							strokeWidth={2}
+							x1={0}
+							x2={14}
+							y1={3}
+							y2={3}
+						/>
+					</svg>
+					<span className="text-foreground">{item.value}</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
 export default function PnlGraphChart({
 	dual,
 	points,
@@ -177,6 +240,7 @@ export default function PnlGraphChart({
 	const showLegend = dual || showEvCash;
 	const dualDomains = dual ? alignedDualDomains(points) : null;
 	const singleColor = dual ? COLOR_CASH : COLOR_PRIMARY;
+	const legendItems = legendItemsFor(dual, showEvCash, singleColor);
 	return (
 		<div className="h-full w-full">
 			<ResponsiveContainer height="100%" width="100%">
@@ -233,9 +297,8 @@ export default function PnlGraphChart({
 					/>
 					{showLegend ? (
 						<Legend
-							iconSize={10}
-							iconType="line"
-							wrapperStyle={{ fontSize: 11, paddingTop: 4 }}
+							content={() => <CustomLegend items={legendItems} />}
+							wrapperStyle={{ outline: "none" }}
 						/>
 					) : null}
 					{dual ? (

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-chart.tsx
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-chart.tsx
@@ -1,5 +1,6 @@
 import {
 	CartesianGrid,
+	Legend,
 	Line,
 	LineChart,
 	ResponsiveContainer,
@@ -9,6 +10,11 @@ import {
 } from "recharts";
 import { formatCompactNumber } from "@/utils/format-number";
 import type { PnlGraphXAxis } from "./aggregate-pnl-points";
+
+const COLOR_CASH = "oklch(0.62 0.21 250)";
+const COLOR_TOURNAMENT = "oklch(0.75 0.16 70)";
+const COLOR_EV_CASH = "oklch(0.7 0.17 162)";
+const COLOR_PRIMARY = "var(--color-primary)";
 
 function formatXTick(value: number, xAxis: PnlGraphXAxis): string {
 	if (xAxis === "date") {
@@ -36,6 +42,7 @@ function formatTooltipLabel(value: number, xAxis: PnlGraphXAxis): string {
 interface ChartPoint {
 	cashCumulative?: number;
 	cumulative?: number;
+	evCashCumulative?: number;
 	tournamentCumulative?: number;
 	x: number;
 }
@@ -91,102 +98,143 @@ function CustomTooltip({ active, label, payload, xAxis }: CustomTooltipProps) {
 interface PnlGraphChartProps {
 	dual: boolean;
 	points: ChartPoint[];
+	showEvCash: boolean;
 	xAxisType: PnlGraphXAxis;
 }
 
 export default function PnlGraphChart({
 	dual,
 	points,
+	showEvCash,
 	xAxisType,
 }: PnlGraphChartProps) {
+	const showLegend = dual || showEvCash;
 	return (
-		<ResponsiveContainer height="100%" width="100%">
-			<LineChart
-				data={points}
-				margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
-			>
-				<CartesianGrid className="stroke-border" strokeDasharray="3 3" />
-				<XAxis
-					dataKey="x"
-					domain={["dataMin", "dataMax"]}
-					tick={{ fontSize: 10 }}
-					tickFormatter={(v: number) => formatXTick(v, xAxisType)}
-					type="number"
-				/>
-				{dual ? (
-					<>
-						<YAxis
-							tick={{ fontSize: 10 }}
-							tickFormatter={(v: number) => formatCompactNumber(v)}
-							width={50}
-							yAxisId="bb"
-						/>
-						<YAxis
-							orientation="right"
-							tick={{ fontSize: 10 }}
-							tickFormatter={(v: number) => formatCompactNumber(v)}
-							width={50}
-							yAxisId="bi"
-						/>
-					</>
-				) : (
-					<YAxis
+		<div className="h-full w-full focus:outline-none [&_.recharts-surface]:focus:outline-none [&_.recharts-surface]:focus-visible:outline-none [&_.recharts-wrapper]:focus:outline-none [&_.recharts-wrapper]:focus-visible:outline-none">
+			<ResponsiveContainer height="100%" width="100%">
+				<LineChart
+					data={points}
+					margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+				>
+					<CartesianGrid className="stroke-border" strokeDasharray="3 3" />
+					<XAxis
+						dataKey="x"
+						domain={["dataMin", "dataMax"]}
 						tick={{ fontSize: 10 }}
-						tickFormatter={(v: number) => formatCompactNumber(v)}
-						width={50}
+						tickFormatter={(v: number) => formatXTick(v, xAxisType)}
+						type="number"
 					/>
-				)}
-				<Tooltip
-					content={(props) => (
-						<CustomTooltip
-							active={props.active}
-							label={props.label as number | string | undefined}
-							payload={
-								props.payload as readonly TooltipPayloadItem[] | undefined
-							}
-							xAxis={xAxisType}
+					{dual ? (
+						<>
+							<YAxis
+								tick={{ fontSize: 10 }}
+								tickFormatter={(v: number) => formatCompactNumber(v)}
+								width={50}
+								yAxisId="bb"
+							/>
+							<YAxis
+								orientation="right"
+								tick={{ fontSize: 10 }}
+								tickFormatter={(v: number) => formatCompactNumber(v)}
+								width={50}
+								yAxisId="bi"
+							/>
+						</>
+					) : (
+						<YAxis
+							tick={{ fontSize: 10 }}
+							tickFormatter={(v: number) => formatCompactNumber(v)}
+							width={50}
 						/>
 					)}
-					cursor={false}
-					wrapperStyle={{ outline: "none" }}
-				/>
-				{dual ? (
-					<>
-						<Line
-							className="stroke-chart-1"
-							connectNulls
-							dataKey="cashCumulative"
-							dot={false}
-							isAnimationActive={false}
-							name="BB (cash)"
-							strokeWidth={2}
-							type="linear"
-							yAxisId="bb"
-						/>
-						<Line
-							className="stroke-chart-2"
-							connectNulls
-							dataKey="tournamentCumulative"
-							dot={false}
-							isAnimationActive={false}
-							name="BI (tournament)"
-							strokeWidth={2}
-							type="linear"
-							yAxisId="bi"
-						/>
-					</>
-				) : (
-					<Line
-						className="stroke-primary"
-						dataKey="cumulative"
-						dot={false}
-						isAnimationActive={false}
-						name="Cumulative"
-						strokeWidth={2}
-						type="linear"
+					<Tooltip
+						content={(props) => (
+							<CustomTooltip
+								active={props.active}
+								label={props.label as number | string | undefined}
+								payload={
+									props.payload as readonly TooltipPayloadItem[] | undefined
+								}
+								xAxis={xAxisType}
+							/>
+						)}
+						cursor={false}
+						wrapperStyle={{ outline: "none" }}
 					/>
-				)}
-			</LineChart>
-		</ResponsiveContainer>
+					{showLegend ? (
+						<Legend
+							iconSize={10}
+							iconType="line"
+							wrapperStyle={{ fontSize: 11, paddingTop: 4 }}
+						/>
+					) : null}
+					{dual ? (
+						<>
+							<Line
+								connectNulls
+								dataKey="cashCumulative"
+								dot={false}
+								isAnimationActive={false}
+								name="BB (cash)"
+								stroke={COLOR_CASH}
+								strokeWidth={2}
+								type="linear"
+								yAxisId="bb"
+							/>
+							<Line
+								connectNulls
+								dataKey="tournamentCumulative"
+								dot={false}
+								isAnimationActive={false}
+								name="BI (tournament)"
+								stroke={COLOR_TOURNAMENT}
+								strokeWidth={2}
+								type="linear"
+								yAxisId="bi"
+							/>
+							{showEvCash ? (
+								<Line
+									connectNulls
+									dataKey="evCashCumulative"
+									dot={false}
+									isAnimationActive={false}
+									name="EV BB (cash)"
+									stroke={COLOR_EV_CASH}
+									strokeDasharray="4 4"
+									strokeWidth={2}
+									type="linear"
+									yAxisId="bb"
+								/>
+							) : null}
+						</>
+					) : (
+						<>
+							<Line
+								dataKey="cumulative"
+								dot={false}
+								isAnimationActive={false}
+								name="Cumulative"
+								stroke={COLOR_PRIMARY}
+								strokeWidth={2}
+								type="linear"
+							/>
+							{showEvCash ? (
+								<Line
+									connectNulls
+									dataKey="evCashCumulative"
+									dot={false}
+									isAnimationActive={false}
+									name="EV (cash)"
+									stroke={COLOR_EV_CASH}
+									strokeDasharray="4 4"
+									strokeWidth={2}
+									type="linear"
+								/>
+							) : null}
+						</>
+					)}
+				</LineChart>
+			</ResponsiveContainer>
+		</div>
 	);
 }

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-widget.tsx
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-widget.tsx
@@ -1,12 +1,4 @@
-import {
-	CartesianGrid,
-	Line,
-	LineChart,
-	ResponsiveContainer,
-	Tooltip,
-	XAxis,
-	YAxis,
-} from "recharts";
+import { lazy, Suspense } from "react";
 import type {
 	WidgetEditProps,
 	WidgetRenderProps,
@@ -25,7 +17,6 @@ import {
 	SelectValue,
 } from "@/shared/components/ui/select";
 import { Skeleton } from "@/shared/components/ui/skeleton";
-import { formatCompactNumber } from "@/utils/format-number";
 import { usePnlGraphEditForm } from "./use-pnl-graph-edit-form";
 import {
 	type PnlGraphSessionType,
@@ -33,6 +24,8 @@ import {
 	type PnlGraphXAxis,
 	usePnlGraphWidget,
 } from "./use-pnl-graph-widget";
+
+const PnlGraphChart = lazy(() => import("./pnl-graph-chart"));
 
 const X_AXIS_LABEL: Record<PnlGraphXAxis, string> = {
 	date: "Date",
@@ -54,26 +47,6 @@ const UNIT_LABEL: Record<PnlGraphUnit, string> = {
 
 const NONE_VALUE = "__none__";
 
-function formatXTick(value: number, xAxis: PnlGraphXAxis): string {
-	if (xAxis === "date") {
-		const d = new Date(value);
-		const month = String(d.getUTCMonth() + 1).padStart(2, "0");
-		const day = String(d.getUTCDate()).padStart(2, "0");
-		return `${month}/${day}`;
-	}
-	return formatCompactNumber(value);
-}
-
-function formatTooltipLabel(value: number, xAxis: PnlGraphXAxis): string {
-	if (xAxis === "date") {
-		return new Date(value).toISOString().slice(0, 10);
-	}
-	if (xAxis === "playTime") {
-		return `${value.toFixed(0)} min`;
-	}
-	return `Session ${value}`;
-}
-
 interface ChartBodyProps {
 	isLoading: boolean;
 	points: { cumulative: number; x: number }[];
@@ -92,44 +65,9 @@ function ChartBody({ isLoading, points, xAxisType }: ChartBodyProps) {
 		);
 	}
 	return (
-		<ResponsiveContainer height="100%" width="100%">
-			<LineChart
-				data={points}
-				margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
-			>
-				<CartesianGrid className="stroke-border" strokeDasharray="3 3" />
-				<XAxis
-					dataKey="x"
-					domain={["dataMin", "dataMax"]}
-					tick={{ fontSize: 10 }}
-					tickFormatter={(v: number) => formatXTick(v, xAxisType)}
-					type="number"
-				/>
-				<YAxis
-					tick={{ fontSize: 10 }}
-					tickFormatter={(v: number) => formatCompactNumber(v)}
-					width={50}
-				/>
-				<Tooltip
-					formatter={(value) =>
-						typeof value === "number" ? formatCompactNumber(value) : ""
-					}
-					labelFormatter={(label) =>
-						typeof label === "number"
-							? formatTooltipLabel(label, xAxisType)
-							: ""
-					}
-				/>
-				<Line
-					className="stroke-primary"
-					dataKey="cumulative"
-					dot={false}
-					isAnimationActive={false}
-					strokeWidth={2}
-					type="monotone"
-				/>
-			</LineChart>
-		</ResponsiveContainer>
+		<Suspense fallback={<Skeleton className="h-full w-full" />}>
+			<PnlGraphChart points={points} xAxisType={xAxisType} />
+		</Suspense>
 	);
 }
 

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-widget.tsx
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-widget.tsx
@@ -1,0 +1,519 @@
+import {
+	CartesianGrid,
+	Line,
+	LineChart,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import type {
+	WidgetEditProps,
+	WidgetRenderProps,
+} from "@/features/dashboard/widgets/registry";
+import { Button } from "@/shared/components/ui/button";
+import { Checkbox } from "@/shared/components/ui/checkbox";
+import { DialogActionRow } from "@/shared/components/ui/dialog-action-row";
+import { Field } from "@/shared/components/ui/field";
+import { Input } from "@/shared/components/ui/input";
+import { Label } from "@/shared/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/shared/components/ui/select";
+import { Skeleton } from "@/shared/components/ui/skeleton";
+import { formatCompactNumber } from "@/utils/format-number";
+import { usePnlGraphEditForm } from "./use-pnl-graph-edit-form";
+import {
+	type PnlGraphSessionType,
+	type PnlGraphUnit,
+	type PnlGraphXAxis,
+	usePnlGraphWidget,
+} from "./use-pnl-graph-widget";
+
+const X_AXIS_LABEL: Record<PnlGraphXAxis, string> = {
+	date: "Date",
+	sessionCount: "Session #",
+	playTime: "Play Time (min)",
+};
+
+const SESSION_TYPE_LABEL: Record<PnlGraphSessionType, string> = {
+	all: "All",
+	cash_game: "Cash Game",
+	tournament: "Tournament",
+};
+
+const UNIT_LABEL: Record<PnlGraphUnit, string> = {
+	currency: "Currency",
+	bb: "BB (cash)",
+	bi: "BI (tournament)",
+};
+
+const NONE_VALUE = "__none__";
+
+function formatXTick(value: number, xAxis: PnlGraphXAxis): string {
+	if (xAxis === "date") {
+		const d = new Date(value);
+		const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+		const day = String(d.getUTCDate()).padStart(2, "0");
+		return `${month}/${day}`;
+	}
+	return formatCompactNumber(value);
+}
+
+function formatTooltipLabel(value: number, xAxis: PnlGraphXAxis): string {
+	if (xAxis === "date") {
+		return new Date(value).toISOString().slice(0, 10);
+	}
+	if (xAxis === "playTime") {
+		return `${value.toFixed(0)} min`;
+	}
+	return `Session ${value}`;
+}
+
+interface ChartBodyProps {
+	isLoading: boolean;
+	points: { cumulative: number; x: number }[];
+	xAxisType: PnlGraphXAxis;
+}
+
+function ChartBody({ isLoading, points, xAxisType }: ChartBodyProps) {
+	if (isLoading) {
+		return <Skeleton className="h-full w-full" />;
+	}
+	if (points.length === 0) {
+		return (
+			<div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+				No data
+			</div>
+		);
+	}
+	return (
+		<ResponsiveContainer height="100%" width="100%">
+			<LineChart
+				data={points}
+				margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+			>
+				<CartesianGrid className="stroke-border" strokeDasharray="3 3" />
+				<XAxis
+					dataKey="x"
+					domain={["dataMin", "dataMax"]}
+					tick={{ fontSize: 10 }}
+					tickFormatter={(v: number) => formatXTick(v, xAxisType)}
+					type="number"
+				/>
+				<YAxis
+					tick={{ fontSize: 10 }}
+					tickFormatter={(v: number) => formatCompactNumber(v)}
+					width={50}
+				/>
+				<Tooltip
+					formatter={(value) =>
+						typeof value === "number" ? formatCompactNumber(value) : ""
+					}
+					labelFormatter={(label) =>
+						typeof label === "number"
+							? formatTooltipLabel(label, xAxisType)
+							: ""
+					}
+				/>
+				<Line
+					className="stroke-primary"
+					dataKey="cumulative"
+					dot={false}
+					isAnimationActive={false}
+					strokeWidth={2}
+					type="monotone"
+				/>
+			</LineChart>
+		</ResponsiveContainer>
+	);
+}
+
+export function PnlGraphWidget({ config }: WidgetRenderProps) {
+	const {
+		isLoading,
+		onChangeDateRangeDays,
+		onChangeSessionType,
+		onChangeUnit,
+		onChangeXAxis,
+		parsed,
+		points,
+		skippedCount,
+		state,
+	} = usePnlGraphWidget(config);
+
+	const flags = parsed.showFilters;
+	const anyFilter =
+		flags.xAxis || flags.dateRange || flags.sessionType || flags.unit;
+
+	return (
+		<div className="flex h-full flex-col gap-2 p-2">
+			{anyFilter ? (
+				<div className="flex flex-wrap items-center gap-2">
+					{flags.xAxis ? (
+						<Select
+							onValueChange={(v) => onChangeXAxis(v as PnlGraphXAxis)}
+							value={state.xAxis}
+						>
+							<SelectTrigger className="h-8 w-auto text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="date">{X_AXIS_LABEL.date}</SelectItem>
+								<SelectItem value="sessionCount">
+									{X_AXIS_LABEL.sessionCount}
+								</SelectItem>
+								<SelectItem value="playTime">
+									{X_AXIS_LABEL.playTime}
+								</SelectItem>
+							</SelectContent>
+						</Select>
+					) : null}
+					{flags.dateRange ? (
+						<Input
+							className="h-8 w-24 text-xs"
+							inputMode="numeric"
+							onChange={(e) => {
+								const v = e.target.value.trim();
+								onChangeDateRangeDays(v === "" ? null : Number.parseInt(v, 10));
+							}}
+							placeholder="days"
+							value={
+								state.dateRangeDays === null ? "" : String(state.dateRangeDays)
+							}
+						/>
+					) : null}
+					{flags.sessionType ? (
+						<Select
+							onValueChange={(v) =>
+								onChangeSessionType(v as PnlGraphSessionType)
+							}
+							value={state.sessionType}
+						>
+							<SelectTrigger className="h-8 w-auto text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">{SESSION_TYPE_LABEL.all}</SelectItem>
+								<SelectItem value="cash_game">
+									{SESSION_TYPE_LABEL.cash_game}
+								</SelectItem>
+								<SelectItem value="tournament">
+									{SESSION_TYPE_LABEL.tournament}
+								</SelectItem>
+							</SelectContent>
+						</Select>
+					) : null}
+					{flags.unit ? (
+						<Select
+							onValueChange={(v) => onChangeUnit(v as PnlGraphUnit)}
+							value={state.unit}
+						>
+							<SelectTrigger className="h-8 w-auto text-xs">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="currency">{UNIT_LABEL.currency}</SelectItem>
+								<SelectItem value="bb">{UNIT_LABEL.bb}</SelectItem>
+								<SelectItem value="bi">{UNIT_LABEL.bi}</SelectItem>
+							</SelectContent>
+						</Select>
+					) : null}
+				</div>
+			) : null}
+
+			<div className="min-h-0 flex-1">
+				<ChartBody
+					isLoading={isLoading}
+					points={points}
+					xAxisType={state.xAxis}
+				/>
+			</div>
+
+			{skippedCount > 0 ? (
+				<div className="text-muted-foreground text-xs">
+					{skippedCount} session{skippedCount === 1 ? "" : "s"} skipped (no unit
+					info)
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+export function PnlGraphEditForm({
+	config,
+	onCancel,
+	onSave,
+}: WidgetEditProps) {
+	const { form, stores, ringGames, currencies } = usePnlGraphEditForm({
+		config,
+		onSave,
+	});
+
+	return (
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				form.handleSubmit();
+			}}
+		>
+			<form.Field name="xAxis">
+				{(field) => (
+					<Field htmlFor={field.name} label="X Axis">
+						<Select
+							onValueChange={(value) =>
+								field.handleChange(value as PnlGraphXAxis)
+							}
+							value={field.state.value}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="date">{X_AXIS_LABEL.date}</SelectItem>
+								<SelectItem value="sessionCount">
+									{X_AXIS_LABEL.sessionCount}
+								</SelectItem>
+								<SelectItem value="playTime">
+									{X_AXIS_LABEL.playTime}
+								</SelectItem>
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
+
+			<form.Field name="dateRangeDays">
+				{(field) => (
+					<Field
+						description="Leave empty to use all-time data."
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Date Range (days)"
+					>
+						<Input
+							id={field.name}
+							inputMode="numeric"
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
+
+			<form.Field name="sessionType">
+				{(field) => (
+					<Field htmlFor={field.name} label="Session Type">
+						<Select
+							onValueChange={(value) =>
+								field.handleChange(value as PnlGraphSessionType)
+							}
+							value={field.state.value}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">{SESSION_TYPE_LABEL.all}</SelectItem>
+								<SelectItem value="cash_game">
+									{SESSION_TYPE_LABEL.cash_game}
+								</SelectItem>
+								<SelectItem value="tournament">
+									{SESSION_TYPE_LABEL.tournament}
+								</SelectItem>
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
+
+			<form.Field name="unit">
+				{(field) => (
+					<Field
+						description="BB only counts cash sessions; BI only counts tournaments."
+						htmlFor={field.name}
+						label="Unit"
+					>
+						<Select
+							onValueChange={(value) =>
+								field.handleChange(value as PnlGraphUnit)
+							}
+							value={field.state.value}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="currency">{UNIT_LABEL.currency}</SelectItem>
+								<SelectItem value="bb">{UNIT_LABEL.bb}</SelectItem>
+								<SelectItem value="bi">{UNIT_LABEL.bi}</SelectItem>
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
+
+			<form.Field name="storeId">
+				{(field) => (
+					<Field htmlFor={field.name} label="Store">
+						<Select
+							onValueChange={(value) => field.handleChange(value)}
+							value={field.state.value}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value={NONE_VALUE}>(All stores)</SelectItem>
+								{stores.map((s) => (
+									<SelectItem key={s.id} value={s.id}>
+										{s.name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
+
+			<form.Subscribe selector={(s) => s.values.storeId}>
+				{(storeId) =>
+					storeId === NONE_VALUE ? null : (
+						<form.Field name="ringGameId">
+							{(field) => (
+								<Field htmlFor={field.name} label="Ring Game">
+									<Select
+										onValueChange={(value) => field.handleChange(value)}
+										value={field.state.value}
+									>
+										<SelectTrigger className="w-full" id={field.name}>
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value={NONE_VALUE}>
+												(All ring games)
+											</SelectItem>
+											{ringGames.map((rg) => (
+												<SelectItem key={rg.id} value={rg.id}>
+													{rg.name}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</Field>
+							)}
+						</form.Field>
+					)
+				}
+			</form.Subscribe>
+
+			<form.Field name="currencyId">
+				{(field) => (
+					<Field htmlFor={field.name} label="Currency">
+						<Select
+							onValueChange={(value) => field.handleChange(value)}
+							value={field.state.value}
+						>
+							<SelectTrigger className="w-full" id={field.name}>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value={NONE_VALUE}>(All currencies)</SelectItem>
+								{currencies.map((c) => (
+									<SelectItem key={c.id} value={c.id}>
+										{c.name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</Field>
+				)}
+			</form.Field>
+
+			<Field label="Show in widget">
+				<div className="grid grid-cols-2 gap-2">
+					<EditFormToggle fieldName="showXAxis" form={form} label="X Axis" />
+					<EditFormToggle
+						fieldName="showDateRange"
+						form={form}
+						label="Date Range"
+					/>
+					<EditFormToggle
+						fieldName="showSessionType"
+						form={form}
+						label="Session Type"
+					/>
+					<EditFormToggle fieldName="showUnit" form={form} label="Unit" />
+					<EditFormToggle fieldName="showStore" form={form} label="Store" />
+					<EditFormToggle
+						fieldName="showRingGame"
+						form={form}
+						label="Ring Game"
+					/>
+					<EditFormToggle
+						fieldName="showCurrency"
+						form={form}
+						label="Currency"
+					/>
+				</div>
+			</Field>
+
+			<DialogActionRow>
+				<Button onClick={onCancel} type="button" variant="outline">
+					Cancel
+				</Button>
+				<form.Subscribe
+					selector={(state) => [state.canSubmit, state.isSubmitting]}
+				>
+					{([canSubmit, isSubmitting]) => (
+						<Button disabled={!canSubmit || isSubmitting} type="submit">
+							{isSubmitting ? "Saving..." : "Save"}
+						</Button>
+					)}
+				</form.Subscribe>
+			</DialogActionRow>
+		</form>
+	);
+}
+
+interface EditFormToggleProps {
+	fieldName:
+		| "showXAxis"
+		| "showDateRange"
+		| "showSessionType"
+		| "showUnit"
+		| "showStore"
+		| "showRingGame"
+		| "showCurrency";
+	form: ReturnType<typeof usePnlGraphEditForm>["form"];
+	label: string;
+}
+
+function EditFormToggle({ form, fieldName, label }: EditFormToggleProps) {
+	return (
+		<form.Field name={fieldName}>
+			{(field) => {
+				const id = `pnl-graph-${fieldName}`;
+				return (
+					<div className="flex items-center gap-2">
+						<Checkbox
+							checked={field.state.value}
+							id={id}
+							onCheckedChange={(next) => field.handleChange(next === true)}
+						/>
+						<Label className="cursor-pointer text-sm" htmlFor={id}>
+							{label}
+						</Label>
+					</div>
+				);
+			}}
+		</form.Field>
+	);
+}

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-widget.tsx
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-widget.tsx
@@ -45,10 +45,12 @@ const UNIT_LABEL: Record<PnlGraphUnit, string> = {
 };
 
 const NONE_VALUE = "__none__";
+const ALL_VALUE = "__all__";
 
 interface AggregatedPoint {
 	cashCumulative?: number;
 	cumulative?: number;
+	evCashCumulative?: number;
 	tournamentCumulative?: number;
 	x: number;
 }
@@ -57,10 +59,17 @@ interface ChartBodyProps {
 	dual: boolean;
 	isLoading: boolean;
 	points: AggregatedPoint[];
+	showEvCash: boolean;
 	xAxisType: PnlGraphXAxis;
 }
 
-function ChartBody({ dual, isLoading, points, xAxisType }: ChartBodyProps) {
+function ChartBody({
+	dual,
+	isLoading,
+	points,
+	showEvCash,
+	xAxisType,
+}: ChartBodyProps) {
 	if (isLoading) {
 		return <Skeleton className="h-full w-full" />;
 	}
@@ -73,111 +82,205 @@ function ChartBody({ dual, isLoading, points, xAxisType }: ChartBodyProps) {
 	}
 	return (
 		<Suspense fallback={<Skeleton className="h-full w-full" />}>
-			<PnlGraphChart dual={dual} points={points} xAxisType={xAxisType} />
+			<PnlGraphChart
+				dual={dual}
+				points={points}
+				showEvCash={showEvCash}
+				xAxisType={xAxisType}
+			/>
 		</Suspense>
 	);
 }
 
-export function PnlGraphWidget({ config }: WidgetRenderProps) {
-	const {
-		isLoading,
-		onChangeDateRangeDays,
-		onChangeSessionType,
-		onChangeUnit,
-		onChangeXAxis,
-		parsed,
-		points,
-		skippedCount,
-		state,
-	} = usePnlGraphWidget(config);
+type InlineHandlers = ReturnType<typeof usePnlGraphWidget>;
+type InlineFiltersProps = Pick<
+	InlineHandlers,
+	| "currencies"
+	| "onChangeCurrencyId"
+	| "onChangeDateRangeDays"
+	| "onChangeSessionType"
+	| "onChangeStoreId"
+	| "onChangeUnit"
+	| "onChangeXAxis"
+	| "state"
+	| "stores"
+> & {
+	flags: InlineHandlers["parsed"]["showFilters"];
+};
 
+function InlineFilters(props: InlineFiltersProps) {
+	const { flags } = props;
+	return (
+		<div className="flex flex-wrap items-center gap-2">
+			{flags.xAxis ? <XAxisSelect {...props} /> : null}
+			{flags.dateRange ? <DateRangeInput {...props} /> : null}
+			{flags.sessionType ? <SessionTypeSelect {...props} /> : null}
+			{flags.unit ? <UnitSelect {...props} /> : null}
+			{flags.store ? <StoreSelect {...props} /> : null}
+			{flags.currency ? <CurrencySelect {...props} /> : null}
+		</div>
+	);
+}
+
+function XAxisSelect({
+	onChangeXAxis,
+	state,
+}: Pick<InlineFiltersProps, "onChangeXAxis" | "state">) {
+	return (
+		<Select
+			onValueChange={(v) => onChangeXAxis(v as PnlGraphXAxis)}
+			value={state.xAxis}
+		>
+			<SelectTrigger className="h-8 w-auto text-xs">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectItem value="date">{X_AXIS_LABEL.date}</SelectItem>
+				<SelectItem value="sessionCount">
+					{X_AXIS_LABEL.sessionCount}
+				</SelectItem>
+				<SelectItem value="playTime">{X_AXIS_LABEL.playTime}</SelectItem>
+			</SelectContent>
+		</Select>
+	);
+}
+
+function DateRangeInput({
+	onChangeDateRangeDays,
+	state,
+}: Pick<InlineFiltersProps, "onChangeDateRangeDays" | "state">) {
+	return (
+		<Input
+			className="h-8 w-24 text-xs"
+			inputMode="numeric"
+			onChange={(e) => {
+				const v = e.target.value.trim();
+				onChangeDateRangeDays(v === "" ? null : Number.parseInt(v, 10));
+			}}
+			placeholder="days"
+			value={state.dateRangeDays === null ? "" : String(state.dateRangeDays)}
+		/>
+	);
+}
+
+function SessionTypeSelect({
+	onChangeSessionType,
+	state,
+}: Pick<InlineFiltersProps, "onChangeSessionType" | "state">) {
+	return (
+		<Select
+			onValueChange={(v) => onChangeSessionType(v as PnlGraphSessionType)}
+			value={state.sessionType}
+		>
+			<SelectTrigger className="h-8 w-auto text-xs">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectItem value="all">{SESSION_TYPE_LABEL.all}</SelectItem>
+				<SelectItem value="cash_game">
+					{SESSION_TYPE_LABEL.cash_game}
+				</SelectItem>
+				<SelectItem value="tournament">
+					{SESSION_TYPE_LABEL.tournament}
+				</SelectItem>
+			</SelectContent>
+		</Select>
+	);
+}
+
+function UnitSelect({
+	onChangeUnit,
+	state,
+}: Pick<InlineFiltersProps, "onChangeUnit" | "state">) {
+	return (
+		<Select
+			onValueChange={(v) => onChangeUnit(v as PnlGraphUnit)}
+			value={state.unit}
+		>
+			<SelectTrigger className="h-8 w-auto text-xs">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectItem value="currency">{UNIT_LABEL.currency}</SelectItem>
+				<SelectItem value="normalized">{UNIT_LABEL.normalized}</SelectItem>
+			</SelectContent>
+		</Select>
+	);
+}
+
+function StoreSelect({
+	onChangeStoreId,
+	state,
+	stores,
+}: Pick<InlineFiltersProps, "onChangeStoreId" | "state" | "stores">) {
+	return (
+		<Select
+			onValueChange={(v) => onChangeStoreId(v === ALL_VALUE ? null : v)}
+			value={state.storeId ?? ALL_VALUE}
+		>
+			<SelectTrigger className="h-8 w-auto text-xs">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectItem value={ALL_VALUE}>All stores</SelectItem>
+				{stores.map((s) => (
+					<SelectItem key={s.id} value={s.id}>
+						{s.name}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+function CurrencySelect({
+	currencies,
+	onChangeCurrencyId,
+	state,
+}: Pick<InlineFiltersProps, "currencies" | "onChangeCurrencyId" | "state">) {
+	return (
+		<Select
+			onValueChange={(v) => onChangeCurrencyId(v === ALL_VALUE ? null : v)}
+			value={state.currencyId ?? ALL_VALUE}
+		>
+			<SelectTrigger className="h-8 w-auto text-xs">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectItem value={ALL_VALUE}>All currencies</SelectItem>
+				{currencies.map((c) => (
+					<SelectItem key={c.id} value={c.id}>
+						{c.name}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+export function PnlGraphWidget({ config }: WidgetRenderProps) {
+	const widget = usePnlGraphWidget(config);
+	const { isLoading, parsed, points, skippedCount, state } = widget;
 	const flags = parsed.showFilters;
 	const anyFilter =
-		flags.xAxis || flags.dateRange || flags.sessionType || flags.unit;
+		flags.xAxis ||
+		flags.dateRange ||
+		flags.sessionType ||
+		flags.unit ||
+		flags.store ||
+		flags.currency;
 	const dualSeries = state.unit === "normalized" && state.sessionType === "all";
 
 	return (
 		<div className="flex h-full flex-col gap-2 p-2">
-			{anyFilter ? (
-				<div className="flex flex-wrap items-center gap-2">
-					{flags.xAxis ? (
-						<Select
-							onValueChange={(v) => onChangeXAxis(v as PnlGraphXAxis)}
-							value={state.xAxis}
-						>
-							<SelectTrigger className="h-8 w-auto text-xs">
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value="date">{X_AXIS_LABEL.date}</SelectItem>
-								<SelectItem value="sessionCount">
-									{X_AXIS_LABEL.sessionCount}
-								</SelectItem>
-								<SelectItem value="playTime">
-									{X_AXIS_LABEL.playTime}
-								</SelectItem>
-							</SelectContent>
-						</Select>
-					) : null}
-					{flags.dateRange ? (
-						<Input
-							className="h-8 w-24 text-xs"
-							inputMode="numeric"
-							onChange={(e) => {
-								const v = e.target.value.trim();
-								onChangeDateRangeDays(v === "" ? null : Number.parseInt(v, 10));
-							}}
-							placeholder="days"
-							value={
-								state.dateRangeDays === null ? "" : String(state.dateRangeDays)
-							}
-						/>
-					) : null}
-					{flags.sessionType ? (
-						<Select
-							onValueChange={(v) =>
-								onChangeSessionType(v as PnlGraphSessionType)
-							}
-							value={state.sessionType}
-						>
-							<SelectTrigger className="h-8 w-auto text-xs">
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value="all">{SESSION_TYPE_LABEL.all}</SelectItem>
-								<SelectItem value="cash_game">
-									{SESSION_TYPE_LABEL.cash_game}
-								</SelectItem>
-								<SelectItem value="tournament">
-									{SESSION_TYPE_LABEL.tournament}
-								</SelectItem>
-							</SelectContent>
-						</Select>
-					) : null}
-					{flags.unit ? (
-						<Select
-							onValueChange={(v) => onChangeUnit(v as PnlGraphUnit)}
-							value={state.unit}
-						>
-							<SelectTrigger className="h-8 w-auto text-xs">
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value="currency">{UNIT_LABEL.currency}</SelectItem>
-								<SelectItem value="normalized">
-									{UNIT_LABEL.normalized}
-								</SelectItem>
-							</SelectContent>
-						</Select>
-					) : null}
-				</div>
-			) : null}
+			{anyFilter ? <InlineFilters {...widget} flags={flags} /> : null}
 
 			<div className="min-h-0 flex-1">
 				<ChartBody
 					dual={dualSeries}
 					isLoading={isLoading}
 					points={points}
+					showEvCash={state.showEvCash}
 					xAxisType={state.xAxis}
 				/>
 			</div>
@@ -384,6 +487,29 @@ export function PnlGraphEditForm({
 						</Select>
 					</Field>
 				)}
+			</form.Field>
+
+			<form.Field name="showEvCash">
+				{(field) => {
+					const id = "pnl-graph-show-ev-cash";
+					return (
+						<Field
+							description="Adds an EV-based cumulative line for cash sessions."
+							label="Cash EV P&L line"
+						>
+							<div className="flex items-center gap-2">
+								<Checkbox
+									checked={field.state.value}
+									id={id}
+									onCheckedChange={(next) => field.handleChange(next === true)}
+								/>
+								<Label className="cursor-pointer text-sm" htmlFor={id}>
+									Show
+								</Label>
+							</div>
+						</Field>
+					);
+				}}
 			</form.Field>
 
 			<Field label="Show in widget">

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-widget.tsx
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/pnl-graph-widget.tsx
@@ -30,7 +30,7 @@ const PnlGraphChart = lazy(() => import("./pnl-graph-chart"));
 const X_AXIS_LABEL: Record<PnlGraphXAxis, string> = {
 	date: "Date",
 	sessionCount: "Session #",
-	playTime: "Play Time (min)",
+	playTime: "Play Time (h)",
 };
 
 const SESSION_TYPE_LABEL: Record<PnlGraphSessionType, string> = {
@@ -40,20 +40,27 @@ const SESSION_TYPE_LABEL: Record<PnlGraphSessionType, string> = {
 };
 
 const UNIT_LABEL: Record<PnlGraphUnit, string> = {
-	currency: "Currency",
-	bb: "BB (cash)",
-	bi: "BI (tournament)",
+	currency: "Actual Value",
+	normalized: "Normalized (BB / BI)",
 };
 
 const NONE_VALUE = "__none__";
 
+interface AggregatedPoint {
+	cashCumulative?: number;
+	cumulative?: number;
+	tournamentCumulative?: number;
+	x: number;
+}
+
 interface ChartBodyProps {
+	dual: boolean;
 	isLoading: boolean;
-	points: { cumulative: number; x: number }[];
+	points: AggregatedPoint[];
 	xAxisType: PnlGraphXAxis;
 }
 
-function ChartBody({ isLoading, points, xAxisType }: ChartBodyProps) {
+function ChartBody({ dual, isLoading, points, xAxisType }: ChartBodyProps) {
 	if (isLoading) {
 		return <Skeleton className="h-full w-full" />;
 	}
@@ -66,7 +73,7 @@ function ChartBody({ isLoading, points, xAxisType }: ChartBodyProps) {
 	}
 	return (
 		<Suspense fallback={<Skeleton className="h-full w-full" />}>
-			<PnlGraphChart points={points} xAxisType={xAxisType} />
+			<PnlGraphChart dual={dual} points={points} xAxisType={xAxisType} />
 		</Suspense>
 	);
 }
@@ -87,6 +94,7 @@ export function PnlGraphWidget({ config }: WidgetRenderProps) {
 	const flags = parsed.showFilters;
 	const anyFilter =
 		flags.xAxis || flags.dateRange || flags.sessionType || flags.unit;
+	const dualSeries = state.unit === "normalized" && state.sessionType === "all";
 
 	return (
 		<div className="flex h-full flex-col gap-2 p-2">
@@ -156,8 +164,9 @@ export function PnlGraphWidget({ config }: WidgetRenderProps) {
 							</SelectTrigger>
 							<SelectContent>
 								<SelectItem value="currency">{UNIT_LABEL.currency}</SelectItem>
-								<SelectItem value="bb">{UNIT_LABEL.bb}</SelectItem>
-								<SelectItem value="bi">{UNIT_LABEL.bi}</SelectItem>
+								<SelectItem value="normalized">
+									{UNIT_LABEL.normalized}
+								</SelectItem>
 							</SelectContent>
 						</Select>
 					) : null}
@@ -166,6 +175,7 @@ export function PnlGraphWidget({ config }: WidgetRenderProps) {
 
 			<div className="min-h-0 flex-1">
 				<ChartBody
+					dual={dualSeries}
 					isLoading={isLoading}
 					points={points}
 					xAxisType={state.xAxis}
@@ -275,7 +285,7 @@ export function PnlGraphEditForm({
 			<form.Field name="unit">
 				{(field) => (
 					<Field
-						description="BB only counts cash sessions; BI only counts tournaments."
+						description="Normalized = BB for cash sessions, BI for tournaments."
 						htmlFor={field.name}
 						label="Unit"
 					>
@@ -290,8 +300,9 @@ export function PnlGraphEditForm({
 							</SelectTrigger>
 							<SelectContent>
 								<SelectItem value="currency">{UNIT_LABEL.currency}</SelectItem>
-								<SelectItem value="bb">{UNIT_LABEL.bb}</SelectItem>
-								<SelectItem value="bi">{UNIT_LABEL.bi}</SelectItem>
+								<SelectItem value="normalized">
+									{UNIT_LABEL.normalized}
+								</SelectItem>
 							</SelectContent>
 						</Select>
 					</Field>
@@ -391,11 +402,6 @@ export function PnlGraphEditForm({
 					<EditFormToggle fieldName="showUnit" form={form} label="Unit" />
 					<EditFormToggle fieldName="showStore" form={form} label="Store" />
 					<EditFormToggle
-						fieldName="showRingGame"
-						form={form}
-						label="Ring Game"
-					/>
-					<EditFormToggle
 						fieldName="showCurrency"
 						form={form}
 						label="Currency"
@@ -428,7 +434,6 @@ interface EditFormToggleProps {
 		| "showSessionType"
 		| "showUnit"
 		| "showStore"
-		| "showRingGame"
 		| "showCurrency";
 	form: ReturnType<typeof usePnlGraphEditForm>["form"];
 	label: string;

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-edit-form.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-edit-form.ts
@@ -27,6 +27,7 @@ const editFormSchema = z.object({
 	storeId: z.string(),
 	ringGameId: z.string(),
 	currencyId: z.string(),
+	showEvCash: z.boolean(),
 	showXAxis: z.boolean(),
 	showDateRange: z.boolean(),
 	showSessionType: z.boolean(),
@@ -86,6 +87,7 @@ export function usePnlGraphEditForm({
 			storeId: parsed.storeId ?? NONE_VALUE,
 			ringGameId: parsed.ringGameId ?? NONE_VALUE,
 			currencyId: parsed.currencyId ?? NONE_VALUE,
+			showEvCash: parsed.showEvCash,
 			showXAxis: parsed.showFilters.xAxis,
 			showDateRange: parsed.showFilters.dateRange,
 			showSessionType: parsed.showFilters.sessionType,
@@ -103,6 +105,7 @@ export function usePnlGraphEditForm({
 				storeId: value.storeId === NONE_VALUE ? null : value.storeId,
 				ringGameId: value.ringGameId === NONE_VALUE ? null : value.ringGameId,
 				currencyId: value.currencyId === NONE_VALUE ? null : value.currencyId,
+				showEvCash: value.showEvCash,
 				showFilters: {
 					xAxis: value.showXAxis,
 					dateRange: value.showDateRange,

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-edit-form.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-edit-form.ts
@@ -32,7 +32,6 @@ const editFormSchema = z.object({
 	showSessionType: z.boolean(),
 	showUnit: z.boolean(),
 	showStore: z.boolean(),
-	showRingGame: z.boolean(),
 	showCurrency: z.boolean(),
 });
 
@@ -92,7 +91,6 @@ export function usePnlGraphEditForm({
 			showSessionType: parsed.showFilters.sessionType,
 			showUnit: parsed.showFilters.unit,
 			showStore: parsed.showFilters.store,
-			showRingGame: parsed.showFilters.ringGame,
 			showCurrency: parsed.showFilters.currency,
 		},
 		onSubmit: async ({ value }) => {
@@ -111,7 +109,6 @@ export function usePnlGraphEditForm({
 					sessionType: value.showSessionType,
 					unit: value.showUnit,
 					store: value.showStore,
-					ringGame: value.showRingGame,
 					currency: value.showCurrency,
 				},
 			});

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-edit-form.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-edit-form.ts
@@ -1,0 +1,129 @@
+import { useForm } from "@tanstack/react-form";
+import { useQuery } from "@tanstack/react-query";
+import z from "zod";
+import type { WidgetEditProps } from "@/features/dashboard/widgets/registry";
+import { optionalNumericString } from "@/shared/lib/form-fields";
+import { trpc } from "@/utils/trpc";
+import {
+	PNL_GRAPH_SESSION_TYPE_VALUES,
+	PNL_GRAPH_UNIT_VALUES,
+	PNL_GRAPH_X_AXIS_VALUES,
+	type PnlGraphSessionType,
+	type PnlGraphUnit,
+	type PnlGraphXAxis,
+	parsePnlGraphWidgetConfig,
+} from "./use-pnl-graph-widget";
+
+const editFormSchema = z.object({
+	xAxis: z.enum(PNL_GRAPH_X_AXIS_VALUES as [PnlGraphXAxis, ...PnlGraphXAxis[]]),
+	dateRangeDays: optionalNumericString({ integer: true, min: 1, max: 3650 }),
+	sessionType: z.enum(
+		PNL_GRAPH_SESSION_TYPE_VALUES as [
+			PnlGraphSessionType,
+			...PnlGraphSessionType[],
+		]
+	),
+	unit: z.enum(PNL_GRAPH_UNIT_VALUES as [PnlGraphUnit, ...PnlGraphUnit[]]),
+	storeId: z.string(),
+	ringGameId: z.string(),
+	currencyId: z.string(),
+	showXAxis: z.boolean(),
+	showDateRange: z.boolean(),
+	showSessionType: z.boolean(),
+	showUnit: z.boolean(),
+	showStore: z.boolean(),
+	showRingGame: z.boolean(),
+	showCurrency: z.boolean(),
+});
+
+const NONE_VALUE = "__none__";
+
+interface RingGameItem {
+	id: string;
+	name: string;
+	storeId?: string | null;
+}
+
+interface StoreItem {
+	id: string;
+	name: string;
+}
+
+interface CurrencyItem {
+	id: string;
+	name: string;
+}
+
+interface UsePnlGraphEditFormOptions {
+	config: WidgetEditProps["config"];
+	onSave: WidgetEditProps["onSave"];
+}
+
+export function usePnlGraphEditForm({
+	config,
+	onSave,
+}: UsePnlGraphEditFormOptions) {
+	const parsed = parsePnlGraphWidgetConfig(config);
+	const storesQuery = useQuery(trpc.store.list.queryOptions());
+	const currenciesQuery = useQuery(trpc.currency.list.queryOptions());
+	const ringGamesQuery = useQuery(
+		trpc.ringGame.listByStore.queryOptions(
+			{ storeId: parsed.storeId ?? "" },
+			{ enabled: parsed.storeId !== null }
+		)
+	);
+
+	const stores = (storesQuery.data ?? []) as StoreItem[];
+	const ringGames = (ringGamesQuery.data ?? []) as RingGameItem[];
+	const currencies = (currenciesQuery.data ?? []) as CurrencyItem[];
+
+	const form = useForm({
+		defaultValues: {
+			xAxis: parsed.xAxis,
+			dateRangeDays:
+				parsed.dateRangeDays === null ? "" : String(parsed.dateRangeDays),
+			sessionType: parsed.sessionType,
+			unit: parsed.unit,
+			storeId: parsed.storeId ?? NONE_VALUE,
+			ringGameId: parsed.ringGameId ?? NONE_VALUE,
+			currencyId: parsed.currencyId ?? NONE_VALUE,
+			showXAxis: parsed.showFilters.xAxis,
+			showDateRange: parsed.showFilters.dateRange,
+			showSessionType: parsed.showFilters.sessionType,
+			showUnit: parsed.showFilters.unit,
+			showStore: parsed.showFilters.store,
+			showRingGame: parsed.showFilters.ringGame,
+			showCurrency: parsed.showFilters.currency,
+		},
+		onSubmit: async ({ value }) => {
+			const trimmed = value.dateRangeDays.trim();
+			await onSave({
+				xAxis: value.xAxis,
+				dateRangeDays: trimmed === "" ? null : Number.parseInt(trimmed, 10),
+				sessionType: value.sessionType,
+				unit: value.unit,
+				storeId: value.storeId === NONE_VALUE ? null : value.storeId,
+				ringGameId: value.ringGameId === NONE_VALUE ? null : value.ringGameId,
+				currencyId: value.currencyId === NONE_VALUE ? null : value.currencyId,
+				showFilters: {
+					xAxis: value.showXAxis,
+					dateRange: value.showDateRange,
+					sessionType: value.showSessionType,
+					unit: value.showUnit,
+					store: value.showStore,
+					ringGame: value.showRingGame,
+					currency: value.showCurrency,
+				},
+			});
+		},
+		validators: { onSubmit: editFormSchema },
+	});
+
+	return {
+		currencies,
+		form,
+		NONE_VALUE,
+		ringGames,
+		stores,
+	};
+}

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-widget.ts
@@ -4,19 +4,21 @@ import { trpc } from "@/utils/trpc";
 import {
 	type AggregatedPoint,
 	aggregatePnlPoints,
+	type PnlGraphSessionType,
 	type PnlGraphUnit,
 	type PnlGraphXAxis,
 	type PnlSeriesPoint,
 } from "./aggregate-pnl-points";
 
-export type { PnlGraphUnit, PnlGraphXAxis } from "./aggregate-pnl-points";
-
-export type PnlGraphSessionType = "all" | "cash_game" | "tournament";
+export type {
+	PnlGraphSessionType,
+	PnlGraphUnit,
+	PnlGraphXAxis,
+} from "./aggregate-pnl-points";
 
 export interface PnlGraphFilterFlags {
 	currency: boolean;
 	dateRange: boolean;
-	ringGame: boolean;
 	sessionType: boolean;
 	store: boolean;
 	unit: boolean;
@@ -39,7 +41,7 @@ export const PNL_GRAPH_X_AXIS_VALUES: PnlGraphXAxis[] = [
 	"sessionCount",
 	"playTime",
 ];
-export const PNL_GRAPH_UNIT_VALUES: PnlGraphUnit[] = ["currency", "bb", "bi"];
+export const PNL_GRAPH_UNIT_VALUES: PnlGraphUnit[] = ["currency", "normalized"];
 export const PNL_GRAPH_SESSION_TYPE_VALUES: PnlGraphSessionType[] = [
 	"all",
 	"cash_game",
@@ -52,7 +54,6 @@ const DEFAULT_FLAGS: PnlGraphFilterFlags = {
 	sessionType: false,
 	unit: false,
 	store: false,
-	ringGame: false,
 	currency: false,
 };
 
@@ -79,7 +80,6 @@ function parseFlags(value: unknown): PnlGraphFilterFlags {
 		sessionType: raw.sessionType === true,
 		unit: raw.unit === true,
 		store: raw.store === true,
-		ringGame: raw.ringGame === true,
 		currency: raw.currency === true,
 	};
 }
@@ -131,12 +131,6 @@ function configToState(parsed: PnlGraphParsedConfig): PnlGraphRuntimeState {
 export function effectiveTypeFilter(
 	state: PnlGraphRuntimeState
 ): "cash_game" | "tournament" | undefined {
-	if (state.unit === "bb") {
-		return "cash_game";
-	}
-	if (state.unit === "bi") {
-		return "tournament";
-	}
 	return state.sessionType === "all" ? undefined : state.sessionType;
 }
 
@@ -181,7 +175,12 @@ export function usePnlGraphWidget(
 	);
 
 	const rawPoints = (query.data?.points ?? []) as PnlSeriesPoint[];
-	const aggregated = aggregatePnlPoints(rawPoints, state.xAxis, state.unit);
+	const aggregated = aggregatePnlPoints(
+		rawPoints,
+		state.xAxis,
+		state.unit,
+		state.sessionType
+	);
 
 	return {
 		error: query.error,

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-widget.ts
@@ -30,6 +30,7 @@ export interface PnlGraphParsedConfig {
 	dateRangeDays: number | null;
 	ringGameId: string | null;
 	sessionType: PnlGraphSessionType;
+	showEvCash: boolean;
 	showFilters: PnlGraphFilterFlags;
 	storeId: string | null;
 	unit: PnlGraphUnit;
@@ -102,6 +103,7 @@ export function parsePnlGraphWidgetConfig(
 		storeId: parseStringOrNull(raw.storeId),
 		ringGameId: parseStringOrNull(raw.ringGameId),
 		currencyId: parseStringOrNull(raw.currencyId),
+		showEvCash: raw.showEvCash === true,
 		showFilters: parseFlags(raw.showFilters),
 	};
 }
@@ -111,6 +113,7 @@ export interface PnlGraphRuntimeState {
 	dateRangeDays: number | null;
 	ringGameId: string | null;
 	sessionType: PnlGraphSessionType;
+	showEvCash: boolean;
 	storeId: string | null;
 	unit: PnlGraphUnit;
 	xAxis: PnlGraphXAxis;
@@ -125,6 +128,7 @@ function configToState(parsed: PnlGraphParsedConfig): PnlGraphRuntimeState {
 		storeId: parsed.storeId,
 		ringGameId: parsed.ringGameId,
 		currencyId: parsed.currencyId,
+		showEvCash: parsed.showEvCash,
 	};
 }
 
@@ -134,7 +138,13 @@ export function effectiveTypeFilter(
 	return state.sessionType === "all" ? undefined : state.sessionType;
 }
 
+export interface PnlGraphSelectOption {
+	id: string;
+	name: string;
+}
+
 interface UsePnlGraphWidgetResult {
+	currencies: PnlGraphSelectOption[];
 	error: unknown;
 	isLoading: boolean;
 	onChangeCurrencyId: (value: string | null) => void;
@@ -149,6 +159,7 @@ interface UsePnlGraphWidgetResult {
 	rawPoints: PnlSeriesPoint[];
 	skippedCount: number;
 	state: PnlGraphRuntimeState;
+	stores: PnlGraphSelectOption[];
 }
 
 export function usePnlGraphWidget(
@@ -174,15 +185,31 @@ export function usePnlGraphWidget(
 		})
 	);
 
-	const rawPoints = (query.data?.points ?? []) as PnlSeriesPoint[];
-	const aggregated = aggregatePnlPoints(
-		rawPoints,
-		state.xAxis,
-		state.unit,
-		state.sessionType
+	const storesQuery = useQuery(
+		trpc.store.list.queryOptions(undefined, {
+			enabled: parsed.showFilters.store,
+		})
+	);
+	const currenciesQuery = useQuery(
+		trpc.currency.list.queryOptions(undefined, {
+			enabled: parsed.showFilters.currency,
+		})
 	);
 
+	const rawPoints = (query.data?.points ?? []) as PnlSeriesPoint[];
+	const aggregated = aggregatePnlPoints({
+		rawPoints,
+		xAxis: state.xAxis,
+		unit: state.unit,
+		sessionType: state.sessionType,
+		showEvCash: state.showEvCash,
+	});
+
+	const stores = (storesQuery.data ?? []) as PnlGraphSelectOption[];
+	const currencies = (currenciesQuery.data ?? []) as PnlGraphSelectOption[];
+
 	return {
+		currencies,
 		error: query.error,
 		isLoading: query.isLoading,
 		onChangeCurrencyId: (value) =>
@@ -201,5 +228,6 @@ export function usePnlGraphWidget(
 		rawPoints,
 		skippedCount: aggregated.skippedCount,
 		state,
+		stores,
 	};
 }

--- a/apps/web/src/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-widget.ts
+++ b/apps/web/src/features/dashboard/widgets/pnl-graph-widget/use-pnl-graph-widget.ts
@@ -1,0 +1,206 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { trpc } from "@/utils/trpc";
+import {
+	type AggregatedPoint,
+	aggregatePnlPoints,
+	type PnlGraphUnit,
+	type PnlGraphXAxis,
+	type PnlSeriesPoint,
+} from "./aggregate-pnl-points";
+
+export type { PnlGraphUnit, PnlGraphXAxis } from "./aggregate-pnl-points";
+
+export type PnlGraphSessionType = "all" | "cash_game" | "tournament";
+
+export interface PnlGraphFilterFlags {
+	currency: boolean;
+	dateRange: boolean;
+	ringGame: boolean;
+	sessionType: boolean;
+	store: boolean;
+	unit: boolean;
+	xAxis: boolean;
+}
+
+export interface PnlGraphParsedConfig {
+	currencyId: string | null;
+	dateRangeDays: number | null;
+	ringGameId: string | null;
+	sessionType: PnlGraphSessionType;
+	showFilters: PnlGraphFilterFlags;
+	storeId: string | null;
+	unit: PnlGraphUnit;
+	xAxis: PnlGraphXAxis;
+}
+
+export const PNL_GRAPH_X_AXIS_VALUES: PnlGraphXAxis[] = [
+	"date",
+	"sessionCount",
+	"playTime",
+];
+export const PNL_GRAPH_UNIT_VALUES: PnlGraphUnit[] = ["currency", "bb", "bi"];
+export const PNL_GRAPH_SESSION_TYPE_VALUES: PnlGraphSessionType[] = [
+	"all",
+	"cash_game",
+	"tournament",
+];
+
+const DEFAULT_FLAGS: PnlGraphFilterFlags = {
+	xAxis: false,
+	dateRange: false,
+	sessionType: false,
+	unit: false,
+	store: false,
+	ringGame: false,
+	currency: false,
+};
+
+function parseStringOrNull(value: unknown): string | null {
+	return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function parseEnum<T extends string>(
+	value: unknown,
+	allowed: readonly T[],
+	fallback: T
+): T {
+	return allowed.includes(value as T) ? (value as T) : fallback;
+}
+
+function parseFlags(value: unknown): PnlGraphFilterFlags {
+	if (!value || typeof value !== "object") {
+		return DEFAULT_FLAGS;
+	}
+	const raw = value as Record<string, unknown>;
+	return {
+		xAxis: raw.xAxis === true,
+		dateRange: raw.dateRange === true,
+		sessionType: raw.sessionType === true,
+		unit: raw.unit === true,
+		store: raw.store === true,
+		ringGame: raw.ringGame === true,
+		currency: raw.currency === true,
+	};
+}
+
+export function parsePnlGraphWidgetConfig(
+	raw: Record<string, unknown>
+): PnlGraphParsedConfig {
+	return {
+		xAxis: parseEnum(raw.xAxis, PNL_GRAPH_X_AXIS_VALUES, "date"),
+		dateRangeDays:
+			typeof raw.dateRangeDays === "number" && raw.dateRangeDays > 0
+				? raw.dateRangeDays
+				: null,
+		sessionType: parseEnum(
+			raw.sessionType,
+			PNL_GRAPH_SESSION_TYPE_VALUES,
+			"all"
+		),
+		unit: parseEnum(raw.unit, PNL_GRAPH_UNIT_VALUES, "currency"),
+		storeId: parseStringOrNull(raw.storeId),
+		ringGameId: parseStringOrNull(raw.ringGameId),
+		currencyId: parseStringOrNull(raw.currencyId),
+		showFilters: parseFlags(raw.showFilters),
+	};
+}
+
+export interface PnlGraphRuntimeState {
+	currencyId: string | null;
+	dateRangeDays: number | null;
+	ringGameId: string | null;
+	sessionType: PnlGraphSessionType;
+	storeId: string | null;
+	unit: PnlGraphUnit;
+	xAxis: PnlGraphXAxis;
+}
+
+function configToState(parsed: PnlGraphParsedConfig): PnlGraphRuntimeState {
+	return {
+		xAxis: parsed.xAxis,
+		dateRangeDays: parsed.dateRangeDays,
+		sessionType: parsed.sessionType,
+		unit: parsed.unit,
+		storeId: parsed.storeId,
+		ringGameId: parsed.ringGameId,
+		currencyId: parsed.currencyId,
+	};
+}
+
+export function effectiveTypeFilter(
+	state: PnlGraphRuntimeState
+): "cash_game" | "tournament" | undefined {
+	if (state.unit === "bb") {
+		return "cash_game";
+	}
+	if (state.unit === "bi") {
+		return "tournament";
+	}
+	return state.sessionType === "all" ? undefined : state.sessionType;
+}
+
+interface UsePnlGraphWidgetResult {
+	error: unknown;
+	isLoading: boolean;
+	onChangeCurrencyId: (value: string | null) => void;
+	onChangeDateRangeDays: (value: number | null) => void;
+	onChangeRingGameId: (value: string | null) => void;
+	onChangeSessionType: (value: PnlGraphSessionType) => void;
+	onChangeStoreId: (value: string | null) => void;
+	onChangeUnit: (value: PnlGraphUnit) => void;
+	onChangeXAxis: (value: PnlGraphXAxis) => void;
+	parsed: PnlGraphParsedConfig;
+	points: AggregatedPoint[];
+	rawPoints: PnlSeriesPoint[];
+	skippedCount: number;
+	state: PnlGraphRuntimeState;
+}
+
+export function usePnlGraphWidget(
+	config: Record<string, unknown>
+): UsePnlGraphWidgetResult {
+	const parsed = parsePnlGraphWidgetConfig(config);
+	const [state, setState] = useState<PnlGraphRuntimeState>(() =>
+		configToState(parsed)
+	);
+
+	const dateFrom =
+		state.dateRangeDays === null
+			? undefined
+			: Math.floor(Date.now() / 1000) - state.dateRangeDays * 86_400;
+
+	const query = useQuery(
+		trpc.session.profitLossSeries.queryOptions({
+			type: effectiveTypeFilter(state),
+			storeId: state.storeId ?? undefined,
+			ringGameId: state.ringGameId ?? undefined,
+			currencyId: state.currencyId ?? undefined,
+			dateFrom,
+		})
+	);
+
+	const rawPoints = (query.data?.points ?? []) as PnlSeriesPoint[];
+	const aggregated = aggregatePnlPoints(rawPoints, state.xAxis, state.unit);
+
+	return {
+		error: query.error,
+		isLoading: query.isLoading,
+		onChangeCurrencyId: (value) =>
+			setState((s) => ({ ...s, currencyId: value })),
+		onChangeDateRangeDays: (value) =>
+			setState((s) => ({ ...s, dateRangeDays: value })),
+		onChangeRingGameId: (value) =>
+			setState((s) => ({ ...s, ringGameId: value })),
+		onChangeSessionType: (value) =>
+			setState((s) => ({ ...s, sessionType: value })),
+		onChangeStoreId: (value) => setState((s) => ({ ...s, storeId: value })),
+		onChangeUnit: (value) => setState((s) => ({ ...s, unit: value })),
+		onChangeXAxis: (value) => setState((s) => ({ ...s, xAxis: value })),
+		parsed,
+		points: aggregated.points,
+		rawPoints,
+		skippedCount: aggregated.skippedCount,
+		state,
+	};
+}

--- a/apps/web/src/features/dashboard/widgets/registry/registry.test.ts
+++ b/apps/web/src/features/dashboard/widgets/registry/registry.test.ts
@@ -4,6 +4,9 @@ vi.mock("@/utils/trpc", () => ({
 	trpc: {
 		session: {
 			list: { queryOptions: () => ({ queryKey: ["session-list"] }) },
+			profitLossSeries: {
+				queryOptions: () => ({ queryKey: ["session-pnl-series"] }),
+			},
 		},
 		liveCashGameSession: {
 			list: { queryOptions: () => ({ queryKey: ["live-cash-list"] }) },
@@ -13,6 +16,14 @@ vi.mock("@/utils/trpc", () => ({
 		},
 		currency: {
 			list: { queryOptions: () => ({ queryKey: ["currency-list"] }) },
+		},
+		store: {
+			list: { queryOptions: () => ({ queryKey: ["store-list"] }) },
+		},
+		ringGame: {
+			listByStore: {
+				queryOptions: () => ({ queryKey: ["ring-game-list-by-store"] }),
+			},
 		},
 		dashboardWidget: {
 			list: { queryOptions: () => ({ queryKey: ["widget-list"] }) },
@@ -26,11 +37,12 @@ const { getWidgetEntry, listWidgetTypes, widgetRegistry } = await import(
 );
 
 describe("widget registry", () => {
-	it("has entries for all 4 MVP widget types", () => {
+	it("has entries for all registered widget types", () => {
 		expect(Object.keys(widgetRegistry).sort()).toEqual(
 			[
 				"active_session",
 				"currency_balance",
+				"pnl_graph",
 				"recent_sessions",
 				"summary_stats",
 			].sort()
@@ -39,7 +51,7 @@ describe("widget registry", () => {
 
 	it("lists all widget entries", () => {
 		const entries = listWidgetTypes();
-		expect(entries).toHaveLength(4);
+		expect(entries).toHaveLength(5);
 		for (const entry of entries) {
 			expect(entry.label).toBeTruthy();
 			expect(entry.Render).toBeTruthy();
@@ -52,5 +64,6 @@ describe("widget registry", () => {
 	it("returns entry by type", () => {
 		expect(getWidgetEntry("summary_stats").type).toBe("summary_stats");
 		expect(getWidgetEntry("active_session").type).toBe("active_session");
+		expect(getWidgetEntry("pnl_graph").type).toBe("pnl_graph");
 	});
 });

--- a/apps/web/src/features/dashboard/widgets/registry/registry.ts
+++ b/apps/web/src/features/dashboard/widgets/registry/registry.ts
@@ -1,6 +1,7 @@
 import type { TablerIcon } from "@tabler/icons-react";
 import {
 	IconBolt,
+	IconChartLine,
 	IconCoin,
 	IconListDetails,
 	IconReportAnalytics,
@@ -44,6 +45,7 @@ import {
 	CurrencyBalanceEditForm,
 	CurrencyBalanceWidget,
 } from "../currency-balance-widget";
+import { PnlGraphEditForm, PnlGraphWidget } from "../pnl-graph-widget";
 import {
 	RecentSessionsEditForm,
 	RecentSessionsWidget,
@@ -105,6 +107,19 @@ export const widgetRegistry: Record<WidgetType, WidgetRegistryEntry> = {
 			mobile: { w: 3, h: 2 },
 		},
 		minSize: { w: 2, h: 2 },
+	},
+	pnl_graph: {
+		type: "pnl_graph",
+		label: "P&L Graph",
+		description: "Cumulative profit and loss over time, sessions, or play time",
+		icon: IconChartLine,
+		Render: PnlGraphWidget,
+		EditForm: PnlGraphEditForm,
+		defaultSize: {
+			desktop: { w: 6, h: 5 },
+			mobile: { w: 6, h: 4 },
+		},
+		minSize: { w: 3, h: 3 },
 	},
 };
 

--- a/apps/web/src/features/live-sessions/components/cash-game-stack-form/cash-game-stack-form.tsx
+++ b/apps/web/src/features/live-sessions/components/cash-game-stack-form/cash-game-stack-form.tsx
@@ -113,7 +113,7 @@ export function CashGameStackForm({
 			<div className="-mx-4 border-t" />
 
 			<div className="flex flex-col gap-2">
-				<p className="font-medium text-muted-foreground text-xs">Events</p>
+				<p className="font-medium text-muted-foreground text-xs">Timeline</p>
 				<div className="grid grid-cols-2 gap-2">
 					<Button
 						onClick={() => setAllInBottomSheetOpen(true)}

--- a/apps/web/src/features/live-sessions/components/session-events-scene/session-events-scene.tsx
+++ b/apps/web/src/features/live-sessions/components/session-events-scene/session-events-scene.tsx
@@ -145,7 +145,7 @@ export function SessionEventsScene({
 
 	return (
 		<div className="p-4 md:p-6">
-			<PageHeader heading="Events" />
+			<PageHeader heading="Timeline" />
 			{events.length === 0 ? (
 				<EmptyState
 					className="border-none bg-transparent px-0 py-8"

--- a/apps/web/src/features/live-sessions/components/session-result-chart/__tests__/session-result-chart.test.tsx
+++ b/apps/web/src/features/live-sessions/components/session-result-chart/__tests__/session-result-chart.test.tsx
@@ -1,0 +1,154 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const queryFn = vi.fn(async () => [] as unknown[]);
+
+vi.mock("@/utils/trpc", () => ({
+	trpc: {
+		sessionEvent: {
+			list: {
+				queryOptions: (input: unknown) => ({
+					queryKey: ["sessionEvent", "list", input],
+					queryFn,
+				}),
+			},
+		},
+	},
+}));
+
+// Avoid actually loading recharts in tests; the wrapper's lazy boundary still
+// resolves, but the impl module is replaced with a tiny stub so jsdom doesn't
+// have to render SVG.
+vi.mock(
+	"@/features/live-sessions/components/session-result-chart/session-result-chart-impl",
+	() => ({
+		default: ({
+			points,
+			sessionType,
+		}: {
+			points: unknown[];
+			sessionType: string;
+		}) =>
+			createElement(
+				"div",
+				{
+					"data-testid": "chart-impl",
+					"data-session-type": sessionType,
+					"data-point-count": String(points.length),
+				},
+				"chart"
+			),
+	})
+);
+
+import { SessionResultChart } from "@/features/live-sessions/components/session-result-chart/session-result-chart";
+
+function createClient(): QueryClient {
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0, staleTime: Number.POSITIVE_INFINITY },
+			mutations: { retry: false },
+		},
+	});
+}
+
+function wrap(ui: ReactNode) {
+	return createElement(QueryClientProvider, { client: createClient() }, ui);
+}
+
+describe("SessionResultChart", () => {
+	it("renders nothing when enabled=false", () => {
+		queryFn.mockClear();
+		const { container } = render(
+			wrap(
+				createElement(SessionResultChart, {
+					enabled: false,
+					liveSessionId: "s1",
+					sessionType: "cash_game",
+				})
+			)
+		);
+		expect(container.firstChild).toBeNull();
+		expect(queryFn).not.toHaveBeenCalled();
+	});
+
+	it("renders the empty state when fewer than 2 derived points", async () => {
+		queryFn.mockClear();
+		queryFn.mockResolvedValueOnce([]);
+		render(
+			wrap(
+				createElement(SessionResultChart, {
+					enabled: true,
+					liveSessionId: "s1",
+					sessionType: "cash_game",
+				})
+			)
+		);
+		expect(await screen.findByText("Not enough data yet")).toBeTruthy();
+	});
+
+	it("renders the chart impl when there are >=2 derived cash points", async () => {
+		queryFn.mockClear();
+		queryFn.mockResolvedValueOnce([
+			{
+				id: "e1",
+				eventType: "session_start",
+				occurredAt: "2026-04-01T10:00:00Z",
+				payload: { buyInAmount: 10_000 },
+			},
+			{
+				id: "e2",
+				eventType: "update_stack",
+				occurredAt: "2026-04-01T10:30:00Z",
+				payload: { stackAmount: 12_000 },
+			},
+		]);
+		render(
+			wrap(
+				createElement(SessionResultChart, {
+					enabled: true,
+					liveSessionId: "cash-1",
+					sessionType: "cash_game",
+				})
+			)
+		);
+		const impl = await screen.findByTestId("chart-impl");
+		expect(impl.getAttribute("data-session-type")).toBe("cash_game");
+		expect(impl.getAttribute("data-point-count")).toBe("2");
+	});
+
+	it("passes tournament points through to the impl", async () => {
+		queryFn.mockClear();
+		queryFn.mockResolvedValueOnce([
+			{
+				id: "e1",
+				eventType: "session_start",
+				occurredAt: "2026-04-01T10:00:00Z",
+				payload: {},
+			},
+			{
+				id: "e2",
+				eventType: "update_stack",
+				occurredAt: "2026-04-01T10:05:00Z",
+				payload: { stackAmount: 10_000 },
+			},
+		]);
+		render(
+			wrap(
+				createElement(SessionResultChart, {
+					enabled: true,
+					liveSessionId: "trn-1",
+					sessionType: "tournament",
+				})
+			)
+		);
+		await waitFor(() =>
+			expect(screen.queryByTestId("chart-impl")).not.toBeNull()
+		);
+		const impl = screen.getByTestId("chart-impl");
+		expect(impl.getAttribute("data-session-type")).toBe("tournament");
+		expect(impl.getAttribute("data-point-count")).toBe("2");
+	});
+});

--- a/apps/web/src/features/live-sessions/components/session-result-chart/__tests__/use-session-result-chart.test.ts
+++ b/apps/web/src/features/live-sessions/components/session-result-chart/__tests__/use-session-result-chart.test.ts
@@ -1,0 +1,183 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+interface CapturedInput {
+	liveCashGameSessionId?: string;
+	liveTournamentSessionId?: string;
+}
+
+const captured: {
+	lastInput: CapturedInput | null;
+	enabledSeen: boolean | undefined;
+} = { lastInput: null, enabledSeen: undefined };
+
+const queryFn = vi.fn(async () => [] as unknown[]);
+
+vi.mock("@/utils/trpc", () => ({
+	trpc: {
+		sessionEvent: {
+			list: {
+				queryOptions: (input: CapturedInput) => {
+					captured.lastInput = input;
+					return {
+						queryKey: ["sessionEvent", "list", input],
+						queryFn,
+					};
+				},
+			},
+		},
+	},
+}));
+
+import { useSessionResultChart } from "@/features/live-sessions/components/session-result-chart/use-session-result-chart";
+
+function createClient(): QueryClient {
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0, staleTime: Number.POSITIVE_INFINITY },
+			mutations: { retry: false },
+		},
+	});
+}
+
+function wrapper(client: QueryClient) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(QueryClientProvider, { client }, children);
+	};
+}
+
+describe("useSessionResultChart", () => {
+	it("does not fetch when enabled=false", () => {
+		queryFn.mockClear();
+		captured.lastInput = null;
+		const { result } = renderHook(
+			() =>
+				useSessionResultChart({
+					liveSessionId: "s1",
+					sessionType: "cash_game",
+					enabled: false,
+				}),
+			{ wrapper: wrapper(createClient()) }
+		);
+		expect(queryFn).not.toHaveBeenCalled();
+		expect(result.current.points).toEqual([]);
+		expect(result.current.isLoading).toBe(false);
+	});
+
+	it("fetches with liveCashGameSessionId for cash sessions when enabled", async () => {
+		queryFn.mockClear();
+		captured.lastInput = null;
+		queryFn.mockResolvedValueOnce([]);
+		renderHook(
+			() =>
+				useSessionResultChart({
+					liveSessionId: "cash-1",
+					sessionType: "cash_game",
+					enabled: true,
+				}),
+			{ wrapper: wrapper(createClient()) }
+		);
+		await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1));
+		expect(captured.lastInput).toEqual({ liveCashGameSessionId: "cash-1" });
+	});
+
+	it("fetches with liveTournamentSessionId for tournaments when enabled", async () => {
+		queryFn.mockClear();
+		captured.lastInput = null;
+		queryFn.mockResolvedValueOnce([]);
+		renderHook(
+			() =>
+				useSessionResultChart({
+					liveSessionId: "trn-1",
+					sessionType: "tournament",
+					enabled: true,
+				}),
+			{ wrapper: wrapper(createClient()) }
+		);
+		await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1));
+		expect(captured.lastInput).toEqual({ liveTournamentSessionId: "trn-1" });
+	});
+
+	it("derives a cash timeline (pl + evPl) from fetched events", async () => {
+		queryFn.mockClear();
+		queryFn.mockResolvedValueOnce([
+			{
+				id: "e1",
+				eventType: "session_start",
+				occurredAt: "2026-04-01T10:00:00Z",
+				payload: { buyInAmount: 10_000 },
+			},
+			{
+				id: "e2",
+				eventType: "update_stack",
+				occurredAt: "2026-04-01T10:30:00Z",
+				payload: { stackAmount: 12_000 },
+			},
+		]);
+		const { result } = renderHook(
+			() =>
+				useSessionResultChart({
+					liveSessionId: "cash-1",
+					sessionType: "cash_game",
+					enabled: true,
+				}),
+			{ wrapper: wrapper(createClient()) }
+		);
+		await waitFor(() => expect(result.current.points).toHaveLength(2));
+		expect(result.current.sessionType).toBe("cash_game");
+		expect(result.current.isEmpty).toBe(false);
+		expect(result.current.points[1]).toMatchObject({ pl: 2000, evPl: 2000 });
+	});
+
+	it("derives a tournament timeline (stack + averageStack)", async () => {
+		queryFn.mockClear();
+		queryFn.mockResolvedValueOnce([
+			{
+				id: "e1",
+				eventType: "session_start",
+				occurredAt: "2026-04-01T10:00:00Z",
+				payload: {},
+			},
+			{
+				id: "e2",
+				eventType: "update_stack",
+				occurredAt: "2026-04-01T10:05:00Z",
+				payload: { stackAmount: 10_000 },
+			},
+		]);
+		const { result } = renderHook(
+			() =>
+				useSessionResultChart({
+					liveSessionId: "trn-1",
+					sessionType: "tournament",
+					enabled: true,
+				}),
+			{ wrapper: wrapper(createClient()) }
+		);
+		await waitFor(() => expect(result.current.points).toHaveLength(2));
+		expect(result.current.sessionType).toBe("tournament");
+		expect(result.current.points[1]).toMatchObject({
+			stack: 10_000,
+			averageStack: null,
+		});
+	});
+
+	it("reports isEmpty=true when fewer than 2 derived points", async () => {
+		queryFn.mockClear();
+		queryFn.mockResolvedValueOnce([]);
+		const { result } = renderHook(
+			() =>
+				useSessionResultChart({
+					liveSessionId: "cash-1",
+					sessionType: "cash_game",
+					enabled: true,
+				}),
+			{ wrapper: wrapper(createClient()) }
+		);
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.points).toEqual([]);
+		expect(result.current.isEmpty).toBe(true);
+	});
+});

--- a/apps/web/src/features/live-sessions/components/session-result-chart/index.ts
+++ b/apps/web/src/features/live-sessions/components/session-result-chart/index.ts
@@ -1,0 +1,2 @@
+export { SessionResultChart } from "./session-result-chart";
+export { useSessionResultChart } from "./use-session-result-chart";

--- a/apps/web/src/features/live-sessions/components/session-result-chart/session-result-chart-impl.tsx
+++ b/apps/web/src/features/live-sessions/components/session-result-chart/session-result-chart-impl.tsx
@@ -1,0 +1,212 @@
+import {
+	CartesianGrid,
+	Legend,
+	Line,
+	LineChart,
+	ReferenceLine,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { formatCompactNumber } from "@/utils/format-number";
+
+const COLOR_CASH = "oklch(0.62 0.21 250)";
+const COLOR_TOURNAMENT = "oklch(0.75 0.16 70)";
+
+interface SeriesMeta {
+	color: string;
+	dashed: boolean;
+	dataKey: string;
+	name: string;
+}
+
+const CASH_SERIES: SeriesMeta[] = [
+	{ name: "P&L", dataKey: "pl", color: COLOR_CASH, dashed: false },
+	{ name: "EV P&L", dataKey: "evPl", color: COLOR_CASH, dashed: true },
+];
+
+const TOURNAMENT_SERIES: SeriesMeta[] = [
+	{ name: "Stack", dataKey: "stack", color: COLOR_TOURNAMENT, dashed: false },
+	{
+		name: "Avg stack",
+		dataKey: "averageStack",
+		color: COLOR_TOURNAMENT,
+		dashed: true,
+	},
+];
+
+function formatXTick(ms: number): string {
+	const totalMinutes = Math.max(0, Math.round(ms / 60_000));
+	const hours = Math.floor(totalMinutes / 60);
+	const minutes = totalMinutes % 60;
+	return `${hours}:${String(minutes).padStart(2, "0")}`;
+}
+
+interface TooltipPayloadItem {
+	color?: string;
+	dataKey?: string | number;
+	name?: string | number;
+	value?: number | string | (number | string)[];
+}
+
+interface CustomTooltipProps {
+	active?: boolean;
+	label?: number | string;
+	payload?: readonly TooltipPayloadItem[];
+}
+
+function CustomTooltip({ active, label, payload }: CustomTooltipProps) {
+	if (!(active && payload) || payload.length === 0) {
+		return null;
+	}
+	return (
+		<div className="rounded-md border border-border bg-popover px-2 py-1 text-popover-foreground text-xs shadow-md">
+			{typeof label === "number" ? (
+				<div className="text-muted-foreground">{formatXTick(label)}</div>
+			) : null}
+			{payload.map((item) => (
+				<div
+					className="flex items-center gap-2"
+					key={String(item.dataKey ?? item.name)}
+				>
+					<span
+						className="inline-block h-2 w-2 rounded-full"
+						style={{ backgroundColor: item.color }}
+					/>
+					<span className="text-muted-foreground">
+						{String(item.name ?? "")}
+					</span>
+					<span className="font-medium tabular-nums">
+						{typeof item.value === "number"
+							? formatCompactNumber(item.value)
+							: ""}
+					</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
+function CustomLegend({ items }: { items: SeriesMeta[] }) {
+	return (
+		<div className="flex flex-wrap items-center justify-center gap-3 pt-1 text-[11px]">
+			{items.map((item) => (
+				<div className="flex items-center gap-1.5" key={item.dataKey}>
+					<svg
+						aria-hidden="true"
+						className="shrink-0"
+						height={6}
+						viewBox="0 0 14 6"
+						width={14}
+					>
+						<line
+							stroke={item.color}
+							strokeDasharray={item.dashed ? "3 2" : undefined}
+							strokeWidth={2}
+							x1={0}
+							x2={14}
+							y1={3}
+							y2={3}
+						/>
+					</svg>
+					<span className="text-foreground">{item.name}</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
+interface ChartPoint {
+	averageStack?: number | null;
+	evPl?: number;
+	pl?: number;
+	stack?: number;
+	t: number;
+}
+
+interface SessionResultChartImplProps {
+	points: ChartPoint[];
+	sessionType: "cash_game" | "tournament";
+}
+
+function activeSeries(
+	sessionType: "cash_game" | "tournament",
+	points: ChartPoint[]
+): SeriesMeta[] {
+	if (sessionType === "cash_game") {
+		return CASH_SERIES;
+	}
+	const hasAverage = points.some((p) => p.averageStack != null);
+	return hasAverage ? TOURNAMENT_SERIES : [TOURNAMENT_SERIES[0]];
+}
+
+export default function SessionResultChartImpl({
+	points,
+	sessionType,
+}: SessionResultChartImplProps) {
+	const series = activeSeries(sessionType, points);
+	const isCash = sessionType === "cash_game";
+	return (
+		<div className="h-full w-full">
+			<ResponsiveContainer height="100%" width="100%">
+				<LineChart
+					data={points}
+					margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+				>
+					<CartesianGrid className="stroke-border" strokeDasharray="3 3" />
+					<XAxis
+						dataKey="t"
+						domain={["dataMin", "dataMax"]}
+						tick={{ fontSize: 10 }}
+						tickFormatter={(v: number) => formatXTick(v)}
+						type="number"
+					/>
+					<YAxis
+						tick={{ fontSize: 10 }}
+						tickFormatter={(v: number) => formatCompactNumber(v)}
+						width={50}
+					/>
+					{isCash ? (
+						<ReferenceLine
+							className="stroke-muted-foreground"
+							strokeDasharray="2 2"
+							y={0}
+						/>
+					) : null}
+					<Tooltip
+						content={(props) => (
+							<CustomTooltip
+								active={props.active}
+								label={props.label as number | string | undefined}
+								payload={
+									props.payload as readonly TooltipPayloadItem[] | undefined
+								}
+							/>
+						)}
+						cursor={false}
+						wrapperStyle={{ outline: "none" }}
+					/>
+					<Legend
+						content={() => <CustomLegend items={series} />}
+						wrapperStyle={{ outline: "none" }}
+					/>
+					{series.map((s) => (
+						<Line
+							connectNulls
+							dataKey={s.dataKey}
+							dot={false}
+							isAnimationActive={false}
+							key={s.dataKey}
+							name={s.name}
+							stroke={s.color}
+							strokeDasharray={s.dashed ? "4 4" : undefined}
+							strokeWidth={2}
+							type="linear"
+						/>
+					))}
+				</LineChart>
+			</ResponsiveContainer>
+		</div>
+	);
+}

--- a/apps/web/src/features/live-sessions/components/session-result-chart/session-result-chart.tsx
+++ b/apps/web/src/features/live-sessions/components/session-result-chart/session-result-chart.tsx
@@ -1,0 +1,46 @@
+import { lazy, Suspense } from "react";
+import { Skeleton } from "@/shared/components/ui/skeleton";
+import { useSessionResultChart } from "./use-session-result-chart";
+
+const SessionResultChartImpl = lazy(
+	() => import("./session-result-chart-impl")
+);
+
+interface SessionResultChartProps {
+	enabled: boolean;
+	liveSessionId: string;
+	sessionType: "cash_game" | "tournament";
+}
+
+export function SessionResultChart({
+	enabled,
+	liveSessionId,
+	sessionType,
+}: SessionResultChartProps) {
+	const { isEmpty, isLoading, points } = useSessionResultChart({
+		enabled,
+		liveSessionId,
+		sessionType,
+	});
+
+	if (!enabled) {
+		return null;
+	}
+	if (isLoading) {
+		return <Skeleton className="h-40 w-full" />;
+	}
+	if (isEmpty) {
+		return (
+			<div className="flex h-40 items-center justify-center text-muted-foreground text-xs">
+				Not enough data yet
+			</div>
+		);
+	}
+	return (
+		<div className="h-40 w-full">
+			<Suspense fallback={<Skeleton className="h-full w-full" />}>
+				<SessionResultChartImpl points={points} sessionType={sessionType} />
+			</Suspense>
+		</div>
+	);
+}

--- a/apps/web/src/features/live-sessions/components/session-result-chart/use-session-result-chart.ts
+++ b/apps/web/src/features/live-sessions/components/session-result-chart/use-session-result-chart.ts
@@ -1,0 +1,57 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+	type CashTimelinePoint,
+	deriveCashGameTimeline,
+	deriveTournamentTimeline,
+	type TimelineEvent,
+	type TournamentTimelinePoint,
+} from "@/features/live-sessions/utils/session-timeline";
+import { trpc } from "@/utils/trpc";
+
+export type SessionType = "cash_game" | "tournament";
+
+export type SessionResultPoint = CashTimelinePoint | TournamentTimelinePoint;
+
+interface UseSessionResultChartArgs {
+	enabled: boolean;
+	liveSessionId: string;
+	sessionType: SessionType;
+}
+
+interface UseSessionResultChartResult {
+	error: unknown;
+	isEmpty: boolean;
+	isLoading: boolean;
+	points: SessionResultPoint[];
+	sessionType: SessionType;
+}
+
+export function useSessionResultChart({
+	liveSessionId,
+	sessionType,
+	enabled,
+}: UseSessionResultChartArgs): UseSessionResultChartResult {
+	const queryInput =
+		sessionType === "tournament"
+			? { liveTournamentSessionId: liveSessionId }
+			: { liveCashGameSessionId: liveSessionId };
+
+	const eventsQuery = useQuery({
+		...trpc.sessionEvent.list.queryOptions(queryInput),
+		enabled,
+	});
+
+	const events = (eventsQuery.data ?? []) as TimelineEvent[];
+	const points: SessionResultPoint[] =
+		sessionType === "tournament"
+			? deriveTournamentTimeline(events)
+			: deriveCashGameTimeline(events);
+
+	return {
+		error: eventsQuery.error,
+		isEmpty: !eventsQuery.isLoading && points.length < 2,
+		isLoading: eventsQuery.isLoading,
+		points,
+		sessionType,
+	};
+}

--- a/apps/web/src/features/live-sessions/components/tournament-stack-form/tournament-stack-form.tsx
+++ b/apps/web/src/features/live-sessions/components/tournament-stack-form/tournament-stack-form.tsx
@@ -194,7 +194,7 @@ export function TournamentStackForm({
 			<div className="-mx-4 border-t" />
 
 			<div className="flex flex-col gap-2">
-				<p className="font-medium text-muted-foreground text-xs">Events</p>
+				<p className="font-medium text-muted-foreground text-xs">Timeline</p>
 				<div className="grid grid-cols-2 gap-2">
 					<Button
 						onClick={() => setChipPurchaseSheetOpen(true)}

--- a/apps/web/src/features/live-sessions/utils/__tests__/session-timeline.test.ts
+++ b/apps/web/src/features/live-sessions/utils/__tests__/session-timeline.test.ts
@@ -419,4 +419,132 @@ describe("deriveTournamentTimeline", () => {
 		];
 		expect(() => deriveTournamentTimeline(events)).toThrow();
 	});
+
+	it("session_end with non-winning placement drops stack to 0", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: {
+					stackAmount: 10_000,
+					remainingPlayers: 30,
+					totalEntries: 50,
+				},
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "session_end",
+				payload: {
+					beforeDeadline: false,
+					placement: 7,
+					totalEntries: 50,
+					prizeMoney: 0,
+					bountyPrizes: 0,
+				},
+				offsetMin: 60,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points.at(-1)).toEqual({
+			t: 60 * 60_000,
+			stack: 0,
+			averageStack: 25_000 / 1.5, // (10000 * 50) / 30 — preserved from last update_stack
+		});
+	});
+
+	it("session_end with placement=1 sets stack to startingStack * totalEntries (winner takes all)", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "session_end",
+				payload: {
+					beforeDeadline: false,
+					placement: 1,
+					totalEntries: 50,
+					prizeMoney: 100_000,
+					bountyPrizes: 0,
+				},
+				offsetMin: 120,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points.at(-1)).toMatchObject({
+			t: 120 * 60_000,
+			stack: 10_000 * 50,
+		});
+	});
+
+	it("session_end with placement=1 includes recorded chip purchases in winner stack", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: {
+					stackAmount: 10_000,
+					totalEntries: 50,
+					chipPurchaseCounts: [
+						{ name: "Rebuy", count: 20, chipsPerUnit: 10_000 },
+					],
+				},
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "session_end",
+				payload: {
+					beforeDeadline: false,
+					placement: 1,
+					totalEntries: 50,
+					prizeMoney: 100_000,
+					bountyPrizes: 0,
+				},
+				offsetMin: 120,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		// 10000 * 50 + 20 * 10000 = 500000 + 200000 = 700000
+		expect(points.at(-1)?.stack).toBe(700_000);
+	});
+
+	it("session_end with beforeDeadline=true does not alter the running stack", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "session_end",
+				payload: {
+					beforeDeadline: true,
+					prizeMoney: 0,
+					bountyPrizes: 0,
+				},
+				offsetMin: 60,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points.at(-1)).toMatchObject({ t: 60 * 60_000, stack: 10_000 });
+	});
 });

--- a/apps/web/src/features/live-sessions/utils/__tests__/session-timeline.test.ts
+++ b/apps/web/src/features/live-sessions/utils/__tests__/session-timeline.test.ts
@@ -1,0 +1,422 @@
+import { computeCashGamePLFromEvents } from "@sapphire2/api/services/live-session-pl";
+import { describe, expect, it } from "vitest";
+import {
+	deriveCashGameTimeline,
+	deriveTournamentTimeline,
+	type TimelineEvent,
+} from "@/features/live-sessions/utils/session-timeline";
+
+const T0 = new Date("2026-04-01T10:00:00Z").getTime();
+
+function event(
+	overrides: Partial<TimelineEvent> & {
+		eventType: string;
+		payload: unknown;
+		offsetMin?: number;
+	}
+): TimelineEvent {
+	const { offsetMin, ...rest } = overrides;
+	return {
+		occurredAt: new Date(T0 + (offsetMin ?? 0) * 60_000).toISOString(),
+		...rest,
+	} as TimelineEvent;
+}
+
+// Reuse the API's serialized-payload signature so we can cross-check final values.
+function toServerEvent(e: TimelineEvent): {
+	eventType: string;
+	payload: string;
+} {
+	return { eventType: e.eventType, payload: JSON.stringify(e.payload) };
+}
+
+describe("deriveCashGameTimeline", () => {
+	it("returns an empty array when no events are present", () => {
+		expect(deriveCashGameTimeline([])).toEqual([]);
+	});
+
+	it("returns an empty array when session_start is missing (no anchor)", () => {
+		const events = [
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 5000 },
+				offsetMin: 5,
+			}),
+		];
+		expect(deriveCashGameTimeline(events)).toEqual([]);
+	});
+
+	it("starts at pl=0 / evPl=0 on session_start", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		expect(points).toEqual([{ t: 0, pl: 0, evPl: 0 }]);
+	});
+
+	it("update_stack snapshots running pl as stack - totalBuyIn", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 12_000 },
+				offsetMin: 30,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		expect(points).toHaveLength(2);
+		expect(points[1]).toEqual({ t: 30 * 60_000, pl: 2000, evPl: 2000 });
+	});
+
+	it("chips_add_remove (positive) leaves pl unchanged but increases buy-in basis", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 12_000 },
+				offsetMin: 30,
+			}),
+			event({
+				eventType: "chips_add_remove",
+				payload: { amount: 5000 },
+				offsetMin: 31,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 17_000 },
+				offsetMin: 32,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		// At chips_add_remove(+): stack=17000 (was 12000 + 5000), totalBuyIn=15000 → pl unchanged at 2000
+		expect(points[2]).toEqual({ t: 31 * 60_000, pl: 2000, evPl: 2000 });
+		// Subsequent update_stack repeats the same pl when stack matches totalBuyIn shift
+		expect(points[3]).toEqual({ t: 32 * 60_000, pl: 2000, evPl: 2000 });
+	});
+
+	it("chips_add_remove (negative) accumulates chipRemoveTotal so pl is stable", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 12_000 },
+				offsetMin: 30,
+			}),
+			event({
+				eventType: "chips_add_remove",
+				payload: { amount: -3000 },
+				offsetMin: 31,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		// stack=9000, chipRemoveTotal=3000, totalBuyIn=10000 → pl = 9000 + 3000 - 10000 = 2000
+		expect(points[2]).toEqual({ t: 31 * 60_000, pl: 2000, evPl: 2000 });
+	});
+
+	it("all_in adds positive evDiff when wins underperform equity", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			// pot=1000, trials=1, equity=60% (=600 EV), wins=0 (=0 actual) → evDiff=+600
+			event({
+				eventType: "all_in",
+				payload: { potSize: 1000, trials: 1, equity: 60, wins: 0 },
+				offsetMin: 5,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		expect(points[1]).toEqual({ t: 5 * 60_000, pl: 0, evPl: 600 });
+	});
+
+	it("multiple all_in events accumulate evDiff", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "all_in",
+				payload: { potSize: 1000, trials: 1, equity: 60, wins: 0 },
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "all_in",
+				payload: { potSize: 500, trials: 1, equity: 50, wins: 1 },
+				offsetMin: 10,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		// 1st: +600. 2nd: 500*0.5 - 500*1 = -250 → cumulative evDiff = 350
+		expect(points[2]?.evPl).toBe(350);
+	});
+
+	it("session_end snapshots final pl matching computeCashGamePLFromEvents", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 15_000 },
+				offsetMin: 30,
+			}),
+			event({
+				eventType: "all_in",
+				payload: { potSize: 1000, trials: 1, equity: 60, wins: 0 },
+				offsetMin: 35,
+			}),
+			event({
+				eventType: "session_end",
+				payload: { cashOutAmount: 14_000 },
+				offsetMin: 60,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		const finalServer = computeCashGamePLFromEvents(events.map(toServerEvent));
+		const last = points.at(-1);
+		expect(last?.pl).toBe(finalServer.profitLoss);
+		expect(last?.evPl).toBe((finalServer.profitLoss ?? 0) + finalServer.evDiff);
+	});
+
+	it("ignores unrelated event types (player_join, memo, pause, resume)", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: 10_000 },
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "player_join",
+				payload: { isHero: true, seatPosition: 3 },
+				offsetMin: 1,
+			}),
+			event({
+				eventType: "memo",
+				payload: { text: "hi" },
+				offsetMin: 2,
+			}),
+			event({
+				eventType: "session_pause",
+				payload: {},
+				offsetMin: 3,
+			}),
+			event({
+				eventType: "session_resume",
+				payload: {},
+				offsetMin: 4,
+			}),
+		];
+		const points = deriveCashGameTimeline(events);
+		expect(points).toHaveLength(1);
+		expect(points[0]).toEqual({ t: 0, pl: 0, evPl: 0 });
+	});
+
+	it("rejects malformed payloads via Zod (throws)", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: { buyInAmount: -5 },
+				offsetMin: 0,
+			}),
+		];
+		expect(() => deriveCashGameTimeline(events)).toThrow();
+	});
+});
+
+describe("deriveTournamentTimeline", () => {
+	it("returns an empty array for no events", () => {
+		expect(deriveTournamentTimeline([])).toEqual([]);
+	});
+
+	it("returns an empty array when session_start is missing", () => {
+		const events = [
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 0,
+			}),
+		];
+		expect(deriveTournamentTimeline(events)).toEqual([]);
+	});
+
+	it("first update_stack establishes the starting stack and emits null averageStack until totalEntries arrives", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 5,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points).toHaveLength(2);
+		expect(points[1]).toEqual({
+			t: 5 * 60_000,
+			stack: 10_000,
+			averageStack: null,
+		});
+	});
+
+	it("computes averageStack = startingStack * totalEntries / remainingPlayers when both are present", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: {
+					stackAmount: 15_000,
+					remainingPlayers: 20,
+					totalEntries: 50,
+				},
+				offsetMin: 30,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		// startingStack=10000 (from first update_stack)
+		// averageStack = 10000 * 50 / 20 = 25000
+		expect(points[2]).toEqual({
+			t: 30 * 60_000,
+			stack: 15_000,
+			averageStack: 25_000,
+		});
+	});
+
+	it("retains the latest known totalEntries/remainingPlayers across subsequent stack updates", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: {
+					stackAmount: 15_000,
+					remainingPlayers: 20,
+					totalEntries: 50,
+				},
+				offsetMin: 30,
+			}),
+			// no remaining/total here — should reuse previous values
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 18_000 },
+				offsetMin: 60,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points[3]).toEqual({
+			t: 60 * 60_000,
+			stack: 18_000,
+			averageStack: 25_000,
+		});
+	});
+
+	it("purchase_chips adds chips to running stack", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: 10_000 },
+				offsetMin: 5,
+			}),
+			event({
+				eventType: "purchase_chips",
+				payload: { name: "Rebuy", cost: 1000, chips: 5000 },
+				offsetMin: 10,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points[2]).toEqual({
+			t: 10 * 60_000,
+			stack: 15_000,
+			averageStack: null,
+		});
+	});
+
+	it("ignores unrelated event types (memo, pause, resume, player_join)", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "memo",
+				payload: { text: "x" },
+				offsetMin: 1,
+			}),
+			event({
+				eventType: "session_pause",
+				payload: {},
+				offsetMin: 2,
+			}),
+			event({
+				eventType: "player_join",
+				payload: { isHero: false },
+				offsetMin: 3,
+			}),
+		];
+		const points = deriveTournamentTimeline(events);
+		expect(points).toEqual([{ t: 0, stack: 0, averageStack: null }]);
+	});
+
+	it("rejects malformed update_stack payload via Zod (throws)", () => {
+		const events = [
+			event({
+				eventType: "session_start",
+				payload: {},
+				offsetMin: 0,
+			}),
+			event({
+				eventType: "update_stack",
+				payload: { stackAmount: -100 },
+				offsetMin: 5,
+			}),
+		];
+		expect(() => deriveTournamentTimeline(events)).toThrow();
+	});
+});

--- a/apps/web/src/features/live-sessions/utils/session-timeline.ts
+++ b/apps/web/src/features/live-sessions/utils/session-timeline.ts
@@ -1,0 +1,190 @@
+import {
+	allInPayload,
+	cashSessionEndPayload,
+	cashSessionStartPayload,
+	chipsAddRemovePayload,
+	purchaseChipsPayload,
+	updateStackPayload,
+} from "@sapphire2/db/constants/session-event-types";
+
+export interface TimelineEvent {
+	eventType: string;
+	occurredAt: string | Date | number;
+	payload: unknown;
+}
+
+export interface CashTimelinePoint {
+	evPl: number;
+	pl: number;
+	t: number;
+}
+
+export interface TournamentTimelinePoint {
+	averageStack: number | null;
+	stack: number;
+	t: number;
+}
+
+function toMs(value: string | Date | number): number {
+	if (typeof value === "number") {
+		return value;
+	}
+	if (value instanceof Date) {
+		return value.getTime();
+	}
+	return new Date(value).getTime();
+}
+
+interface CashAcc {
+	chipRemoveTotal: number;
+	evDiff: number;
+	stack: number;
+	totalBuyIn: number;
+}
+
+function cashPoint(t: number, acc: CashAcc): CashTimelinePoint {
+	const pl = acc.stack + acc.chipRemoveTotal - acc.totalBuyIn;
+	return { t, pl, evPl: pl + acc.evDiff };
+}
+
+export function deriveCashGameTimeline(
+	events: TimelineEvent[]
+): CashTimelinePoint[] {
+	const startIndex = events.findIndex((e) => e.eventType === "session_start");
+	if (startIndex === -1) {
+		return [];
+	}
+	const anchor = toMs(events[startIndex].occurredAt);
+	const acc: CashAcc = {
+		stack: 0,
+		totalBuyIn: 0,
+		chipRemoveTotal: 0,
+		evDiff: 0,
+	};
+	const points: CashTimelinePoint[] = [];
+
+	for (let i = startIndex; i < events.length; i++) {
+		const e = events[i];
+		const t = toMs(e.occurredAt) - anchor;
+
+		if (e.eventType === "session_start") {
+			const data = cashSessionStartPayload.parse(e.payload);
+			acc.stack += data.buyInAmount;
+			acc.totalBuyIn += data.buyInAmount;
+			points.push(cashPoint(t, acc));
+			continue;
+		}
+		if (e.eventType === "update_stack") {
+			const data = updateStackPayload.parse(e.payload);
+			acc.stack = data.stackAmount;
+			points.push(cashPoint(t, acc));
+			continue;
+		}
+		if (e.eventType === "chips_add_remove") {
+			const data = chipsAddRemovePayload.parse(e.payload);
+			if (data.amount > 0) {
+				acc.totalBuyIn += data.amount;
+				acc.stack += data.amount;
+			} else {
+				acc.chipRemoveTotal += -data.amount;
+				acc.stack -= -data.amount;
+			}
+			points.push(cashPoint(t, acc));
+			continue;
+		}
+		if (e.eventType === "all_in") {
+			const data = allInPayload.parse(e.payload);
+			acc.evDiff +=
+				data.potSize * (data.equity / 100) -
+				(data.potSize / data.trials) * data.wins;
+			points.push(cashPoint(t, acc));
+			continue;
+		}
+		if (e.eventType === "session_end") {
+			const data = cashSessionEndPayload.parse(e.payload);
+			acc.stack = data.cashOutAmount;
+			points.push(cashPoint(t, acc));
+		}
+	}
+
+	return points;
+}
+
+interface TournamentAcc {
+	remainingPlayers: number | null;
+	stack: number;
+	startingStack: number | null;
+	totalEntries: number | null;
+}
+
+function tournamentAverageStack(acc: TournamentAcc): number | null {
+	if (
+		acc.startingStack === null ||
+		acc.totalEntries === null ||
+		acc.remainingPlayers === null ||
+		acc.remainingPlayers <= 0
+	) {
+		return null;
+	}
+	return (acc.startingStack * acc.totalEntries) / acc.remainingPlayers;
+}
+
+function tournamentPoint(
+	t: number,
+	acc: TournamentAcc
+): TournamentTimelinePoint {
+	return {
+		t,
+		stack: acc.stack,
+		averageStack: tournamentAverageStack(acc),
+	};
+}
+
+export function deriveTournamentTimeline(
+	events: TimelineEvent[]
+): TournamentTimelinePoint[] {
+	const startIndex = events.findIndex((e) => e.eventType === "session_start");
+	if (startIndex === -1) {
+		return [];
+	}
+	const anchor = toMs(events[startIndex].occurredAt);
+	const acc: TournamentAcc = {
+		stack: 0,
+		startingStack: null,
+		totalEntries: null,
+		remainingPlayers: null,
+	};
+	const points: TournamentTimelinePoint[] = [];
+
+	for (let i = startIndex; i < events.length; i++) {
+		const e = events[i];
+		const t = toMs(e.occurredAt) - anchor;
+
+		if (e.eventType === "session_start") {
+			points.push(tournamentPoint(t, acc));
+			continue;
+		}
+		if (e.eventType === "update_stack") {
+			const data = updateStackPayload.parse(e.payload);
+			acc.stack = data.stackAmount;
+			if (acc.startingStack === null) {
+				acc.startingStack = data.stackAmount;
+			}
+			if (data.totalEntries != null) {
+				acc.totalEntries = data.totalEntries;
+			}
+			if (data.remainingPlayers != null) {
+				acc.remainingPlayers = data.remainingPlayers;
+			}
+			points.push(tournamentPoint(t, acc));
+			continue;
+		}
+		if (e.eventType === "purchase_chips") {
+			const data = purchaseChipsPayload.parse(e.payload);
+			acc.stack += data.chips;
+			points.push(tournamentPoint(t, acc));
+		}
+	}
+
+	return points;
+}

--- a/apps/web/src/features/live-sessions/utils/session-timeline.ts
+++ b/apps/web/src/features/live-sessions/utils/session-timeline.ts
@@ -4,6 +4,7 @@ import {
 	cashSessionStartPayload,
 	chipsAddRemovePayload,
 	purchaseChipsPayload,
+	tournamentSessionEndPayload,
 	updateStackPayload,
 } from "@sapphire2/db/constants/session-event-types";
 
@@ -110,7 +111,14 @@ export function deriveCashGameTimeline(
 	return points;
 }
 
+interface ChipPurchaseCount {
+	chipsPerUnit: number;
+	count: number;
+	name: string;
+}
+
 interface TournamentAcc {
+	chipPurchaseCounts: ChipPurchaseCount[];
 	remainingPlayers: number | null;
 	stack: number;
 	startingStack: number | null;
@@ -129,6 +137,15 @@ function tournamentAverageStack(acc: TournamentAcc): number | null {
 	return (acc.startingStack * acc.totalEntries) / acc.remainingPlayers;
 }
 
+function totalChipsInPlay(acc: TournamentAcc, totalEntries: number): number {
+	const baseChips = (acc.startingStack ?? 0) * totalEntries;
+	const purchaseChips = acc.chipPurchaseCounts.reduce(
+		(sum, c) => sum + c.count * c.chipsPerUnit,
+		0
+	);
+	return baseChips + purchaseChips;
+}
+
 function tournamentPoint(
 	t: number,
 	acc: TournamentAcc
@@ -138,6 +155,58 @@ function tournamentPoint(
 		stack: acc.stack,
 		averageStack: tournamentAverageStack(acc),
 	};
+}
+
+function applyTournamentUpdateStack(
+	acc: TournamentAcc,
+	payload: unknown
+): void {
+	const data = updateStackPayload.parse(payload);
+	acc.stack = data.stackAmount;
+	if (acc.startingStack === null) {
+		acc.startingStack = data.stackAmount;
+	}
+	if (data.totalEntries != null) {
+		acc.totalEntries = data.totalEntries;
+	}
+	if (data.remainingPlayers != null) {
+		acc.remainingPlayers = data.remainingPlayers;
+	}
+	if (data.chipPurchaseCounts) {
+		acc.chipPurchaseCounts = data.chipPurchaseCounts;
+	}
+}
+
+function applyTournamentSessionEnd(acc: TournamentAcc, payload: unknown): void {
+	const data = tournamentSessionEndPayload.parse(payload);
+	if (data.beforeDeadline === false) {
+		acc.totalEntries = data.totalEntries;
+		acc.stack =
+			data.placement === 1 ? totalChipsInPlay(acc, data.totalEntries) : 0;
+	}
+}
+
+function applyTournamentEvent(
+	acc: TournamentAcc,
+	eventType: string,
+	payload: unknown
+): boolean {
+	if (eventType === "session_start") {
+		return true;
+	}
+	if (eventType === "update_stack") {
+		applyTournamentUpdateStack(acc, payload);
+		return true;
+	}
+	if (eventType === "purchase_chips") {
+		acc.stack += purchaseChipsPayload.parse(payload).chips;
+		return true;
+	}
+	if (eventType === "session_end") {
+		applyTournamentSessionEnd(acc, payload);
+		return true;
+	}
+	return false;
 }
 
 export function deriveTournamentTimeline(
@@ -153,36 +222,15 @@ export function deriveTournamentTimeline(
 		startingStack: null,
 		totalEntries: null,
 		remainingPlayers: null,
+		chipPurchaseCounts: [],
 	};
 	const points: TournamentTimelinePoint[] = [];
 
 	for (let i = startIndex; i < events.length; i++) {
 		const e = events[i];
-		const t = toMs(e.occurredAt) - anchor;
-
-		if (e.eventType === "session_start") {
-			points.push(tournamentPoint(t, acc));
-			continue;
-		}
-		if (e.eventType === "update_stack") {
-			const data = updateStackPayload.parse(e.payload);
-			acc.stack = data.stackAmount;
-			if (acc.startingStack === null) {
-				acc.startingStack = data.stackAmount;
-			}
-			if (data.totalEntries != null) {
-				acc.totalEntries = data.totalEntries;
-			}
-			if (data.remainingPlayers != null) {
-				acc.remainingPlayers = data.remainingPlayers;
-			}
-			points.push(tournamentPoint(t, acc));
-			continue;
-		}
-		if (e.eventType === "purchase_chips") {
-			const data = purchaseChipsPayload.parse(e.payload);
-			acc.stack += data.chips;
-			points.push(tournamentPoint(t, acc));
+		const handled = applyTournamentEvent(acc, e.eventType, e.payload);
+		if (handled) {
+			points.push(tournamentPoint(toMs(e.occurredAt) - anchor, acc));
 		}
 	}
 

--- a/apps/web/src/features/sessions/components/session-card/session-card.test.tsx
+++ b/apps/web/src/features/sessions/components/session-card/session-card.test.tsx
@@ -10,6 +10,13 @@ vi.mock("@tanstack/react-router", () => ({
 	),
 }));
 
+vi.mock(
+	"@/features/live-sessions/components/session-result-chart",
+	() => ({
+		SessionResultChart: () => null,
+	})
+);
+
 function makeCashGameSession(
 	overrides: Record<string, unknown> = {}
 ): Parameters<typeof SessionCard>[0]["session"] {

--- a/apps/web/src/features/sessions/components/session-card/session-card.test.tsx
+++ b/apps/web/src/features/sessions/components/session-card/session-card.test.tsx
@@ -10,12 +10,9 @@ vi.mock("@tanstack/react-router", () => ({
 	),
 }));
 
-vi.mock(
-	"@/features/live-sessions/components/session-result-chart",
-	() => ({
-		SessionResultChart: () => null,
-	})
-);
+vi.mock("@/features/live-sessions/components/session-result-chart", () => ({
+	SessionResultChart: () => null,
+}));
 
 function makeCashGameSession(
 	overrides: Record<string, unknown> = {}

--- a/apps/web/src/features/sessions/components/session-card/session-card.test.tsx
+++ b/apps/web/src/features/sessions/components/session-card/session-card.test.tsx
@@ -484,7 +484,7 @@ describe("SessionCard", () => {
 
 		await user.click(screen.getByRole("button", { expanded: false }));
 
-		expect(screen.getByRole("link", { name: "Events" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Timeline" })).toBeInTheDocument();
 
 		await user.click(screen.getByRole("button", { name: "Reopen" }));
 		expect(onReopen).toHaveBeenCalledWith("live-1");

--- a/apps/web/src/features/sessions/components/session-card/session-card.tsx
+++ b/apps/web/src/features/sessions/components/session-card/session-card.tsx
@@ -10,6 +10,7 @@ import {
 	IconTrophy,
 } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
+import { SessionResultChart } from "@/features/live-sessions/components/session-result-chart";
 import { EntityListItem } from "@/shared/components/management/entity-list-item";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
@@ -432,7 +433,13 @@ export function SessionCard({
 	onDelete,
 	onReopen,
 }: SessionCardProps) {
-	const { isSharing, onShare } = useSessionCard(session);
+	const {
+		expandedValue,
+		isExpanded,
+		isSharing,
+		onExpandedValueChange,
+		onShare,
+	} = useSessionCard(session);
 	const isTournament = session.type === "tournament";
 	const liveSessionId =
 		session.liveCashGameSessionId ?? session.liveTournamentSessionId;
@@ -452,8 +459,10 @@ export function SessionCard({
 				</Button>
 			}
 			deleteLabel="session"
+			expandedValue={expandedValue}
 			onDelete={() => onDelete(session.id)}
 			onEdit={() => onEdit(session)}
+			onExpandedValueChange={onExpandedValueChange}
 			summary={
 				<div className="flex w-full items-start justify-between gap-3 pr-1 text-left">
 					<SessionHeader bbBiMode={bbBiMode} session={session} />
@@ -465,6 +474,15 @@ export function SessionCard({
 					<TournamentDetails session={session} />
 				) : (
 					<CashGameDetails bbBiMode={bbBiMode} session={session} />
+				)}
+				{liveSessionId && (
+					<div className="mt-2 border-t pt-2">
+						<SessionResultChart
+							enabled={isExpanded}
+							liveSessionId={liveSessionId}
+							sessionType={isTournament ? "tournament" : "cash_game"}
+						/>
+					</div>
 				)}
 				{session.memo && (
 					<div className="mt-2 border-t pt-2">

--- a/apps/web/src/features/sessions/components/session-card/session-card.tsx
+++ b/apps/web/src/features/sessions/components/session-card/session-card.tsx
@@ -484,7 +484,7 @@ export function SessionCard({
 								to="/live-sessions/$sessionType/$sessionId/events"
 							>
 								<IconList size={12} />
-								Events
+								Timeline
 							</Link>
 						</Button>
 						{onReopen && (

--- a/apps/web/src/features/sessions/components/session-card/use-session-card.ts
+++ b/apps/web/src/features/sessions/components/session-card/use-session-card.ts
@@ -4,6 +4,7 @@ import { shareSession } from "@/features/sessions/utils/share-session";
 
 export function useSessionCard(session: ShareableSession) {
 	const [isSharing, setIsSharing] = useState(false);
+	const [expandedValue, setExpandedValue] = useState<string | null>(null);
 
 	const handleShare = async () => {
 		setIsSharing(true);
@@ -15,7 +16,10 @@ export function useSessionCard(session: ShareableSession) {
 	};
 
 	return {
+		expandedValue,
+		isExpanded: expandedValue !== null,
 		isSharing,
+		onExpandedValueChange: setExpandedValue,
 		onShare: handleShare,
 	};
 }

--- a/apps/web/src/features/stores/hooks/__tests__/use-store-games.test.ts
+++ b/apps/web/src/features/stores/hooks/__tests__/use-store-games.test.ts
@@ -170,6 +170,119 @@ describe("useStoreGames", () => {
 			});
 		});
 	});
+
+	describe("with includeAll: true", () => {
+		const BASE_RING = {
+			variant: "holdem",
+			blind1: 1,
+			blind2: 2,
+			blind3: null,
+			ante: 0,
+			anteType: "none",
+			tableSize: 9,
+			currencyId: "c1",
+		};
+
+		it("merges active and archived ring games into a single list", async () => {
+			const qc = createClient();
+			qc.setQueryData(
+				["ringGame", "listByStore", { storeId: "store-1" }],
+				[
+					{
+						id: "r-active",
+						name: "Active Game",
+						...BASE_RING,
+						archivedAt: null,
+					},
+				]
+			);
+			qc.setQueryData(
+				[
+					"ringGame",
+					"listByStore",
+					{ storeId: "store-1", includeArchived: true },
+				],
+				[
+					{
+						id: "r-archived",
+						name: "Archived Game",
+						...BASE_RING,
+						archivedAt: "2026-01-01",
+					},
+				]
+			);
+			const { result } = renderHook(
+				() => useStoreGames("store-1", { includeAll: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await waitFor(() => expect(result.current.ringGames).toHaveLength(2));
+			expect(result.current.ringGames.map((g) => g.id)).toEqual(
+				expect.arrayContaining(["r-active", "r-archived"])
+			);
+		});
+
+		it("merges active and archived tournaments into a single list", async () => {
+			const qc = createClient();
+			qc.setQueryData(
+				["tournament", "listByStore", { storeId: "s-1" }],
+				[{ id: "t-active", name: "Active Tourney", buyIn: 100, entryFee: 10 }]
+			);
+			qc.setQueryData(
+				[
+					"tournament",
+					"listByStore",
+					{ storeId: "s-1", includeArchived: true },
+				],
+				[
+					{
+						id: "t-archived",
+						name: "Archived Tourney",
+						buyIn: 200,
+						entryFee: 20,
+					},
+				]
+			);
+			const { result } = renderHook(
+				() => useStoreGames("s-1", { includeAll: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await waitFor(() => expect(result.current.tournaments).toHaveLength(2));
+			expect(result.current.tournaments.map((t) => t.id)).toEqual(
+				expect.arrayContaining(["t-active", "t-archived"])
+			);
+		});
+
+		it("excludes archived games when includeAll is not set", async () => {
+			const qc = createClient();
+			qc.setQueryData(
+				["ringGame", "listByStore", { storeId: "store-2" }],
+				[{ id: "r-only-active", name: "Active", ...BASE_RING }]
+			);
+			qc.setQueryData(
+				[
+					"ringGame",
+					"listByStore",
+					{ storeId: "store-2", includeArchived: true },
+				],
+				[{ id: "r-archived-only", name: "Archived", ...BASE_RING }]
+			);
+			const { result } = renderHook(() => useStoreGames("store-2"), {
+				wrapper: makeWrapper(qc),
+			});
+			await waitFor(() => expect(result.current.ringGames).toHaveLength(1));
+			expect(result.current.ringGames[0].id).toBe("r-only-active");
+		});
+
+		it("returns empty arrays when storeId is undefined even with includeAll", () => {
+			const qc = createClient();
+			const { result } = renderHook(
+				() => useStoreGames(undefined, { includeAll: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			expect(result.current.ringGames).toEqual([]);
+			expect(result.current.tournaments).toEqual([]);
+		});
+	});
 });
 
 describe("useEntityLists", () => {

--- a/apps/web/src/features/stores/hooks/use-store-games.ts
+++ b/apps/web/src/features/stores/hooks/use-store-games.ts
@@ -1,17 +1,46 @@
 import { useQuery } from "@tanstack/react-query";
 import { trpc } from "@/utils/trpc";
 
-export function useStoreGames(storeId: string | undefined) {
+export function useStoreGames(
+	storeId: string | undefined,
+	options?: { includeAll?: boolean }
+) {
+	const includeAll = options?.includeAll ?? false;
+
 	const ringGamesQuery = useQuery({
 		...trpc.ringGame.listByStore.queryOptions({ storeId: storeId ?? "" }),
 		enabled: !!storeId,
+	});
+	const archivedRingGamesQuery = useQuery({
+		...trpc.ringGame.listByStore.queryOptions({
+			storeId: storeId ?? "",
+			includeArchived: true,
+		}),
+		enabled: !!storeId && includeAll,
 	});
 	const tournamentsQuery = useQuery({
 		...trpc.tournament.listByStore.queryOptions({ storeId: storeId ?? "" }),
 		enabled: !!storeId,
 	});
+	const archivedTournamentsQuery = useQuery({
+		...trpc.tournament.listByStore.queryOptions({
+			storeId: storeId ?? "",
+			includeArchived: true,
+		}),
+		enabled: !!storeId && includeAll,
+	});
+
+	const allRingGames = [
+		...(ringGamesQuery.data ?? []),
+		...(includeAll ? (archivedRingGamesQuery.data ?? []) : []),
+	];
+	const allTournaments = [
+		...(tournamentsQuery.data ?? []),
+		...(includeAll ? (archivedTournamentsQuery.data ?? []) : []),
+	];
+
 	return {
-		ringGames: (ringGamesQuery.data ?? []).map((g) => ({
+		ringGames: allRingGames.map((g) => ({
 			id: g.id,
 			name: g.name,
 			variant: g.variant,
@@ -23,7 +52,7 @@ export function useStoreGames(storeId: string | undefined) {
 			tableSize: g.tableSize,
 			currencyId: g.currencyId,
 		})),
-		tournaments: (tournamentsQuery.data ?? []).map((t) => ({
+		tournaments: allTournaments.map((t) => ({
 			id: t.id,
 			name: t.name,
 			buyIn: t.buyIn,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -128,4 +128,10 @@
 	html {
 		@apply font-mono;
 	}
+	.recharts-wrapper,
+	.recharts-wrapper *,
+	.recharts-surface,
+	.recharts-surface * {
+		outline: none !important;
+	}
 }

--- a/apps/web/src/routes/sessions/-use-sessions-page.ts
+++ b/apps/web/src/routes/sessions/-use-sessions-page.ts
@@ -35,7 +35,7 @@ export function useSessionsPage() {
 
 	const { stores, currencies } = useEntityLists();
 	const createGames = useStoreGames(selectedStoreId);
-	const editGames = useStoreGames(editStoreId);
+	const editGames = useStoreGames(editStoreId, { includeAll: true });
 
 	const handleCreate = (values: SessionFormValues) => {
 		create(values).then(() => {

--- a/apps/web/src/routes/sessions/__tests__/use-sessions-page.test.ts
+++ b/apps/web/src/routes/sessions/__tests__/use-sessions-page.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
 	lastFilters: null as Record<string, unknown> | null,
 	lastCreateGamesStoreId: null as string | undefined | null,
 	lastEditGamesStoreId: null as string | undefined | null,
+	lastEditIncludeAll: null as boolean | null,
 	lastCalledSlot: "create" as "create" | "edit",
 	sessions: [] as Record<string, unknown>[],
 	availableTags: [] as Array<{ id: string; name: string }>,
@@ -48,7 +49,10 @@ vi.mock("@/features/stores/hooks/use-store-games", () => ({
 		stores: mocks.stores,
 		currencies: mocks.currencies,
 	}),
-	useStoreGames: (storeId: string | undefined) => {
+	useStoreGames: (
+		storeId: string | undefined,
+		options?: { includeAll?: boolean }
+	) => {
 		// useSessionsPage calls useStoreGames twice per render (create + edit
 		// slots). Track each by alternating the slot name.
 		if (mocks.lastCalledSlot === "create") {
@@ -56,6 +60,7 @@ vi.mock("@/features/stores/hooks/use-store-games", () => ({
 			mocks.lastCalledSlot = "edit";
 		} else {
 			mocks.lastEditGamesStoreId = storeId;
+			mocks.lastEditIncludeAll = options?.includeAll ?? false;
 			mocks.lastCalledSlot = "create";
 		}
 		return { ringGames: [], tournaments: [], isLoading: false };
@@ -87,6 +92,7 @@ describe("useSessionsPage", () => {
 		mocks.lastFilters = null;
 		mocks.lastCreateGamesStoreId = null;
 		mocks.lastEditGamesStoreId = null;
+		mocks.lastEditIncludeAll = null;
 		mocks.lastCalledSlot = "create";
 		mocks.sessions = [];
 		mocks.availableTags = [];
@@ -272,6 +278,14 @@ describe("useSessionsPage", () => {
 				);
 			});
 			expect(result.current.editingSession?.id).toBe("s1");
+		});
+	});
+
+	describe("edit games use includeAll", () => {
+		it("passes includeAll: true to useStoreGames for the edit slot", () => {
+			renderHook(() => useSessionsPage());
+			// The edit slot is the second call to useStoreGames each render cycle.
+			expect(mocks.lastEditIncludeAll).toBe(true);
 		});
 	});
 

--- a/apps/web/src/routes/sessions/index.tsx
+++ b/apps/web/src/routes/sessions/index.tsx
@@ -59,11 +59,11 @@ function SessionsPage() {
 							variant="outline"
 						>
 							<IconTags size={16} />
-							Manage Tags
+							Tags
 						</Button>
 						<Button onClick={() => handleCreateDialogOpenChange(true)}>
 							<IconPlus size={16} />
-							New Session
+							New
 						</Button>
 					</>
 				}

--- a/apps/web/src/shared/components/app-navigation/app-navigation.tsx
+++ b/apps/web/src/shared/components/app-navigation/app-navigation.tsx
@@ -61,7 +61,7 @@ const NORMAL_RIGHT_ITEMS: readonly NavigationItem[] = [
 ] as const;
 
 const LIVE_LEFT_ITEMS: readonly NavigationItem[] = [
-	{ to: "/active-session/events", label: "Events", icon: IconList },
+	{ to: "/active-session/events", label: "Timeline", icon: IconList },
 	{ to: "/active-session/game", label: "Game", icon: IconCards },
 ] as const;
 

--- a/bun.lock
+++ b/bun.lock
@@ -84,6 +84,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-grid-layout": "^1.5.2",
+        "recharts": "^3.8.1",
         "shadcn": "^4.1.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -800,6 +801,8 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
     "@remirror/core-constants": ["@remirror/core-constants@3.0.0", "", {}, "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.12", "", { "os": "android", "cpu": "arm64" }, "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA=="],
@@ -1080,6 +1083,24 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -1292,6 +1313,28 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
@@ -1305,6 +1348,8 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "decode-bmp": ["decode-bmp@0.2.1", "", { "dependencies": { "@canvas/image-data": "^1.0.0", "to-data-view": "^1.1.0" } }, "sha512-NiOaGe+GN0KJqi2STf24hfMkFitDUaIoUU3eKvP/wAbLe8o6FuW5n/x7MHPR0HKvBokp6MQY/j7w8lewEeVCIA=="],
 
@@ -1383,6 +1428,8 @@
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "es-toolkit": ["es-toolkit@1.46.1", "", {}, "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="],
 
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
@@ -1534,6 +1581,8 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
@@ -1541,6 +1590,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
@@ -1938,7 +1989,9 @@
 
     "react-hook-form": ["react-hook-form@7.71.2", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA=="],
 
-    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
@@ -1952,7 +2005,13 @@
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
+    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -2250,6 +2309,8 @@
 
     "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
+
     "vite": ["vite@8.0.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ=="],
 
     "vite-plugin-pwa": ["vite-plugin-pwa@1.2.0", "", { "dependencies": { "debug": "^4.3.6", "pretty-bytes": "^6.1.1", "tinyglobby": "^0.2.10", "workbox-build": "^7.4.0", "workbox-window": "^7.4.0" }, "peerDependencies": { "@vite-pwa/assets-generator": "^1.0.0", "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@vite-pwa/assets-generator"] }, "sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw=="],
@@ -2382,6 +2443,8 @@
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
+
     "@rollup/plugin-babel/rollup": ["rollup@2.80.0", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ=="],
 
     "@rollup/plugin-node-resolve/@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
@@ -2462,9 +2525,9 @@
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
-    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
-
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "react-grid-layout/fast-equals": ["fast-equals@4.0.3", "", {}, "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@sapphire2/api": "workspace:*",
         "@sapphire2/auth": "workspace:*",
+        "@sapphire2/db": "workspace:*",
         "@sapphire2/env": "workspace:*",
         "@tabler/icons-react": "^3.41.1",
         "@tailwindcss/typography": "^0.5.19",

--- a/packages/api/src/__tests__/dashboard-widget.test.ts
+++ b/packages/api/src/__tests__/dashboard-widget.test.ts
@@ -215,6 +215,7 @@ describe("widget config parsing", () => {
 			dateRangeDays: number | null;
 			ringGameId: string | null;
 			sessionType: string;
+			showEvCash: boolean;
 			showFilters: Record<string, boolean>;
 			storeId: string | null;
 			unit: string;
@@ -227,6 +228,7 @@ describe("widget config parsing", () => {
 		expect(parsed.storeId).toBeNull();
 		expect(parsed.ringGameId).toBeNull();
 		expect(parsed.currencyId).toBeNull();
+		expect(parsed.showEvCash).toBe(false);
 		expect(parsed.showFilters.xAxis).toBe(false);
 	});
 

--- a/packages/api/src/__tests__/dashboard-widget.test.ts
+++ b/packages/api/src/__tests__/dashboard-widget.test.ts
@@ -237,7 +237,7 @@ describe("widget config parsing", () => {
 				xAxis: "playTime",
 				dateRangeDays: 30,
 				sessionType: "cash_game",
-				unit: "bb",
+				unit: "normalized",
 				storeId: "s1",
 				ringGameId: "rg1",
 				currencyId: "c1",
@@ -251,7 +251,7 @@ describe("widget config parsing", () => {
 			xAxis: string;
 		};
 		expect(parsed.xAxis).toBe("playTime");
-		expect(parsed.unit).toBe("bb");
+		expect(parsed.unit).toBe("normalized");
 		expect(parsed.storeId).toBe("s1");
 		expect(parsed.ringGameId).toBe("rg1");
 		expect(parsed.showFilters.xAxis).toBe(true);
@@ -259,10 +259,10 @@ describe("widget config parsing", () => {
 		expect(parsed.showFilters.dateRange).toBe(false);
 	});
 
-	it("falls back to defaults for invalid pnl_graph enum values", () => {
+	it("falls back to defaults for invalid pnl_graph enum values, including legacy 'bb'/'bi'", () => {
 		const parsed = parseWidgetConfig(
 			"pnl_graph",
-			JSON.stringify({ xAxis: "weird", unit: "satoshi" })
+			JSON.stringify({ xAxis: "weird", unit: "bb" })
 		) as { unit: string; xAxis: string };
 		expect(parsed.xAxis).toBe("date");
 		expect(parsed.unit).toBe("currency");

--- a/packages/api/src/__tests__/dashboard-widget.test.ts
+++ b/packages/api/src/__tests__/dashboard-widget.test.ts
@@ -209,6 +209,65 @@ describe("widget config parsing", () => {
 		expect((parsed as { type: string }).type).toBe("all");
 	});
 
+	it("returns pnl_graph defaults with currency unit and date axis", () => {
+		const parsed = parseWidgetConfig("pnl_graph", "{}") as {
+			currencyId: string | null;
+			dateRangeDays: number | null;
+			ringGameId: string | null;
+			sessionType: string;
+			showFilters: Record<string, boolean>;
+			storeId: string | null;
+			unit: string;
+			xAxis: string;
+		};
+		expect(parsed.xAxis).toBe("date");
+		expect(parsed.dateRangeDays).toBeNull();
+		expect(parsed.sessionType).toBe("all");
+		expect(parsed.unit).toBe("currency");
+		expect(parsed.storeId).toBeNull();
+		expect(parsed.ringGameId).toBeNull();
+		expect(parsed.currencyId).toBeNull();
+		expect(parsed.showFilters.xAxis).toBe(false);
+	});
+
+	it("preserves valid pnl_graph config values", () => {
+		const parsed = parseWidgetConfig(
+			"pnl_graph",
+			JSON.stringify({
+				xAxis: "playTime",
+				dateRangeDays: 30,
+				sessionType: "cash_game",
+				unit: "bb",
+				storeId: "s1",
+				ringGameId: "rg1",
+				currencyId: "c1",
+				showFilters: { xAxis: true, unit: true },
+			})
+		) as {
+			ringGameId: string | null;
+			showFilters: Record<string, boolean>;
+			storeId: string | null;
+			unit: string;
+			xAxis: string;
+		};
+		expect(parsed.xAxis).toBe("playTime");
+		expect(parsed.unit).toBe("bb");
+		expect(parsed.storeId).toBe("s1");
+		expect(parsed.ringGameId).toBe("rg1");
+		expect(parsed.showFilters.xAxis).toBe(true);
+		expect(parsed.showFilters.unit).toBe(true);
+		expect(parsed.showFilters.dateRange).toBe(false);
+	});
+
+	it("falls back to defaults for invalid pnl_graph enum values", () => {
+		const parsed = parseWidgetConfig(
+			"pnl_graph",
+			JSON.stringify({ xAxis: "weird", unit: "satoshi" })
+		) as { unit: string; xAxis: string };
+		expect(parsed.xAxis).toBe("date");
+		expect(parsed.unit).toBe("currency");
+	});
+
 	it("stringifies config safely", () => {
 		expect(stringifyWidgetConfig({ foo: "bar" })).toBe('{"foo":"bar"}');
 		expect(stringifyWidgetConfig(null)).toBe("{}");

--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -17,8 +17,50 @@ describe("session router", () => {
 
 	it("exposes exactly the expected procedure set", () => {
 		expect(Object.keys(appRouter.session).sort()).toEqual(
-			["create", "delete", "getById", "list", "update"].sort()
+			[
+				"create",
+				"delete",
+				"getById",
+				"list",
+				"profitLossSeries",
+				"update",
+			].sort()
 		);
+	});
+});
+
+describe("session.profitLossSeries input validation", () => {
+	function getSchema() {
+		return (
+			appRouter.session.profitLossSeries as unknown as {
+				_def: { inputs: unknown[] };
+			}
+		)._def.inputs[0] as { safeParse: (v: unknown) => { success: boolean } };
+	}
+
+	it("accepts an empty object (all filters optional)", () => {
+		expect(getSchema().safeParse({}).success).toBe(true);
+	});
+
+	it("accepts the full filter combination", () => {
+		expect(
+			getSchema().safeParse({
+				type: "cash_game",
+				storeId: "s1",
+				ringGameId: "rg1",
+				currencyId: "c1",
+				dateFrom: 1_700_000_000,
+				dateTo: 1_800_000_000,
+			}).success
+		).toBe(true);
+	});
+
+	it("rejects an unknown type value", () => {
+		expect(getSchema().safeParse({ type: "spin_and_go" }).success).toBe(false);
+	});
+
+	it("rejects non-numeric dateFrom", () => {
+		expect(getSchema().safeParse({ dateFrom: "today" }).success).toBe(false);
 	});
 });
 

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -14,7 +14,7 @@ import {
 } from "@sapphire2/db/schema/store";
 import { tournament } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
-import { and, desc, eq, gte, inArray, lt, lte } from "drizzle-orm";
+import { and, asc, desc, eq, gte, inArray, lt, lte } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
 
@@ -1432,6 +1432,124 @@ export const sessionRouter = router({
 			);
 
 			return updated;
+		}),
+
+	profitLossSeries: protectedProcedure
+		.input(
+			z.object({
+				type: z.enum(["cash_game", "tournament"]).optional(),
+				storeId: z.string().optional(),
+				ringGameId: z.string().optional(),
+				currencyId: z.string().optional(),
+				dateFrom: z.number().optional(),
+				dateTo: z.number().optional(),
+			})
+		)
+		.query(async ({ ctx, input }) => {
+			const userId = ctx.session.user.id;
+			const conditions = [eq(gameSession.userId, userId)];
+			if (input.type) {
+				conditions.push(eq(gameSession.kind, input.type));
+			}
+			if (input.storeId) {
+				conditions.push(eq(gameSession.storeId, input.storeId));
+			}
+			if (input.currencyId) {
+				conditions.push(eq(gameSession.currencyId, input.currencyId));
+			}
+			if (input.ringGameId) {
+				conditions.push(eq(sessionCashDetail.ringGameId, input.ringGameId));
+			}
+			if (input.dateFrom !== undefined) {
+				conditions.push(
+					gte(gameSession.sessionDate, new Date(input.dateFrom * 1000))
+				);
+			}
+			if (input.dateTo !== undefined) {
+				conditions.push(
+					lte(gameSession.sessionDate, new Date(input.dateTo * 1000))
+				);
+			}
+
+			const rows = await ctx.db
+				.select({
+					id: gameSession.id,
+					type: gameSession.kind,
+					sessionDate: gameSession.sessionDate,
+					startedAt: gameSession.startedAt,
+					endedAt: gameSession.endedAt,
+					breakMinutes: gameSession.breakMinutes,
+					buyIn: sessionCashDetail.buyIn,
+					cashOut: sessionCashDetail.cashOut,
+					ringGameBlind2: ringGame.blind2,
+					tournamentBuyIn: sessionTournamentDetail.tournamentBuyIn,
+					entryFee: sessionTournamentDetail.entryFee,
+					rebuyCount: sessionTournamentDetail.rebuyCount,
+					rebuyCost: sessionTournamentDetail.rebuyCost,
+					addonCost: sessionTournamentDetail.addonCost,
+					prizeMoney: sessionTournamentDetail.prizeMoney,
+					bountyPrizes: sessionTournamentDetail.bountyPrizes,
+				})
+				.from(gameSession)
+				.leftJoin(
+					sessionCashDetail,
+					eq(sessionCashDetail.sessionId, gameSession.id)
+				)
+				.leftJoin(ringGame, eq(ringGame.id, sessionCashDetail.ringGameId))
+				.leftJoin(
+					sessionTournamentDetail,
+					eq(sessionTournamentDetail.sessionId, gameSession.id)
+				)
+				.where(and(...conditions))
+				.orderBy(asc(gameSession.sessionDate), asc(gameSession.id));
+
+			const points = rows.map((r) => {
+				let profitLoss = 0;
+				let buyInTotal: number | null = null;
+				if (r.type === "cash_game" && r.buyIn !== null && r.cashOut !== null) {
+					profitLoss = computeCashGamePL(r.buyIn, r.cashOut);
+					buyInTotal = r.buyIn;
+				} else if (r.type === "tournament") {
+					profitLoss = computeTournamentPL(
+						r.tournamentBuyIn,
+						r.entryFee,
+						r.rebuyCount,
+						r.rebuyCost,
+						r.addonCost,
+						r.prizeMoney,
+						r.bountyPrizes
+					);
+					buyInTotal =
+						(r.tournamentBuyIn ?? 0) +
+						(r.entryFee ?? 0) +
+						(r.rebuyCount ?? 0) * (r.rebuyCost ?? 0) +
+						(r.addonCost ?? 0);
+					if (buyInTotal === 0) {
+						buyInTotal = null;
+					}
+				}
+
+				let playMinutes: number | null = null;
+				if (r.startedAt && r.endedAt) {
+					const elapsed = Math.max(
+						0,
+						(r.endedAt.getTime() - r.startedAt.getTime()) / 60_000
+					);
+					playMinutes = Math.max(0, elapsed - (r.breakMinutes ?? 0));
+				}
+
+				return {
+					id: r.id,
+					type: r.type as "cash_game" | "tournament",
+					sessionDate: Math.floor(r.sessionDate.getTime() / 1000),
+					profitLoss,
+					playMinutes,
+					bigBlind: r.ringGameBlind2 ?? null,
+					buyInTotal,
+				};
+			});
+
+			return { points };
 		}),
 
 	delete: protectedProcedure

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -725,6 +725,107 @@ interface ListItemRaw {
 	type: string;
 }
 
+interface ProfitLossSeriesRow {
+	addonCost: number | null;
+	bountyPrizes: number | null;
+	breakMinutes: number | null;
+	buyIn: number | null;
+	cashOut: number | null;
+	endedAt: Date | null;
+	entryFee: number | null;
+	evCashOut: number | null;
+	id: string;
+	prizeMoney: number | null;
+	rebuyCost: number | null;
+	rebuyCount: number | null;
+	ringGameBlind2: number | null;
+	sessionDate: Date;
+	startedAt: Date | null;
+	tournamentBuyIn: number | null;
+	type: string;
+}
+
+interface CashGameStats {
+	buyInTotal: number | null;
+	evProfitLoss: number | null;
+	profitLoss: number;
+}
+
+function computeCashStats(r: ProfitLossSeriesRow): CashGameStats {
+	if (r.buyIn === null || r.cashOut === null) {
+		return { profitLoss: 0, evProfitLoss: null, buyInTotal: null };
+	}
+	return {
+		profitLoss: computeCashGamePL(r.buyIn, r.cashOut),
+		evProfitLoss:
+			r.evCashOut === null ? null : computeCashGamePL(r.buyIn, r.evCashOut),
+		buyInTotal: r.buyIn,
+	};
+}
+
+interface TournamentStats {
+	buyInTotal: number | null;
+	profitLoss: number;
+}
+
+function computeTournamentStats(r: ProfitLossSeriesRow): TournamentStats {
+	const profitLoss = computeTournamentPL(
+		r.tournamentBuyIn,
+		r.entryFee,
+		r.rebuyCount,
+		r.rebuyCost,
+		r.addonCost,
+		r.prizeMoney,
+		r.bountyPrizes
+	);
+	const total =
+		(r.tournamentBuyIn ?? 0) +
+		(r.entryFee ?? 0) +
+		(r.rebuyCount ?? 0) * (r.rebuyCost ?? 0) +
+		(r.addonCost ?? 0);
+	return { profitLoss, buyInTotal: total === 0 ? null : total };
+}
+
+function computePlayMinutes(r: ProfitLossSeriesRow): number | null {
+	if (!(r.startedAt && r.endedAt)) {
+		return null;
+	}
+	const elapsed = Math.max(
+		0,
+		(r.endedAt.getTime() - r.startedAt.getTime()) / 60_000
+	);
+	return Math.max(0, elapsed - (r.breakMinutes ?? 0));
+}
+
+function toProfitLossSeriesPoint(r: ProfitLossSeriesRow) {
+	const cashStats =
+		r.type === "cash_game"
+			? computeCashStats(r)
+			: ({
+					profitLoss: 0,
+					evProfitLoss: null,
+					buyInTotal: null,
+				} satisfies CashGameStats);
+	const tourneyStats =
+		r.type === "tournament"
+			? computeTournamentStats(r)
+			: ({ profitLoss: 0, buyInTotal: null } satisfies TournamentStats);
+	const profitLoss =
+		r.type === "cash_game" ? cashStats.profitLoss : tourneyStats.profitLoss;
+	const buyInTotal =
+		r.type === "cash_game" ? cashStats.buyInTotal : tourneyStats.buyInTotal;
+	return {
+		id: r.id,
+		type: r.type as "cash_game" | "tournament",
+		sessionDate: Math.floor(r.sessionDate.getTime() / 1000),
+		profitLoss,
+		evProfitLoss: cashStats.evProfitLoss,
+		playMinutes: computePlayMinutes(r),
+		bigBlind: r.ringGameBlind2 ?? null,
+		buyInTotal,
+	};
+}
+
 function enrichItemWithPL<T extends ListItemRaw>(item: T) {
 	let profitLoss: number | null = null;
 	let evProfitLoss: number | null = null;
@@ -1434,6 +1535,7 @@ export const sessionRouter = router({
 			return updated;
 		}),
 
+	// pnl_graph widget — see apps/web/src/features/dashboard/widgets/pnl-graph-widget
 	profitLossSeries: protectedProcedure
 		.input(
 			z.object({
@@ -1481,6 +1583,7 @@ export const sessionRouter = router({
 					breakMinutes: gameSession.breakMinutes,
 					buyIn: sessionCashDetail.buyIn,
 					cashOut: sessionCashDetail.cashOut,
+					evCashOut: sessionCashDetail.evCashOut,
 					ringGameBlind2: ringGame.blind2,
 					tournamentBuyIn: sessionTournamentDetail.tournamentBuyIn,
 					entryFee: sessionTournamentDetail.entryFee,
@@ -1503,53 +1606,7 @@ export const sessionRouter = router({
 				.where(and(...conditions))
 				.orderBy(asc(gameSession.sessionDate), asc(gameSession.id));
 
-			const points = rows.map((r) => {
-				let profitLoss = 0;
-				let buyInTotal: number | null = null;
-				if (r.type === "cash_game" && r.buyIn !== null && r.cashOut !== null) {
-					profitLoss = computeCashGamePL(r.buyIn, r.cashOut);
-					buyInTotal = r.buyIn;
-				} else if (r.type === "tournament") {
-					profitLoss = computeTournamentPL(
-						r.tournamentBuyIn,
-						r.entryFee,
-						r.rebuyCount,
-						r.rebuyCost,
-						r.addonCost,
-						r.prizeMoney,
-						r.bountyPrizes
-					);
-					buyInTotal =
-						(r.tournamentBuyIn ?? 0) +
-						(r.entryFee ?? 0) +
-						(r.rebuyCount ?? 0) * (r.rebuyCost ?? 0) +
-						(r.addonCost ?? 0);
-					if (buyInTotal === 0) {
-						buyInTotal = null;
-					}
-				}
-
-				let playMinutes: number | null = null;
-				if (r.startedAt && r.endedAt) {
-					const elapsed = Math.max(
-						0,
-						(r.endedAt.getTime() - r.startedAt.getTime()) / 60_000
-					);
-					playMinutes = Math.max(0, elapsed - (r.breakMinutes ?? 0));
-				}
-
-				return {
-					id: r.id,
-					type: r.type as "cash_game" | "tournament",
-					sessionDate: Math.floor(r.sessionDate.getTime() / 1000),
-					profitLoss,
-					playMinutes,
-					bigBlind: r.ringGameBlind2 ?? null,
-					buyInTotal,
-				};
-			});
-
-			return { points };
+			return { points: rows.map(toProfitLossSeriesPoint) };
 		}),
 
 	delete: protectedProcedure

--- a/packages/api/src/types/dashboard-widget.ts
+++ b/packages/api/src/types/dashboard-widget.ts
@@ -8,6 +8,7 @@ export const widgetTypeSchema = z.enum([
 	"recent_sessions",
 	"active_session",
 	"currency_balance",
+	"pnl_graph",
 ]);
 export type WidgetType = z.infer<typeof widgetTypeSchema>;
 
@@ -53,11 +54,57 @@ export const currencyBalanceConfigSchema = z.object({
 });
 export type CurrencyBalanceConfig = z.infer<typeof currencyBalanceConfigSchema>;
 
+export const pnlGraphXAxisSchema = z.enum(["date", "sessionCount", "playTime"]);
+export type PnlGraphXAxis = z.infer<typeof pnlGraphXAxisSchema>;
+
+export const pnlGraphSessionTypeSchema = z.enum([
+	"all",
+	"cash_game",
+	"tournament",
+]);
+export type PnlGraphSessionType = z.infer<typeof pnlGraphSessionTypeSchema>;
+
+export const pnlGraphUnitSchema = z.enum(["currency", "bb", "bi"]);
+export type PnlGraphUnit = z.infer<typeof pnlGraphUnitSchema>;
+
+const pnlGraphFilterFlagsSchema = z
+	.object({
+		xAxis: z.boolean().default(false),
+		dateRange: z.boolean().default(false),
+		sessionType: z.boolean().default(false),
+		unit: z.boolean().default(false),
+		store: z.boolean().default(false),
+		ringGame: z.boolean().default(false),
+		currency: z.boolean().default(false),
+	})
+	.default({
+		xAxis: false,
+		dateRange: false,
+		sessionType: false,
+		unit: false,
+		store: false,
+		ringGame: false,
+		currency: false,
+	});
+
+export const pnlGraphConfigSchema = z.object({
+	xAxis: pnlGraphXAxisSchema.default("date"),
+	dateRangeDays: z.number().int().min(1).max(3650).nullable().default(null),
+	sessionType: pnlGraphSessionTypeSchema.default("all"),
+	unit: pnlGraphUnitSchema.default("currency"),
+	storeId: z.string().nullable().default(null),
+	ringGameId: z.string().nullable().default(null),
+	currencyId: z.string().nullable().default(null),
+	showFilters: pnlGraphFilterFlagsSchema,
+});
+export type PnlGraphConfig = z.infer<typeof pnlGraphConfigSchema>;
+
 export const widgetConfigSchema = z.union([
 	summaryStatsConfigSchema,
 	recentSessionsConfigSchema,
 	activeSessionConfigSchema,
 	currencyBalanceConfigSchema,
+	pnlGraphConfigSchema,
 ]);
 
 const configSchemaByType = {
@@ -65,6 +112,7 @@ const configSchemaByType = {
 	recent_sessions: recentSessionsConfigSchema,
 	active_session: activeSessionConfigSchema,
 	currency_balance: currencyBalanceConfigSchema,
+	pnl_graph: pnlGraphConfigSchema,
 } as const;
 
 export function parseWidgetConfig(

--- a/packages/api/src/types/dashboard-widget.ts
+++ b/packages/api/src/types/dashboard-widget.ts
@@ -93,6 +93,7 @@ export const pnlGraphConfigSchema = z.object({
 	storeId: z.string().nullable().default(null),
 	ringGameId: z.string().nullable().default(null),
 	currencyId: z.string().nullable().default(null),
+	showEvCash: z.boolean().default(false),
 	showFilters: pnlGraphFilterFlagsSchema,
 });
 export type PnlGraphConfig = z.infer<typeof pnlGraphConfigSchema>;

--- a/packages/api/src/types/dashboard-widget.ts
+++ b/packages/api/src/types/dashboard-widget.ts
@@ -64,7 +64,7 @@ export const pnlGraphSessionTypeSchema = z.enum([
 ]);
 export type PnlGraphSessionType = z.infer<typeof pnlGraphSessionTypeSchema>;
 
-export const pnlGraphUnitSchema = z.enum(["currency", "bb", "bi"]);
+export const pnlGraphUnitSchema = z.enum(["currency", "normalized"]);
 export type PnlGraphUnit = z.infer<typeof pnlGraphUnitSchema>;
 
 const pnlGraphFilterFlagsSchema = z
@@ -74,7 +74,6 @@ const pnlGraphFilterFlagsSchema = z
 		sessionType: z.boolean().default(false),
 		unit: z.boolean().default(false),
 		store: z.boolean().default(false),
-		ringGame: z.boolean().default(false),
 		currency: z.boolean().default(false),
 	})
 	.default({
@@ -83,7 +82,6 @@ const pnlGraphFilterFlagsSchema = z
 		sessionType: false,
 		unit: false,
 		store: false,
-		ringGame: false,
 		currency: false,
 	});
 

--- a/packages/db/src/__tests__/session-blind-level-schema.test.ts
+++ b/packages/db/src/__tests__/session-blind-level-schema.test.ts
@@ -1,0 +1,101 @@
+import { getTableColumns } from "drizzle-orm";
+import { getTableConfig } from "drizzle-orm/sqlite-core";
+import { describe, expect, it } from "vitest";
+import { sessionBlindLevel } from "../schema/session-blind-level";
+
+describe("SessionBlindLevel schema — columns", () => {
+	const columns = getTableColumns(sessionBlindLevel);
+
+	it("has all expected columns", () => {
+		expect(Object.keys(columns)).toEqual(
+			expect.arrayContaining([
+				"id",
+				"sessionId",
+				"level",
+				"isBreak",
+				"blind1",
+				"blind2",
+				"blind3",
+				"ante",
+				"minutes",
+			])
+		);
+	});
+
+	it("id is the primary key", () => {
+		expect(columns.id.primary).toBe(true);
+	});
+
+	it("sessionId is non-null string", () => {
+		expect(columns.sessionId.notNull).toBe(true);
+		expect(columns.sessionId.dataType).toBe("string");
+	});
+
+	it("level is non-null integer", () => {
+		expect(columns.level.notNull).toBe(true);
+		expect(columns.level.dataType).toBe("number");
+	});
+
+	it("isBreak is non-null boolean with default false", () => {
+		expect(columns.isBreak.notNull).toBe(true);
+		expect(columns.isBreak.dataType).toBe("boolean");
+		expect(columns.isBreak.default).toBe(false);
+	});
+
+	it("blind1 / blind2 / blind3 / ante / minutes are nullable integers", () => {
+		for (const key of [
+			"blind1",
+			"blind2",
+			"blind3",
+			"ante",
+			"minutes",
+		] as const) {
+			expect(columns[key].notNull).toBe(false);
+			expect(columns[key].dataType).toBe("number");
+		}
+	});
+});
+
+describe("SessionBlindLevel — FK cascade policies", () => {
+	const config = getTableConfig(sessionBlindLevel);
+	const fkByColumn = (columnName: string) =>
+		config.foreignKeys.find((fk) =>
+			fk.reference().columns.some((c) => c.name === columnName)
+		);
+
+	it("sessionId FK cascades (levels die with parent session)", () => {
+		expect(fkByColumn("session_id")?.onDelete).toBe("cascade");
+	});
+
+	it("has exactly 1 foreign key", () => {
+		expect(config.foreignKeys).toHaveLength(1);
+	});
+
+	it("sessionId FK references game_session.id", () => {
+		const fk = fkByColumn("session_id");
+		expect(fk?.reference().foreignColumns.map((c) => c.name)).toEqual(["id"]);
+	});
+});
+
+describe("SessionBlindLevel — indexes", () => {
+	const config = getTableConfig(sessionBlindLevel);
+	const idxNames = config.indexes.map((i) => i.config.name);
+
+	it("has session_blind_level_session_idx for per-session lookups", () => {
+		expect(idxNames).toContain("session_blind_level_session_idx");
+	});
+
+	it("has no unique indexes", () => {
+		const uniqueIdxs = config.indexes.filter(
+			(i) => (i.config as unknown as { unique: boolean }).unique === true
+		);
+		expect(uniqueIdxs).toHaveLength(0);
+	});
+});
+
+describe("SessionBlindLevel — table name", () => {
+	it("table is named session_blind_level", () => {
+		const config = getTableConfig(sessionBlindLevel);
+		expect(config.name).toBe("session_blind_level");
+	});
+});

--- a/packages/db/src/__tests__/session-cash-detail-schema.test.ts
+++ b/packages/db/src/__tests__/session-cash-detail-schema.test.ts
@@ -14,6 +14,16 @@ describe("SessionCashDetail schema — columns", () => {
 				"buyIn",
 				"cashOut",
 				"evCashOut",
+				"name",
+				"variant",
+				"blind1",
+				"blind2",
+				"blind3",
+				"ante",
+				"anteType",
+				"minBuyIn",
+				"maxBuyIn",
+				"tableSize",
 			])
 		);
 	});
@@ -26,13 +36,10 @@ describe("SessionCashDetail schema — columns", () => {
 		expect(columns.ringGameId.notNull).toBe(false);
 	});
 
-	it("buyIn / cashOut / evCashOut are nullable", () => {
+	it("buyIn / cashOut / evCashOut are nullable integers", () => {
 		expect(columns.buyIn.notNull).toBe(false);
 		expect(columns.cashOut.notNull).toBe(false);
 		expect(columns.evCashOut.notNull).toBe(false);
-	});
-
-	it("buyIn / cashOut / evCashOut are integer type", () => {
 		expect(columns.buyIn.dataType).toBe("number");
 		expect(columns.cashOut.dataType).toBe("number");
 		expect(columns.evCashOut.dataType).toBe("number");
@@ -40,6 +47,37 @@ describe("SessionCashDetail schema — columns", () => {
 
 	it("ringGameId is string type", () => {
 		expect(columns.ringGameId.dataType).toBe("string");
+	});
+
+	it("name is nullable string (display name owned by session)", () => {
+		expect(columns.name.notNull).toBe(false);
+		expect(columns.name.dataType).toBe("string");
+	});
+
+	it("variant is non-null string with default 'nlh'", () => {
+		expect(columns.variant.notNull).toBe(true);
+		expect(columns.variant.dataType).toBe("string");
+		expect(columns.variant.default).toBe("nlh");
+	});
+
+	it("blind1 / blind2 / blind3 / ante / minBuyIn / maxBuyIn / tableSize are nullable integers", () => {
+		for (const key of [
+			"blind1",
+			"blind2",
+			"blind3",
+			"ante",
+			"minBuyIn",
+			"maxBuyIn",
+			"tableSize",
+		] as const) {
+			expect(columns[key].notNull).toBe(false);
+			expect(columns[key].dataType).toBe("number");
+		}
+	});
+
+	it("anteType is nullable string", () => {
+		expect(columns.anteType.notNull).toBe(false);
+		expect(columns.anteType.dataType).toBe("string");
 	});
 });
 

--- a/packages/db/src/__tests__/session-chip-purchase-schema.test.ts
+++ b/packages/db/src/__tests__/session-chip-purchase-schema.test.ts
@@ -1,0 +1,92 @@
+import { getTableColumns } from "drizzle-orm";
+import { getTableConfig } from "drizzle-orm/sqlite-core";
+import { describe, expect, it } from "vitest";
+import { sessionChipPurchase } from "../schema/session-chip-purchase";
+
+describe("SessionChipPurchase schema — columns", () => {
+	const columns = getTableColumns(sessionChipPurchase);
+
+	it("has all expected columns", () => {
+		expect(Object.keys(columns)).toEqual(
+			expect.arrayContaining([
+				"id",
+				"sessionId",
+				"name",
+				"cost",
+				"chips",
+				"sortOrder",
+			])
+		);
+	});
+
+	it("id is the primary key", () => {
+		expect(columns.id.primary).toBe(true);
+	});
+
+	it("sessionId is non-null string", () => {
+		expect(columns.sessionId.notNull).toBe(true);
+		expect(columns.sessionId.dataType).toBe("string");
+	});
+
+	it("name is non-null string", () => {
+		expect(columns.name.notNull).toBe(true);
+		expect(columns.name.dataType).toBe("string");
+	});
+
+	it("cost / chips are non-null integers", () => {
+		expect(columns.cost.notNull).toBe(true);
+		expect(columns.cost.dataType).toBe("number");
+		expect(columns.chips.notNull).toBe(true);
+		expect(columns.chips.dataType).toBe("number");
+	});
+
+	it("sortOrder is non-null integer with default 0", () => {
+		expect(columns.sortOrder.notNull).toBe(true);
+		expect(columns.sortOrder.dataType).toBe("number");
+		expect(columns.sortOrder.default).toBe(0);
+	});
+});
+
+describe("SessionChipPurchase — FK cascade policies", () => {
+	const config = getTableConfig(sessionChipPurchase);
+	const fkByColumn = (columnName: string) =>
+		config.foreignKeys.find((fk) =>
+			fk.reference().columns.some((c) => c.name === columnName)
+		);
+
+	it("sessionId FK cascades (purchases die with parent session)", () => {
+		expect(fkByColumn("session_id")?.onDelete).toBe("cascade");
+	});
+
+	it("has exactly 1 foreign key", () => {
+		expect(config.foreignKeys).toHaveLength(1);
+	});
+
+	it("sessionId FK references game_session.id", () => {
+		const fk = fkByColumn("session_id");
+		expect(fk?.reference().foreignColumns.map((c) => c.name)).toEqual(["id"]);
+	});
+});
+
+describe("SessionChipPurchase — indexes", () => {
+	const config = getTableConfig(sessionChipPurchase);
+	const idxNames = config.indexes.map((i) => i.config.name);
+
+	it("has session_chip_purchase_session_idx for per-session lookups", () => {
+		expect(idxNames).toContain("session_chip_purchase_session_idx");
+	});
+
+	it("has no unique indexes", () => {
+		const uniqueIdxs = config.indexes.filter(
+			(i) => (i.config as unknown as { unique: boolean }).unique === true
+		);
+		expect(uniqueIdxs).toHaveLength(0);
+	});
+});
+
+describe("SessionChipPurchase — table name", () => {
+	it("table is named session_chip_purchase", () => {
+		const config = getTableConfig(sessionChipPurchase);
+		expect(config.name).toBe("session_chip_purchase");
+	});
+});

--- a/packages/db/src/__tests__/session-tournament-detail-schema.test.ts
+++ b/packages/db/src/__tests__/session-tournament-detail-schema.test.ts
@@ -17,13 +17,24 @@ describe("SessionTournamentDetail schema — columns", () => {
 				"totalEntries",
 				"beforeDeadline",
 				"prizeMoney",
-				"rebuyCount",
-				"rebuyCost",
-				"addonCost",
+				"chipPurchaseCount",
+				"chipPurchaseTotalCost",
 				"bountyPrizes",
 				"timerStartedAt",
+				"name",
+				"variant",
+				"startingStack",
+				"bountyAmount",
+				"tableSize",
 			])
 		);
+	});
+
+	it("does not retain legacy rebuy/addon scalar columns", () => {
+		const keys = Object.keys(columns);
+		expect(keys).not.toContain("rebuyCount");
+		expect(keys).not.toContain("rebuyCost");
+		expect(keys).not.toContain("addonCost");
 	});
 
 	it("sessionId is primary key (PK=FK)", () => {
@@ -40,9 +51,8 @@ describe("SessionTournamentDetail schema — columns", () => {
 		expect(columns.placement.notNull).toBe(false);
 		expect(columns.totalEntries.notNull).toBe(false);
 		expect(columns.prizeMoney.notNull).toBe(false);
-		expect(columns.rebuyCount.notNull).toBe(false);
-		expect(columns.rebuyCost.notNull).toBe(false);
-		expect(columns.addonCost.notNull).toBe(false);
+		expect(columns.chipPurchaseCount.notNull).toBe(false);
+		expect(columns.chipPurchaseTotalCost.notNull).toBe(false);
 		expect(columns.bountyPrizes.notNull).toBe(false);
 	});
 
@@ -62,10 +72,27 @@ describe("SessionTournamentDetail schema — columns", () => {
 		expect(columns.placement.dataType).toBe("number");
 		expect(columns.totalEntries.dataType).toBe("number");
 		expect(columns.prizeMoney.dataType).toBe("number");
-		expect(columns.rebuyCount.dataType).toBe("number");
-		expect(columns.rebuyCost.dataType).toBe("number");
-		expect(columns.addonCost.dataType).toBe("number");
+		expect(columns.chipPurchaseCount.dataType).toBe("number");
+		expect(columns.chipPurchaseTotalCost.dataType).toBe("number");
 		expect(columns.bountyPrizes.dataType).toBe("number");
+	});
+
+	it("name is nullable string (display name owned by session)", () => {
+		expect(columns.name.notNull).toBe(false);
+		expect(columns.name.dataType).toBe("string");
+	});
+
+	it("variant is non-null string with default 'nlh'", () => {
+		expect(columns.variant.notNull).toBe(true);
+		expect(columns.variant.dataType).toBe("string");
+		expect(columns.variant.default).toBe("nlh");
+	});
+
+	it("startingStack / bountyAmount / tableSize are nullable integers", () => {
+		for (const key of ["startingStack", "bountyAmount", "tableSize"] as const) {
+			expect(columns[key].notNull).toBe(false);
+			expect(columns[key].dataType).toBe("number");
+		}
 	});
 });
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -22,9 +22,17 @@ import {
 import { ringGame, ringGameRelations } from "./schema/ring-game";
 import { gameSession, gameSessionRelations } from "./schema/session";
 import {
+	sessionBlindLevel,
+	sessionBlindLevelRelations,
+} from "./schema/session-blind-level";
+import {
 	sessionCashDetail,
 	sessionCashDetailRelations,
 } from "./schema/session-cash-detail";
+import {
+	sessionChipPurchase,
+	sessionChipPurchaseRelations,
+} from "./schema/session-chip-purchase";
 import { sessionEvent, sessionEventRelations } from "./schema/session-event";
 import {
 	sessionTablePlayer,
@@ -104,6 +112,10 @@ export const schema = {
 	sessionCashDetailRelations,
 	sessionTournamentDetail,
 	sessionTournamentDetailRelations,
+	sessionBlindLevel,
+	sessionBlindLevelRelations,
+	sessionChipPurchase,
+	sessionChipPurchaseRelations,
 	player,
 	playerRelations,
 	playerTag,

--- a/packages/db/src/schema/session-blind-level.ts
+++ b/packages/db/src/schema/session-blind-level.ts
@@ -1,0 +1,31 @@
+import { relations } from "drizzle-orm";
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { gameSession } from "./session";
+
+export const sessionBlindLevel = sqliteTable(
+	"session_blind_level",
+	{
+		id: text("id").primaryKey(),
+		sessionId: text("session_id")
+			.notNull()
+			.references(() => gameSession.id, { onDelete: "cascade" }),
+		level: integer("level").notNull(),
+		isBreak: integer("is_break", { mode: "boolean" }).notNull().default(false),
+		blind1: integer("blind1"),
+		blind2: integer("blind2"),
+		blind3: integer("blind3"),
+		ante: integer("ante"),
+		minutes: integer("minutes"),
+	},
+	(t) => [index("session_blind_level_session_idx").on(t.sessionId)]
+);
+
+export const sessionBlindLevelRelations = relations(
+	sessionBlindLevel,
+	({ one }) => ({
+		session: one(gameSession, {
+			fields: [sessionBlindLevel.sessionId],
+			references: [gameSession.id],
+		}),
+	})
+);

--- a/packages/db/src/schema/session-cash-detail.ts
+++ b/packages/db/src/schema/session-cash-detail.ts
@@ -15,6 +15,16 @@ export const sessionCashDetail = sqliteTable(
 		buyIn: integer("buy_in"),
 		cashOut: integer("cash_out"),
 		evCashOut: integer("ev_cash_out"),
+		name: text("name"),
+		variant: text("variant").notNull().default("nlh"),
+		blind1: integer("blind1"),
+		blind2: integer("blind2"),
+		blind3: integer("blind3"),
+		ante: integer("ante"),
+		anteType: text("ante_type"),
+		minBuyIn: integer("min_buy_in"),
+		maxBuyIn: integer("max_buy_in"),
+		tableSize: integer("table_size"),
 	},
 	(t) => [index("session_cash_ring_idx").on(t.ringGameId)]
 );

--- a/packages/db/src/schema/session-chip-purchase.ts
+++ b/packages/db/src/schema/session-chip-purchase.ts
@@ -1,0 +1,28 @@
+import { relations } from "drizzle-orm";
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { gameSession } from "./session";
+
+export const sessionChipPurchase = sqliteTable(
+	"session_chip_purchase",
+	{
+		id: text("id").primaryKey(),
+		sessionId: text("session_id")
+			.notNull()
+			.references(() => gameSession.id, { onDelete: "cascade" }),
+		name: text("name").notNull(),
+		cost: integer("cost").notNull(),
+		chips: integer("chips").notNull(),
+		sortOrder: integer("sort_order").notNull().default(0),
+	},
+	(t) => [index("session_chip_purchase_session_idx").on(t.sessionId)]
+);
+
+export const sessionChipPurchaseRelations = relations(
+	sessionChipPurchase,
+	({ one }) => ({
+		session: one(gameSession, {
+			fields: [sessionChipPurchase.sessionId],
+			references: [gameSession.id],
+		}),
+	})
+);

--- a/packages/db/src/schema/session-tournament-detail.ts
+++ b/packages/db/src/schema/session-tournament-detail.ts
@@ -18,11 +18,15 @@ export const sessionTournamentDetail = sqliteTable(
 		totalEntries: integer("total_entries"),
 		beforeDeadline: integer("before_deadline", { mode: "boolean" }),
 		prizeMoney: integer("prize_money"),
-		rebuyCount: integer("rebuy_count"),
-		rebuyCost: integer("rebuy_cost"),
-		addonCost: integer("addon_cost"),
+		chipPurchaseCount: integer("chip_purchase_count"),
+		chipPurchaseTotalCost: integer("chip_purchase_total_cost"),
 		bountyPrizes: integer("bounty_prizes"),
 		timerStartedAt: integer("timer_started_at", { mode: "timestamp" }),
+		name: text("name"),
+		variant: text("variant").notNull().default("nlh"),
+		startingStack: integer("starting_stack"),
+		bountyAmount: integer("bounty_amount"),
+		tableSize: integer("table_size"),
 	},
 	(t) => [index("session_tournament_tournament_idx").on(t.tournamentId)]
 );

--- a/packages/db/src/schema/session.ts
+++ b/packages/db/src/schema/session.ts
@@ -7,6 +7,8 @@ import {
 	text,
 } from "drizzle-orm/sqlite-core";
 import { user } from "./auth";
+import { sessionBlindLevel } from "./session-blind-level";
+import { sessionChipPurchase } from "./session-chip-purchase";
 import { sessionToSessionTag } from "./session-tag";
 import { currency, currencyTransaction, store } from "./store";
 
@@ -65,4 +67,6 @@ export const gameSessionRelations = relations(gameSession, ({ one, many }) => ({
 	}),
 	transactions: many(currencyTransaction),
 	tagLinks: many(sessionToSessionTag),
+	blindLevels: many(sessionBlindLevel),
+	chipPurchases: many(sessionChipPurchase),
 }));


### PR DESCRIPTION
## 概要

Linear SA2-22 (#259) 対応。セッションがゲーム定義(基本設定 + ブラインドストラクチャー + チップ購入カタログ)の完全コピーを保持し、計算/表示の真実とする設計に切り替える。`ring_game` / `tournament` テーブルへの参照は集計用のリンクとしてのみ残し、セッション編集はテンプレートに伝播させない。

進行中(draft)。詳細プランは `/root/.claude/plans/work-on-linear-issue-mutable-crayon.md`。

## 主な変更点 (継続中)

### スキーマ層 (本コミット完了)

- `session_cash_detail` にゲーム定義カラム追加: `name`, `variant`, `blind1-3`, `ante`, `anteType`, `minBuyIn`, `maxBuyIn`, `tableSize`
- `session_tournament_detail`:
  - 追加: `name`, `variant`, `startingStack`, `bountyAmount`, `tableSize`
  - 整理: `rebuyCount` / `rebuyCost` / `addonCost` を廃止し、`chipPurchaseCount` + `chipPurchaseTotalCost`(どちらも総和)に統合。これによりライブ集計とマニュアル入力で食い違っていた `rebuyCost` のセマンティクスを統一し、PL 計算の乗算バグを解消する
- 新規テーブル:
  - `session_blind_level`: トーナメントセッション固有のブラインドストラクチャー (FK→`game_session`, cascade)
  - `session_chip_purchase`: チップ購入カタログ (FK→`game_session`, cascade)
- `gameSession` の relations に `blindLevels` / `chipPurchases` を追加
- スキーマテスト 58 件を更新・新設しすべてパス

### 後続コミットで対応予定

- マイグレーション SQL `0024_session_owns_game_config.sql` (ALTER + CREATE + バックフィル UPDATE/INSERT)
- `packages/api/src/routers/session.ts`:
  - `create`: アドホック `ring_game` 自動生成を停止、サーバ側でゲーム + ブラインド構造 + チップ購入カタログを `session_*` テーブルに複製
  - `update`: 編集を `session_*_detail` / `session_blind_level` / `session_chip_purchase` のみに書き、テンプレート (`ring_game` / `tournament` / `blind_level` / `tournament_chip_purchase`) には伝播させない
  - `list`: `ringGameId` / `tournamentId` フィルタ追加。詳細クエリの `join` ソースをセッション所有テーブルに切替
- ライブセッションタイマー: `tournament.blind_level` から `session_blind_level` へ参照切替
- `live-session-pl.ts`: `chipPurchaseCount` / `chipPurchaseTotalCost` への列名移行
- フロントエンド:
  - `SessionItem` 型と `buildCreatePayload` 拡張
  - `link-selectors`: トーナメント選択時にストラクチャー/カタログをプレフィル
  - `session-card`: セッション所有フィールドからブラインド表示
  - トーナメントセッション詳細・編集ページのストラクチャー読み書き先切替

## Test plan

- [x] スキーマテスト (`bunx vitest run --project db`) 58 件パス
- [ ] API テスト (create / update / list) — 後続コミット
- [ ] Web テスト (フォームプレフィル / カード表示) — 後続コミット
- [ ] 手動検証:
  - キャッシュ: ゲーム未選択で作成 → `ring_game` 行が増えない
  - キャッシュ: ゲーム選択で作成 → セッションの設定値が選択ゲームと一致
  - キャッシュ: セッションの blind1 を編集 → `session_cash_detail.blind1` のみ変更、`ring_game` は不変
  - トーナメント: トーナメント選択で作成 → ストラクチャー / カタログが session_* テーブルに複製される
  - トーナメント: ストラクチャー編集 → `session_blind_level` のみ変更、`blind_level` テンプレートは不変
  - ライブタイマー: `session_blind_level` を参照して進行
- [ ] 最終: `bun run lint && bun run check-types && bun run test`

https://claude.ai/code/session_01S1dRS82EB4yDv3nn1J66mG

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1dRS82EB4yDv3nn1J66mG)_