### PR TITLE
fix(events): default occurredAt to now instead of sessionDate

### DIFF
--- a/packages/api/src/routers/session-event.ts
+++ b/packages/api/src/routers/session-event.ts
@@ -26,6 +26,7 @@ import {
 	assertOccurredAtOrdering,
 	floorToMinute,
 	nextAppendSortOrder,
+	resolveOccurredAt,
 } from "../utils/session-event-time";
 
 type DbInstance = Parameters<
@@ -203,7 +204,7 @@ export const sessionEventRouter = router({
 			}
 
 			const userId = ctx.session.user.id;
-			const { sessionType, sessionDate } = await resolveSessionOwnership(
+			const { sessionType } = await resolveSessionOwnership(
 				ctx.db,
 				sessionId,
 				userId
@@ -243,10 +244,7 @@ export const sessionEventRouter = router({
 				input.payload,
 				sessionType
 			);
-			const rawOccurredAt = input.occurredAt
-				? new Date(input.occurredAt * 1000)
-				: sessionDate;
-			const occurredAtDate = floorToMinute(rawOccurredAt);
+			const occurredAtDate = resolveOccurredAt(input.occurredAt, new Date());
 
 			const sortOrder = await nextAppendSortOrder(ctx.db, sessionId);
 

--- a/packages/api/src/utils/__tests__/session-event-time.test.ts
+++ b/packages/api/src/utils/__tests__/session-event-time.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { floorToMinute, nextAppendSortOrder } from "../session-event-time";
+import {
+	floorToMinute,
+	nextAppendSortOrder,
+	resolveOccurredAt,
+} from "../session-event-time";
 
 describe("floorToMinute", () => {
 	it("zeroes out seconds and milliseconds", () => {
@@ -45,6 +49,73 @@ function makeMaxSortOrderDb(rows: { maxSortOrder: number | null }[]) {
 		selectSpy,
 	};
 }
+
+describe("resolveOccurredAt", () => {
+	it("returns floored client-supplied seconds when occurredAt is provided", () => {
+		const now = new Date("2026-04-24T12:00:00.000Z");
+		// 2026-04-24T10:30:42Z in unix seconds
+		const supplied = Math.floor(
+			new Date("2026-04-24T10:30:42.123Z").getTime() / 1000
+		);
+		const result = resolveOccurredAt(supplied, now);
+		expect(result.toISOString()).toBe("2026-04-24T10:30:00.000Z");
+	});
+
+	it("falls back to floored now when occurredAt is undefined", () => {
+		const now = new Date("2026-04-24T15:47:33.500Z");
+		const result = resolveOccurredAt(undefined, now);
+		expect(result.toISOString()).toBe("2026-04-24T15:47:00.000Z");
+	});
+
+	it("uses distinct now values for sequential events in different minutes", () => {
+		// Regression: the previous implementation defaulted to sessionDate, so
+		// every event created without an explicit occurredAt collapsed onto the
+		// same timestamp. Each call must use the now passed in.
+		const first = resolveOccurredAt(
+			undefined,
+			new Date("2026-04-24T18:00:10.000Z")
+		);
+		const second = resolveOccurredAt(
+			undefined,
+			new Date("2026-04-24T18:01:20.000Z")
+		);
+		const third = resolveOccurredAt(
+			undefined,
+			new Date("2026-04-24T18:02:30.000Z")
+		);
+		expect([
+			first.toISOString(),
+			second.toISOString(),
+			third.toISOString(),
+		]).toEqual([
+			"2026-04-24T18:00:00.000Z",
+			"2026-04-24T18:01:00.000Z",
+			"2026-04-24T18:02:00.000Z",
+		]);
+	});
+
+	it("does not collapse onto sessionDate when no occurredAt is supplied", () => {
+		// The original bug: any default that ignored `now` made every event share
+		// one timestamp. Guard against a regression by passing a sessionDate-like
+		// value as `now` only when the caller actually wants it.
+		const now = new Date("2026-04-24T22:15:00.000Z");
+		const result = resolveOccurredAt(undefined, now);
+		expect(result.getTime()).toBe(now.getTime());
+	});
+
+	it("treats occurredAt = 0 as a real epoch value, not as missing", () => {
+		const now = new Date("2026-04-24T12:00:00.000Z");
+		const result = resolveOccurredAt(0, now);
+		expect(result.toISOString()).toBe("1970-01-01T00:00:00.000Z");
+	});
+
+	it("does not mutate the supplied now", () => {
+		const now = new Date("2026-04-24T15:47:33.500Z");
+		const original = now.getTime();
+		resolveOccurredAt(undefined, now);
+		expect(now.getTime()).toBe(original);
+	});
+});
 
 describe("nextAppendSortOrder", () => {
 	it("returns 0 when the session has no events", async () => {

--- a/packages/api/src/utils/session-event-time.ts
+++ b/packages/api/src/utils/session-event-time.ts
@@ -13,6 +13,18 @@ export function floorToMinute(date: Date): Date {
 	return copy;
 }
 
+// Resolves the `occurredAt` for a session event. Falls back to `now` when the
+// caller omits a timestamp — never to a fixed value like `sessionDate`, which
+// would collapse every default-timestamped event onto a single instant.
+export function resolveOccurredAt(
+	occurredAtSeconds: number | undefined,
+	now: Date
+): Date {
+	const raw =
+		occurredAtSeconds === undefined ? now : new Date(occurredAtSeconds * 1000);
+	return floorToMinute(raw);
+}
+
 export async function nextAppendSortOrder(
 	db: DbInstance,
 	sessionId: string


### PR DESCRIPTION
## 概要

`sessionEvent.create` ですべてのイベントの `occurredAt` が同一になってしまうバグを修正します。

## 原因

`packages/api/src/routers/session-event.ts` の create ハンドラで、クライアントが `occurredAt` を渡さなかった場合のフォールバックが `sessionDate`（セッション開始日時、セッション中は不変）になっていました。

```ts
// 修正前
const rawOccurredAt = input.occurredAt
  ? new Date(input.occurredAt * 1000)
  : sessionDate;
const occurredAtDate = floorToMinute(rawOccurredAt);
```

`apps/web` のどの呼び出し側も `occurredAt` を渡していない (`use-cash-game-stack.ts` / `use-tournament-stack.ts` / `use-mobile-nav.ts` / `use-create-session.ts` すべて) ため、同一セッション内のすべてのイベントが `sessionDate` という同じタイムスタンプに丸まっていました。

## 修正

`packages/api/src/utils/session-event-time.ts` に `resolveOccurredAt(occurredAtSeconds, now)` を切り出し、未指定時のフォールバックを「現在時刻」に変更しました。`floorToMinute` による分単位の正規化は `assertOccurredAtOrdering` が分単位順序を保証するために必要なので維持しています。

## テスト

`packages/api/src/utils/__tests__/session-event-time.test.ts` に `resolveOccurredAt` の単体テストを追加 (6 ケース、TDD で red → green を確認)。

- クライアント指定値の minute flooring
- `undefined` 時の `now` フォールバック
- 連続イベントで `now` ごとに異なる値を返すこと（回帰テスト）
- `occurredAt = 0` を欠損ではなく 1970-01-01 として扱うこと
- `now` を変更しないこと

## 検証

- `bunx vitest run --project api`: 22 files / 548 tests pass
- `bun run check-types`: pass
- `bunx ultracite check`: pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01HKSpYvt17pjCNx4hXSu6vj)_