### PR TITLE
ci(review): pre-merge レビューを Opus 化し /review の全体レビューを追加

### DIFF
--- a/.github/workflows/pre-merge-review.yml
+++ b/.github/workflows/pre-merge-review.yml
@@ -1,11 +1,16 @@
-name: Pre-merge review (docs & tests)
+name: Pre-merge review (docs & tests) + general review
 
-# マージ前ゲート: PR の変更範囲に対して
-#   A) 関連する rule / README / docs が最新化されているか
-#   B) テストが CLAUDE.md の TDD 規約が定める粒度を満たしているか
-# のみを AI レビューで検証し、正式レビュー (APPROVE / REQUEST_CHANGES) を投稿する。
-# REQUEST_CHANGES の場合はジョブを fail させるので、このジョブを required status
-# check に設定すればマージをブロックできる（有効化手順は PR / リポジトリ設定側）。
+# 2 系統の AI レビューを走らせる:
+#   1) pre-merge-review (ゲート): PR の変更範囲に対して
+#        A) 関連する rule / README / docs が最新化されているか
+#        B) テストが CLAUDE.md の TDD 規約が定める粒度を満たしているか
+#      のみを検証し、正式レビュー (APPROVE / REQUEST_CHANGES) を投稿する。
+#      REQUEST_CHANGES の場合はジョブを fail させるので、このジョブを required
+#      status check に設定すればマージをブロックできる。
+#   2) general-review (助言): 組込み `/review` で PR 全体をレビューしインライン
+#      コメントを投稿する。ゲートではなく抜け漏れ補完用なので、結果でマージは
+#      ブロックしない。
+# 抜け漏れ低減のため、いずれも Opus を使用する。
 
 on:
   pull_request:
@@ -106,8 +111,8 @@ jobs:
             Be strict but fair: block only on the two axes above, and only on
             issues introduced by THIS PR's diff (not pre-existing problems).
           claude_args: |
-            --max-turns 25
-            --model claude-sonnet-4-6
+            --max-turns 40
+            --model opus
             --allowedTools "Read,Grep,Glob,Write,Bash(gh pr *),Bash(git diff:*),Bash(git log:*)"
 
       - name: Enforce verdict
@@ -122,3 +127,27 @@ jobs:
           if [ "${verdict}" != "APPROVE" ]; then
             echo "::warning::No explicit verdict file was produced; not blocking. Inspect the Claude pre-merge review step."
           fi
+
+  general-review:
+    name: general-review
+    # 助言レビュー。ドラフトは対象外（準備が整った PR のみ）。
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      # 組込み `/review` で PR 全体をレビューしインラインコメントを投稿する。
+      # ゲートではないので verdict ファイルは書かず、結果でマージはブロックしない。
+      - name: Claude general review
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: "/review"
+          claude_args: |
+            --max-turns 40
+            --model opus


### PR DESCRIPTION
## 背景

自動レビュー（`pre-merge-review`）に抜け漏れが多いとのフィードバックを受け、レビュー品質を底上げする。あわせて、2軸ゲート（docs/rules・テスト粒度）だけでなく **PR 全体の一般レビュー** も欲しいという要望に対応する。

直近の `pre-merge-review` は `claude-sonnet-4-6` が **25 turns 上限で途中終了**して判定ファイルを出せず、ジョブが落ちる非決定的フレークが発生していた（差分が大きいPRで顕著）。

## 変更

`.github/workflows/pre-merge-review.yml` のみ:

1. **pre-merge-review（ゲート）を Opus 化**
   - `--model claude-sonnet-4-6` → `--model opus`（最新 Opus をエイリアスで追従）
   - `--max-turns 25` → `--max-turns 40`（ターン上限フレークの低減＋より丁寧なレビューの余地）
   - プロンプト・2軸ロジック・verdict ゲート（`REQUEST_CHANGES` で fail）は不変。

2. **general-review（助言）job を新設**
   - 組込み `/review` で PR 全体をレビューしインラインコメントを投稿。
   - `--model opus` / `--max-turns 40`。
   - **ゲートではない**: verdict ファイルは書かず、結果でマージはブロックしない（抜け漏れ補完用）。ドラフトは対象外。

## 注意

- `pull_request` イベントのワークフローは **ベース（dev）側の定義**で実行されるため、この変更は **dev にマージされて以降の PR** から有効になる（本PR自身の現在の `pre-merge-review` 実行には反映されない）。
- README / docs にこのワークフローの参照はなく（`rg` 確認済み）、ドキュメント同期は不要。

## 検証

- ワークフロー YAML を `yaml.safe_load` でパースし、`jobs: [pre-merge-review, general-review]` を確認。

---
_Generated by [Claude Code](https://claude.ai/code/session_018QymNGyyKuxWvuJ6JVQyoA)_