### PR TITLE
fix(web): トランザクション行のキーボード操作対応 + dashboard 残存参照の整理

### DIFF
--- a/apps/web/src/features/auth/pages/login-page/login-page.tsx
+++ b/apps/web/src/features/auth/pages/login-page/login-page.tsx
@@ -16,7 +16,7 @@ export function LoginPage() {
 					heading="Why sign in here"
 				>
 					<ul className="space-y-2 text-muted-foreground text-sm">
-						<li>Resume your dashboard and current live-session flow.</li>
+						<li>Resume your statistics and current live-session flow.</li>
 						<li>
 							Use email/password or connected Google and Discord accounts.
 						</li>

--- a/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/__tests__/transaction-list.test.tsx
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/__tests__/transaction-list.test.tsx
@@ -5,6 +5,8 @@ import { TransactionListV2 } from "@/features/currencies/pages/currency-detail-p
 
 // Class-presence matcher for `size-8` (whole-word, single tailwind class).
 const SIZE_8_CLASS = /(^| )size-8( |$)/;
+// Accessible-name matcher for the row-level "View session" navigation button.
+const VIEW_SESSION_NAME = /view session/i;
 
 const regularTransaction = {
 	id: "tx1",
@@ -276,6 +278,106 @@ describe("TransactionListV2", () => {
 			/>
 		);
 		expect(screen.getAllByText("2026/03/20")).toHaveLength(1);
+	});
+
+	it("marks navigable session rows as a keyboard-operable button with an accessible name", () => {
+		render(
+			<TransactionListV2
+				onNavigateToSession={vi.fn()}
+				transactions={[sessionTransaction]}
+			/>
+		);
+		expect(
+			screen.getByRole("button", { name: "View session NLH 1/2" })
+		).toBeInTheDocument();
+	});
+
+	it("falls back to a generic label when a navigable session row has no name", () => {
+		render(
+			<TransactionListV2
+				onNavigateToSession={vi.fn()}
+				transactions={[{ ...sessionTransaction, sessionName: null }]}
+			/>
+		);
+		expect(
+			screen.getByRole("button", { name: "View session" })
+		).toBeInTheDocument();
+	});
+
+	it("makes the navigable session row focusable with tabIndex 0", () => {
+		render(
+			<TransactionListV2
+				onNavigateToSession={vi.fn()}
+				transactions={[sessionTransaction]}
+			/>
+		);
+		expect(
+			screen.getByRole("button", { name: "View session NLH 1/2" })
+		).toHaveAttribute("tabindex", "0");
+	});
+
+	it("navigates with the sessionId when Enter is pressed on a focused session row", async () => {
+		const user = userEvent.setup();
+		const onNavigateToSession = vi.fn();
+		render(
+			<TransactionListV2
+				onNavigateToSession={onNavigateToSession}
+				transactions={[sessionTransaction]}
+			/>
+		);
+		screen.getByRole("button", { name: "View session NLH 1/2" }).focus();
+		await user.keyboard("{Enter}");
+		expect(onNavigateToSession).toHaveBeenCalledTimes(1);
+		expect(onNavigateToSession).toHaveBeenCalledWith("session-1");
+	});
+
+	it("navigates with the sessionId when Space is pressed on a focused session row", async () => {
+		const user = userEvent.setup();
+		const onNavigateToSession = vi.fn();
+		render(
+			<TransactionListV2
+				onNavigateToSession={onNavigateToSession}
+				transactions={[sessionTransaction]}
+			/>
+		);
+		screen.getByRole("button", { name: "View session NLH 1/2" }).focus();
+		await user.keyboard("[Space]");
+		expect(onNavigateToSession).toHaveBeenCalledTimes(1);
+		expect(onNavigateToSession).toHaveBeenCalledWith("session-1");
+	});
+
+	it("ignores unrelated keys on a focused session row", async () => {
+		const user = userEvent.setup();
+		const onNavigateToSession = vi.fn();
+		render(
+			<TransactionListV2
+				onNavigateToSession={onNavigateToSession}
+				transactions={[sessionTransaction]}
+			/>
+		);
+		screen.getByRole("button", { name: "View session NLH 1/2" }).focus();
+		await user.keyboard("{Escape}");
+		await user.keyboard("a");
+		expect(onNavigateToSession).not.toHaveBeenCalled();
+	});
+
+	it("does not expose a navigation button on regular (non-session) rows", () => {
+		render(
+			<TransactionListV2
+				onNavigateToSession={vi.fn()}
+				transactions={[regularTransaction]}
+			/>
+		);
+		expect(
+			screen.queryByRole("button", { name: VIEW_SESSION_NAME })
+		).not.toBeInTheDocument();
+	});
+
+	it("does not expose a navigation button when onNavigateToSession is not provided", () => {
+		render(<TransactionListV2 transactions={[sessionTransaction]} />);
+		expect(
+			screen.queryByRole("button", { name: VIEW_SESSION_NAME })
+		).not.toBeInTheDocument();
 	});
 
 	it("renders a separate date header per distinct day", () => {

--- a/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-row/transaction-row.tsx
+++ b/apps/web/src/features/currencies/pages/currency-detail-page/transaction-list/transaction-row/transaction-row.tsx
@@ -1,4 +1,5 @@
 import { IconChevronRight, IconDotsVertical } from "@tabler/icons-react";
+import type { KeyboardEvent } from "react";
 import {
 	getAmountColorClass,
 	getAmountDisplay,
@@ -68,22 +69,39 @@ export function TransactionRow({
 	const isSessionGenerated = !!tx.sessionId;
 	const isNavigable = isSessionGenerated && !!onNavigateToSession;
 
-	const handleRowClick = isNavigable
-		? () => {
-				if (onNavigateToSession && tx.sessionId) {
-					onNavigateToSession(tx.sessionId);
+	const navigateToSession = () => {
+		if (onNavigateToSession && tx.sessionId) {
+			onNavigateToSession(tx.sessionId);
+		}
+	};
+
+	const handleRowClick = isNavigable ? navigateToSession : undefined;
+
+	const handleRowKeyDown = isNavigable
+		? (event: KeyboardEvent<HTMLTableRowElement>) => {
+				if (event.key === "Enter" || event.key === " ") {
+					event.preventDefault();
+					navigateToSession();
 				}
 			}
 		: undefined;
 
 	return (
 		<TableRow
+			aria-label={
+				isNavigable
+					? `View session${tx.sessionName ? ` ${tx.sessionName}` : ""}`
+					: undefined
+			}
 			className={
 				isNavigable
 					? "cursor-pointer hover:bg-muted/50"
 					: "hover:bg-transparent"
 			}
 			onClick={handleRowClick}
+			onKeyDown={handleRowKeyDown}
+			role={isNavigable ? "button" : undefined}
+			tabIndex={isNavigable ? 0 : undefined}
 		>
 			<TableCell className={`${COMPACT_CELL} w-px`}>
 				{isSessionGenerated ? (

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 
 /**
  * The public landing page was removed — the root path only dispatches:
- * signed-in users land on the dashboard, everyone else on the login page.
+ * signed-in users land on the statistics page, everyone else on the login page.
  *
  * The session is read from router context (fetched once by __root's
  * beforeLoad guard) instead of calling getSession again; the guard has

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -2126,7 +2126,7 @@ export const sessionRouter = router({
 			return updated;
 		}),
 
-	// pnl_graph widget — see apps/web/src/features/dashboard/widgets/pnl-graph-widget
+	// profit/loss time series — shared by the statistics page and the stats router
 	profitLossSeries: protectedProcedure
 		.input(
 			z.object({


### PR DESCRIPTION
## 概要

v3.1.0 リリース PR (#362) の自動プレマージレビューで挙がった軽微な指摘を `dev` 側で解消します。リリースブランチは dev と完全一致させる方針のため、修正はここ（dev）に入れ、その後 `release/v3.1.0` を作り直して取り込みます。

## 変更内容

### a11y: トランザクション行のキーボード操作対応
セッション由来のトランザクション行は `<tr>` の `onClick` のみでセッションへ遷移しており、キーボード／スクリーンリーダー利用者が操作できませんでした。ナビゲーション可能な行に以下を付与:

- `role="button"` / `tabIndex={0}`（フォーカス可能化）
- `aria-label`（`View session <セッション名>`、名前が無い場合は `View session`）
- `onKeyDown`（Enter / Space で遷移、Space は既定スクロールを `preventDefault`）

マウスでの行クリック挙動は従来どおり維持しています。

### dashboard 残存参照の整理
統計ページ移行（SA2-54/55）で陳腐化した参照を更新:

- `apps/web/src/routes/index.tsx` — コメントの遷移先を dashboard → statistics に修正
- `packages/api/src/routers/session.ts` — 削除済みパスを指すコメントを実態に合わせて更新
- `apps/web/src/features/auth/pages/login-page/login-page.tsx` — UI コピー「Resume your dashboard ...」→「Resume your statistics ...」

## テスト

`transaction-list.test.tsx` に a11y ナビゲーションのテストを追加（role/accessible name、tabIndex、Enter/Space 遷移、無関係キーの無視、非ナビ行・ハンドラ未指定時にボタンを露出しないこと）。

- `bunx vitest run --project web-dom .../transaction-list/__tests__/transaction-list.test.tsx` → 35 passed
- `bun run check-types` → clean
- `bunx ultracite check`（変更ファイル）→ clean

https://claude.ai/code/session_01DG155fjue7GwvkgZymhr5w

---
_Generated by [Claude Code](https://claude.ai/code/session_01DG155fjue7GwvkgZymhr5w)_