### PR TITLE
feat(settings): light/dark/system theme toggle (SA2-43)

### DIFF
--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -4,6 +4,7 @@ import { authClient } from "@/lib/auth-client";
 import { LinkedAccounts } from "@/shared/components/linked-accounts";
 import { PageHeader } from "@/shared/components/page-header";
 import { PageSection } from "@/shared/components/page-section";
+import { ThemeSetting } from "@/shared/components/theme-setting";
 import { Button } from "@/shared/components/ui/button";
 
 export const Route = createFileRoute("/settings")({
@@ -37,12 +38,21 @@ function SettingsComponent() {
 				heading="Settings"
 			/>
 
-			<PageSection
-				description="Connect social providers or add an email and password login."
-				heading="Linked Accounts"
-			>
-				<LinkedAccounts />
-			</PageSection>
+			<div className="space-y-6">
+				<PageSection
+					description="Choose a light or dark theme, or follow your system setting."
+					heading="Appearance"
+				>
+					<ThemeSetting />
+				</PageSection>
+
+				<PageSection
+					description="Connect social providers or add an email and password login."
+					heading="Linked Accounts"
+				>
+					<LinkedAccounts />
+				</PageSection>
+			</div>
 		</div>
 	);
 }

--- a/apps/web/src/shared/components/theme-setting/__tests__/use-theme-setting.test.ts
+++ b/apps/web/src/shared/components/theme-setting/__tests__/use-theme-setting.test.ts
@@ -1,0 +1,80 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { THEME_OPTIONS, useThemeSetting } from "../use-theme-setting";
+
+const mocks = vi.hoisted(() => ({
+	setTheme: vi.fn(),
+	theme: undefined as string | undefined,
+}));
+
+vi.mock("next-themes", () => ({
+	useTheme: () => ({
+		setTheme: mocks.setTheme,
+		theme: mocks.theme,
+	}),
+}));
+
+describe("THEME_OPTIONS", () => {
+	it("has 3 options in order: light, dark, system", () => {
+		expect(THEME_OPTIONS).toHaveLength(3);
+		expect(THEME_OPTIONS[0].value).toBe("light");
+		expect(THEME_OPTIONS[0].label).toBe("Light");
+		expect(THEME_OPTIONS[1].value).toBe("dark");
+		expect(THEME_OPTIONS[1].label).toBe("Dark");
+		expect(THEME_OPTIONS[2].value).toBe("system");
+		expect(THEME_OPTIONS[2].label).toBe("System");
+	});
+
+	it("each option has an icon", () => {
+		for (const option of THEME_OPTIONS) {
+			expect(option.icon).toBeDefined();
+		}
+	});
+});
+
+describe("useThemeSetting", () => {
+	it("returns options identical to THEME_OPTIONS", () => {
+		const { result } = renderHook(() => useThemeSetting());
+		expect(result.current.options).toBe(THEME_OPTIONS);
+	});
+
+	it("delegates onValueChange to setTheme with the given value", () => {
+		const { result } = renderHook(() => useThemeSetting());
+
+		act(() => {
+			result.current.onValueChange("light");
+		});
+		expect(mocks.setTheme).toHaveBeenCalledTimes(1);
+		expect(mocks.setTheme).toHaveBeenCalledWith("light");
+
+		act(() => {
+			result.current.onValueChange("dark");
+		});
+		expect(mocks.setTheme).toHaveBeenCalledTimes(2);
+		expect(mocks.setTheme).toHaveBeenNthCalledWith(2, "dark");
+
+		act(() => {
+			result.current.onValueChange("system");
+		});
+		expect(mocks.setTheme).toHaveBeenCalledTimes(3);
+		expect(mocks.setTheme).toHaveBeenNthCalledWith(3, "system");
+	});
+
+	it("returns value reflecting the current theme after mount", () => {
+		mocks.theme = "light";
+		const { result } = renderHook(() => useThemeSetting());
+		expect(result.current.value).toBe("light");
+	});
+
+	it("returns value 'dark' when theme is 'dark'", () => {
+		mocks.theme = "dark";
+		const { result } = renderHook(() => useThemeSetting());
+		expect(result.current.value).toBe("dark");
+	});
+
+	it("returns empty string when theme is undefined", () => {
+		mocks.theme = undefined;
+		const { result } = renderHook(() => useThemeSetting());
+		expect(result.current.value).toBe("");
+	});
+});

--- a/apps/web/src/shared/components/theme-setting/index.ts
+++ b/apps/web/src/shared/components/theme-setting/index.ts
@@ -1,0 +1,1 @@
+export { ThemeSetting } from "./theme-setting";

--- a/apps/web/src/shared/components/theme-setting/theme-setting.test.tsx
+++ b/apps/web/src/shared/components/theme-setting/theme-setting.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ThemeSetting } from "./theme-setting";
+
+const mocks = vi.hoisted(() => ({
+	setTheme: vi.fn(),
+	theme: "dark" as string | undefined,
+}));
+
+vi.mock("next-themes", () => ({
+	useTheme: () => ({
+		setTheme: mocks.setTheme,
+		theme: mocks.theme,
+	}),
+}));
+
+describe("ThemeSetting", () => {
+	it("renders Light, Dark, and System radio options", () => {
+		render(<ThemeSetting />);
+
+		expect(screen.getByRole("radio", { name: "Light" })).toBeInTheDocument();
+		expect(screen.getByRole("radio", { name: "Dark" })).toBeInTheDocument();
+		expect(screen.getByRole("radio", { name: "System" })).toBeInTheDocument();
+	});
+
+	it("has aria-label='Theme' on the radio group", () => {
+		render(<ThemeSetting />);
+
+		expect(
+			screen.getByRole("radiogroup", { name: "Theme" })
+		).toBeInTheDocument();
+	});
+
+	it("marks the current theme option as checked and others as unchecked", () => {
+		mocks.theme = "dark";
+		render(<ThemeSetting />);
+
+		expect(screen.getByRole("radio", { name: "Dark" })).toBeChecked();
+		expect(screen.getByRole("radio", { name: "Light" })).not.toBeChecked();
+		expect(screen.getByRole("radio", { name: "System" })).not.toBeChecked();
+	});
+
+	it("calls setTheme with the selected value when a different option is clicked", async () => {
+		mocks.theme = "dark";
+		mocks.setTheme.mockClear();
+		const user = userEvent.setup();
+
+		render(<ThemeSetting />);
+
+		await user.click(screen.getByRole("radio", { name: "Light" }));
+		expect(mocks.setTheme).toHaveBeenCalledTimes(1);
+		expect(mocks.setTheme).toHaveBeenCalledWith("light");
+	});
+
+	it("does not call setTheme when the currently selected option is clicked (RadioGroup semantics)", async () => {
+		mocks.theme = "dark";
+		mocks.setTheme.mockClear();
+		const user = userEvent.setup();
+
+		render(<ThemeSetting />);
+
+		await user.click(screen.getByRole("radio", { name: "Dark" }));
+		expect(mocks.setTheme).not.toHaveBeenCalled();
+	});
+
+	it("calls setTheme with 'system' when System is clicked", async () => {
+		mocks.theme = "dark";
+		mocks.setTheme.mockClear();
+		const user = userEvent.setup();
+
+		render(<ThemeSetting />);
+
+		await user.click(screen.getByRole("radio", { name: "System" }));
+		expect(mocks.setTheme).toHaveBeenCalledTimes(1);
+		expect(mocks.setTheme).toHaveBeenCalledWith("system");
+	});
+});

--- a/apps/web/src/shared/components/theme-setting/theme-setting.tsx
+++ b/apps/web/src/shared/components/theme-setting/theme-setting.tsx
@@ -1,0 +1,35 @@
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
+import { cn } from "@/lib/utils";
+import { RadioGroup } from "@/shared/components/ui/radio-group";
+import { useThemeSetting } from "./use-theme-setting";
+
+export function ThemeSetting() {
+	const { options, onValueChange, value } = useThemeSetting();
+
+	return (
+		<RadioGroup
+			aria-label="Theme"
+			className="grid grid-cols-3 gap-2"
+			onValueChange={onValueChange}
+			value={value}
+		>
+			{options.map(({ value: optionValue, label, icon: Icon }) => (
+				<RadioGroupPrimitive.Item
+					aria-label={label}
+					className={cn(
+						"flex cursor-pointer flex-col items-center gap-2 rounded-md border border-input bg-card px-3 py-4 font-medium text-sm outline-none transition-colors",
+						"hover:bg-accent hover:text-accent-foreground",
+						"focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50",
+						"disabled:cursor-not-allowed disabled:opacity-50",
+						"data-[state=checked]:border-primary data-[state=checked]:bg-accent data-[state=checked]:text-accent-foreground"
+					)}
+					key={optionValue}
+					value={optionValue}
+				>
+					<Icon size={20} />
+					{label}
+				</RadioGroupPrimitive.Item>
+			))}
+		</RadioGroup>
+	);
+}

--- a/apps/web/src/shared/components/theme-setting/use-theme-setting.ts
+++ b/apps/web/src/shared/components/theme-setting/use-theme-setting.ts
@@ -1,0 +1,18 @@
+import { IconDeviceDesktop, IconMoon, IconSun } from "@tabler/icons-react";
+import { useTheme } from "next-themes";
+
+export const THEME_OPTIONS = [
+	{ value: "light", label: "Light", icon: IconSun },
+	{ value: "dark", label: "Dark", icon: IconMoon },
+	{ value: "system", label: "System", icon: IconDeviceDesktop },
+] as const;
+
+export function useThemeSetting() {
+	const { setTheme, theme } = useTheme();
+
+	return {
+		options: THEME_OPTIONS,
+		onValueChange: setTheme,
+		value: theme ?? "",
+	};
+}


### PR DESCRIPTION
## Summary

- 設定ページ (`/settings`) に **Appearance** セクションを追加し、Light / Dark / System の 3 択 RadioGroup トグルを設置した（SA2-43）
- ロジックは `useThemeSetting` hook に分離（`web-hooks-separation.md` 準拠）
- `next-themes` の `useTheme()` 経由で既存の `ThemeProvider`（`storageKey="vite-ui-theme"`）と連携し、選択はリロードをまたいで localStorage に永続化される
- アイコンは `@tabler/icons-react`（`IconSun` / `IconMoon` / `IconDeviceDesktop`）を使用
- テーマはレガシーのまま（`web-theme.md` 方針: 既存ページは明示指示なしに v2 移行しない）

## New files

- `apps/web/src/shared/components/theme-setting/use-theme-setting.ts` — hook
- `apps/web/src/shared/components/theme-setting/theme-setting.tsx` — presentational component
- `apps/web/src/shared/components/theme-setting/index.ts`
- `apps/web/src/shared/components/theme-setting/__tests__/use-theme-setting.test.ts` — 6 tests
- `apps/web/src/shared/components/theme-setting/theme-setting.test.tsx` — 6 tests

## Test plan

- [ ] `bunx vitest run --project web-dom apps/web/src/shared/components/theme-setting` → 13 tests pass
- [ ] `bun run check-types` → 0 errors
- [ ] `bun run lint` → 0 errors
- [ ] 手動: `/settings` を開き Appearance セクションの Light / Dark / System を切り替えて動作確認
- [ ] リロード後も選択が保持されることを確認

https://claude.ai/code/session_014Ki2VCCobs19oL4Zg32k68

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ki2VCCobs19oL4Zg32k68)_