### PR TITLE
feat: Login/SignUpページをV2 UIに移行 (SA2-49)

### DIFF
--- a/apps/web/src/shared/components/auth-form-shell/auth-form-shell.tsx
+++ b/apps/web/src/shared/components/auth-form-shell/auth-form-shell.tsx
@@ -30,16 +30,16 @@ export function AuthFormShell({
 	title,
 }: AuthFormShellProps) {
 	return (
-		<div className="w-full rounded-2xl border bg-card/95 p-6 shadow-sm backdrop-blur sm:p-8">
+		<div className="w-full rounded-2xl border bg-card/95 p-6 backdrop-blur sm:p-8">
 			<div className="mb-6 space-y-2 text-center">
 				{eyebrow ? (
 					<p className="font-medium text-primary text-xs uppercase tracking-[0.24em]">
 						{eyebrow}
 					</p>
 				) : null}
-				<h1 className="font-bold text-3xl">{title}</h1>
+				<h1 className="t-h2">{title}</h1>
 				{description ? (
-					<p className="text-balance text-muted-foreground text-sm">
+					<p className="t-body text-balance text-muted-foreground">
 						{description}
 					</p>
 				) : null}

--- a/apps/web/src/shared/components/public-page-shell/public-page-shell.tsx
+++ b/apps/web/src/shared/components/public-page-shell/public-page-shell.tsx
@@ -21,7 +21,7 @@ export function PublicPageShell({
 	title,
 }: PublicPageShellProps) {
 	return (
-		<div className="min-h-screen bg-[radial-gradient(circle_at_top,_hsl(var(--primary)/0.14),_transparent_40%),linear-gradient(to_bottom,_hsl(var(--background)),_hsl(var(--muted)/0.3))]">
+		<div className="theme-v2 min-h-screen bg-[radial-gradient(circle_at_top,_hsl(var(--primary)/0.14),_transparent_40%),linear-gradient(to_bottom,_hsl(var(--background)),_hsl(var(--muted)/0.3))]">
 			<div
 				className={cn(
 					"mx-auto flex min-h-screen w-full max-w-6xl flex-col justify-center gap-10 px-4 py-10 sm:px-6 lg:px-8",
@@ -36,9 +36,7 @@ export function PublicPageShell({
 									{eyebrow}
 								</p>
 							) : null}
-							<h1 className="max-w-2xl font-bold text-4xl tracking-tight sm:text-5xl">
-								{title}
-							</h1>
+							<h1 className="t-display max-w-2xl">{title}</h1>
 							<p className="max-w-2xl text-balance text-lg text-muted-foreground">
 								{description}
 							</p>

--- a/apps/web/src/shared/components/sign-in-form/sign-in-form.tsx
+++ b/apps/web/src/shared/components/sign-in-form/sign-in-form.tsx
@@ -34,8 +34,6 @@ export default function SignInForm({
 
 	return (
 		<AuthFormShell
-			description="Use your email and password or continue with a linked provider."
-			eyebrow="Welcome Back"
 			onSwitchMode={onSwitchToSignUp}
 			providerActions={providerActions}
 			switchLabel="Need an account? Sign Up"

--- a/apps/web/src/shared/components/sign-up-form/sign-up-form.tsx
+++ b/apps/web/src/shared/components/sign-up-form/sign-up-form.tsx
@@ -34,8 +34,6 @@ export default function SignUpForm({
 
 	return (
 		<AuthFormShell
-			description="Create your account to start tracking sessions, players, and rooms."
-			eyebrow="New Account"
 			onSwitchMode={onSwitchToSignIn}
 			providerActions={providerActions}
 			switchLabel="Already have an account? Sign In"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `PublicPageShell` の最外側要素に `theme-v2` クラスを追加し、認証ページ全体をv2デザイントークン（blue-600 primary、Noto Sansフォント）に移行
- 左パネルのヒーロー見出しに v2 タイポグラフィクラス `t-display` を適用（36px / font-weight 600 / tight letter-spacing）
- フォームカードのタイトルに `t-h2`、説明文に `t-body` を適用（手書きの `font-bold text-3xl` を置き換え）
- auth フォームカードから `shadow-sm` を削除（v2 デザイン原則: 静止状態のカードはシャドウでなくボーダーで区分）

## Test plan

- [ ] `/login` ページを開き、V2テーマが適用されていることを確認（blue-600 primary、Noto Sansフォント）
- [ ] Sign In / Sign Up の切り替えが正常に動作することを確認
- [ ] フォームカードがシャドウなしのボーダースタイルになっていることを確認
- [ ] ダークモードで正しく表示されることを確認
- [ ] 既存のauth formテスト (24件) がパスすることを確認

Closes SA2-49

https://claude.ai/code/session_01BnKonrjPTkabgdveNrvfjm
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnKonrjPTkabgdveNrvfjm)_