### PR TITLE
fix(rooms): トーナメントストラクチャー入力テーブルの最下行ハイライトが切れるのを修正

### DIFF
--- a/apps/web/src/features/rooms/components/blind-level-editor/blind-level-input/blind-level-input.test.tsx
+++ b/apps/web/src/features/rooms/components/blind-level-editor/blind-level-input/blind-level-input.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { BlindLevelInput } from "./blind-level-input";
+
+describe("BlindLevelInput", () => {
+	it("renders as a text input with a numeric input mode", () => {
+		render(<BlindLevelInput />);
+
+		const input = screen.getByRole("textbox");
+		expect(input).toHaveAttribute("type", "text");
+		expect(input).toHaveAttribute("inputmode", "numeric");
+	});
+
+	it("paints the focus highlight as an inset ring so the bottom row is not clipped by the table's overflow wrapper (SA2-70)", () => {
+		// The shared Table wraps the <table> in an `overflow-x-auto` div, which
+		// the CSS spec coerces to `overflow-y: auto`. An outset focus ring on the
+		// bottom-most cell would overflow that wrapper and be clipped; an inset
+		// ring is painted inside the cell and survives the clip.
+		render(<BlindLevelInput />);
+
+		const input = screen.getByRole("textbox");
+		expect(input).toHaveClass(
+			"focus:bg-accent",
+			"focus:ring-1",
+			"focus:ring-inset",
+			"focus:ring-ring"
+		);
+	});
+
+	it("merges a caller-supplied className with the base classes", () => {
+		render(<BlindLevelInput className="text-left" />);
+
+		const input = screen.getByRole("textbox");
+		expect(input).toHaveClass("text-left", "h-8", "w-full", "focus:ring-inset");
+	});
+
+	it("forwards arbitrary input props such as defaultValue and onBlur", () => {
+		const onBlur = vi.fn();
+		render(<BlindLevelInput defaultValue="100" onBlur={onBlur} />);
+
+		const input = screen.getByRole<HTMLInputElement>("textbox");
+		expect(input.value).toBe("100");
+
+		fireEvent.blur(input);
+		expect(onBlur).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/features/rooms/components/blind-level-editor/blind-level-input/blind-level-input.tsx
+++ b/apps/web/src/features/rooms/components/blind-level-editor/blind-level-input/blind-level-input.tsx
@@ -1,8 +1,13 @@
 import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
+// The focus ring is `ring-inset` so it is painted inside the input box. The
+// shared Table wraps the <table> in an `overflow-x-auto` div, which the CSS
+// spec coerces to `overflow-y: auto`; an outset ring on the bottom-most row
+// would overflow that wrapper and be clipped (SA2-70). An inset ring stays
+// within the cell and survives the clip regardless of the row.
 const BLIND_LEVEL_INPUT_CLASS =
-	"h-8 w-full rounded border-0 bg-transparent text-center text-sm outline-none placeholder:text-muted-foreground/40 focus:bg-accent focus:ring-1 focus:ring-ring";
+	"h-8 w-full rounded border-0 bg-transparent text-center text-sm outline-none placeholder:text-muted-foreground/40 focus:bg-accent focus:ring-1 focus:ring-inset focus:ring-ring";
 
 /**
  * Borderless numeric cell input for the blind structure table. Always renders


### PR DESCRIPTION
## 概要

トーナメントのストラクチャー入力テーブルで、一番下の行のセルにフォーカスした際にハイライト（フォーカスリング）の下端が切れて表示されない不具合を修正します。

Fixes #364 (SA2-70)

## 原因

共有 `Table`（`apps/web/src/shared/components/ui/table/table.tsx`）は `<table>` を `overflow-x-auto` の `div` で包んでいます。CSS の overflow 仕様により、`overflow-x: auto` が指定されると `overflow-y` の計算値は `visible` から `auto` に丸められ、結果として縦方向もクリップされます。

セル入力 `BlindLevelInput` のフォーカス表示は `focus:ring-1 focus:ring-ring`（要素の **外側** に描かれる box-shadow リング）でした。最下行（新規入力用の `EmptyRow` を含む）の入力はテーブル下端と密着しているため、リングの下端 1px がラッパー外にはみ出してクリップされ、ハイライトが切れて見えていました。

## 修正

`BlindLevelInput` のフォーカスリングを `focus:ring-inset` に変更し、リングをセルの **内側** に描画するようにしました。inset リングはセルの内側に収まるため、行の位置やラッパーの `overflow` に依存せず常に表示されます。共有 `Table` プリミティブには手を加えていません（`.claude/rules/web-theme.md` で UI コンポーネントのフォークが禁止されているため）。

## テスト

`blind-level-input.test.tsx` を新規追加（colocate, project `web-dom`）。

- text / numeric inputmode のコントラクト
- SA2-70 リグレッション: フォーカスリングが inset であること
- caller の `className` が base クラスとマージされること
- 任意の input props（`defaultValue` / `onBlur`）が透過されること

確認済み:

- `bunx vitest run --project web-dom .../blind-level-editor/` → 19 passed
- `bun x ultracite check`（変更ファイル）→ clean
- `tsc --noEmit`（web workspace）→ exit 0

https://claude.ai/code/session_01WTfhTyerTn4kV6iw464Nrf

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTfhTyerTn4kV6iw464Nrf)_