### PR TITLE
fix(currencies): Transaction Memo フィールドを Textarea から単行 Input に変更 (SA2-58)

### DIFF
--- a/apps/web/src/features/currencies/pages/currency-detail-page/transaction-form/transaction-form.tsx
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/transaction-form/transaction-form.tsx
@@ -1,6 +1,5 @@
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
-import { Textarea } from "@/shared/components/ui/textarea";
 import { TypeCombobox } from "./type-combobox";
 import {
 	type TransactionFormValues,
@@ -99,7 +98,7 @@ export function TransactionFormV2({
 			<form.Field name="memo">
 				{(field) => (
 					<Field htmlFor={field.name} label="Memo">
-						<Textarea
+						<Input
 							id={field.name}
 							name={field.name}
 							onBlur={field.handleBlur}


### PR DESCRIPTION
## 概要

Linear [SA2-58](https://linear.app/sapphire2/issue/SA2-58) の対応。

- Transaction 編集フォームの Memo フィールドが `Textarea`（複数行）になっていたが、表示領域が 1 行分しかないため `Input`（単行テキスト）に変更した。

## 変更ファイル

- `apps/web/src/features/currencies/pages/currency-detail-page/transaction-form/transaction-form.tsx`
  - `Textarea` を `Input` に置換
  - 不要になった `Textarea` の import を削除

## 検証

- `bunx vitest run --project web-dom` (transaction-form/): **18 passed**
- `bun run lint`: No issues
- `bun run check-types`: Exited with code 0

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgyTpWPTMw8ciasp5L48ox)_