### PR TITLE
ci(release): auto-publish releases on release/v*.*.* merges to main

### DIFF
--- a/.github/rulesets/main-release-only.json
+++ b/.github/rulesets/main-release-only.json
@@ -1,0 +1,35 @@
+{
+  "name": "main-release-only",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          { "context": "pr-target-guard" },
+          { "context": "ci" }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [dev, main]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/pr-target-guard.yml
+++ b/.github/workflows/pr-target-guard.yml
@@ -1,0 +1,20 @@
+name: pr-target-guard
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  pr-target-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce release/vX.Y.Z head branch pattern
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ ! "$HEAD_REF" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::PRs to main must come from a release/vX.Y.Z branch. Got: '$HEAD_REF'"
+            exit 1
+          fi
+          echo "OK: head branch '$HEAD_REF' matches release/vX.Y.Z"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release on Merge to Main
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  release:
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          if [[ ! "$BRANCH" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Branch '$BRANCH' does not match release/vX.Y.Z"
+            exit 1
+          fi
+          VERSION="${BRANCH#release/}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Run Claude Code to draft release notes and publish release
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          prompt: |
+            You are running headlessly in CI to publish a sapphire2 release.
+
+            Inputs from environment:
+            - RELEASE_VERSION: the new version tag, e.g. `v1.5.0`
+            - PR_NUMBER: the merged release PR number
+            - REPO: the GitHub repo in `owner/name` form
+
+            Execute these steps in order. There is no interactive user; do not ask
+            questions. If anything fails, surface the error and stop.
+
+            1. Invoke the `/create-update-notes` skill with `$RELEASE_VERSION` as the
+               argument. Follow its Execution Flow steps 1–6 verbatim, but apply
+               these CI overrides:
+                 - Skip step 7 entirely (no interactive review round-trip).
+                 - In step 8, do NOT print the final block to the user; instead write
+                   only the Markdown body (without the surrounding ```markdown fence)
+                   to `/tmp/release-notes.md`.
+               The skill's "must never publish" rule is explicitly waived for this
+               CI invocation — publishing is required and is handled below.
+
+            2. Create and publish the GitHub Release. This creates the git tag
+               automatically:
+                 gh release create "$RELEASE_VERSION" \
+                   --repo "$REPO" \
+                   --title "$RELEASE_VERSION" \
+                   --notes-file /tmp/release-notes.md \
+                   --target main
+
+            3. Capture the release URL from gh and post a comment on the merged PR:
+                 RELEASE_URL=$(gh release view "$RELEASE_VERSION" --repo "$REPO" --json url --jq .url)
+                 gh pr comment "$PR_NUMBER" --repo "$REPO" \
+                   --body "Released as **$RELEASE_VERSION** → $RELEASE_URL"
+
+            Stop after step 3. Do not modify any files in the repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,12 @@ utils/                     truly global helpers (optimistic-update, formatters, 
 
 When adding a feature, create `apps/web/src/features/<name>/` and colocate everything. Promote to `shared/` only when a second feature imports it.
 
+## Release Flow
+
+- **Branches**: `feature → dev → release/vX.Y.Z → main`. `dev` is the default base for PRs; `main` only accepts PRs whose head branch matches `release/v[0-9]+\.[0-9]+\.[0-9]+` (enforced by [`pr-target-guard.yml`](.github/workflows/pr-target-guard.yml) + GitHub Ruleset [`main-release-only.json`](.github/rulesets/main-release-only.json)).
+- **Cutting a release**: `git checkout -b release/vX.Y.Z dev && git push -u origin HEAD`, then `gh pr create --base main`. On merge, [`release.yml`](.github/workflows/release.yml) auto-generates notes via the `/create-update-notes` skill, creates the tag, and publishes the GitHub Release — which in turn fires [`production-deploy.yml`](.github/workflows/production-deploy.yml).
+- **Manual release notes**: invoke `/create-update-notes vX.Y.Z` locally; the skill stays draft-only when used outside CI.
+
 ## Web UI Essentials (cross-cutting)
 
 Detailed rules live in [`.claude/rules/`](.claude/rules/); the points below apply everywhere in `apps/web/` and are worth keeping top of mind:


### PR DESCRIPTION
Add a Claude Code Action workflow that, on merge of a release/vX.Y.Z PR into main, drafts notes via the /create-update-notes skill and publishes the GitHub Release (which in turn triggers the existing production-deploy workflow). Add a pr-target-guard workflow plus a main-release-only Ruleset so only release/v*.*.* branches can merge into main, and switch CI to also run on dev so PRs can default to dev.