### PR TITLE
fix(SA2-76): guard live-mode cash session start against empty buyIn

### DIFF
--- a/apps/web/src/features/sessions/components/session-wizard/__tests__/use-session-wizard.test.ts
+++ b/apps/web/src/features/sessions/components/session-wizard/__tests__/use-session-wizard.test.ts
@@ -1,0 +1,187 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Tournament rules step transitively imports @/utils/trpc; stub it so the
+// env-validating import chain never loads under jsdom.
+vi.mock("@/utils/trpc", () => ({
+	trpc: {},
+	trpcClient: {
+		blindLevel: {
+			listByTournament: { query: vi.fn().mockResolvedValue([]) },
+		},
+		tournamentChipPurchase: {
+			listByTournament: { query: vi.fn().mockResolvedValue([]) },
+		},
+	},
+}));
+
+import { useSessionWizard } from "@/features/sessions/components/session-wizard/use-session-wizard";
+
+function renderLiveWizard(onSubmit = vi.fn()) {
+	return renderHook(() =>
+		useSessionWizard({
+			mode: "live",
+			onSubmit,
+		})
+	);
+}
+
+describe("useSessionWizard — handleFormSubmit — live cash buyIn validation", () => {
+	it("does not call onSubmit when buyIn is empty on the Start step in live cash mode", () => {
+		const onSubmit = vi.fn();
+		const { result } = renderLiveWizard(onSubmit);
+
+		// Advance to the start step (last step in live mode): master → rules → start
+		act(() => result.current.goToNext());
+		act(() => result.current.goToNext());
+		expect(result.current.currentStep).toBe("start");
+		expect(result.current.isCashGame).toBe(true);
+		expect(result.current.form.getFieldValue("buyIn")).toBe("");
+
+		// Submit with empty buyIn
+		act(() => {
+			result.current.handleFormSubmit();
+		});
+
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("sets Required error on buyIn when empty on the Start step in live cash mode", async () => {
+		const { result } = renderLiveWizard();
+
+		act(() => result.current.goToNext());
+		act(() => result.current.goToNext());
+
+		act(() => {
+			result.current.handleFormSubmit();
+		});
+
+		await waitFor(() => {
+			const errors = result.current.form.state.fieldMeta.buyIn?.errors ?? [];
+			expect(errors).toHaveLength(1);
+			expect((errors[0] as { message: string })?.message).toBe("Required");
+		});
+	});
+
+	it("calls onSubmit when buyIn is non-empty on the Start step in live cash mode", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderLiveWizard(onSubmit);
+
+		act(() => result.current.goToNext());
+		act(() => result.current.goToNext());
+
+		act(() => {
+			result.current.form.setFieldValue("buyIn", "5000");
+		});
+
+		act(() => {
+			result.current.handleFormSubmit();
+		});
+
+		await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+		expect(onSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "cash_game", buyIn: 5000 })
+		);
+	});
+
+	it("clears the Required error on the next submit when buyIn is filled", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderLiveWizard(onSubmit);
+
+		act(() => result.current.goToNext());
+		act(() => result.current.goToNext());
+
+		// First submit — sets error
+		act(() => {
+			result.current.handleFormSubmit();
+		});
+		await waitFor(() => {
+			const errors = result.current.form.state.fieldMeta.buyIn?.errors ?? [];
+			expect(errors).toHaveLength(1);
+		});
+
+		// Fill buyIn and submit again
+		act(() => {
+			result.current.form.setFieldValue("buyIn", "1000");
+		});
+		act(() => {
+			result.current.handleFormSubmit();
+		});
+
+		await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+		const errors = result.current.form.state.fieldMeta.buyIn?.errors ?? [];
+		expect(errors).toHaveLength(0);
+	});
+});
+
+describe("useSessionWizard — handleFormSubmit — live tournament (no buyIn guard)", () => {
+	it("calls onSubmit even with empty buyIn in live tournament mode on the Start step", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(() =>
+			useSessionWizard({ mode: "live", onSubmit })
+		);
+
+		// Switch to tournament
+		act(() => result.current.setSessionType("tournament"));
+
+		// Advance to start step
+		act(() => result.current.goToNext());
+		act(() => result.current.goToNext());
+		expect(result.current.currentStep).toBe("start");
+		expect(result.current.isCashGame).toBe(false);
+
+		act(() => {
+			result.current.handleFormSubmit();
+		});
+
+		await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+		expect(onSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "tournament" })
+		);
+	});
+});
+
+describe("useSessionWizard — handleFormSubmit — manual mode (no buyIn guard)", () => {
+	it("calls onSubmit with empty buyIn in manual cash mode (guard applies to live only)", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(() =>
+			useSessionWizard({ mode: "manual", onSubmit })
+		);
+
+		// Advance to the result step (last step in manual mode): master → rules → result
+		act(() => result.current.goToNext());
+		act(() => result.current.goToNext());
+		expect(result.current.currentStep).toBe("result");
+		expect(result.current.isCashGame).toBe(true);
+
+		act(() => {
+			result.current.handleFormSubmit();
+		});
+
+		// Manual mode does not guard buyIn — onSubmit fires
+		await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+		expect(onSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "cash_game" })
+		);
+	});
+});
+
+describe("useSessionWizard — handleFormSubmit — not on start step", () => {
+	it("does not apply buyIn guard when not on the start step (e.g., Enter on Master step)", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderLiveWizard(onSubmit);
+
+		// Stay on master step (first step)
+		expect(result.current.currentStep).toBe("master");
+
+		// Pressing Enter on master step triggers handleFormSubmit but guard
+		// doesn't apply — the form is not yet on the start step.
+		act(() => {
+			result.current.handleFormSubmit();
+		});
+
+		// Guard skipped — form.handleSubmit runs. schema validates OK (sessionDate
+		// is present via default), onSubmit is called.
+		await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+	});
+});

--- a/apps/web/src/features/sessions/components/session-wizard/session-wizard.tsx
+++ b/apps/web/src/features/sessions/components/session-wizard/session-wizard.tsx
@@ -77,7 +77,7 @@ export function SessionWizard({
 			onSubmit={(e) => {
 				e.preventDefault();
 				e.stopPropagation();
-				state.form.handleSubmit();
+				state.handleFormSubmit();
 			}}
 		>
 			{isLiveLinked && (

--- a/apps/web/src/features/sessions/components/session-wizard/use-session-wizard.ts
+++ b/apps/web/src/features/sessions/components/session-wizard/use-session-wizard.ts
@@ -64,6 +64,33 @@ export function useSessionWizard(args: UseSessionWizardArgs) {
 		}
 	};
 
+	/**
+	 * Wraps `form.handleSubmit` with a live-mode guard: if the wizard is on
+	 * the "start" step, the session type is cash, and the buyIn field is empty,
+	 * the submit is aborted and a "Required" error is placed on the buyIn field
+	 * instead of submitting a session with buyIn = 0.
+	 *
+	 * When buyIn is non-empty, any manually-placed "Required" error from a prior
+	 * failed attempt is cleared so that `isValid` resets to `true` before
+	 * `form.handleSubmit()` checks `canSubmit`.
+	 */
+	const handleFormSubmit = () => {
+		if (mode === "live" && currentStep === "start" && formState.isCashGame) {
+			if (formState.form.getFieldValue("buyIn") === "") {
+				formState.form.setFieldMeta("buyIn", (prev) => ({
+					...prev,
+					errorMap: { ...prev?.errorMap, onSubmit: [{ message: "Required" }] },
+				}));
+				return;
+			}
+			formState.form.setFieldMeta("buyIn", (prev) => ({
+				...prev,
+				errorMap: { ...prev?.errorMap, onSubmit: undefined },
+			}));
+		}
+		formState.form.handleSubmit();
+	};
+
 	return {
 		...formState,
 		mode,
@@ -75,6 +102,7 @@ export function useSessionWizard(args: UseSessionWizardArgs) {
 		isLastStep,
 		goToNext,
 		goToPrev,
+		handleFormSubmit,
 	};
 }
 


### PR DESCRIPTION
## Summary

- **SA2-76**: ライブセッション開始ウィザード（Cash Game）のStartステップで、Initial buy-inを空欄のままSubmitすると `Number("") === 0` に無言で変換されていたバグを修正
- `useSessionWizard` に `handleFormSubmit` ラッパーを追加し、live / start / cash の条件が揃い buyIn が空の場合はフィールドに "Required" エラーを表示してサブミットを中断
- buyIn を入力後の再送信時は手動設定したエラーを事前クリアすることで `canSubmit` が正常に `true` になるよう対処

## Changes

| File | Change |
|---|---|
| `use-session-wizard.ts` | `handleFormSubmit` ラッパー追加（live-mode buyIn guard）|
| `session-wizard.tsx` | `state.form.handleSubmit()` → `state.handleFormSubmit()` に差し替え |
| `__tests__/use-session-wizard.test.ts` | 新規テスト 7 件（TDD: 先にテストを書いてから実装）|

## Test plan

- [x] `bunx vitest run --project web-dom apps/web/src/features/sessions/components/session-wizard` — 47 tests pass
- [x] `bun run lint` — no errors
- [x] `bun run check-types` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EegUG886z7KdM8mWBZrjD3

---
_Generated by [Claude Code](https://claude.ai/code/session_01EegUG886z7KdM8mWBZrjD3)_