### PR TITLE
release: v3.0.0 (fix release.yml — move gh commands to run: steps)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,12 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(gh release create*)",
+      "Bash(gh release view*)",
+      "Bash(gh pr comment*)",
+      "Bash(gh pr review*)"
+    ]
+  },
   "hooks": {
     "Stop": [
       {

--- a/.github/workflows/pre-merge-review.yml
+++ b/.github/workflows/pre-merge-review.yml
@@ -27,15 +27,31 @@ jobs:
 
       - name: Claude review
         uses: anthropics/claude-code-action@v1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             /review
 
-            After completing the review, always post a comment on this PR summarizing the findings.
-            If no issues were found, post a comment confirming the review passed with no problems (e.g. "LGTM" with a brief summary).
+            After completing the review, write a Markdown summary of your findings
+            to `/tmp/review-summary.md` (no surrounding code fence). If no issues were
+            found, write a short confirmation that the review passed with no problems
+            (e.g. "LGTM" with a brief summary).
+
+            Do NOT run any gh commands and do NOT try to post a comment yourself —
+            posting is handled by a later workflow step that reads /tmp/review-summary.md.
           claude_args: |
             --max-turns 40
             --model opus
+
+      - name: Post review summary comment
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -s /tmp/review-summary.md ]; then
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/review-summary.md
+          else
+            echo "::warning::Claude did not produce /tmp/review-summary.md; skipping comment."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,49 +36,45 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved version: $VERSION"
 
-      - name: Run Claude Code to draft release notes and publish release
+      - name: Generate release notes with Claude
         uses: anthropics/claude-code-action@v1
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
           prompt: |
-            You are running headlessly in CI to publish a sapphire2 release.
+            You are running headlessly in CI to generate release notes for a sapphire2 release.
 
-            Inputs from environment:
-            - RELEASE_VERSION: the new version tag, e.g. `v1.5.0`
-            - PR_NUMBER: the merged release PR number
-            - REPO: the GitHub repo in `owner/name` form
+            The new version is: $RELEASE_VERSION
 
-            Execute these steps in order. There is no interactive user; do not ask
-            questions. If anything fails, surface the error and stop.
+            Execute these steps in order. There is no interactive user; do not ask questions.
+            If anything fails, surface the error and stop.
 
-            1. Invoke the `/create-update-notes` skill with `$RELEASE_VERSION` as the
-               argument. Follow its Execution Flow steps 1–6 verbatim, but apply
-               these CI overrides:
+            1. Invoke the `/create-update-notes` skill with `$RELEASE_VERSION` as the argument.
+               Follow its Execution Flow steps 1–6 verbatim, but apply these CI overrides:
                  - Skip step 7 entirely (no interactive review round-trip).
                  - In step 8, do NOT print the final block to the user; instead write
                    only the Markdown body (without the surrounding ```markdown fence)
                    to `/tmp/release-notes.md`.
-               The skill's "must never publish" rule is explicitly waived for this
-               CI invocation — publishing is required and is handled below.
+               The skill's "must never publish" rule is explicitly waived for this CI invocation.
 
-            2. Create and publish the GitHub Release. This creates the git tag
-               automatically:
-                 gh release create "$RELEASE_VERSION" \
-                   --repo "$REPO" \
-                   --title "$RELEASE_VERSION" \
-                   --notes-file /tmp/release-notes.md \
-                   --target main
+            Stop after writing /tmp/release-notes.md. Do NOT run any gh commands.
 
-            3. Capture the release URL from gh and post a comment on the merged PR:
-                 RELEASE_URL=$(gh release view "$RELEASE_VERSION" --repo "$REPO" --json url --jq .url)
-                 gh pr comment "$PR_NUMBER" --repo "$REPO" \
-                   --body "Released as **$RELEASE_VERSION** → $RELEASE_URL"
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh release create "$RELEASE_VERSION" \
+            --repo "$REPO" \
+            --title "$RELEASE_VERSION" \
+            --notes-file /tmp/release-notes.md \
+            --target main
 
-            Stop after step 3. Do not modify any files in the repo.
+          RELEASE_URL=$(gh release view "$RELEASE_VERSION" --repo "$REPO" --json url --jq .url)
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body "Released as **$RELEASE_VERSION** → $RELEASE_URL"


### PR DESCRIPTION
## v3.0.0 リリース再々試行 + release.yml 根本修正

### 問題

`release.yml` が Claude Code に `gh release create` / `gh pr comment` を実行させていたが、CI ヘッドレス環境では Claude Code の permission プロンプトが自動的に拒否されるため、GitHub Release が作成されなかった (#333 で 22 件、#334 で 21 件の permission denial)。

`.claude/settings.json` に `gh` コマンドを allowlist 追加しても効果がなかった（`origin/main` から設定が復元されるタイミングと適用の問題と思われる）。

### 修正内容

`release.yml` を再構成：

- **変更前**: Claude Code が `/create-update-notes` + `gh release create` + `gh pr comment` をすべて実行
- **変更後**: Claude Code は `/create-update-notes` でノート生成のみ → `run:` ステップで `gh release create` / `gh pr comment` を実行

`run:` ステップは Claude Code の permission 機構を経由しないため、`GITHUB_TOKEN` があれば確実に実行される。

このPRのマージで v3.0.0 GitHub Release が自動作成されます。

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeaAYdXpEVayRdLUWmqjPa)_