### PR TITLE
fix(SA2-34): トランザクション追加モーダルからSession Result種別の作成・選択を不可に

### DIFF
--- a/apps/web/src/features/currencies/hooks/__tests__/use-type-combobox.test.ts
+++ b/apps/web/src/features/currencies/hooks/__tests__/use-type-combobox.test.ts
@@ -162,7 +162,7 @@ describe("useTypeCombobox", () => {
 			expect(result.current.canCreate).toBe(true);
 		});
 
-		it("canCreate is false when reservedNames is empty and input matches nothing", () => {
+		it("canCreate is true when reservedNames is empty and input matches nothing", () => {
 			const { result } = renderHook(() =>
 				useTypeCombobox(defaults({ reservedNames: [] }))
 			);

--- a/apps/web/src/features/currencies/hooks/__tests__/use-type-combobox.test.ts
+++ b/apps/web/src/features/currencies/hooks/__tests__/use-type-combobox.test.ts
@@ -137,6 +137,38 @@ describe("useTypeCombobox", () => {
 			act(() => result.current.handleInputChange("   "));
 			expect(result.current.canCreate).toBe(false);
 		});
+
+		it("canCreate is false when input exactly matches a reserved name (case-sensitive)", () => {
+			const { result } = renderHook(() =>
+				useTypeCombobox(defaults({ reservedNames: ["Session Result"] }))
+			);
+			act(() => result.current.handleInputChange("Session Result"));
+			expect(result.current.canCreate).toBe(false);
+		});
+
+		it("canCreate is false when input matches a reserved name case-insensitively", () => {
+			const { result } = renderHook(() =>
+				useTypeCombobox(defaults({ reservedNames: ["Session Result"] }))
+			);
+			act(() => result.current.handleInputChange("session result"));
+			expect(result.current.canCreate).toBe(false);
+		});
+
+		it("canCreate is true for non-reserved input that has no exact match", () => {
+			const { result } = renderHook(() =>
+				useTypeCombobox(defaults({ reservedNames: ["Session Result"] }))
+			);
+			act(() => result.current.handleInputChange("Brand New"));
+			expect(result.current.canCreate).toBe(true);
+		});
+
+		it("canCreate is false when reservedNames is empty and input matches nothing", () => {
+			const { result } = renderHook(() =>
+				useTypeCombobox(defaults({ reservedNames: [] }))
+			);
+			act(() => result.current.handleInputChange("Anything"));
+			expect(result.current.canCreate).toBe(true);
+		});
 	});
 
 	describe("handleSelect", () => {
@@ -243,6 +275,26 @@ describe("useTypeCombobox", () => {
 			);
 			act(() => result.current.handleKeyDown("Enter"));
 			expect(onTypeChange).not.toHaveBeenCalled();
+		});
+
+		it("Enter with reserved name input does not trigger create", () => {
+			const onTypeChange = vi.fn();
+			const onNewTypeNameChange = vi.fn();
+			const { result } = renderHook(() =>
+				useTypeCombobox(
+					defaults({
+						onTypeChange,
+						onNewTypeNameChange,
+						reservedNames: ["Session Result"],
+					})
+				)
+			);
+			act(() => result.current.handleInputChange("Session Result"));
+			act(() => result.current.handleKeyDown("Enter"));
+			expect(onTypeChange).toHaveBeenCalledTimes(1);
+			expect(onTypeChange).toHaveBeenCalledWith("");
+			expect(onNewTypeNameChange).toHaveBeenCalledTimes(1);
+			expect(onNewTypeNameChange).toHaveBeenCalledWith("");
 		});
 
 		it("Escape closes the popover", () => {

--- a/apps/web/src/features/currencies/hooks/use-type-combobox.ts
+++ b/apps/web/src/features/currencies/hooks/use-type-combobox.ts
@@ -6,6 +6,7 @@ interface UseTypeComboboxProps {
 	newTypeName: string;
 	onNewTypeNameChange: (name: string) => void;
 	onTypeChange: (id: string) => void;
+	reservedNames?: readonly string[];
 	typeId: string;
 	types: { id: string; name: string }[];
 }
@@ -14,6 +15,7 @@ export function useTypeCombobox({
 	newTypeName,
 	onNewTypeNameChange,
 	onTypeChange,
+	reservedNames,
 	typeId,
 	types,
 }: UseTypeComboboxProps) {
@@ -48,7 +50,11 @@ export function useTypeCombobox({
 	const exactMatch = types.find(
 		(t) => t.name.toLowerCase() === normalizedInput.toLowerCase()
 	);
-	const canCreate = Boolean(normalizedInput && !exactMatch);
+	const isReserved =
+		reservedNames?.some(
+			(n) => n.toLowerCase() === normalizedInput.toLowerCase()
+		) ?? false;
+	const canCreate = Boolean(normalizedInput && !exactMatch && !isReserved);
 	const shouldShowPopover =
 		isOpen && (types.length > 0 || Boolean(normalizedInput));
 

--- a/apps/web/src/features/currencies/v2/components/transaction-form/__tests__/use-transaction-form.test.ts
+++ b/apps/web/src/features/currencies/v2/components/transaction-form/__tests__/use-transaction-form.test.ts
@@ -33,11 +33,31 @@ describe("useTransactionForm", () => {
 		});
 	});
 
+	it("exposes types from useTransactionTypes with Session Result filtered out", () => {
+		hoisted.useTransactionTypes.mockReturnValue({
+			types: [...TYPES, { id: "t-sr", name: "Session Result" }],
+			createType,
+			isCreatingType: false,
+		});
+		const onSubmit = vi.fn();
+		const { result } = renderHook(() => useTransactionForm({ onSubmit }));
+		expect(result.current.types).toEqual(TYPES);
+		expect(result.current.types.map((t) => t.name)).not.toContain(
+			"Session Result"
+		);
+	});
+
 	it("exposes the list of types from useTransactionTypes", () => {
 		const onSubmit = vi.fn();
 		const { result } = renderHook(() => useTransactionForm({ onSubmit }));
 		expect(result.current.types).toEqual(TYPES);
 		expect(result.current.isCreatingType).toBe(false);
+	});
+
+	it("returns reservedTypeNames containing 'Session Result'", () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(() => useTransactionForm({ onSubmit }));
+		expect(result.current.reservedTypeNames).toContain("Session Result");
 	});
 
 	it("defaults transactedAt to today's ISO date when no defaults provided", () => {

--- a/apps/web/src/features/currencies/v2/components/transaction-form/transaction-form.tsx
+++ b/apps/web/src/features/currencies/v2/components/transaction-form/transaction-form.tsx
@@ -30,6 +30,7 @@ interface TypeComboboxProps {
 	newTypeName: string;
 	onNewTypeNameChange: (name: string) => void;
 	onTypeChange: (id: string) => void;
+	reservedNames?: readonly string[];
 	typeId: string;
 	types: { id: string; name: string }[];
 }
@@ -40,6 +41,7 @@ function TypeCombobox({
 	newTypeName,
 	onNewTypeNameChange,
 	onTypeChange,
+	reservedNames,
 	typeId,
 	types,
 }: TypeComboboxProps) {
@@ -60,6 +62,7 @@ function TypeCombobox({
 		newTypeName,
 		onNewTypeNameChange,
 		onTypeChange,
+		reservedNames,
 		typeId,
 		types,
 	});
@@ -141,7 +144,10 @@ export function TransactionFormV2({
 	formId,
 	onSubmit,
 }: TransactionFormV2Props) {
-	const { form, types } = useTransactionForm({ defaultValues, onSubmit });
+	const { form, types, reservedTypeNames } = useTransactionForm({
+		defaultValues,
+		onSubmit,
+	});
 
 	return (
 		<form
@@ -168,6 +174,7 @@ export function TransactionFormV2({
 									newTypeName={newTypeField.state.value}
 									onNewTypeNameChange={newTypeField.handleChange}
 									onTypeChange={typeField.handleChange}
+									reservedNames={reservedTypeNames}
 									typeId={typeField.state.value}
 									types={types}
 								/>

--- a/apps/web/src/features/currencies/v2/components/transaction-form/use-transaction-form.ts
+++ b/apps/web/src/features/currencies/v2/components/transaction-form/use-transaction-form.ts
@@ -44,11 +44,17 @@ function buildSchema() {
 		});
 }
 
+const RESERVED_TYPE_NAMES = ["Session Result"] as const;
+
 export function useTransactionForm({
 	defaultValues,
 	onSubmit,
 }: UseTransactionFormProps) {
-	const { types, createType, isCreatingType } = useTransactionTypes();
+	const { types: allTypes, createType, isCreatingType } = useTransactionTypes();
+	const types = allTypes.filter(
+		(t) =>
+			!RESERVED_TYPE_NAMES.some((r) => r.toLowerCase() === t.name.toLowerCase())
+	);
 
 	const form = useForm({
 		defaultValues: {
@@ -79,5 +85,10 @@ export function useTransactionForm({
 		},
 	});
 
-	return { form, types, isCreatingType };
+	return {
+		form,
+		types,
+		isCreatingType,
+		reservedTypeNames: RESERVED_TYPE_NAMES,
+	};
 }


### PR DESCRIPTION
## Summary

- `useTypeCombobox` に `reservedNames` プロパティを追加し、予約済み名称と一致する入力に対して `canCreate` を `false` にする（大文字小文字を区別しないマッチ）
- `useTransactionForm` で "Session Result" を `types` リストからフィルタリングし、`reservedTypeNames` を返すよう変更
- `TransactionFormV2` から `TypeCombobox` へ `reservedNames={reservedTypeNames}` を渡す

これにより、v2 のトランザクション追加モーダルから Session Result 種別の選択・新規作成が両方とも不可になります。

## Test plan

- [x] `use-type-combobox` — `reservedNames` あり・なし両方のケースを追加（canCreate、handleKeyDown の Enter キー挙動）
- [x] `use-transaction-form` — Session Result がフィルタリングされること、`reservedTypeNames` に "Session Result" が含まれることを追加
- [x] `bun x vitest run --project web-dom apps/web/src/features/currencies/` → 125 tests pass
- [x] `bun run check-types` → 0 errors
- [x] `bun run lint` → 0 errors

Closes #292

https://claude.ai/code/session_011qz8Aye9Xzhdg3nYKBqd5p

---
_Generated by [Claude Code](https://claude.ai/code/session_011qz8Aye9Xzhdg3nYKBqd5p)_