### PR TITLE
feat(currencies): お気に入り機能の追加 (SA2-24)

### DIFF
--- a/apps/web/src/features/currencies/hooks/__tests__/use-currencies.test.ts
+++ b/apps/web/src/features/currencies/hooks/__tests__/use-currencies.test.ts
@@ -1361,7 +1361,14 @@ describe("useCurrencies", () => {
 		it("flips isFavorite from false to true in the cache immediately", async () => {
 			const qc = createClient();
 			qc.setQueryData(CURRENCY_KEY, [
-				{ id: "c1", name: "Chips", unit: null, balance: 0, isFavorite: false },
+				{
+					id: "c1",
+					name: "Chips",
+					unit: null,
+					balance: 0,
+					isFavorite: false,
+					createdAt: "2024-01-01T00:00:00.000Z",
+				},
 			]);
 			let resolve: ((v: unknown) => void) | undefined;
 			trpcMocks.currencyToggleFavorite.mockImplementation(
@@ -1389,7 +1396,14 @@ describe("useCurrencies", () => {
 		it("flips isFavorite from true to false in the cache immediately", async () => {
 			const qc = createClient();
 			qc.setQueryData(CURRENCY_KEY, [
-				{ id: "c1", name: "Chips", unit: null, balance: 0, isFavorite: true },
+				{
+					id: "c1",
+					name: "Chips",
+					unit: null,
+					balance: 0,
+					isFavorite: true,
+					createdAt: "2024-01-01T00:00:00.000Z",
+				},
 			]);
 			let resolve: ((v: unknown) => void) | undefined;
 			trpcMocks.currencyToggleFavorite.mockImplementation(
@@ -1416,7 +1430,14 @@ describe("useCurrencies", () => {
 
 		it("rolls back to the pre-toggle state when the server rejects", async () => {
 			const original = [
-				{ id: "c1", name: "Chips", unit: null, balance: 0, isFavorite: false },
+				{
+					id: "c1",
+					name: "Chips",
+					unit: null,
+					balance: 0,
+					isFavorite: false,
+					createdAt: "2024-01-01T00:00:00.000Z",
+				},
 			];
 			// The post-error onSettled invalidation triggers a refetch; mirror the
 			// rollback state so the refetch reseeds with the same data onError restores.
@@ -1442,7 +1463,14 @@ describe("useCurrencies", () => {
 		it("isToggleFavoritePending flips true during in-flight mutation", async () => {
 			const qc = createClient();
 			qc.setQueryData(CURRENCY_KEY, [
-				{ id: "c1", name: "Chips", unit: null, balance: 0, isFavorite: false },
+				{
+					id: "c1",
+					name: "Chips",
+					unit: null,
+					balance: 0,
+					isFavorite: false,
+					createdAt: "2024-01-01T00:00:00.000Z",
+				},
 			]);
 			let resolve: ((v: unknown) => void) | undefined;
 			trpcMocks.currencyToggleFavorite.mockImplementation(
@@ -1466,12 +1494,39 @@ describe("useCurrencies", () => {
 			);
 		});
 
-		it("moves the toggled currency to the front when favoriting", async () => {
+		it("places favorited currency at its createdAt position among existing favorites", async () => {
+			// c2 (T3) was non-fav, chronologically between c1(T1) and c3(T4).
+			// After favoriting, sort should interleave it: [c1, c2, c3].
+			// A naive "always move to front/end" or stable sort would give [c1, c3, c2].
+			const T1 = "2024-01-01T00:00:00.000Z";
+			const T3 = "2024-03-01T00:00:00.000Z";
+			const T4 = "2024-04-01T00:00:00.000Z";
 			const qc = createClient();
 			qc.setQueryData(CURRENCY_KEY, [
-				{ id: "c1", name: "Chips", unit: null, balance: 0, isFavorite: false },
-				{ id: "c2", name: "Points", unit: null, balance: 0, isFavorite: false },
-				{ id: "c3", name: "Gold", unit: null, balance: 0, isFavorite: false },
+				{
+					id: "c1",
+					name: "Alpha",
+					unit: null,
+					balance: 0,
+					isFavorite: true,
+					createdAt: T1,
+				},
+				{
+					id: "c3",
+					name: "Gamma",
+					unit: null,
+					balance: 0,
+					isFavorite: true,
+					createdAt: T4,
+				},
+				{
+					id: "c2",
+					name: "Beta",
+					unit: null,
+					balance: 0,
+					isFavorite: false,
+					createdAt: T3,
+				},
 			]);
 			let resolve: ((v: unknown) => void) | undefined;
 			trpcMocks.currencyToggleFavorite.mockImplementation(
@@ -1484,26 +1539,51 @@ describe("useCurrencies", () => {
 				wrapper: makeWrapper(qc),
 			});
 			act(() => {
-				result.current.toggleFavorite("c3");
+				result.current.toggleFavorite("c2");
 			});
 			await waitFor(() => {
 				expect(result.current.currencies.map((c) => c.id)).toEqual([
-					"c3",
 					"c1",
 					"c2",
+					"c3",
 				]);
 			});
-			resolve?.({ id: "c3" });
+			resolve?.({ id: "c2" });
 		});
 
-		it("preserves creation-date order when un-favoriting (stable sort)", async () => {
-			// Server ORDER BY is_favorite DESC, created_at ASC. Cache is already in
-			// server order, so a stable isFavorite sort keeps c1 before c2 — the
-			// same result the server would return if c1 was created first.
+		it("places un-favorited currency at its createdAt position among non-favorites", async () => {
+			// c1 (T2) was fav, chronologically between c2(T1) and c3(T3).
+			// After un-favoriting, sort should interleave it: [c2, c1, c3].
+			// A stable sort would keep c1 before c2 since it was first in the array.
+			const T1 = "2024-01-01T00:00:00.000Z";
+			const T2 = "2024-02-01T00:00:00.000Z";
+			const T3 = "2024-03-01T00:00:00.000Z";
 			const qc = createClient();
 			qc.setQueryData(CURRENCY_KEY, [
-				{ id: "c1", name: "Fav", unit: null, balance: 0, isFavorite: true },
-				{ id: "c2", name: "Normal", unit: null, balance: 0, isFavorite: false },
+				{
+					id: "c1",
+					name: "Fav",
+					unit: null,
+					balance: 0,
+					isFavorite: true,
+					createdAt: T2,
+				},
+				{
+					id: "c2",
+					name: "Old",
+					unit: null,
+					balance: 0,
+					isFavorite: false,
+					createdAt: T1,
+				},
+				{
+					id: "c3",
+					name: "New",
+					unit: null,
+					balance: 0,
+					isFavorite: false,
+					createdAt: T3,
+				},
 			]);
 			let resolve: ((v: unknown) => void) | undefined;
 			trpcMocks.currencyToggleFavorite.mockImplementation(
@@ -1520,8 +1600,9 @@ describe("useCurrencies", () => {
 			});
 			await waitFor(() => {
 				expect(result.current.currencies.map((c) => c.id)).toEqual([
-					"c1",
 					"c2",
+					"c1",
+					"c3",
 				]);
 			});
 			resolve?.({ id: "c1" });

--- a/apps/web/src/features/currencies/hooks/__tests__/use-currencies.test.ts
+++ b/apps/web/src/features/currencies/hooks/__tests__/use-currencies.test.ts
@@ -19,6 +19,10 @@ const trpcMocks = vi.hoisted(() => ({
 	currencyCreate: vi.fn(),
 	currencyUpdate: vi.fn(),
 	currencyDelete: vi.fn(),
+	currencyToggleFavorite: vi.fn(),
+	// queryFn used by useQuery(currency.list). Per-test override controls refetch
+	// payloads (needed for rollback assertions that survive the onSettled refetch).
+	currencyListQueryFn: vi.fn(),
 	txCreate: vi.fn(),
 	txUpdate: vi.fn(),
 	txDelete: vi.fn(),
@@ -34,7 +38,7 @@ vi.mock("@/utils/trpc", () => ({
 			list: {
 				queryOptions: () => ({
 					queryKey: buildKey("currency", "list", undefined),
-					queryFn: () => Promise.resolve([]),
+					queryFn: () => trpcMocks.currencyListQueryFn(),
 				}),
 			},
 		},
@@ -72,6 +76,7 @@ vi.mock("@/utils/trpc", () => ({
 			create: { mutate: trpcMocks.currencyCreate },
 			update: { mutate: trpcMocks.currencyUpdate },
 			delete: { mutate: trpcMocks.currencyDelete },
+			toggleFavorite: { mutate: trpcMocks.currencyToggleFavorite },
 		},
 		currencyTransaction: {
 			create: { mutate: trpcMocks.txCreate },
@@ -130,10 +135,12 @@ describe("useCurrencies", () => {
 		for (const m of Object.values(trpcMocks)) {
 			m.mockReset();
 		}
+		trpcMocks.currencyListQueryFn.mockResolvedValue([]);
 		trpcMocks.txListQueryFn.mockResolvedValue({
 			items: [],
 			nextCursor: undefined,
 		});
+		trpcMocks.currencyToggleFavorite.mockResolvedValue({ id: "c1" });
 	});
 
 	afterEach(() => {
@@ -1347,6 +1354,116 @@ describe("useCurrencies", () => {
 				(result.current as unknown as { resetTransactionState?: unknown })
 					.resetTransactionState
 			).toBeUndefined();
+		});
+	});
+
+	describe("toggleFavorite (楽観的更新)", () => {
+		it("flips isFavorite from false to true in the cache immediately", async () => {
+			const qc = createClient();
+			qc.setQueryData(CURRENCY_KEY, [
+				{ id: "c1", name: "Chips", unit: null, balance: 0, isFavorite: false },
+			]);
+			let resolve: ((v: unknown) => void) | undefined;
+			trpcMocks.currencyToggleFavorite.mockImplementation(
+				() =>
+					new Promise((r) => {
+						resolve = r;
+					})
+			);
+			const { result } = renderHook(() => useCurrencies(null), {
+				wrapper: makeWrapper(qc),
+			});
+			act(() => {
+				result.current.toggleFavorite("c1");
+			});
+			await waitFor(() => {
+				const list =
+					qc.getQueryData<Array<{ id: string; isFavorite: boolean }>>(
+						CURRENCY_KEY
+					);
+				expect(list?.[0]?.isFavorite).toBe(true);
+			});
+			resolve?.({ id: "c1" });
+		});
+
+		it("flips isFavorite from true to false in the cache immediately", async () => {
+			const qc = createClient();
+			qc.setQueryData(CURRENCY_KEY, [
+				{ id: "c1", name: "Chips", unit: null, balance: 0, isFavorite: true },
+			]);
+			let resolve: ((v: unknown) => void) | undefined;
+			trpcMocks.currencyToggleFavorite.mockImplementation(
+				() =>
+					new Promise((r) => {
+						resolve = r;
+					})
+			);
+			const { result } = renderHook(() => useCurrencies(null), {
+				wrapper: makeWrapper(qc),
+			});
+			act(() => {
+				result.current.toggleFavorite("c1");
+			});
+			await waitFor(() => {
+				const list =
+					qc.getQueryData<Array<{ id: string; isFavorite: boolean }>>(
+						CURRENCY_KEY
+					);
+				expect(list?.[0]?.isFavorite).toBe(false);
+			});
+			resolve?.({ id: "c1" });
+		});
+
+		it("rolls back to the pre-toggle state when the server rejects", async () => {
+			const original = [
+				{ id: "c1", name: "Chips", unit: null, balance: 0, isFavorite: false },
+			];
+			// The post-error onSettled invalidation triggers a refetch; mirror the
+			// rollback state so the refetch reseeds with the same data onError restores.
+			trpcMocks.currencyListQueryFn.mockResolvedValue(original);
+			const qc = createClient();
+			qc.setQueryData(CURRENCY_KEY, original);
+			trpcMocks.currencyToggleFavorite.mockRejectedValue(
+				new Error("server error")
+			);
+			const { result } = renderHook(() => useCurrencies(null), {
+				wrapper: makeWrapper(qc),
+			});
+			await act(async () => {
+				await expect(result.current.toggleFavorite("c1")).rejects.toThrow(
+					"server error"
+				);
+			});
+			await waitFor(() =>
+				expect(result.current.currencies[0]?.isFavorite).toBe(false)
+			);
+		});
+
+		it("isToggleFavoritePending flips true during in-flight mutation", async () => {
+			const qc = createClient();
+			qc.setQueryData(CURRENCY_KEY, [
+				{ id: "c1", name: "Chips", unit: null, balance: 0, isFavorite: false },
+			]);
+			let resolve: ((v: unknown) => void) | undefined;
+			trpcMocks.currencyToggleFavorite.mockImplementation(
+				() =>
+					new Promise((r) => {
+						resolve = r;
+					})
+			);
+			const { result } = renderHook(() => useCurrencies(null), {
+				wrapper: makeWrapper(qc),
+			});
+			act(() => {
+				result.current.toggleFavorite("c1");
+			});
+			await waitFor(() =>
+				expect(result.current.isToggleFavoritePending).toBe(true)
+			);
+			resolve?.({ id: "c1" });
+			await waitFor(() =>
+				expect(result.current.isToggleFavoritePending).toBe(false)
+			);
 		});
 	});
 });

--- a/apps/web/src/features/currencies/hooks/__tests__/use-currencies.test.ts
+++ b/apps/web/src/features/currencies/hooks/__tests__/use-currencies.test.ts
@@ -1496,7 +1496,10 @@ describe("useCurrencies", () => {
 			resolve?.({ id: "c3" });
 		});
 
-		it("moves the toggled currency behind non-favorites when un-favoriting", async () => {
+		it("preserves creation-date order when un-favoriting (stable sort)", async () => {
+			// Server ORDER BY is_favorite DESC, created_at ASC. Cache is already in
+			// server order, so a stable isFavorite sort keeps c1 before c2 — the
+			// same result the server would return if c1 was created first.
 			const qc = createClient();
 			qc.setQueryData(CURRENCY_KEY, [
 				{ id: "c1", name: "Fav", unit: null, balance: 0, isFavorite: true },
@@ -1517,8 +1520,8 @@ describe("useCurrencies", () => {
 			});
 			await waitFor(() => {
 				expect(result.current.currencies.map((c) => c.id)).toEqual([
-					"c2",
 					"c1",
+					"c2",
 				]);
 			});
 			resolve?.({ id: "c1" });

--- a/apps/web/src/features/currencies/hooks/__tests__/use-currencies.test.ts
+++ b/apps/web/src/features/currencies/hooks/__tests__/use-currencies.test.ts
@@ -1465,5 +1465,63 @@ describe("useCurrencies", () => {
 				expect(result.current.isToggleFavoritePending).toBe(false)
 			);
 		});
+
+		it("moves the toggled currency to the front when favoriting", async () => {
+			const qc = createClient();
+			qc.setQueryData(CURRENCY_KEY, [
+				{ id: "c1", name: "Chips", unit: null, balance: 0, isFavorite: false },
+				{ id: "c2", name: "Points", unit: null, balance: 0, isFavorite: false },
+				{ id: "c3", name: "Gold", unit: null, balance: 0, isFavorite: false },
+			]);
+			let resolve: ((v: unknown) => void) | undefined;
+			trpcMocks.currencyToggleFavorite.mockImplementation(
+				() =>
+					new Promise((r) => {
+						resolve = r;
+					})
+			);
+			const { result } = renderHook(() => useCurrencies(null), {
+				wrapper: makeWrapper(qc),
+			});
+			act(() => {
+				result.current.toggleFavorite("c3");
+			});
+			await waitFor(() => {
+				expect(result.current.currencies.map((c) => c.id)).toEqual([
+					"c3",
+					"c1",
+					"c2",
+				]);
+			});
+			resolve?.({ id: "c3" });
+		});
+
+		it("moves the toggled currency behind non-favorites when un-favoriting", async () => {
+			const qc = createClient();
+			qc.setQueryData(CURRENCY_KEY, [
+				{ id: "c1", name: "Fav", unit: null, balance: 0, isFavorite: true },
+				{ id: "c2", name: "Normal", unit: null, balance: 0, isFavorite: false },
+			]);
+			let resolve: ((v: unknown) => void) | undefined;
+			trpcMocks.currencyToggleFavorite.mockImplementation(
+				() =>
+					new Promise((r) => {
+						resolve = r;
+					})
+			);
+			const { result } = renderHook(() => useCurrencies(null), {
+				wrapper: makeWrapper(qc),
+			});
+			act(() => {
+				result.current.toggleFavorite("c1");
+			});
+			await waitFor(() => {
+				expect(result.current.currencies.map((c) => c.id)).toEqual([
+					"c2",
+					"c1",
+				]);
+			});
+			resolve?.({ id: "c1" });
+		});
 	});
 });

--- a/apps/web/src/features/currencies/hooks/__tests__/use-currencies.test.ts
+++ b/apps/web/src/features/currencies/hooks/__tests__/use-currencies.test.ts
@@ -288,12 +288,18 @@ describe("useCurrencies", () => {
 			await waitFor(() => {
 				const list =
 					qc.getQueryData<
-						Array<{ id: string; name: string; unit: string | null }>
+						Array<{
+							id: string;
+							name: string;
+							unit: string | null;
+							isFavorite: boolean;
+						}>
 					>(CURRENCY_KEY);
 				expect(list).toHaveLength(2);
 				expect(list?.[1]?.name).toBe("Gold");
 				expect(list?.[1]?.unit).toBe("g");
 				expect(list?.[1]?.id).toMatch(TEMP_ID_PATTERN);
+				expect(list?.[1]?.isFavorite).toBe(false);
 			});
 			resolve?.({ id: "c2" });
 		});

--- a/apps/web/src/features/currencies/hooks/use-currencies.ts
+++ b/apps/web/src/features/currencies/hooks/use-currencies.ts
@@ -27,6 +27,7 @@ export interface TransactionValues {
 }
 
 export interface CurrencyItem {
+	createdAt: Date | string;
 	description?: string | null;
 	id: string;
 	isFavorite: boolean;
@@ -90,6 +91,7 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 						unit: newCurrency.unit ?? null,
 						description: newCurrency.description ?? null,
 						isFavorite: false,
+						createdAt: new Date().toISOString(),
 						balance: 0,
 					},
 				];
@@ -240,15 +242,14 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 				const toggled = old.map((c) =>
 					c.id === id ? { ...c, isFavorite: !c.isFavorite } : c
 				);
-				// Stable sort by isFavorite DESC mirrors the server's
-				// ORDER BY is_favorite DESC, created_at ASC. The cache is already
-				// in server order, so stability preserves the createdAt sub-order
-				// within each group — the toggled item lands at the correct boundary.
+				// Exact replica of server ORDER BY is_favorite DESC, created_at ASC.
 				return [...toggled].sort((a, b) => {
-					if (a.isFavorite === b.isFavorite) {
-						return 0;
+					if (a.isFavorite !== b.isFavorite) {
+						return a.isFavorite ? -1 : 1;
 					}
-					return a.isFavorite ? -1 : 1;
+					return (
+						new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+					);
 				});
 			});
 			return { previous };

--- a/apps/web/src/features/currencies/hooks/use-currencies.ts
+++ b/apps/web/src/features/currencies/hooks/use-currencies.ts
@@ -233,9 +233,25 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 		onMutate: async (id) => {
 			await cancelTargets(queryClient, [{ queryKey: currencyListKey }]);
 			const previous = snapshotQuery(queryClient, currencyListKey);
-			queryClient.setQueryData(currencyListKey, (old) =>
-				old?.map((c) => (c.id === id ? { ...c, isFavorite: !c.isFavorite } : c))
-			);
+			queryClient.setQueryData(currencyListKey, (old) => {
+				if (!old) {
+					return old;
+				}
+				const target = old.find((c) => c.id === id);
+				if (!target) {
+					return old;
+				}
+				const nowFavorite = !target.isFavorite;
+				const updated = { ...target, isFavorite: nowFavorite };
+				const others = old.filter((c) => c.id !== id);
+				const otherFavs = others.filter((c) => c.isFavorite);
+				const otherNonFavs = others.filter((c) => !c.isFavorite);
+				// Mirror server-side ORDER BY is_favorite DESC, created_at ASC:
+				// newly-favorited items go to the front, newly-un-favorited to the end.
+				return nowFavorite
+					? [updated, ...otherFavs, ...otherNonFavs]
+					: [...otherFavs, ...otherNonFavs, updated];
+			});
 			return { previous };
 		},
 		onError: (_err, _vars, context) => {

--- a/apps/web/src/features/currencies/hooks/use-currencies.ts
+++ b/apps/web/src/features/currencies/hooks/use-currencies.ts
@@ -29,6 +29,7 @@ export interface TransactionValues {
 export interface CurrencyItem {
 	description?: string | null;
 	id: string;
+	isFavorite: boolean;
 	name: string;
 	unit?: string | null;
 }
@@ -88,6 +89,7 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 						name: newCurrency.name,
 						unit: newCurrency.unit ?? null,
 						description: newCurrency.description ?? null,
+						isFavorite: false,
 						balance: 0,
 					},
 				];
@@ -225,6 +227,25 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 		},
 	});
 
+	const toggleFavoriteMutation = useMutation({
+		mutationFn: (id: string) =>
+			trpcClient.currency.toggleFavorite.mutate({ id }),
+		onMutate: async (id) => {
+			await cancelTargets(queryClient, [{ queryKey: currencyListKey }]);
+			const previous = snapshotQuery(queryClient, currencyListKey);
+			queryClient.setQueryData(currencyListKey, (old) =>
+				old?.map((c) => (c.id === id ? { ...c, isFavorite: !c.isFavorite } : c))
+			);
+			return { previous };
+		},
+		onError: (_err, _vars, context) => {
+			restoreSnapshots(queryClient, [context?.previous]);
+		},
+		onSettled: () => {
+			invalidateTargets(queryClient, [{ queryKey: currencyListKey }]);
+		},
+	});
+
 	// Load-more is now `fetchNextPage`. The zero-arg wrapper keeps the button's
 	// click event out of `FetchNextPageOptions`, and the guard makes it a no-op
 	// when there is no next page (otherwise React Query would re-fetch page 1)
@@ -248,6 +269,7 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 		isUpdatePending: updateMutation.isPending,
 		isAddTransactionPending: addTransactionMutation.isPending,
 		isEditTransactionPending: editTransactionMutation.isPending,
+		isToggleFavoritePending: toggleFavoriteMutation.isPending,
 		create: (values: CurrencyValues) => createMutation.mutateAsync(values),
 		update: (values: CurrencyValues & { id: string }) =>
 			updateMutation.mutateAsync(values),
@@ -264,6 +286,7 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 		deleteTransaction: (id: string) => {
 			deleteTransactionMutation.mutate(id);
 		},
+		toggleFavorite: (id: string) => toggleFavoriteMutation.mutateAsync(id),
 		fetchNextPage,
 	};
 }

--- a/apps/web/src/features/currencies/hooks/use-currencies.ts
+++ b/apps/web/src/features/currencies/hooks/use-currencies.ts
@@ -237,20 +237,19 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 				if (!old) {
 					return old;
 				}
-				const target = old.find((c) => c.id === id);
-				if (!target) {
-					return old;
-				}
-				const nowFavorite = !target.isFavorite;
-				const updated = { ...target, isFavorite: nowFavorite };
-				const others = old.filter((c) => c.id !== id);
-				const otherFavs = others.filter((c) => c.isFavorite);
-				const otherNonFavs = others.filter((c) => !c.isFavorite);
-				// Mirror server-side ORDER BY is_favorite DESC, created_at ASC:
-				// newly-favorited items go to the front, newly-un-favorited to the end.
-				return nowFavorite
-					? [updated, ...otherFavs, ...otherNonFavs]
-					: [...otherFavs, ...otherNonFavs, updated];
+				const toggled = old.map((c) =>
+					c.id === id ? { ...c, isFavorite: !c.isFavorite } : c
+				);
+				// Stable sort by isFavorite DESC mirrors the server's
+				// ORDER BY is_favorite DESC, created_at ASC. The cache is already
+				// in server order, so stability preserves the createdAt sub-order
+				// within each group — the toggled item lands at the correct boundary.
+				return [...toggled].sort((a, b) => {
+					if (a.isFavorite === b.isFavorite) {
+						return 0;
+					}
+					return a.isFavorite ? -1 : 1;
+				});
 			});
 			return { previous };
 		},

--- a/apps/web/src/features/currencies/v2/components/currency-list-card/__tests__/currency-list-card.test.tsx
+++ b/apps/web/src/features/currencies/v2/components/currency-list-card/__tests__/currency-list-card.test.tsx
@@ -5,14 +5,23 @@ import {
 	RouterProvider,
 } from "@tanstack/react-router";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { CurrencyListCard } from "@/features/currencies/v2/components/currency-list-card";
 
+// biome-ignore lint/suspicious/noEmptyBlockStatements: test helper
+const noop = () => {};
+
 function renderCard(
-	currency: React.ComponentProps<typeof CurrencyListCard>["currency"]
+	currency: React.ComponentProps<typeof CurrencyListCard>["currency"],
+	onToggleFavorite = noop
 ) {
 	const rootRoute = createRootRoute({
-		component: () => <CurrencyListCard currency={currency} />,
+		component: () => (
+			<CurrencyListCard
+				currency={currency}
+				onToggleFavorite={onToggleFavorite}
+			/>
+		),
 	});
 	const detailRoute = createRoute({
 		getParentRoute: () => rootRoute,
@@ -27,47 +36,154 @@ function renderCard(
 
 describe("CurrencyListCard", () => {
 	it("renders the currency name and balance", async () => {
-		renderCard({ id: "c1", name: "Chips", unit: "USD", balance: 1234 });
+		renderCard({
+			id: "c1",
+			name: "Chips",
+			unit: "USD",
+			balance: 1234,
+			isFavorite: false,
+		});
 		expect(await screen.findByText("Chips")).toBeInTheDocument();
 		expect(screen.getByText("1,234")).toBeInTheDocument();
 	});
 
 	it("renders the unit as a suffix to the balance when present", async () => {
-		renderCard({ id: "c1", name: "Chips", unit: "USD", balance: 1234 });
+		renderCard({
+			id: "c1",
+			name: "Chips",
+			unit: "USD",
+			balance: 1234,
+			isFavorite: false,
+		});
 		expect(await screen.findByText("1,234")).toBeInTheDocument();
 		expect(screen.getByText("USD")).toBeInTheDocument();
 	});
 
 	it("omits the unit suffix when unit is null", async () => {
-		renderCard({ id: "c1", name: "Chips", unit: null, balance: 0 });
+		renderCard({
+			id: "c1",
+			name: "Chips",
+			unit: null,
+			balance: 0,
+			isFavorite: false,
+		});
 		expect(await screen.findByText("Chips")).toBeInTheDocument();
 		expect(screen.queryByText("USD")).not.toBeInTheDocument();
 	});
 
 	it("omits the unit suffix when unit is the empty string", async () => {
-		renderCard({ id: "c1", name: "Chips", unit: "", balance: 0 });
+		renderCard({
+			id: "c1",
+			name: "Chips",
+			unit: "",
+			balance: 0,
+			isFavorite: false,
+		});
 		expect(await screen.findByText("Chips")).toBeInTheDocument();
 		expect(screen.queryByText("USD")).not.toBeInTheDocument();
 	});
 
 	it("renders a link to the currency's detail route with the id param", async () => {
-		renderCard({ id: "c42", name: "Chips", unit: null, balance: 0 });
+		renderCard({
+			id: "c42",
+			name: "Chips",
+			unit: null,
+			balance: 0,
+			isFavorite: false,
+		});
 		const link = await screen.findByRole("link");
 		expect(link).toHaveAttribute("href", "/currencies/c42");
 	});
 
 	it("uses compact notation for balances at the 10k boundary", async () => {
-		renderCard({ id: "c1", name: "Chips", unit: null, balance: 10_000 });
+		renderCard({
+			id: "c1",
+			name: "Chips",
+			unit: null,
+			balance: 10_000,
+			isFavorite: false,
+		});
 		expect(await screen.findByText("10k")).toBeInTheDocument();
 	});
 
 	it("renders 0 as plain '0' without compaction", async () => {
-		renderCard({ id: "c1", name: "Chips", unit: null, balance: 0 });
+		renderCard({
+			id: "c1",
+			name: "Chips",
+			unit: null,
+			balance: 0,
+			isFavorite: false,
+		});
 		expect(await screen.findByText("0")).toBeInTheDocument();
 	});
 
 	it("renders negative balances with their native sign", async () => {
-		renderCard({ id: "c1", name: "Chips", unit: null, balance: -500 });
+		renderCard({
+			id: "c1",
+			name: "Chips",
+			unit: null,
+			balance: -500,
+			isFavorite: false,
+		});
 		expect(await screen.findByText("-500")).toBeInTheDocument();
+	});
+
+	describe("favorite star", () => {
+		it("renders a star button with aria-label 'Add to favorites' when isFavorite is false", async () => {
+			renderCard({
+				id: "c1",
+				name: "Chips",
+				unit: null,
+				balance: 0,
+				isFavorite: false,
+			});
+			const btn = await screen.findByRole("button", {
+				name: "Add to favorites",
+			});
+			expect(btn).toBeInTheDocument();
+		});
+
+		it("renders a star button with aria-label 'Remove from favorites' when isFavorite is true", async () => {
+			renderCard({
+				id: "c1",
+				name: "Chips",
+				unit: null,
+				balance: 0,
+				isFavorite: true,
+			});
+			const btn = await screen.findByRole("button", {
+				name: "Remove from favorites",
+			});
+			expect(btn).toBeInTheDocument();
+		});
+
+		it("calls onToggleFavorite when the star button is clicked", async () => {
+			const handler = vi.fn();
+			renderCard(
+				{ id: "c1", name: "Chips", unit: null, balance: 0, isFavorite: false },
+				handler
+			);
+			const btn = await screen.findByRole("button", {
+				name: "Add to favorites",
+			});
+			btn.click();
+			expect(handler).toHaveBeenCalledTimes(1);
+		});
+
+		it("does not navigate to detail page when the star button is clicked", async () => {
+			const handler = vi.fn();
+			renderCard(
+				{ id: "c1", name: "Chips", unit: null, balance: 0, isFavorite: false },
+				handler
+			);
+			const btn = await screen.findByRole("button", {
+				name: "Add to favorites",
+			});
+			const link = screen.getByRole("link");
+			const href = link.getAttribute("href");
+			btn.click();
+			// The link's href must not change — we navigated nowhere.
+			expect(link).toHaveAttribute("href", href);
+		});
 	});
 });

--- a/apps/web/src/features/currencies/v2/components/currency-list-card/currency-list-card.tsx
+++ b/apps/web/src/features/currencies/v2/components/currency-list-card/currency-list-card.tsx
@@ -1,4 +1,8 @@
-import { IconChevronRight } from "@tabler/icons-react";
+import {
+	IconChevronRight,
+	IconStar,
+	IconStarFilled,
+} from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
 import { formatCompactNumber } from "@/utils/format-number";
 
@@ -6,18 +10,38 @@ interface CurrencyListCardProps {
 	currency: {
 		balance: number;
 		id: string;
+		isFavorite: boolean;
 		name: string;
 		unit?: string | null;
 	};
+	onToggleFavorite: () => void;
 }
 
-export function CurrencyListCard({ currency: c }: CurrencyListCardProps) {
+export function CurrencyListCard({
+	currency: c,
+	onToggleFavorite,
+}: CurrencyListCardProps) {
 	return (
 		<Link
 			className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-card-foreground outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
 			params={{ currencyId: c.id }}
 			to="/currencies/$currencyId"
 		>
+			<button
+				aria-label={c.isFavorite ? "Remove from favorites" : "Add to favorites"}
+				className="shrink-0 rounded text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/40"
+				onClick={(e) => {
+					e.preventDefault();
+					onToggleFavorite();
+				}}
+				type="button"
+			>
+				{c.isFavorite ? (
+					<IconStarFilled className="size-4 text-yellow-500" />
+				) : (
+					<IconStar className="size-4" />
+				)}
+			</button>
 			<span className="min-w-0 flex-1 truncate font-medium text-foreground text-sm">
 				{c.name}
 			</span>

--- a/apps/web/src/features/currencies/v2/components/currency-list-card/currency-list-card.tsx
+++ b/apps/web/src/features/currencies/v2/components/currency-list-card/currency-list-card.tsx
@@ -29,7 +29,7 @@ export function CurrencyListCard({
 		>
 			<button
 				aria-label={c.isFavorite ? "Remove from favorites" : "Add to favorites"}
-				className="shrink-0 rounded text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/40"
+				className="-m-1.5 shrink-0 rounded p-1.5 text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/40"
 				onClick={(e) => {
 					e.preventDefault();
 					onToggleFavorite();

--- a/apps/web/src/routes/currencies/$currencyId.tsx
+++ b/apps/web/src/routes/currencies/$currencyId.tsx
@@ -3,6 +3,8 @@ import {
 	IconDotsVertical,
 	IconEdit,
 	IconPlus,
+	IconStar,
+	IconStarFilled,
 	IconTrash,
 } from "@tabler/icons-react";
 import { createFileRoute, Link } from "@tanstack/react-router";
@@ -96,6 +98,7 @@ function CurrencyDetailPage() {
 		fetchNextPage,
 		openEditFromActions,
 		openDeleteFromActions,
+		handleToggleFavorite,
 		openTransactionActions,
 		closeTransactionActions,
 		openEditFromTransactionActions,
@@ -195,6 +198,22 @@ function CurrencyDetailPage() {
 							Edit or delete this currency.
 						</DrawerDescription>
 						<ul className="flex flex-col gap-1 p-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))]">
+							<li>
+								<button
+									className="flex w-full items-center gap-3 rounded-md px-3 py-3 text-left text-foreground text-sm outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/40"
+									onClick={handleToggleFavorite}
+									type="button"
+								>
+									{currency.isFavorite ? (
+										<IconStarFilled className="text-yellow-500" size={18} />
+									) : (
+										<IconStar size={18} />
+									)}
+									{currency.isFavorite
+										? "Remove from favorites"
+										: "Add to favorites"}
+								</button>
+							</li>
 							<li>
 								<button
 									className="flex w-full items-center gap-3 rounded-md px-3 py-3 text-left text-foreground text-sm outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/40"

--- a/apps/web/src/routes/currencies/$currencyId.tsx
+++ b/apps/web/src/routes/currencies/$currencyId.tsx
@@ -137,7 +137,18 @@ function CurrencyDetailPage() {
 		<div className="theme-v2 min-h-full bg-background text-foreground">
 			<div className="p-4">
 				<TopBar onOpenActions={() => setIsActionsOpen(true)} />
-				<PageHeader heading={currency.name} />
+				<PageHeader
+					heading={
+						<span className="flex items-center gap-2">
+							{currency.isFavorite ? (
+								<IconStarFilled className="size-5 shrink-0 text-yellow-500" />
+							) : (
+								<IconStar className="size-5 shrink-0 text-muted-foreground" />
+							)}
+							{currency.name}
+						</span>
+					}
+				/>
 
 				<section
 					aria-label="Balance"

--- a/apps/web/src/routes/currencies/$currencyId.tsx
+++ b/apps/web/src/routes/currencies/$currencyId.tsx
@@ -140,11 +140,22 @@ function CurrencyDetailPage() {
 				<PageHeader
 					heading={
 						<span className="flex items-center gap-2">
-							{currency.isFavorite ? (
-								<IconStarFilled className="size-5 shrink-0 text-yellow-500" />
-							) : (
-								<IconStar className="size-5 shrink-0 text-muted-foreground" />
-							)}
+							<button
+								aria-label={
+									currency.isFavorite
+										? "Remove from favorites"
+										: "Add to favorites"
+								}
+								className="-m-1.5 shrink-0 rounded p-1.5 text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/40"
+								onClick={handleToggleFavorite}
+								type="button"
+							>
+								{currency.isFavorite ? (
+									<IconStarFilled className="size-5 text-yellow-500" />
+								) : (
+									<IconStar className="size-5" />
+								)}
+							</button>
 							{currency.name}
 						</span>
 					}

--- a/apps/web/src/routes/currencies/-use-currencies-page.ts
+++ b/apps/web/src/routes/currencies/-use-currencies-page.ts
@@ -5,12 +5,17 @@ import { useCurrencies } from "@/features/currencies/hooks/use-currencies";
 export function useCurrenciesPage() {
 	const [isCreateOpen, setIsCreateOpen] = useState(false);
 
-	const { currencies, isCreatePending, create } = useCurrencies(null);
+	const { currencies, isCreatePending, create, toggleFavorite } =
+		useCurrencies(null);
 
 	const handleCreate = (values: CurrencyValues) => {
 		create(values).then(() => {
 			setIsCreateOpen(false);
 		});
+	};
+
+	const handleToggleFavorite = (id: string) => {
+		toggleFavorite(id);
 	};
 
 	return {
@@ -19,5 +24,6 @@ export function useCurrenciesPage() {
 		isCreatePending,
 		setIsCreateOpen,
 		handleCreate,
+		handleToggleFavorite,
 	};
 }

--- a/apps/web/src/routes/currencies/-use-currency-detail-page.ts
+++ b/apps/web/src/routes/currencies/-use-currency-detail-page.ts
@@ -11,6 +11,7 @@ export interface CurrencyDetailItem {
 	balance: number;
 	description?: string | null;
 	id: string;
+	isFavorite: boolean;
 	name: string;
 	unit?: string | null;
 }
@@ -36,6 +37,11 @@ export function useCurrencyDetailPage(currencyId: string) {
 	const openDeleteFromActions = () => {
 		setIsActionsOpen(false);
 		setConfirmingDeleteCurrency(true);
+	};
+
+	const handleToggleFavorite = () => {
+		setIsActionsOpen(false);
+		toggleFavorite(currencyId);
 	};
 
 	const openTransactionActions = (transaction: Transaction) => {
@@ -80,6 +86,7 @@ export function useCurrencyDetailPage(currencyId: string) {
 		addTransaction,
 		editTransaction,
 		deleteTransaction,
+		toggleFavorite,
 		fetchNextPage,
 	} = useCurrencies(currencyId);
 
@@ -155,6 +162,7 @@ export function useCurrencyDetailPage(currencyId: string) {
 		fetchNextPage,
 		openEditFromActions,
 		openDeleteFromActions,
+		handleToggleFavorite,
 		openTransactionActions,
 		closeTransactionActions,
 		openEditFromTransactionActions,

--- a/apps/web/src/routes/currencies/__tests__/use-currencies-page.test.ts
+++ b/apps/web/src/routes/currencies/__tests__/use-currencies-page.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
 	create: vi.fn(),
+	toggleFavorite: vi.fn(),
 	lastExpandedId: null as string | null,
 	currencies: [] as Array<{ id: string; name: string; unit?: string | null }>,
 	isCreatePending: false,
@@ -21,6 +22,7 @@ vi.mock("@/features/currencies/hooks/use-currencies", () => ({
 			isUpdatePending: false,
 			isAddTransactionPending: false,
 			isEditTransactionPending: false,
+			isToggleFavoritePending: false,
 			resetTransactionState: vi.fn(),
 			create: mocks.create,
 			update: vi.fn(),
@@ -28,6 +30,7 @@ vi.mock("@/features/currencies/hooks/use-currencies", () => ({
 			addTransaction: vi.fn(),
 			editTransaction: vi.fn(),
 			deleteTransaction: vi.fn(),
+			toggleFavorite: mocks.toggleFavorite,
 			handleLoadMore: vi.fn(),
 		};
 	},
@@ -38,6 +41,7 @@ import { useCurrenciesPage } from "@/routes/currencies/-use-currencies-page";
 describe("useCurrenciesPage", () => {
 	beforeEach(() => {
 		mocks.create.mockReset().mockResolvedValue({ id: "new" });
+		mocks.toggleFavorite.mockReset().mockResolvedValue(undefined);
 		mocks.lastExpandedId = "sentinel";
 		mocks.currencies = [];
 		mocks.isCreatePending = false;
@@ -123,6 +127,17 @@ describe("useCurrenciesPage", () => {
 				await Promise.resolve();
 			});
 			expect(mocks.create).toHaveBeenCalledWith({ name: "JPY" });
+		});
+	});
+
+	describe("handleToggleFavorite", () => {
+		it("delegates to toggleFavorite with the correct id", () => {
+			const { result } = renderHook(() => useCurrenciesPage());
+			act(() => {
+				result.current.handleToggleFavorite("c42");
+			});
+			expect(mocks.toggleFavorite).toHaveBeenCalledTimes(1);
+			expect(mocks.toggleFavorite).toHaveBeenCalledWith("c42");
 		});
 	});
 });

--- a/apps/web/src/routes/currencies/__tests__/use-currencies-page.test.ts
+++ b/apps/web/src/routes/currencies/__tests__/use-currencies-page.test.ts
@@ -5,7 +5,12 @@ const mocks = vi.hoisted(() => ({
 	create: vi.fn(),
 	toggleFavorite: vi.fn(),
 	lastExpandedId: null as string | null,
-	currencies: [] as Array<{ id: string; name: string; unit?: string | null }>,
+	currencies: [] as Array<{
+		id: string;
+		name: string;
+		unit?: string | null;
+		isFavorite: boolean;
+	}>,
 	isCreatePending: false,
 }));
 
@@ -58,11 +63,15 @@ describe("useCurrenciesPage", () => {
 			expect(mocks.lastExpandedId).toBeNull();
 		});
 
-		it("exposes the currencies list straight through", () => {
-			mocks.currencies = [{ id: "c1", name: "USD", unit: "$" }];
+		it("exposes the currencies list straight through including isFavorite", () => {
+			mocks.currencies = [
+				{ id: "c1", name: "USD", unit: "$", isFavorite: true },
+				{ id: "c2", name: "JPY", unit: null, isFavorite: false },
+			];
 			const { result } = renderHook(() => useCurrenciesPage());
 			expect(result.current.currencies).toEqual([
-				{ id: "c1", name: "USD", unit: "$" },
+				{ id: "c1", name: "USD", unit: "$", isFavorite: true },
+				{ id: "c2", name: "JPY", unit: null, isFavorite: false },
 			]);
 		});
 

--- a/apps/web/src/routes/currencies/__tests__/use-currency-detail-page.test.ts
+++ b/apps/web/src/routes/currencies/__tests__/use-currency-detail-page.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
 	addTransaction: vi.fn(),
 	editTransaction: vi.fn(),
 	deleteTransaction: vi.fn(),
+	toggleFavorite: vi.fn(),
 	fetchNextPage: vi.fn(),
 	navigate: vi.fn(),
 	lastExpandedId: null as string | null,
@@ -47,12 +48,14 @@ vi.mock("@/features/currencies/hooks/use-currencies", () => ({
 			isUpdatePending: mocks.isUpdatePending,
 			isAddTransactionPending: mocks.isAddTransactionPending,
 			isEditTransactionPending: mocks.isEditTransactionPending,
+			isToggleFavoritePending: false,
 			create: vi.fn(),
 			update: mocks.update,
 			delete: mocks.del,
 			addTransaction: mocks.addTransaction,
 			editTransaction: mocks.editTransaction,
 			deleteTransaction: mocks.deleteTransaction,
+			toggleFavorite: mocks.toggleFavorite,
 			fetchNextPage: mocks.fetchNextPage,
 		};
 	},
@@ -86,6 +89,7 @@ describe("useCurrencyDetailPage", () => {
 		mocks.addTransaction.mockReset().mockResolvedValue({ id: "tx-new" });
 		mocks.editTransaction.mockReset().mockResolvedValue({ id: "tx-1" });
 		mocks.deleteTransaction.mockReset();
+		mocks.toggleFavorite.mockReset().mockResolvedValue(undefined);
 		mocks.fetchNextPage.mockReset();
 		mocks.navigate.mockReset();
 		mocks.lastExpandedId = null;
@@ -432,6 +436,29 @@ describe("useCurrencyDetailPage", () => {
 		it("is the same reference returned from the inner hook", () => {
 			const { result } = renderHook(() => useCurrencyDetailPage("c1"));
 			expect(result.current.fetchNextPage).toBe(mocks.fetchNextPage);
+		});
+	});
+
+	describe("handleToggleFavorite", () => {
+		it("calls toggleFavorite with the currencyId", () => {
+			const { result } = renderHook(() => useCurrencyDetailPage("c1"));
+			act(() => {
+				result.current.handleToggleFavorite();
+			});
+			expect(mocks.toggleFavorite).toHaveBeenCalledTimes(1);
+			expect(mocks.toggleFavorite).toHaveBeenCalledWith("c1");
+		});
+
+		it("closes the actions drawer when called", () => {
+			const { result } = renderHook(() => useCurrencyDetailPage("c1"));
+			act(() => {
+				result.current.setIsActionsOpen(true);
+			});
+			expect(result.current.isActionsOpen).toBe(true);
+			act(() => {
+				result.current.handleToggleFavorite();
+			});
+			expect(result.current.isActionsOpen).toBe(false);
 		});
 	});
 });

--- a/apps/web/src/routes/currencies/__tests__/use-currency-detail-page.test.ts
+++ b/apps/web/src/routes/currencies/__tests__/use-currency-detail-page.test.ts
@@ -25,6 +25,8 @@ const mocks = vi.hoisted(() => ({
 		name: string;
 		unit?: string | null;
 		balance: number;
+		isFavorite: boolean;
+		createdAt: string;
 	}>,
 	allTransactions: [] as Transaction[],
 	hasNextPage: false,
@@ -72,6 +74,8 @@ const currencyC1 = {
 	name: "USD",
 	unit: "$",
 	balance: 1000,
+	isFavorite: false,
+	createdAt: "2024-01-01T00:00:00.000Z",
 };
 
 const editingTxStub: Transaction = {
@@ -123,6 +127,18 @@ describe("useCurrencyDetailPage", () => {
 			mocks.isLoading = true;
 			const { result } = renderHook(() => useCurrencyDetailPage("c1"));
 			expect(result.current.isLoading).toBe(true);
+		});
+
+		it("currency.isFavorite is false for a non-favorited currency", () => {
+			mocks.currencies = [{ ...currencyC1, isFavorite: false }];
+			const { result } = renderHook(() => useCurrencyDetailPage("c1"));
+			expect(result.current.currency?.isFavorite).toBe(false);
+		});
+
+		it("currency.isFavorite is true for a favorited currency", () => {
+			mocks.currencies = [{ ...currencyC1, isFavorite: true }];
+			const { result } = renderHook(() => useCurrencyDetailPage("c1"));
+			expect(result.current.currency?.isFavorite).toBe(true);
 		});
 	});
 

--- a/apps/web/src/routes/currencies/index.tsx
+++ b/apps/web/src/routes/currencies/index.tsx
@@ -21,6 +21,7 @@ function CurrenciesPage() {
 		isCreatePending,
 		setIsCreateOpen,
 		handleCreate,
+		handleToggleFavorite,
 	} = useCurrenciesPage();
 
 	return (
@@ -51,7 +52,11 @@ function CurrenciesPage() {
 				) : (
 					<div className="flex flex-col gap-2">
 						{currencies.map((c) => (
-							<CurrencyListCard currency={c} key={c.id} />
+							<CurrencyListCard
+								currency={c}
+								key={c.id}
+								onToggleFavorite={() => handleToggleFavorite(c.id)}
+							/>
 						))}
 					</div>
 				)}

--- a/packages/api/src/__tests__/currency.test.ts
+++ b/packages/api/src/__tests__/currency.test.ts
@@ -30,8 +30,12 @@ describe("currency router", () => {
 
 	it("exposes exactly the expected procedure set", () => {
 		expect(Object.keys(appRouter.currency).sort()).toEqual(
-			["create", "delete", "list", "update"].sort()
+			["create", "delete", "list", "toggleFavorite", "update"].sort()
 		);
+	});
+
+	it("has toggleFavorite procedure", () => {
+		expect(appRouter.currency.toggleFavorite).toBeDefined();
 	});
 
 	it("list is a protected query", () => {
@@ -48,6 +52,11 @@ describe("currency router", () => {
 			expectProtected(proc);
 			expectType(proc, "mutation");
 		}
+	});
+
+	it("toggleFavorite is a protected mutation", () => {
+		expectProtected(appRouter.currency.toggleFavorite);
+		expectType(appRouter.currency.toggleFavorite, "mutation");
 	});
 });
 
@@ -171,6 +180,20 @@ describe("currency.delete input validation", () => {
 
 	it("rejects non-string id", () => {
 		expectRejects(appRouter.currency.delete, { id: 42 });
+	});
+});
+
+describe("currency.toggleFavorite input validation", () => {
+	it("accepts a valid id", () => {
+		expectAccepts(appRouter.currency.toggleFavorite, { id: "c1" });
+	});
+
+	it("rejects missing id", () => {
+		expectRejects(appRouter.currency.toggleFavorite, {});
+	});
+
+	it("rejects non-string id", () => {
+		expectRejects(appRouter.currency.toggleFavorite, { id: 42 });
 	});
 });
 

--- a/packages/api/src/routers/currency.ts
+++ b/packages/api/src/routers/currency.ts
@@ -1,6 +1,6 @@
 import { currency, currencyTransaction } from "@sapphire2/db/schema/store";
 import { TRPCError } from "@trpc/server";
-import { eq, sql } from "drizzle-orm";
+import { asc, desc, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
 
@@ -15,6 +15,7 @@ export const currencyRouter = router({
 				name: currency.name,
 				unit: currency.unit,
 				description: currency.description,
+				isFavorite: currency.isFavorite,
 				createdAt: currency.createdAt,
 				updatedAt: currency.updatedAt,
 				balance: sql<number>`COALESCE(SUM(${currencyTransaction.amount}), 0)`,
@@ -25,7 +26,8 @@ export const currencyRouter = router({
 				eq(currencyTransaction.currencyId, currency.id)
 			)
 			.where(eq(currency.userId, userId))
-			.groupBy(currency.id);
+			.groupBy(currency.id)
+			.orderBy(desc(currency.isFavorite), asc(currency.createdAt));
 
 		return currencies;
 	}),
@@ -138,5 +140,40 @@ export const currencyRouter = router({
 
 			await ctx.db.delete(currency).where(eq(currency.id, input.id));
 			return { success: true };
+		}),
+
+	toggleFavorite: protectedProcedure
+		.input(z.object({ id: z.string() }))
+		.mutation(async ({ ctx, input }) => {
+			const userId = ctx.session.user.id;
+			const [found] = await ctx.db
+				.select()
+				.from(currency)
+				.where(eq(currency.id, input.id));
+
+			if (!found) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Currency not found",
+				});
+			}
+
+			if (found.userId !== userId) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "You do not own this currency",
+				});
+			}
+
+			await ctx.db
+				.update(currency)
+				.set({ isFavorite: !found.isFavorite, updatedAt: new Date() })
+				.where(eq(currency.id, input.id));
+
+			const [updated] = await ctx.db
+				.select()
+				.from(currency)
+				.where(eq(currency.id, input.id));
+			return updated;
 		}),
 });

--- a/packages/db/src/__tests__/currency.test.ts
+++ b/packages/db/src/__tests__/currency.test.ts
@@ -15,8 +15,24 @@ describe("Currency schema", () => {
 		expect(columns.name).toBeDefined();
 		expect(columns.unit).toBeDefined();
 		expect(columns.description).toBeDefined();
+		expect(columns.isFavorite).toBeDefined();
 		expect(columns.createdAt).toBeDefined();
 		expect(columns.updatedAt).toBeDefined();
+	});
+
+	it("isFavorite is not null", () => {
+		const columns = getTableColumns(currency);
+		expect(columns.isFavorite.notNull).toBe(true);
+	});
+
+	it("isFavorite has a default value of false", () => {
+		const columns = getTableColumns(currency);
+		expect(columns.isFavorite.hasDefault).toBe(true);
+	});
+
+	it("isFavorite uses boolean mode (stored as integer)", () => {
+		const columns = getTableColumns(currency);
+		expect(columns.isFavorite.dataType).toBe("boolean");
 	});
 
 	it("id is primary key", () => {

--- a/packages/db/src/migrations/0028_currency_add_favorite.sql
+++ b/packages/db/src/migrations/0028_currency_add_favorite.sql
@@ -1,0 +1,2 @@
+-- SA2-24: is_favorite フラグを currency テーブルに追加（デフォルト 0 = 未登録）
+ALTER TABLE currency ADD COLUMN is_favorite INTEGER NOT NULL DEFAULT 0;

--- a/packages/db/src/schema/store.ts
+++ b/packages/db/src/schema/store.ts
@@ -33,6 +33,9 @@ export const currency = sqliteTable(
 		unit: text("unit"),
 		// Optional rich-text description, stored as sanitized HTML (SA2-25).
 		description: text("description"),
+		isFavorite: integer("is_favorite", { mode: "boolean" })
+			.notNull()
+			.default(false),
 		createdAt: integer("created_at", { mode: "timestamp" })
 			.default(sql`(unixepoch())`)
 			.notNull(),


### PR DESCRIPTION
## Summary

- **DB**: `currency` テーブルに `is_favorite` 列を追加（マイグレーション `0028_currency_add_favorite.sql`）
- **API**: `currency.list` にお気に入り先頭ソート（`isFavorite DESC, createdAt ASC`）と `isFavorite` フィールドを追加。`currency.toggleFavorite` ミューテーションを新規追加。ソートはAPIレイヤーで一元管理するため、stores/live-sessions/dashboard など全コンシューマーに自動適用される
- **Web フック**: `use-currencies` に `toggleFavorite` 楽観的更新ミューテーションを追加
- **UI (一覧)**: `CurrencyListCard` に星アイコンボタンを追加。タップで即時トグル、カードのリンク遷移とは独立
- **UI (詳細)**: 通貨詳細ページのアクションシート（⋮メニュー）に「Add to favorites / Remove from favorites」を追加

## Test plan

- [ ] `bunx vitest run --project db packages/db/src/__tests__/currency.test.ts` — DBスキーマテスト
- [ ] `bunx vitest run --project api packages/api/src/__tests__/currency.test.ts` — APIルーターテスト（`toggleFavorite` 含む）
- [ ] `bunx vitest run --project web-dom apps/web/src/features/currencies/hooks/__tests__/use-currencies.test.ts` — 楽観的更新テスト
- [ ] `bunx vitest run --project web-dom apps/web/src/features/currencies/v2/components/currency-list-card/__tests__/currency-list-card.test.tsx` — 星アイコンUIテスト
- [ ] `bunx vitest run --project web-dom apps/web/src/routes/currencies/__tests__/` — ページフックテスト
- [ ] `bun run lint && bun run check-types && bun run test` — CI相当の全チェック（3032テスト全通過確認済み）

https://claude.ai/code/session_018FBtrTXgP67sU9DLz5hpE6

---
_Generated by [Claude Code](https://claude.ai/code/session_018FBtrTXgP67sU9DLz5hpE6)_