### PR TITLE
fix(currencies): 通貨の単位を空欄にしてもクリアされない不具合を修正 (SA2-40)

### DIFF
--- a/apps/web/src/features/currencies/hooks/__tests__/use-currencies.test.ts
+++ b/apps/web/src/features/currencies/hooks/__tests__/use-currencies.test.ts
@@ -436,7 +436,48 @@ describe("useCurrencies", () => {
 			expect(trpcMocks.currencyUpdate).toHaveBeenCalledWith({
 				id: "c1",
 				name: "Chips",
+				unit: null,
 				description: "<p>new</p>",
+			});
+		});
+
+		it("sends an explicit null unit to the server when the unit is cleared", async () => {
+			const qc = createClient();
+			qc.setQueryData(CURRENCY_KEY, [
+				{ id: "c1", name: "Chips", unit: "$", description: null },
+			]);
+			trpcMocks.currencyUpdate.mockResolvedValue({ id: "c1" });
+			const { result } = renderHook(() => useCurrencies(null), {
+				wrapper: makeWrapper(qc),
+			});
+			await act(async () => {
+				await result.current.update({ id: "c1", name: "Chips" });
+			});
+			expect(trpcMocks.currencyUpdate).toHaveBeenCalledWith({
+				id: "c1",
+				name: "Chips",
+				unit: null,
+				description: undefined,
+			});
+		});
+
+		it("forwards a set unit unchanged to the server", async () => {
+			const qc = createClient();
+			qc.setQueryData(CURRENCY_KEY, [
+				{ id: "c1", name: "Chips", unit: null, description: null },
+			]);
+			trpcMocks.currencyUpdate.mockResolvedValue({ id: "c1" });
+			const { result } = renderHook(() => useCurrencies(null), {
+				wrapper: makeWrapper(qc),
+			});
+			await act(async () => {
+				await result.current.update({ id: "c1", name: "Chips", unit: "pt" });
+			});
+			expect(trpcMocks.currencyUpdate).toHaveBeenCalledWith({
+				id: "c1",
+				name: "Chips",
+				unit: "pt",
+				description: undefined,
 			});
 		});
 	});

--- a/apps/web/src/features/currencies/hooks/use-currencies.ts
+++ b/apps/web/src/features/currencies/hooks/use-currencies.ts
@@ -107,8 +107,15 @@ export function useCurrencies(expandedCurrencyId: string | null) {
 	});
 
 	const updateMutation = useMutation({
+		// Send an explicit `null` for a cleared unit so the server overwrites it
+		// rather than treating the omitted (undefined) key as "leave unchanged".
 		mutationFn: (values: CurrencyValues & { id: string }) =>
-			trpcClient.currency.update.mutate(values),
+			trpcClient.currency.update.mutate({
+				id: values.id,
+				name: values.name,
+				unit: values.unit ?? null,
+				description: values.description,
+			}),
 		onMutate: async (updated) => {
 			await cancelTargets(queryClient, [{ queryKey: currencyListKey }]);
 			const previous = snapshotQuery(queryClient, currencyListKey);

--- a/packages/api/src/__tests__/currency.test.ts
+++ b/packages/api/src/__tests__/currency.test.ts
@@ -134,6 +134,10 @@ describe("currency.update input validation", () => {
 		expectAccepts(appRouter.currency.update, { id: "c1", unit: "$" });
 	});
 
+	it("accepts unit cleared to null", () => {
+		expectAccepts(appRouter.currency.update, { id: "c1", unit: null });
+	});
+
 	it("rejects empty name when provided", () => {
 		expectRejects(appRouter.currency.update, { id: "c1", name: "" });
 	});

--- a/packages/api/src/routers/currency.ts
+++ b/packages/api/src/routers/currency.ts
@@ -67,10 +67,13 @@ export const currencyRouter = router({
 			z.object({
 				id: z.string(),
 				name: z.string().min(1).optional(),
+				// Nullable so an explicit `null` clears the unit. `undefined`
+				// (key omitted) still means "leave unchanged".
 				unit: z
 					.string()
 					.max(4)
 					.regex(/^[\x20-\x7e]*$/)
+					.nullable()
 					.optional(),
 				description: z.string().max(50_000).optional().nullable(),
 			})


### PR DESCRIPTION
Linear: [SA2-40 空欄で送信すると値が更新されない](https://linear.app/sapphire2/issue/SA2-40/空欄で送信すると値が更新されない)

## 概要

PR #302 のレビュー指摘（編集モーダルで空欄にして確定すると更新されない / Linear SA2-40）について、**Currency でも同種の不具合が発生していないか調査**した結果、通貨の **単位（unit）** で再現したため修正します（Store/ring-game の修正とは独立した内容のため別PR）。

## 不具合

通貨編集フォームは単位を空欄にすると `undefined` にマップし、tRPC の JSON 送信でキーが欠落します。`currency.update` は `undefined` のフィールドを「変更なし」として無視し、かつ `unit` が nullable でなかったため、**単位を消して確定しても消えません**でした。

> `description` は元々 `nullable` かつ空時に `null` を送る実装になっており、クリア可能です（今回の対象外）。

## 修正

- `currency.update` の `unit` を `nullable` に変更（`undefined` = 変更なし、`null` = クリア、という store の修正と同じ方針）。
- `use-currencies` の update mutation で、クリア時に明示的な `null` を送信。
- 回帰テスト追加:
  - API: `currency.update` が `unit: null` を受理すること。
  - フック: クリア時に `unit: null` を、設定時にその値をサーバーへ送ること。

## 検証

- `bun run check-types` ✅ / `ultracite check` ✅
- `currency` API テスト・`use-currencies` フックテスト green

https://claude.ai/code/session_018QymNGyyKuxWvuJ6JVQyoA