### PR TITLE
feat(SA2-56): 通貨詳細ページのセッション結果行にセッション名とリンクを追加

### DIFF
--- a/apps/web/src/features/currencies/hooks/use-currencies.ts
+++ b/apps/web/src/features/currencies/hooks/use-currencies.ts
@@ -41,6 +41,8 @@ export interface Transaction {
 	currencyId?: string;
 	id: string;
 	memo?: string | null;
+	sessionId?: string | null;
+	sessionName?: string | null;
 	transactedAt: Date | string;
 	transactionTypeId?: string;
 	transactionTypeName: string;

--- a/apps/web/src/features/currencies/hooks/use-currencies.ts
+++ b/apps/web/src/features/currencies/hooks/use-currencies.ts
@@ -4,6 +4,10 @@ import {
 	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
+
+export type { Transaction } from "@/features/currencies/utils/types";
+
+import type { Transaction } from "@/features/currencies/utils/types";
 import {
 	cancelTargets,
 	invalidateTargets,
@@ -12,9 +16,6 @@ import {
 	updateInfiniteQueryItems,
 } from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
-import type { Transaction } from "@/features/currencies/utils/types";
-
-export type { Transaction };
 
 export interface CurrencyValues {
 	description?: string | null;

--- a/apps/web/src/features/currencies/hooks/use-currencies.ts
+++ b/apps/web/src/features/currencies/hooks/use-currencies.ts
@@ -12,6 +12,9 @@ import {
 	updateInfiniteQueryItems,
 } from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
+import type { Transaction } from "@/features/currencies/utils/types";
+
+export type { Transaction };
 
 export interface CurrencyValues {
 	description?: string | null;
@@ -33,19 +36,6 @@ export interface CurrencyItem {
 	isFavorite: boolean;
 	name: string;
 	unit?: string | null;
-}
-
-export interface Transaction {
-	amount: number;
-	createdAt?: Date | string;
-	currencyId?: string;
-	id: string;
-	memo?: string | null;
-	sessionId?: string | null;
-	sessionName?: string | null;
-	transactedAt: Date | string;
-	transactionTypeId?: string;
-	transactionTypeName: string;
 }
 
 export function useCurrencies(expandedCurrencyId: string | null) {

--- a/apps/web/src/features/currencies/pages/currency-detail-page/__tests__/currency-detail-page.test.tsx
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/__tests__/currency-detail-page.test.tsx
@@ -140,9 +140,11 @@ vi.mock(
 	() => ({
 		TransactionListV2: ({
 			onLoadMore,
+			onNavigateToSession,
 			onOpenActions,
 		}: {
 			onLoadMore?: () => void;
+			onNavigateToSession?: (sessionId: string) => void;
 			onOpenActions?: (tx: { id: string }) => void;
 		}) => (
 			<div data-testid="transaction-list-stub">
@@ -151,6 +153,12 @@ vi.mock(
 				</button>
 				<button onClick={() => onLoadMore?.()} type="button">
 					stub-load-more
+				</button>
+				<button
+					onClick={() => onNavigateToSession?.("session-xyz")}
+					type="button"
+				>
+					stub-navigate-to-session
 				</button>
 			</div>
 		),
@@ -233,6 +241,7 @@ function baseState() {
 		openDeleteFromTransactionActions: vi.fn(),
 		cancelDeleteTransaction: vi.fn(),
 		handleConfirmDeleteTransaction: vi.fn(),
+		handleNavigateToSession: vi.fn(),
 	};
 }
 
@@ -388,6 +397,17 @@ describe("CurrencyDetailPage", () => {
 			render(<Component />);
 			await user.click(screen.getByRole("button", { name: "stub-load-more" }));
 			expect(state.fetchNextPage).toHaveBeenCalledTimes(1);
+		});
+
+		it("wires the transaction list onNavigateToSession to handleNavigateToSession", async () => {
+			const user = userEvent.setup();
+			const state = setState();
+			render(<Component />);
+			await user.click(
+				screen.getByRole("button", { name: "stub-navigate-to-session" })
+			);
+			expect(state.handleNavigateToSession).toHaveBeenCalledTimes(1);
+			expect(state.handleNavigateToSession).toHaveBeenCalledWith("session-xyz");
 		});
 	});
 

--- a/apps/web/src/features/currencies/pages/currency-detail-page/__tests__/use-currency-detail-page.test.ts
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/__tests__/use-currency-detail-page.test.ts
@@ -483,13 +483,6 @@ describe("useCurrencyDetailPage", () => {
 			});
 		});
 
-		it("does not navigate when called without a sessionId", () => {
-			const { result } = renderHook(() => useCurrencyDetailPage("c1"));
-			act(() => {
-				result.current.handleNavigateToSession("");
-			});
-			expect(mocks.navigate).not.toHaveBeenCalled();
-		});
 	});
 
 	describe("handleToggleFavorite", () => {

--- a/apps/web/src/features/currencies/pages/currency-detail-page/__tests__/use-currency-detail-page.test.ts
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/__tests__/use-currency-detail-page.test.ts
@@ -470,6 +470,28 @@ describe("useCurrencyDetailPage", () => {
 		});
 	});
 
+	describe("handleNavigateToSession", () => {
+		it("navigates to the session detail page with the given sessionId", () => {
+			const { result } = renderHook(() => useCurrencyDetailPage("c1"));
+			act(() => {
+				result.current.handleNavigateToSession("session-abc");
+			});
+			expect(mocks.navigate).toHaveBeenCalledTimes(1);
+			expect(mocks.navigate).toHaveBeenCalledWith({
+				to: "/sessions/$sessionId",
+				params: { sessionId: "session-abc" },
+			});
+		});
+
+		it("does not navigate when called without a sessionId", () => {
+			const { result } = renderHook(() => useCurrencyDetailPage("c1"));
+			act(() => {
+				result.current.handleNavigateToSession("");
+			});
+			expect(mocks.navigate).not.toHaveBeenCalled();
+		});
+	});
+
 	describe("handleToggleFavorite", () => {
 		it("calls toggleFavorite with the currencyId", () => {
 			const { result } = renderHook(() => useCurrencyDetailPage("c1"));

--- a/apps/web/src/features/currencies/pages/currency-detail-page/__tests__/use-currency-detail-page.test.ts
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/__tests__/use-currency-detail-page.test.ts
@@ -482,7 +482,6 @@ describe("useCurrencyDetailPage", () => {
 				params: { sessionId: "session-abc" },
 			});
 		});
-
 	});
 
 	describe("handleToggleFavorite", () => {

--- a/apps/web/src/features/currencies/pages/currency-detail-page/currency-detail-page.tsx
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/currency-detail-page.tsx
@@ -60,6 +60,7 @@ export function CurrencyDetailPage({ currencyId }: CurrencyDetailPageProps) {
 		openDeleteFromTransactionActions,
 		cancelDeleteTransaction,
 		handleConfirmDeleteTransaction,
+		handleNavigateToSession,
 	} = useCurrencyDetailPage(currencyId);
 
 	if (isLoading) {
@@ -138,6 +139,7 @@ export function CurrencyDetailPage({ currencyId }: CurrencyDetailPageProps) {
 						isLoading={isTransactionsLoading}
 						isLoadingMore={isFetchingNextPage}
 						onLoadMore={fetchNextPage}
+						onNavigateToSession={handleNavigateToSession}
 						onOpenActions={openTransactionActions}
 						transactions={transactions}
 					/>

--- a/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/__tests__/transaction-list.test.tsx
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/__tests__/transaction-list.test.tsx
@@ -12,6 +12,7 @@ const regularTransaction = {
 	transactionTypeName: "Purchase",
 	transactedAt: "2026-03-20T10:00:00Z",
 	sessionId: null,
+	sessionName: null,
 	memo: "Regular transaction",
 };
 
@@ -21,6 +22,7 @@ const sessionTransaction = {
 	transactionTypeName: "Session Result",
 	transactedAt: "2026-03-20T12:00:00Z",
 	sessionId: "session-1",
+	sessionName: "NLH 1/2",
 	memo: null,
 };
 
@@ -153,11 +155,11 @@ describe("TransactionListV2", () => {
 		expect(screen.getByRole("button", { name: "Loading..." })).toBeDisabled();
 	});
 
-	it("reserves the same width on session rows as the action button takes on editable rows so the amount column stays aligned", () => {
+	it("reserves the same width on session rows as the action button takes on editable rows so the amount column stays aligned (no onNavigateToSession)", () => {
 		// The 3-dots IconButton uses size="icon-sm" which renders at
 		// --h-control-sm = 2rem = 32px = size-8. The placeholder span on
-		// session rows must match so the right-edge of the amount column
-		// is identical across both row types.
+		// session rows without a navigation handler must match so the right-edge
+		// of the amount column is identical across both row types.
 		const { container } = render(
 			<TransactionListV2
 				onOpenActions={vi.fn()}
@@ -167,6 +169,79 @@ describe("TransactionListV2", () => {
 		const placeholder = container.querySelector("span[aria-hidden]");
 		expect(placeholder).not.toBeNull();
 		expect(placeholder?.className).toMatch(SIZE_8_CLASS);
+	});
+
+	it("displays the session name in the memo column for session-generated rows", () => {
+		render(<TransactionListV2 transactions={[sessionTransaction]} />);
+		expect(screen.getByText("NLH 1/2")).toBeInTheDocument();
+	});
+
+	it("does not show the session name for regular (non-session) rows", () => {
+		render(<TransactionListV2 transactions={[regularTransaction]} />);
+		expect(screen.queryByText("NLH 1/2")).not.toBeInTheDocument();
+	});
+
+	it("shows an empty memo cell when sessionName is null for a session row", () => {
+		render(
+			<TransactionListV2
+				transactions={[{ ...sessionTransaction, sessionName: null }]}
+			/>
+		);
+		// Session row should not show the regular memo or any session name
+		expect(screen.queryByText("Regular transaction")).not.toBeInTheDocument();
+	});
+
+	it("shows a chevron indicator on session rows when onNavigateToSession is provided", () => {
+		const { container } = render(
+			<TransactionListV2
+				onNavigateToSession={vi.fn()}
+				transactions={[sessionTransaction]}
+			/>
+		);
+		// The chevron span preserves size-8 alignment like the action button
+		const chevronSpan = container.querySelector("span[aria-hidden]");
+		expect(chevronSpan).not.toBeNull();
+		expect(chevronSpan?.className).toMatch(SIZE_8_CLASS);
+	});
+
+	it("does not show the placeholder span on session rows when onNavigateToSession is provided", () => {
+		const { container } = render(
+			<TransactionListV2
+				onNavigateToSession={vi.fn()}
+				transactions={[sessionTransaction]}
+			/>
+		);
+		// Only one aria-hidden span (the chevron) should exist, not the plain placeholder
+		const spans = container.querySelectorAll("span[aria-hidden]");
+		expect(spans).toHaveLength(1);
+	});
+
+	it("calls onNavigateToSession with the sessionId when a session row is clicked", async () => {
+		const user = userEvent.setup();
+		const onNavigateToSession = vi.fn();
+		render(
+			<TransactionListV2
+				onNavigateToSession={onNavigateToSession}
+				transactions={[sessionTransaction]}
+			/>
+		);
+		// Click on the session name text (inside the row)
+		await user.click(screen.getByText("NLH 1/2"));
+		expect(onNavigateToSession).toHaveBeenCalledTimes(1);
+		expect(onNavigateToSession).toHaveBeenCalledWith("session-1");
+	});
+
+	it("does not call onNavigateToSession when a regular transaction row is clicked", async () => {
+		const user = userEvent.setup();
+		const onNavigateToSession = vi.fn();
+		render(
+			<TransactionListV2
+				onNavigateToSession={onNavigateToSession}
+				transactions={[regularTransaction]}
+			/>
+		);
+		await user.click(screen.getByText("Regular transaction"));
+		expect(onNavigateToSession).not.toHaveBeenCalled();
 	});
 
 	it("calls onLoadMore when the Load more button is clicked", async () => {

--- a/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-list.tsx
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-list.tsx
@@ -20,6 +20,8 @@ interface TransactionListV2Props {
 	isLoading?: boolean;
 	isLoadingMore?: boolean;
 	onLoadMore?: () => void;
+	/** Called when a session-generated row is clicked. Navigates to the session detail page. */
+	onNavigateToSession?: (sessionId: string) => void;
 	/**
 	 * Called when the trailing 3-dots overflow button is tapped on a
 	 * non-session row. The page opens an action sheet (Edit / Delete)
@@ -35,6 +37,7 @@ const COLUMN_COUNT = 4;
 
 export function TransactionListV2({
 	transactions,
+	onNavigateToSession,
 	onOpenActions,
 	hasMore,
 	isLoading,
@@ -88,6 +91,7 @@ export function TransactionListV2({
 								<TransactionRow
 									fmt={fmt}
 									key={tx.id}
+									onNavigateToSession={onNavigateToSession}
 									onOpenActions={onOpenActions}
 									transaction={tx}
 								/>

--- a/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-row/index.ts
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-row/index.ts
@@ -1,2 +1,2 @@
-export { type Transaction } from "@/features/currencies/utils/types";
+export type { Transaction } from "@/features/currencies/utils/types";
 export { TransactionRow } from "./transaction-row";

--- a/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-row/index.ts
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-row/index.ts
@@ -1,1 +1,2 @@
-export { type Transaction, TransactionRow } from "./transaction-row";
+export { type Transaction } from "@/features/currencies/utils/types";
+export { TransactionRow } from "./transaction-row";

--- a/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-row/transaction-row.tsx
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-row/transaction-row.tsx
@@ -1,4 +1,4 @@
-import { IconDotsVertical } from "@tabler/icons-react";
+import { IconChevronRight, IconDotsVertical } from "@tabler/icons-react";
 import {
 	getAmountColorClass,
 	getAmountDisplay,
@@ -12,6 +12,7 @@ export interface Transaction {
 	id: string;
 	memo?: string | null;
 	sessionId?: string | null;
+	sessionName?: string | null;
 	transactedAt: Date | string;
 	transactionTypeName: string;
 }
@@ -20,12 +21,53 @@ const COMPACT_CELL = "px-3 py-1.5 align-middle";
 
 interface TransactionRowProps {
 	fmt: (n: number) => string;
+	onNavigateToSession?: (sessionId: string) => void;
 	onOpenActions?: (transaction: Transaction) => void;
 	transaction: Transaction;
 }
 
+function ActionCell({
+	isNavigable,
+	isSessionGenerated,
+	onNavigateToSession,
+	onOpenActions,
+	tx,
+}: {
+	isNavigable: boolean;
+	isSessionGenerated: boolean;
+	onNavigateToSession?: (sessionId: string) => void;
+	onOpenActions?: (transaction: Transaction) => void;
+	tx: Transaction;
+}) {
+	if (isNavigable && onNavigateToSession && tx.sessionId) {
+		return (
+			<span
+				aria-hidden
+				className="flex size-8 items-center justify-center text-muted-foreground"
+			>
+				<IconChevronRight className="size-4" />
+			</span>
+		);
+	}
+	if (isSessionGenerated || !onOpenActions) {
+		return <span aria-hidden className="block size-8" />;
+	}
+	return (
+		<Button
+			aria-label="Transaction actions"
+			onClick={() => onOpenActions(tx)}
+			size="icon-sm"
+			type="button"
+			variant="ghost"
+		>
+			<IconDotsVertical className="size-4" />
+		</Button>
+	);
+}
+
 export function TransactionRow({
 	fmt,
+	onNavigateToSession,
 	onOpenActions,
 	transaction,
 }: TransactionRowProps) {
@@ -33,9 +75,26 @@ export function TransactionRow({
 	const amountClass = getAmountColorClass(tx.amount);
 	const amountDisplay = getAmountDisplay(tx.amount, fmt);
 	const isSessionGenerated = !!tx.sessionId;
+	const isNavigable =
+		isSessionGenerated && !!onNavigateToSession && !!tx.sessionId;
+
+	const handleRowClick = isNavigable
+		? () => {
+				if (onNavigateToSession && tx.sessionId) {
+					onNavigateToSession(tx.sessionId);
+				}
+			}
+		: undefined;
 
 	return (
-		<TableRow className="hover:bg-transparent">
+		<TableRow
+			className={
+				isNavigable
+					? "cursor-pointer hover:bg-muted/50"
+					: "hover:bg-transparent"
+			}
+			onClick={handleRowClick}
+		>
 			<TableCell className={`${COMPACT_CELL} w-px`}>
 				{isSessionGenerated ? (
 					<Badge className="shrink-0 text-[10px]" variant="secondary">
@@ -50,7 +109,7 @@ export function TransactionRow({
 			<TableCell
 				className={`${COMPACT_CELL} max-w-0 truncate text-muted-foreground text-xs`}
 			>
-				{tx.memo ?? ""}
+				{isSessionGenerated ? (tx.sessionName ?? "") : (tx.memo ?? "")}
 			</TableCell>
 			<TableCell
 				className={`${COMPACT_CELL} w-px text-right font-mono font-semibold text-sm tabular-nums`}
@@ -58,19 +117,13 @@ export function TransactionRow({
 				<span className={amountClass}>{amountDisplay}</span>
 			</TableCell>
 			<TableCell className={`${COMPACT_CELL} w-px pl-0`}>
-				{isSessionGenerated || !onOpenActions ? (
-					<span aria-hidden className="block size-8" />
-				) : (
-					<Button
-						aria-label="Transaction actions"
-						onClick={() => onOpenActions(tx)}
-						size="icon-sm"
-						type="button"
-						variant="ghost"
-					>
-						<IconDotsVertical className="size-4" />
-					</Button>
-				)}
+				<ActionCell
+					isNavigable={isNavigable}
+					isSessionGenerated={isSessionGenerated}
+					onNavigateToSession={onNavigateToSession}
+					onOpenActions={onOpenActions}
+					tx={tx}
+				/>
 			</TableCell>
 		</TableRow>
 	);

--- a/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-row/transaction-row.tsx
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-row/transaction-row.tsx
@@ -1,4 +1,5 @@
 import { IconChevronRight, IconDotsVertical } from "@tabler/icons-react";
+import type { Transaction } from "@/features/currencies/utils/types";
 import {
 	getAmountColorClass,
 	getAmountDisplay,
@@ -6,16 +7,6 @@ import {
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import { TableCell, TableRow } from "@/shared/components/ui/table";
-
-export interface Transaction {
-	amount: number;
-	id: string;
-	memo?: string | null;
-	sessionId?: string | null;
-	sessionName?: string | null;
-	transactedAt: Date | string;
-	transactionTypeName: string;
-}
 
 const COMPACT_CELL = "px-3 py-1.5 align-middle";
 
@@ -75,8 +66,7 @@ export function TransactionRow({
 	const amountClass = getAmountColorClass(tx.amount);
 	const amountDisplay = getAmountDisplay(tx.amount, fmt);
 	const isSessionGenerated = !!tx.sessionId;
-	const isNavigable =
-		isSessionGenerated && !!onNavigateToSession && !!tx.sessionId;
+	const isNavigable = isSessionGenerated && !!onNavigateToSession;
 
 	const handleRowClick = isNavigable
 		? () => {

--- a/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-row/transaction-row.tsx
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-row/transaction-row.tsx
@@ -1,9 +1,9 @@
 import { IconChevronRight, IconDotsVertical } from "@tabler/icons-react";
-import type { Transaction } from "@/features/currencies/utils/types";
 import {
 	getAmountColorClass,
 	getAmountDisplay,
 } from "@/features/currencies/utils/transaction-list-helpers";
+import type { Transaction } from "@/features/currencies/utils/types";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import { TableCell, TableRow } from "@/shared/components/ui/table";

--- a/apps/web/src/features/currencies/pages/currency-detail-page/use-currency-detail-page.ts
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/use-currency-detail-page.ts
@@ -136,9 +136,6 @@ export function useCurrencyDetailPage(currencyId: string) {
 	};
 
 	const handleNavigateToSession = (sessionId: string) => {
-		if (!sessionId) {
-			return;
-		}
 		navigate({ to: "/sessions/$sessionId", params: { sessionId } });
 	};
 

--- a/apps/web/src/features/currencies/pages/currency-detail-page/use-currency-detail-page.ts
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/use-currency-detail-page.ts
@@ -135,6 +135,13 @@ export function useCurrencyDetailPage(currencyId: string) {
 		setPendingDeleteTransaction(null);
 	};
 
+	const handleNavigateToSession = (sessionId: string) => {
+		if (!sessionId) {
+			return;
+		}
+		navigate({ to: "/sessions/$sessionId", params: { sessionId } });
+	};
+
 	return {
 		currency,
 		isLoading,
@@ -171,5 +178,6 @@ export function useCurrencyDetailPage(currencyId: string) {
 		openDeleteFromTransactionActions,
 		cancelDeleteTransaction,
 		handleConfirmDeleteTransaction,
+		handleNavigateToSession,
 	};
 }

--- a/apps/web/src/features/currencies/utils/types.ts
+++ b/apps/web/src/features/currencies/utils/types.ts
@@ -1,0 +1,12 @@
+export interface Transaction {
+	amount: number;
+	createdAt?: Date | string;
+	currencyId?: string;
+	id: string;
+	memo?: string | null;
+	sessionId?: string | null;
+	sessionName?: string | null;
+	transactedAt: Date | string;
+	transactionTypeId?: string;
+	transactionTypeName: string;
+}

--- a/packages/api/src/routers/currency-transaction.ts
+++ b/packages/api/src/routers/currency-transaction.ts
@@ -3,6 +3,9 @@ import {
 	currencyTransaction,
 	transactionType,
 } from "@sapphire2/db/schema/currency";
+import { gameSession } from "@sapphire2/db/schema/session";
+import { sessionCashDetail } from "@sapphire2/db/schema/session-cash-detail";
+import { sessionTournamentDetail } from "@sapphire2/db/schema/session-tournament-detail";
 import { TRPCError } from "@trpc/server";
 import { and, desc, eq, sql } from "drizzle-orm";
 import { z } from "zod";
@@ -53,6 +56,9 @@ export const currencyTransactionRouter = router({
 					transactionTypeId: currencyTransaction.transactionTypeId,
 					transactionTypeName: transactionType.name,
 					sessionId: currencyTransaction.sessionId,
+					sessionName: sql<
+						string | null
+					>`CASE WHEN ${gameSession.kind} = 'cash_game' THEN ${sessionCashDetail.ruleName} WHEN ${gameSession.kind} = 'tournament' THEN ${sessionTournamentDetail.ruleName} ELSE NULL END`,
 					amount: currencyTransaction.amount,
 					transactedAt: currencyTransaction.transactedAt,
 					memo: currencyTransaction.memo,
@@ -62,6 +68,18 @@ export const currencyTransactionRouter = router({
 				.innerJoin(
 					transactionType,
 					eq(transactionType.id, currencyTransaction.transactionTypeId)
+				)
+				.leftJoin(
+					gameSession,
+					eq(gameSession.id, currencyTransaction.sessionId)
+				)
+				.leftJoin(
+					sessionCashDetail,
+					eq(sessionCashDetail.sessionId, gameSession.id)
+				)
+				.leftJoin(
+					sessionTournamentDetail,
+					eq(sessionTournamentDetail.sessionId, gameSession.id)
 				)
 				.where(and(...conditions))
 				.orderBy(


### PR DESCRIPTION
## Summary

- **API**: `listByCurrency` クエリに `session_cash_detail` / `session_tournament_detail` を LEFT JOIN し、セッション名（ゲーム種別のルール名）を返すフィールド `sessionName` を追加
- **UI**: Transactions セクションの SessionResult 行に、メモ列へのセッション名表示と、末尾列の `>` (chevron) アイコンによるリンク表示を追加。行全体クリックでセッション詳細画面へ遷移

## Changes

### Backend (`packages/api/src/routers/currency-transaction.ts`)
- `gameSession`, `sessionCashDetail`, `sessionTournamentDetail` を LEFT JOIN
- `CASE WHEN kind = 'cash_game' THEN cash_detail.rule_name WHEN kind = 'tournament' THEN tournament_detail.rule_name ELSE NULL END` で `sessionName` を生成

### Frontend
- `use-currencies.ts`: `Transaction` インターフェースに `sessionId`, `sessionName` を追加
- `transaction-row.tsx`: セッション行でメモ列にセッション名表示、末尾列に `IconChevronRight` を表示、行クリックでナビゲーション
- `transaction-list.tsx`: `onNavigateToSession` プロップを追加して `TransactionRow` へ渡す
- `use-currency-detail-page.ts`: `handleNavigateToSession` ハンドラを追加（`/sessions/$sessionId` へ遷移）
- `currency-detail-page.tsx`: `onNavigateToSession` を `TransactionListV2` へ渡す

## Test plan

- [ ] `transaction-list.test.tsx`: セッション名表示・chevron表示・行クリックのテスト追加 (9ファイル177テスト通過)
- [ ] `use-currency-detail-page.test.ts`: `handleNavigateToSession` のナビゲーション動作テスト追加
- [ ] `currency-detail-page.test.tsx`: `onNavigateToSession` の配線テスト追加
- [ ] `bun run check-types` 通過
- [ ] `bun run lint` 通過

https://claude.ai/code/session_01VT6dFQXByT5Sy9uoDqtTgk

---
_Generated by [Claude Code](https://claude.ai/code/session_01VT6dFQXByT5Sy9uoDqtTgk)_