### PR TITLE
fix(release): 自動リリースノート生成を structured output で修正 (SA2-72)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,10 @@ jobs:
             echo "::error::Claude produced no structured output; cannot build release notes"
             exit 1
           fi
-          # jq -e fails on both invalid JSON and a null/empty release_notes, so a
-          # bad payload still surfaces the dump below instead of only jq's stderr.
-          if ! BODY=$(printf '%s' "$STRUCTURED_OUTPUT" | jq -er '.release_notes // empty'); then
+          # jq -e fails on invalid JSON and a null/missing release_notes; the
+          # extra -z check also rejects an empty-string body ("" // empty is ""),
+          # so a bad payload surfaces the dump below instead of publishing empty.
+          if ! BODY=$(printf '%s' "$STRUCTURED_OUTPUT" | jq -er '.release_notes // empty') || [ -z "$BODY" ]; then
             echo "::error::structured output had no usable release_notes (invalid JSON or empty body)"
             echo "structured_output was: $STRUCTURED_OUTPUT"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,11 @@ jobs:
 
       # Capture the notes via the action's structured output instead of asking
       # Claude to write a file. A headless run does not reliably produce a
-      # /tmp file, which silently left the publish step with no notes (the same
-      # failure mode fixed in pre-merge-review.yml). --json-schema forces the
-      # result onto steps.<id>.outputs.structured_output, the officially
-      # documented machine-readable channel.
+      # /tmp file, which silently left the publish step with no notes — the same
+      # failure mode pre-merge-review.yml hit (it solved it via track_progress;
+      # here we use structured output). --json-schema forces the result onto
+      # steps.<id>.outputs.structured_output, the officially documented
+      # machine-readable channel.
       - name: Generate release notes with Claude
         id: notes
         uses: anthropics/claude-code-action@v1
@@ -81,12 +82,14 @@ jobs:
             echo "::error::Claude produced no structured output; cannot build release notes"
             exit 1
           fi
-          printf '%s' "$STRUCTURED_OUTPUT" | jq -r '.release_notes // empty' > /tmp/release-notes.md
-          if [ ! -s /tmp/release-notes.md ]; then
-            echo "::error::release notes body is missing or empty in structured output"
+          # jq -e fails on both invalid JSON and a null/empty release_notes, so a
+          # bad payload still surfaces the dump below instead of only jq's stderr.
+          if ! BODY=$(printf '%s' "$STRUCTURED_OUTPUT" | jq -er '.release_notes // empty'); then
+            echo "::error::structured output had no usable release_notes (invalid JSON or empty body)"
             echo "structured_output was: $STRUCTURED_OUTPUT"
             exit 1
           fi
+          printf '%s\n' "$BODY" > /tmp/release-notes.md
           echo "--- Generated release notes ---"
           cat /tmp/release-notes.md
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,15 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved version: $VERSION"
 
+      # Capture the notes via the action's structured output instead of asking
+      # Claude to write a file. A headless run does not reliably produce a
+      # /tmp file, which silently left the publish step with no notes (the same
+      # failure mode fixed in pre-merge-review.yml). --json-schema forces the
+      # result onto steps.<id>.outputs.structured_output, the officially
+      # documented machine-readable channel.
       - name: Generate release notes with Claude
+        id: notes
         uses: anthropics/claude-code-action@v1
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
@@ -47,20 +52,43 @@ jobs:
           prompt: |
             You are running headlessly in CI to generate release notes for a sapphire2 release.
 
-            The new version is: $RELEASE_VERSION
+            The new version is: ${{ steps.version.outputs.version }}
 
             Execute these steps in order. There is no interactive user; do not ask questions.
             If anything fails, surface the error and stop.
 
-            1. Invoke the `/create-update-notes` skill with `$RELEASE_VERSION` as the argument.
+            1. Invoke the `/create-update-notes` skill with `${{ steps.version.outputs.version }}` as the argument.
                Follow its Execution Flow steps 1–6 verbatim, but apply these CI overrides:
                  - Skip step 7 entirely (no interactive review round-trip).
-                 - In step 8, do NOT print the final block to the user; instead write
-                   only the Markdown body (without the surrounding ```markdown fence)
-                   to `/tmp/release-notes.md`.
+                 - Skip step 8's "print to the user" behavior; do NOT emit a fenced
+                   ```markdown block and do NOT write any file.
                The skill's "must never publish" rule is explicitly waived for this CI invocation.
 
-            Stop after writing /tmp/release-notes.md. Do NOT run any gh commands.
+            2. Return the result as structured output: a single JSON object whose
+               `release_notes` field holds ONLY the Markdown body (the same content
+               that would normally go inside the ```markdown fence — no fence, no
+               surrounding commentary, no tag/title or exclusion list).
+
+            Do NOT run any gh commands and do NOT create the release yourself.
+          claude_args: |
+            --json-schema '{"type":"object","properties":{"release_notes":{"type":"string"}},"required":["release_notes"]}'
+
+      - name: Write release notes to file
+        env:
+          STRUCTURED_OUTPUT: ${{ steps.notes.outputs.structured_output }}
+        run: |
+          if [ -z "$STRUCTURED_OUTPUT" ]; then
+            echo "::error::Claude produced no structured output; cannot build release notes"
+            exit 1
+          fi
+          printf '%s' "$STRUCTURED_OUTPUT" | jq -r '.release_notes // empty' > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "::error::release notes body is missing or empty in structured output"
+            echo "structured_output was: $STRUCTURED_OUTPUT"
+            exit 1
+          fi
+          echo "--- Generated release notes ---"
+          cat /tmp/release-notes.md
 
       - name: Publish GitHub Release
         env:


### PR DESCRIPTION
## 概要

Linear SA2-72 / #366 の対応。`release.yml` の自動リリースノート生成が機能せず、リリースを作成できなかった不具合を修正する。

## 原因

`Generate release notes with Claude` ステップは `claude-code-action` 経由で Claude に `/tmp/release-notes.md` を書かせ、後続の `gh release create --notes-file /tmp/release-notes.md` でそれを読む構成だった。

しかし headless 実行の Claude はこのファイルを確実には生成しない。ファイルが無いと publish ステップで「出力ファイルがなく、リリースが作成できない」状態になる。これは `pre-merge-review.yml` で既に修正済みのサイレント失敗（Claude が `/tmp/review-summary.md` を書かないとコメント投稿が黙って飛ばされる）と全く同じ症状。

## 修正方針（公式パターン準拠）

Claude にファイルを書かせる依存をやめ、`claude-code-action` 公式の **structured output** を使う:

- `claude_args` に `--json-schema '{"type":"object","properties":{"release_notes":{"type":"string"}},"required":["release_notes"]}'` を渡し、本文を `steps.notes.outputs.structured_output` に確実に載せる（usage.md でマシン可読出力として推奨されている経路）。
- 専用の `Write release notes to file` ステップで `jq -r '.release_notes // empty'` 抽出し、
  - structured output が空 → 明示的に `::error::` で失敗
  - 本文が空/欠落 → 明示的に `::error::` で失敗（`structured_output` の中身もログ出力）
  したうえでファイル化する。これにより「黙ってファイルが無いまま進む」ことがなくなる。
- プロンプトの `$RELEASE_VERSION` 参照を GitHub Actions 式 `${{ steps.version.outputs.version }}` に統一し、env 経由の置換に依存しないようにした。

## 動作確認

- `release.yml` の YAML パースが通ることを確認。
- 抽出ロジック（`jq` + 空チェック）を、(1) 正常な JSON（`\n` が正しく改行に展開される）、(2) `release_notes` 欠落、(3) structured output 空文字、の 3 ケースでローカル検証し、いずれも期待通り（正常抽出 / エラー検出 / エラー検出）になることを確認。

実際のリリースノート生成は本番の release/v*.*.* マージ時にしか走らないため、CI 上での end-to-end 検証は次回リリースで確認する。

https://claude.ai/code/session_011dMc3RrgwQ2aqDynHuARC8

---
_Generated by [Claude Code](https://claude.ai/code/session_011dMc3RrgwQ2aqDynHuARC8)_