### PR TITLE
feat(web): add Sapphire 2 theme as scope-class for gradual migration

### DIFF
--- a/.claude/rules/web-theme.md
+++ b/.claude/rules/web-theme.md
@@ -1,0 +1,78 @@
+---
+paths:
+  - "apps/web/**"
+---
+
+# Theme Migration (Legacy ↔ v2 coexistence)
+
+The web app is in a **theme migration period**. Two shadcn/ui themes coexist:
+
+- **Legacy theme** (default): the existing tokens in `apps/web/src/index.css` `:root` / `.dark`. Used by all currently-shipping pages and components.
+- **Theme v2** (Sapphire 2 Design System): scope-class theme `theme-v2` defined in the same file, derived from the design handoff bundle. Token-only difference — no component code is forked.
+
+## When to use which
+
+| Situation | Theme |
+|---|---|
+| Default. Touching an existing page / component that has not been opted in. | Legacy |
+| The user explicitly says **"新テーマを使う" / "use the new theme" / "use theme-v2"**. | **v2** |
+| Newly created routes / features designed against the v2 handoff (`/tmp/design/sapphire-2-design-system/` while extracted, or the bundle's source-of-truth `colors_and_type.css`). | **v2** |
+
+If unsure, **ask** before opting a subtree in. Mixing both inside the same visible region is a bug — the boundary belongs at a route layout or a clearly separated panel.
+
+## How to opt a subtree into v2
+
+Apply `className="theme-v2"` to the **outermost element of the subtree** you want themed (typically the route's layout `<Outlet>` wrapper). Tokens cascade via CSS variables, so every `bg-background` / `bg-primary` / `border-border` etc. utility inside that subtree resolves to v2 values automatically. No component changes required.
+
+```tsx
+// apps/web/src/routes/<v2-route>/route.tsx (example)
+export const Route = createFileRoute("/<v2-route>")({
+  component: () => (
+    <div className="theme-v2 min-h-screen bg-background text-foreground">
+      <Outlet />
+    </div>
+  ),
+});
+```
+
+Dark mode keeps working — `next-themes` toggles `.dark` on `<html>`, and the v2 dark block (`.dark .theme-v2`) takes effect automatically.
+
+### Radix portals
+
+Dialog / Popover / Select / Tooltip / DropdownMenu / Sonner render to `document.body` via portal, **outside** the `.theme-v2` subtree. Inside a v2 region, portal content will fall back to the legacy theme unless explicitly themed. Two options:
+
+1. **Pass `container`** to the Radix `Portal` to keep the content inside the v2 subtree.
+2. **Add the `theme-v2` class to the portal root** via `className` prop on shadcn components that accept one for their content (most do).
+
+If a portal-heavy screen is hard to scope, escalate the v2 class to `<html>` on routes that are fully migrated — same trick as `.dark`. Document the route in the PR.
+
+## Tokens v2 adds (not present in legacy)
+
+v2 introduces `--success` / `--warning` / `--info` (and their `-foreground` pairs) inside the `.theme-v2` scope only. Outside the scope these are undefined — use them only inside v2 regions, via arbitrary values:
+
+```tsx
+<span className="bg-[hsl(var(--success))] text-[hsl(var(--success-foreground))]">…</span>
+```
+
+If a v2 component needs these as first-class Tailwind utilities (`bg-success` etc.), extend `@theme inline` in `index.css` **and** add fallback values to `:root` + `.dark` so legacy regions don't break.
+
+## Design source-of-truth
+
+The Sapphire 2 Design System handoff bundle drives v2 decisions (colors, radius, typography scale, motion durations, component composition rules — buttons, alerts, cards, sheets, toasts, etc.). When designing a v2 surface:
+
+- Color philosophy: **blue-600 primary in light, blue-500 in dark**. Neutrals = slate only. Semantic colors carry meaning, never decoration.
+- **Radius 8px base** (legacy is 7.2px). All other radii derive from `--radius`.
+- **Borders, not shadows**, for structural separation in resting cards. Shadows reserved for floating surfaces.
+- **Sentence case** UI copy, no trailing periods on labels, no emoji in product UI.
+- **Mobile data entry = bottom sheets** (already enforced by [`web-ui.md`](web-ui.md) — `Drawer`, not `Dialog`).
+- Hover/press: background opacity shift only. No scale/translate on tool surfaces.
+- Focus ring: 2px `--ring` (blue) with 2px transparent offset — non-negotiable accessibility primitive.
+
+For anything ambiguous (component composition, spacing, typography mapping to `t-*` classes), refer back to the bundle README (`sapphire-2-design-system/project/README.md`) or `colors_and_type.css` / `components.css`.
+
+## Don'ts
+
+- **Don't fork `shared/components/ui/`** for v2. Components stay single-source; only tokens differ. If a v2 surface needs different markup, raise it for discussion before duplicating.
+- **Don't apply `theme-v2` to `<html>` globally** while migration is in progress — that effectively flips the default and defeats the gradual rollout.
+- **Don't introduce a third theme** ad-hoc. If a route needs a one-off accent, scope it to that route with CSS variables, don't create another `theme-*` class.
+- **Don't put Japanese into v2 UI copy.** Same rule as [`web-ui.md`](web-ui.md); v2 doubles down on it ("Direct, terse, neutral. Sentence case.").

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ Detailed rules live in [`.claude/rules/`](.claude/rules/); the points below appl
 - **Mobile forms are bottom sheets.** Use shadcn `Drawer`, not `Dialog`.
 - **Pages start with [`PageHeader`](apps/web/src/shared/components/page-header/page-header.tsx).** Do not hand-roll titles / action rows.
 - **Logic lives in `useXxx` hooks, not in components.** Components render JSX from destructured hook returns. Verification & full forbidden list: [`.claude/rules/web-hooks-separation.md`](.claude/rules/web-hooks-separation.md).
+- **Theme migration in progress.** Two shadcn/ui themes coexist: the **legacy theme** (default, `:root` / `.dark` in `apps/web/src/index.css`) and **theme v2** (Sapphire 2 Design System, scope class `theme-v2` in the same file). When the user says **"新テーマを使う" / "use the new theme"**, design and apply changes against **v2** — wrap the migrated subtree in `<div className="theme-v2">` and follow the Sapphire 2 design rules. Full migration policy: [`.claude/rules/web-theme.md`](.claude/rules/web-theme.md).
 
 ## Testing
 
@@ -160,6 +161,7 @@ The following rule files live in `.claude/rules/` and are loaded automatically w
 | `web-forms.md` | `apps/web/**` | `@tanstack/react-form` in hooks, no `type="number"`, no placeholders, `SelectWithClear` for clearable selects. |
 | `web-ui.md` | `apps/web/**` | PageHeader, shadcn primitives (Table / Badge / Avatar / RadioGroup), mobile = Drawer, tabler-icons. |
 | `web-data-fetching.md` | `apps/web/**` | Optimistic updates must go through `utils/optimistic-update.ts` helpers. |
+| `web-theme.md` | `apps/web/**` | Legacy ↔ v2 theme coexistence; how to opt a subtree into Sapphire 2 tokens via `theme-v2` scope class. |
 
 ## Maintaining This File (Self-Evolution)
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -135,3 +135,97 @@
 		outline: none !important;
 	}
 }
+
+/* =============================================================================
+   Theme v2 — Sapphire 2 Design System (gradual migration scope)
+   Apply `theme-v2` to a subtree (typically a route layout) to opt that subtree
+   into the new design tokens. The legacy theme remains active everywhere else.
+   See .claude/rules/web-theme.md for usage and migration policy.
+   ============================================================================= */
+
+.theme-v2 {
+	--background: hsl(0 0% 100%);
+	--foreground: hsl(222.2 84% 4.9%);
+	--card: hsl(0 0% 100%);
+	--card-foreground: hsl(222.2 84% 4.9%);
+	--popover: hsl(0 0% 100%);
+	--popover-foreground: hsl(222.2 84% 4.9%);
+	--primary: hsl(221.2 83.2% 53.3%);
+	--primary-foreground: hsl(210 40% 98%);
+	--secondary: hsl(210 40% 96.1%);
+	--secondary-foreground: hsl(222.2 47.4% 11.2%);
+	--muted: hsl(210 40% 96.1%);
+	--muted-foreground: hsl(215.4 16.3% 46.9%);
+	--accent: hsl(210 40% 96.1%);
+	--accent-foreground: hsl(222.2 47.4% 11.2%);
+	--destructive: hsl(0 84.2% 60.2%);
+	--destructive-foreground: hsl(210 40% 98%);
+	--success: hsl(142 71% 45%);
+	--success-foreground: hsl(210 40% 98%);
+	--warning: hsl(38 92% 50%);
+	--warning-foreground: hsl(222.2 47.4% 11.2%);
+	--info: hsl(199 89% 48%);
+	--info-foreground: hsl(210 40% 98%);
+	--border: hsl(214.3 31.8% 91.4%);
+	--input: hsl(214.3 31.8% 91.4%);
+	--ring: hsl(221.2 83.2% 53.3%);
+	--chart-1: hsl(221 83% 53%);
+	--chart-2: hsl(199 89% 48%);
+	--chart-3: hsl(262 83% 58%);
+	--chart-4: hsl(142 71% 45%);
+	--chart-5: hsl(38 92% 50%);
+	--radius: 0.5rem;
+	--sidebar: hsl(210 40% 98%);
+	--sidebar-foreground: hsl(222.2 84% 4.9%);
+	--sidebar-primary: hsl(221.2 83.2% 53.3%);
+	--sidebar-primary-foreground: hsl(210 40% 98%);
+	--sidebar-accent: hsl(210 40% 96.1%);
+	--sidebar-accent-foreground: hsl(222.2 47.4% 11.2%);
+	--sidebar-border: hsl(214.3 31.8% 91.4%);
+	--sidebar-ring: hsl(221.2 83.2% 53.3%);
+
+	font-family: var(--font-sans);
+	font-feature-settings: "cv11", "ss01", "ss03";
+}
+
+.dark .theme-v2,
+.theme-v2.dark {
+	--background: hsl(222.2 84% 4.9%);
+	--foreground: hsl(210 40% 98%);
+	--card: hsl(222.2 84% 4.9%);
+	--card-foreground: hsl(210 40% 98%);
+	--popover: hsl(222.2 84% 4.9%);
+	--popover-foreground: hsl(210 40% 98%);
+	--primary: hsl(217.2 91.2% 59.8%);
+	--primary-foreground: hsl(222.2 47.4% 11.2%);
+	--secondary: hsl(217.2 32.6% 17.5%);
+	--secondary-foreground: hsl(210 40% 98%);
+	--muted: hsl(217.2 32.6% 17.5%);
+	--muted-foreground: hsl(215 20.2% 65.1%);
+	--accent: hsl(217.2 32.6% 17.5%);
+	--accent-foreground: hsl(210 40% 98%);
+	--destructive: hsl(0 62.8% 50%);
+	--destructive-foreground: hsl(210 40% 98%);
+	--success: hsl(142 71% 45%);
+	--success-foreground: hsl(210 40% 98%);
+	--warning: hsl(38 92% 50%);
+	--warning-foreground: hsl(222.2 47.4% 11.2%);
+	--info: hsl(199 89% 48%);
+	--info-foreground: hsl(210 40% 98%);
+	--border: hsl(217.2 32.6% 17.5%);
+	--input: hsl(217.2 32.6% 17.5%);
+	--ring: hsl(224.3 76.3% 48%);
+	--chart-1: hsl(217 91% 60%);
+	--chart-2: hsl(199 89% 60%);
+	--chart-3: hsl(262 83% 70%);
+	--chart-4: hsl(142 71% 55%);
+	--chart-5: hsl(38 92% 60%);
+	--sidebar: hsl(222.2 84% 4.9%);
+	--sidebar-foreground: hsl(210 40% 98%);
+	--sidebar-primary: hsl(217.2 91.2% 59.8%);
+	--sidebar-primary-foreground: hsl(222.2 47.4% 11.2%);
+	--sidebar-accent: hsl(217.2 32.6% 17.5%);
+	--sidebar-accent-foreground: hsl(210 40% 98%);
+	--sidebar-border: hsl(217.2 32.6% 17.5%);
+	--sidebar-ring: hsl(224.3 76.3% 48%);
+}


### PR DESCRIPTION
## Summary

- shadcn/ui の新テーマ「Sapphire 2 Design System」を **スコープクラス方式** で追加し、既存（legacy）テーマと共存させる。これにより段階的に v2 へ移行できる。
- v2 のトークンは `apps/web/src/index.css` の `.theme-v2` / `.dark .theme-v2` ブロックに定義。コンポーネント本体は変更なし — サブツリーを `<div className="theme-v2">` で囲むだけで v2 トークンが適用される。
- 既存（legacy）の `:root` / `.dark` トークンは一切変更していないので、未移行のページには影響なし。

## What's included in v2

設計ハンドオフ（Sapphire 2 Design System: shadcn/ui + Radix + Tailwind, Blue primary, Slate neutrals）に基づき下記をトークン化:

- `--primary`: blue-600（light） / blue-500（dark）
- 中性色は slate に統一（cool blue-tinted gray）
- 新規セマンティック: `--success` / `--warning` / `--info`（v2 スコープ内のみ）
- `--radius: 0.5rem`（8px base）
- font-family を Inter sans に切替（legacy は body が mono のため）+ Inter feature settings (`cv11`, `ss01`, `ss03`)

## Migration policy (shared memory)

`CLAUDE.md` トップに移行期の注意書きを追加し、詳細ルールは `.claude/rules/web-theme.md` に切り出し。

> 「新テーマを使う」と指定があった場合は **v2** を使って設計し、対象サブツリーを `<div className="theme-v2">` で囲む。Sapphire 2 のデザイン原則（sentence case コピー、border-based 構造、focus ring 2px blue、bottom sheet on mobile、no emoji 等）に従う。

Radix Portal は subtree 外にレンダリングされる点は rule ファイルに明記済み（Dialog/Popover/Select/Sonner などは container 渡しか `<html>` 昇格で対応）。

## Test plan

- [x] `bun run lint` 通過
- [x] `bun run check-types` 通過
- [x] legacy トークン（`:root` / `.dark`）に変更がないことを diff で確認
- [ ] v2 を適用した最初のルートで実機確認（次の v2 移行 PR で実施）

https://claude.ai/code/session_01TfNt8vorKfcLC1uPPQSJ33

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfNt8vorKfcLC1uPPQSJ33)_