### PR TITLE
ci(review): track_progress でレビューコメントを確実に投稿する

### DIFF
--- a/.github/workflows/pre-merge-review.yml
+++ b/.github/workflows/pre-merge-review.yml
@@ -29,29 +29,25 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # track_progress lets the action itself create a single tracking comment
+          # on the PR and keep it updated with the review results. Posting is handled
+          # by the action (using GITHUB_TOKEN), not by Claude — so a summary comment
+          # is always posted. The previous approach made Claude write
+          # /tmp/review-summary.md and a later step posted it, which silently skipped
+          # the comment whenever Claude did not produce the file.
+          track_progress: true
           prompt: |
             /review
 
-            After completing the review, write a Markdown summary of your findings
-            to `/tmp/review-summary.md` (no surrounding code fence). If no issues were
-            found, write a short confirmation that the review passed with no problems
-            (e.g. "LGTM" with a brief summary).
+            Post specific issues as inline comments on the relevant lines. End the
+            session with a Markdown summary of your findings grouped by severity, or,
+            if there were none, a short confirmation that the review passed with no
+            problems (e.g. "LGTM" with a brief summary).
 
-            Do NOT run any gh commands and do NOT try to post a comment yourself —
-            posting is handled by a later workflow step that reads /tmp/review-summary.md.
+            The tracking comment on this PR is created and updated automatically from
+            this session, so do NOT run `gh pr comment` to post the top-level summary
+            yourself — just make the summary your final message.
           claude_args: |
             --max-turns 40
             --model opus
-
-      - name: Post review summary comment
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          if [ -s /tmp/review-summary.md ]; then
-            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/review-summary.md
-          else
-            echo "::warning::Claude did not produce /tmp/review-summary.md; skipping comment."
-          fi
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## 背景 / 問題

PR review ワークフロー（`pre-merge-review.yml`）が毎回コメントを投稿できていなかった。

これまでの設計は次の2段構えだった:

1. `claude-code-action` で `/review` を実行し、Claude に `/tmp/review-summary.md` を書かせる
2. 後続の `run:` ステップがそのファイルを読んで `gh pr comment` で投稿する

この方式には2つの弱点があり、コメントが投稿されないケースが発生していた:

- **ファイル生成が LLM の挙動依存**。40 ターンのレビュー後に毎回確実に `/tmp/review-summary.md` を書くわけではなく、書かれなければ `[ -s ... ]` 判定で警告を出してスキップしていた。
- **headless CI ではツール権限が自動拒否されやすい**。`/tmp` への書き込みや `gh` 実行が通らないことがある（過去に `gh` を `run:` ステップへ逃がした経緯と同根）。

## 修正内容

`claude-code-action@v1` のネイティブ機能 **`track_progress: true`** を有効化した。

- アクション側（TypeScript / `GITHUB_TOKEN` 利用）が PR に単一のトラッキングコメントを作成し、進捗と最終結果で更新し続ける。
- 投稿が **LLM の挙動やファイル生成に依存しない**ため、サマリコメントは必ず投稿される。
- これに伴い、ファイル方式のプロンプト指示と後続の投稿ステップ（`Post review summary comment`）を削除。
- 公式 `pr-review-comprehensive.yml` サンプルに倣い、inline コメント / PR 読み取り用の `allowedTools`（`mcp__github_inline_comment__create_inline_comment`, `Bash(gh pr diff:*)`, `Bash(gh pr view:*)`）のみ許可。

## 動作確認

- ワークフロー YAML の構文を検証済み（`yaml.safe_load` 通過）。
- 実挙動はこの PR 自体（`opened` トリガー）で確認可能。

https://claude.ai/code/session_019r67ZegNJbLVx7DzM56JtQ

---
_Generated by [Claude Code](https://claude.ai/code/session_019r67ZegNJbLVx7DzM56JtQ)_