### PR TITLE
Make transaction memo a single-line input and reorder form fields

### DIFF
--- a/apps/web/src/features/currencies/pages/currency-detail-page/transaction-form/__tests__/transaction-form.test.tsx
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/transaction-form/__tests__/transaction-form.test.tsx
@@ -7,6 +7,8 @@ const TYPES = [
 	{ id: "t2", name: "Withdrawal" },
 ];
 
+const REQUIRED_ASTERISK_SUFFIX = /\s*\*$/;
+
 const hoisted = vi.hoisted(() => ({
 	useTransactionTypes: vi.fn(),
 }));
@@ -32,6 +34,25 @@ describe("TransactionFormV2", () => {
 		expect(screen.getByText("Amount")).toBeInTheDocument();
 		expect(screen.getByText("Date")).toBeInTheDocument();
 		expect(screen.getByText("Memo")).toBeInTheDocument();
+	});
+
+	it("renders the fields in the order Date, Type, Memo, Amount", () => {
+		const { container } = render(
+			<TransactionFormV2 formId="x" onSubmit={vi.fn()} />
+		);
+		const labels = [...container.querySelectorAll("label")].map((label) =>
+			label.textContent?.replace(REQUIRED_ASTERISK_SUFFIX, "")
+		);
+		expect(labels).toEqual(["Date", "Type", "Memo", "Amount"]);
+	});
+
+	it("renders Memo as a single-line text input, not a textarea", () => {
+		const { container } = render(
+			<TransactionFormV2 formId="x" onSubmit={vi.fn()} />
+		);
+		const memo = screen.getByLabelText("Memo");
+		expect(memo.tagName).toBe("INPUT");
+		expect(container.querySelector("textarea")).toBeNull();
 	});
 
 	it("assigns the supplied formId to the <form> element so an external Save button can submit it", () => {

--- a/apps/web/src/features/currencies/pages/currency-detail-page/transaction-form/transaction-form.tsx
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/transaction-form/transaction-form.tsx
@@ -1,6 +1,5 @@
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
-import { Textarea } from "@/shared/components/ui/textarea";
 import { TypeCombobox } from "./type-combobox";
 import {
 	type TransactionFormValues,
@@ -33,6 +32,25 @@ export function TransactionFormV2({
 				form.handleSubmit();
 			}}
 		>
+			<form.Field name="transactedAt">
+				{(field) => (
+					<Field
+						error={field.state.meta.errors[0]?.message}
+						htmlFor={field.name}
+						label="Date"
+						required
+					>
+						<Input
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							type="date"
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
 			<form.Field name="transactionTypeId">
 				{(typeField) => (
 					<form.Field name="newTypeName">
@@ -57,6 +75,19 @@ export function TransactionFormV2({
 					</form.Field>
 				)}
 			</form.Field>
+			<form.Field name="memo">
+				{(field) => (
+					<Field htmlFor={field.name} label="Memo">
+						<Input
+							id={field.name}
+							name={field.name}
+							onBlur={field.handleBlur}
+							onChange={(e) => field.handleChange(e.target.value)}
+							value={field.state.value}
+						/>
+					</Field>
+				)}
+			</form.Field>
 			<form.Field name="amount">
 				{(field) => (
 					<Field
@@ -69,38 +100,6 @@ export function TransactionFormV2({
 						<Input
 							id={field.name}
 							inputMode="numeric"
-							name={field.name}
-							onBlur={field.handleBlur}
-							onChange={(e) => field.handleChange(e.target.value)}
-							value={field.state.value}
-						/>
-					</Field>
-				)}
-			</form.Field>
-			<form.Field name="transactedAt">
-				{(field) => (
-					<Field
-						error={field.state.meta.errors[0]?.message}
-						htmlFor={field.name}
-						label="Date"
-						required
-					>
-						<Input
-							id={field.name}
-							name={field.name}
-							onBlur={field.handleBlur}
-							onChange={(e) => field.handleChange(e.target.value)}
-							type="date"
-							value={field.state.value}
-						/>
-					</Field>
-				)}
-			</form.Field>
-			<form.Field name="memo">
-				{(field) => (
-					<Field htmlFor={field.name} label="Memo">
-						<Textarea
-							id={field.name}
 							name={field.name}
 							onBlur={field.handleBlur}
 							onChange={(e) => field.handleChange(e.target.value)}


### PR DESCRIPTION
## 概要

通貨詳細ページのトランザクションフォーム（追加・編集共通の `TransactionFormV2`）に対する2件のIssue対応です。

- **SA2-58 (#344)**: メモ欄を `Textarea` から単行の `Input` に変更。トランザクション一覧での表示領域が1行分しかないため、複数行入力は不要。
- **SA2-68 (#358)**: フィールド順を「Date → Type → Memo → Amount」に変更。

## 変更内容

- `transaction-form.tsx`: フィールドの並び順を変更し、Memo の `Textarea` を `Input` に置換（`Textarea` の import も削除）。
- `transaction-form.test.tsx`: TDDで先行追加したテスト2件
  - フィールドが Date / Type / Memo / Amount の順で描画されること
  - Memo が `<textarea>` ではなく単行の `<input>` で描画されること

## 検証

- `bunx vitest run --project web-dom .../transaction-form/` — 54件すべてグリーン
- `bun x ultracite check` — エラーなし
- `bun run check-types` — エラーなし

Closes #344
Closes #358

https://claude.ai/code/session_01VtHBuN6LmtpeQv4i3Q5jFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtHBuN6LmtpeQv4i3Q5jFm)_