### PR TITLE
feat(SA2-41): ライブセッション開始時に位置情報から最寄りRoomをデフォルト選択

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -216,6 +216,7 @@ jobs:
           echo "${{ secrets.DISCORD_CLIENT_ID }}" | bunx wrangler secret put DISCORD_CLIENT_ID --name "${WORKER_NAME}"
           echo "${{ secrets.DISCORD_CLIENT_SECRET }}" | bunx wrangler secret put DISCORD_CLIENT_SECRET --name "${WORKER_NAME}"
           echo "${{ secrets.ANTHROPIC_API_KEY }}" | bunx wrangler secret put ANTHROPIC_API_KEY --name "${WORKER_NAME}"
+          echo "${{ secrets.GOOGLE_MAPS_API_KEY }}" | bunx wrangler secret put GOOGLE_MAPS_API_KEY --name "${WORKER_NAME}"
 
   deploy-web:
     needs: [setup, deploy-api]

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -219,6 +219,7 @@ jobs:
           echo "${{ secrets.DISCORD_CLIENT_ID }}" | bunx wrangler secret put DISCORD_CLIENT_ID --name "${{ needs.setup.outputs.worker_name }}"
           echo "${{ secrets.DISCORD_CLIENT_SECRET }}" | bunx wrangler secret put DISCORD_CLIENT_SECRET --name "${{ needs.setup.outputs.worker_name }}"
           echo "${{ secrets.ANTHROPIC_API_KEY }}" | bunx wrangler secret put ANTHROPIC_API_KEY --name "${{ needs.setup.outputs.worker_name }}"
+          echo "${{ secrets.GOOGLE_MAPS_API_KEY }}" | bunx wrangler secret put GOOGLE_MAPS_API_KEY --name "${{ needs.setup.outputs.worker_name }}"
 
   deploy-web:
     needs: [setup, deploy-api]

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -68,6 +68,7 @@ jobs:
           echo "${{ secrets.DISCORD_CLIENT_ID }}" | bunx wrangler secret put DISCORD_CLIENT_ID
           echo "${{ secrets.DISCORD_CLIENT_SECRET }}" | bunx wrangler secret put DISCORD_CLIENT_SECRET
           echo "${{ secrets.ANTHROPIC_API_KEY }}" | bunx wrangler secret put ANTHROPIC_API_KEY
+          echo "${{ secrets.GOOGLE_MAPS_API_KEY }}" | bunx wrangler secret put GOOGLE_MAPS_API_KEY
 
   deploy-web:
     needs: [ci, deploy-api]

--- a/apps/server/.dev.vars.example
+++ b/apps/server/.dev.vars.example
@@ -4,5 +4,6 @@ BETTER_AUTH_URL=http://localhost:8787
 CORS_ORIGIN=http://localhost:3001
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_MAPS_API_KEY=your-google-maps-api-key
 DISCORD_CLIENT_ID=your-discord-client-id
 DISCORD_CLIENT_SECRET=your-discord-client-secret

--- a/apps/server/src/worker.ts
+++ b/apps/server/src/worker.ts
@@ -16,6 +16,7 @@ interface Env {
 	DISCORD_CLIENT_SECRET?: string;
 	GOOGLE_CLIENT_ID?: string;
 	GOOGLE_CLIENT_SECRET?: string;
+	GOOGLE_MAPS_API_KEY?: string;
 }
 
 const app = new Hono<{ Bindings: Env }>();
@@ -76,7 +77,8 @@ app.use("/trpc/*", (c, next) => {
 	const contextFactory = createContextFactory(
 		auth,
 		db,
-		c.env.ANTHROPIC_API_KEY
+		c.env.ANTHROPIC_API_KEY,
+		c.env.GOOGLE_MAPS_API_KEY
 	);
 	const middleware = trpcServer({
 		router: appRouter,

--- a/apps/web/src/features/live-sessions/components/create-session-dialog/create-session-dialog.tsx
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/create-session-dialog.tsx
@@ -25,10 +25,11 @@ export function CreateSessionDialog({
 		ringGames,
 		tournaments,
 		setSelectedRoomId,
+		defaultRoomId,
 		handleSubmit,
 		isLoading,
 		handleReset,
-	} = useCreateSessionDialog({ onOpenChange });
+	} = useCreateSessionDialog({ onOpenChange, open });
 
 	return (
 		<FormSheet
@@ -45,6 +46,7 @@ export function CreateSessionDialog({
 		>
 			<LiveSessionForm
 				currencies={currencies}
+				defaultRoomId={defaultRoomId}
 				formId={LIVE_SESSION_FORM_ID}
 				onRoomChange={setSelectedRoomId}
 				onSubmit={handleSubmit}

--- a/apps/web/src/features/live-sessions/components/create-session-dialog/live-session-form/__tests__/use-live-session-form.test.ts
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/live-session-form/__tests__/use-live-session-form.test.ts
@@ -61,6 +61,64 @@ describe("useLiveSessionForm — rule disclosure", () => {
 	});
 });
 
+describe("useLiveSessionForm — geolocation default room", () => {
+	it("seeds the room selection from defaultRoomId", async () => {
+		const onRoomChange = vi.fn();
+		const { result } = renderHook(() =>
+			useLiveSessionForm({
+				defaultRoomId: "room-near",
+				onRoomChange,
+				onSubmit: vi.fn(),
+				ringGames: [RING_GAME],
+			})
+		);
+		await waitFor(() =>
+			expect(result.current.state.selectedRoomId).toBe("room-near")
+		);
+		expect(onRoomChange).toHaveBeenCalledWith("room-near");
+	});
+
+	it("does not override a room the user already picked", async () => {
+		const { result } = renderHook(
+			({ defaultRoomId }) =>
+				useLiveSessionForm({
+					defaultRoomId,
+					onSubmit: vi.fn(),
+					ringGames: [RING_GAME],
+				}),
+			{ initialProps: { defaultRoomId: undefined as string | undefined } }
+		);
+
+		act(() => result.current.state.handleRoomChange("room-manual"));
+		expect(result.current.state.selectedRoomId).toBe("room-manual");
+
+		// A geolocation suggestion that arrives afterwards must not clobber it.
+		await waitFor(() =>
+			expect(result.current.state.selectedRoomId).toBe("room-manual")
+		);
+	});
+
+	it("does not re-seed after the user clears the selection", async () => {
+		const { result } = renderHook(() =>
+			useLiveSessionForm({
+				defaultRoomId: "room-near",
+				onSubmit: vi.fn(),
+				ringGames: [RING_GAME],
+			})
+		);
+		await waitFor(() =>
+			expect(result.current.state.selectedRoomId).toBe("room-near")
+		);
+
+		act(() => result.current.state.handleRoomChange(undefined));
+		expect(result.current.state.selectedRoomId).toBeUndefined();
+		// Clearing is a deliberate user action — the default must stay cleared.
+		await waitFor(() =>
+			expect(result.current.state.selectedRoomId).toBeUndefined()
+		);
+	});
+});
+
 describe("useLiveSessionForm — submit", () => {
 	it("prevents default, stops propagation and routes shaped cash values to onSubmit", async () => {
 		const onSubmit = vi.fn();

--- a/apps/web/src/features/live-sessions/components/create-session-dialog/live-session-form/live-session-form.tsx
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/live-session-form/live-session-form.tsx
@@ -16,6 +16,8 @@ import { useLiveSessionForm } from "./use-live-session-form";
 
 interface LiveSessionFormProps {
 	currencies?: Array<{ id: string; name: string }>;
+	/** Geolocation-nearest room to pre-select as the default. */
+	defaultRoomId?: string;
 	/** Stable id the FormSheet toolbar's submit button targets via `form`. */
 	formId: string;
 	onRoomChange?: (roomId: string | undefined) => void;
@@ -33,6 +35,7 @@ interface LiveSessionFormProps {
  */
 export function LiveSessionForm({
 	currencies,
+	defaultRoomId,
 	formId,
 	onRoomChange,
 	onSubmit,
@@ -41,7 +44,13 @@ export function LiveSessionForm({
 	tournaments,
 }: LiveSessionFormProps) {
 	const { state, rulesOpen, setRulesOpen, rulesSummary, onFormSubmit } =
-		useLiveSessionForm({ onRoomChange, onSubmit, ringGames, tournaments });
+		useLiveSessionForm({
+			defaultRoomId,
+			onRoomChange,
+			onSubmit,
+			ringGames,
+			tournaments,
+		});
 
 	return (
 		<form className="flex flex-col gap-4" id={formId} onSubmit={onFormSubmit}>

--- a/apps/web/src/features/live-sessions/components/create-session-dialog/live-session-form/use-live-session-form.ts
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/live-session-form/use-live-session-form.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/features/sessions/utils/session-form-helpers";
 
 interface UseLiveSessionFormArgs {
+	defaultRoomId?: string;
 	onRoomChange?: (roomId: string | undefined) => void;
 	onSubmit: (values: SessionFormValues) => void;
 	ringGames?: RingGameOption[];
@@ -21,6 +22,7 @@ interface UseLiveSessionFormArgs {
  * laid out on one screen with the rule overrides behind a collapsible.
  */
 export function useLiveSessionForm({
+	defaultRoomId,
 	onRoomChange,
 	onSubmit,
 	ringGames,
@@ -28,6 +30,7 @@ export function useLiveSessionForm({
 }: UseLiveSessionFormArgs) {
 	const state = useSessionWizard({
 		mode: "live",
+		defaultRoomId,
 		onRoomChange,
 		onSubmit,
 		ringGames,

--- a/apps/web/src/features/live-sessions/components/create-session-dialog/use-create-session-dialog.ts
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/use-create-session-dialog.ts
@@ -7,10 +7,12 @@ import type {
 
 interface UseCreateSessionDialogOptions {
 	onOpenChange: (open: boolean) => void;
+	open?: boolean;
 }
 
 export function useCreateSessionDialog({
 	onOpenChange,
+	open,
 }: UseCreateSessionDialogOptions) {
 	const {
 		rooms,
@@ -18,10 +20,11 @@ export function useCreateSessionDialog({
 		ringGames,
 		tournaments,
 		setSelectedRoomId,
+		nearestRoomId,
 		createCash,
 		createTournament,
 		isLoading,
-	} = useCreateSession({ onClose: () => onOpenChange(false) });
+	} = useCreateSession({ onClose: () => onOpenChange(false), open });
 
 	const handleReset = () => {
 		setSelectedRoomId(undefined);
@@ -60,6 +63,7 @@ export function useCreateSessionDialog({
 		ringGames: ringGames as RingGameOption[],
 		tournaments: tournaments as TournamentOption[],
 		setSelectedRoomId,
+		defaultRoomId: nearestRoomId,
 		handleSubmit,
 		isLoading,
 		handleReset,

--- a/apps/web/src/features/live-sessions/hooks/__tests__/use-create-session.test.ts
+++ b/apps/web/src/features/live-sessions/hooks/__tests__/use-create-session.test.ts
@@ -14,10 +14,23 @@ const trpcMocks = vi.hoisted(() => ({
 	createCash: vi.fn(),
 	createTournament: vi.fn(),
 	sessionEventCreate: vi.fn(),
+	roomUpdate: vi.fn(),
+}));
+const geoMock = vi.hoisted(() => ({
+	coords: null as { latitude: number; longitude: number } | null,
 }));
 
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => navigateMock,
+}));
+
+vi.mock("@/shared/hooks/use-geolocation", () => ({
+	useGeolocation: () => ({
+		coords: geoMock.coords,
+		status: "idle",
+		error: null,
+		request: vi.fn(),
+	}),
 }));
 
 vi.mock("@/utils/trpc", () => ({
@@ -89,6 +102,9 @@ vi.mock("@/utils/trpc", () => ({
 		sessionEvent: {
 			create: { mutate: trpcMocks.sessionEventCreate },
 		},
+		room: {
+			update: { mutate: trpcMocks.roomUpdate },
+		},
 	},
 }));
 
@@ -115,6 +131,7 @@ describe("useCreateSession", () => {
 		for (const m of Object.values(trpcMocks)) {
 			m.mockReset();
 		}
+		geoMock.coords = null;
 	});
 	afterEach(() => {
 		vi.restoreAllMocks();
@@ -334,6 +351,193 @@ describe("useCreateSession", () => {
 			expect(trpcMocks.sessionEventCreate).not.toHaveBeenCalled();
 			expect(navigateMock).not.toHaveBeenCalled();
 			expect(onClose).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("nearestRoomId (geolocation default)", () => {
+		function seedRooms(qc: QueryClient) {
+			qc.setQueryData(
+				["room", "list"],
+				[
+					{
+						id: "osaka",
+						name: "Osaka",
+						latitude: 34.6937,
+						longitude: 135.5023,
+					},
+					{
+						id: "tokyo",
+						name: "Tokyo",
+						latitude: 35.6812,
+						longitude: 139.7671,
+					},
+				]
+			);
+		}
+
+		it("resolves to the closest in-range room when coords are available", async () => {
+			geoMock.coords = { latitude: 35.6812, longitude: 139.7671 };
+			const qc = createClient();
+			seedRooms(qc);
+			const { result } = renderHook(
+				() => useCreateSession({ onClose: vi.fn(), open: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await waitFor(() => expect(result.current.nearestRoomId).toBe("tokyo"));
+		});
+
+		it("is undefined when location is unavailable", async () => {
+			geoMock.coords = null;
+			const qc = createClient();
+			seedRooms(qc);
+			const { result } = renderHook(
+				() => useCreateSession({ onClose: vi.fn(), open: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await waitFor(() => expect(result.current.rooms).toHaveLength(2));
+			expect(result.current.nearestRoomId).toBeUndefined();
+		});
+
+		it("is undefined when no room is within the radius", async () => {
+			geoMock.coords = { latitude: 35.6812, longitude: 139.7671 };
+			const qc = createClient();
+			qc.setQueryData(
+				["room", "list"],
+				[
+					{
+						id: "osaka",
+						name: "Osaka",
+						latitude: 34.6937,
+						longitude: 135.5023,
+					},
+				]
+			);
+			const { result } = renderHook(
+				() => useCreateSession({ onClose: vi.fn(), open: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
+			expect(result.current.nearestRoomId).toBeUndefined();
+		});
+
+		it("ignores rooms without coordinates", async () => {
+			geoMock.coords = { latitude: 35.6812, longitude: 139.7671 };
+			const qc = createClient();
+			qc.setQueryData(
+				["room", "list"],
+				[{ id: "no-coords", name: "Legacy", latitude: null, longitude: null }]
+			);
+			const { result } = renderHook(
+				() => useCreateSession({ onClose: vi.fn(), open: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
+			expect(result.current.nearestRoomId).toBeUndefined();
+		});
+	});
+
+	describe("recordRoomLocation on session start", () => {
+		it("writes the device coords onto the room after a cash session starts", async () => {
+			geoMock.coords = { latitude: 35.6, longitude: 139.7 };
+			const qc = createClient();
+			trpcMocks.createCash.mockResolvedValue({ id: "new-1" });
+			trpcMocks.roomUpdate.mockResolvedValue({ id: "s1" });
+			const { result } = renderHook(
+				() => useCreateSession({ onClose: vi.fn(), open: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await act(async () => {
+				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
+				await Promise.resolve();
+			});
+			await waitFor(() => {
+				expect(trpcMocks.roomUpdate).toHaveBeenCalledWith({
+					id: "s1",
+					latitude: 35.6,
+					longitude: 139.7,
+				});
+			});
+		});
+
+		it("writes the device coords onto the room after a tournament starts", async () => {
+			geoMock.coords = { latitude: 12.34, longitude: 56.78 };
+			const qc = createClient();
+			trpcMocks.createTournament.mockResolvedValue({ id: "tr-1" });
+			trpcMocks.sessionEventCreate.mockResolvedValue({ id: "ev-1" });
+			trpcMocks.roomUpdate.mockResolvedValue({ id: "s9" });
+			const { result } = renderHook(
+				() => useCreateSession({ onClose: vi.fn(), open: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await act(async () => {
+				result.current.createTournament({
+					buyIn: 10_000,
+					startingStack: 20_000,
+					roomId: "s9",
+				});
+				await Promise.resolve();
+			});
+			await waitFor(() => {
+				expect(trpcMocks.roomUpdate).toHaveBeenCalledWith({
+					id: "s9",
+					latitude: 12.34,
+					longitude: 56.78,
+				});
+			});
+		});
+
+		it("does not record location when coords are unavailable", async () => {
+			geoMock.coords = null;
+			const qc = createClient();
+			trpcMocks.createCash.mockResolvedValue({ id: "new-1" });
+			const { result } = renderHook(
+				() => useCreateSession({ onClose: vi.fn(), open: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await act(async () => {
+				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
+				await Promise.resolve();
+			});
+			await waitFor(() => expect(trpcMocks.createCash).toHaveBeenCalled());
+			await Promise.resolve();
+			expect(trpcMocks.roomUpdate).not.toHaveBeenCalled();
+		});
+
+		it("does not record location when no room is selected", async () => {
+			geoMock.coords = { latitude: 35.6, longitude: 139.7 };
+			const qc = createClient();
+			trpcMocks.createCash.mockResolvedValue({ id: "new-1" });
+			const { result } = renderHook(
+				() => useCreateSession({ onClose: vi.fn(), open: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await act(async () => {
+				result.current.createCash({ initialBuyIn: 5000 });
+				await Promise.resolve();
+			});
+			await waitFor(() => expect(trpcMocks.createCash).toHaveBeenCalled());
+			await Promise.resolve();
+			expect(trpcMocks.roomUpdate).not.toHaveBeenCalled();
+		});
+
+		it("still finishes starting the session when the location write fails", async () => {
+			geoMock.coords = { latitude: 35.6, longitude: 139.7 };
+			const qc = createClient();
+			const onClose = vi.fn();
+			trpcMocks.createCash.mockResolvedValue({ id: "new-1" });
+			trpcMocks.roomUpdate.mockRejectedValue(new Error("offline"));
+			const { result } = renderHook(
+				() => useCreateSession({ onClose, open: true }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await act(async () => {
+				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
+				await Promise.resolve();
+			});
+			await waitFor(() => {
+				expect(onClose).toHaveBeenCalledTimes(1);
+				expect(navigateMock).toHaveBeenCalledWith({ to: "/active-session" });
+			});
 		});
 	});
 });

--- a/apps/web/src/features/live-sessions/hooks/__tests__/use-create-session.test.ts
+++ b/apps/web/src/features/live-sessions/hooks/__tests__/use-create-session.test.ts
@@ -14,7 +14,6 @@ const trpcMocks = vi.hoisted(() => ({
 	createCash: vi.fn(),
 	createTournament: vi.fn(),
 	sessionEventCreate: vi.fn(),
-	roomUpdate: vi.fn(),
 }));
 const geoMock = vi.hoisted(() => ({
 	coords: null as { latitude: number; longitude: number } | null,
@@ -101,9 +100,6 @@ vi.mock("@/utils/trpc", () => ({
 		},
 		sessionEvent: {
 			create: { mutate: trpcMocks.sessionEventCreate },
-		},
-		room: {
-			update: { mutate: trpcMocks.roomUpdate },
 		},
 	},
 }));
@@ -433,111 +429,6 @@ describe("useCreateSession", () => {
 			);
 			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
 			expect(result.current.nearestRoomId).toBeUndefined();
-		});
-	});
-
-	describe("recordRoomLocation on session start", () => {
-		it("writes the device coords onto the room after a cash session starts", async () => {
-			geoMock.coords = { latitude: 35.6, longitude: 139.7 };
-			const qc = createClient();
-			trpcMocks.createCash.mockResolvedValue({ id: "new-1" });
-			trpcMocks.roomUpdate.mockResolvedValue({ id: "s1" });
-			const { result } = renderHook(
-				() => useCreateSession({ onClose: vi.fn(), open: true }),
-				{ wrapper: makeWrapper(qc) }
-			);
-			await act(async () => {
-				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
-				await Promise.resolve();
-			});
-			await waitFor(() => {
-				expect(trpcMocks.roomUpdate).toHaveBeenCalledWith({
-					id: "s1",
-					latitude: 35.6,
-					longitude: 139.7,
-				});
-			});
-		});
-
-		it("writes the device coords onto the room after a tournament starts", async () => {
-			geoMock.coords = { latitude: 12.34, longitude: 56.78 };
-			const qc = createClient();
-			trpcMocks.createTournament.mockResolvedValue({ id: "tr-1" });
-			trpcMocks.sessionEventCreate.mockResolvedValue({ id: "ev-1" });
-			trpcMocks.roomUpdate.mockResolvedValue({ id: "s9" });
-			const { result } = renderHook(
-				() => useCreateSession({ onClose: vi.fn(), open: true }),
-				{ wrapper: makeWrapper(qc) }
-			);
-			await act(async () => {
-				result.current.createTournament({
-					buyIn: 10_000,
-					startingStack: 20_000,
-					roomId: "s9",
-				});
-				await Promise.resolve();
-			});
-			await waitFor(() => {
-				expect(trpcMocks.roomUpdate).toHaveBeenCalledWith({
-					id: "s9",
-					latitude: 12.34,
-					longitude: 56.78,
-				});
-			});
-		});
-
-		it("does not record location when coords are unavailable", async () => {
-			geoMock.coords = null;
-			const qc = createClient();
-			trpcMocks.createCash.mockResolvedValue({ id: "new-1" });
-			const { result } = renderHook(
-				() => useCreateSession({ onClose: vi.fn(), open: true }),
-				{ wrapper: makeWrapper(qc) }
-			);
-			await act(async () => {
-				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
-				await Promise.resolve();
-			});
-			await waitFor(() => expect(trpcMocks.createCash).toHaveBeenCalled());
-			await Promise.resolve();
-			expect(trpcMocks.roomUpdate).not.toHaveBeenCalled();
-		});
-
-		it("does not record location when no room is selected", async () => {
-			geoMock.coords = { latitude: 35.6, longitude: 139.7 };
-			const qc = createClient();
-			trpcMocks.createCash.mockResolvedValue({ id: "new-1" });
-			const { result } = renderHook(
-				() => useCreateSession({ onClose: vi.fn(), open: true }),
-				{ wrapper: makeWrapper(qc) }
-			);
-			await act(async () => {
-				result.current.createCash({ initialBuyIn: 5000 });
-				await Promise.resolve();
-			});
-			await waitFor(() => expect(trpcMocks.createCash).toHaveBeenCalled());
-			await Promise.resolve();
-			expect(trpcMocks.roomUpdate).not.toHaveBeenCalled();
-		});
-
-		it("still finishes starting the session when the location write fails", async () => {
-			geoMock.coords = { latitude: 35.6, longitude: 139.7 };
-			const qc = createClient();
-			const onClose = vi.fn();
-			trpcMocks.createCash.mockResolvedValue({ id: "new-1" });
-			trpcMocks.roomUpdate.mockRejectedValue(new Error("offline"));
-			const { result } = renderHook(
-				() => useCreateSession({ onClose, open: true }),
-				{ wrapper: makeWrapper(qc) }
-			);
-			await act(async () => {
-				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
-				await Promise.resolve();
-			});
-			await waitFor(() => {
-				expect(onClose).toHaveBeenCalledTimes(1);
-				expect(navigateMock).toHaveBeenCalledWith({ to: "/active-session" });
-			});
 		});
 	});
 });

--- a/apps/web/src/features/live-sessions/hooks/use-create-session.ts
+++ b/apps/web/src/features/live-sessions/hooks/use-create-session.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { findNearestRoom } from "@/features/live-sessions/utils/geo";
+import { useGeolocation } from "@/shared/hooks/use-geolocation";
 import { invalidateTargets } from "@/utils/optimistic-update";
 import { trpc, trpcClient } from "@/utils/trpc";
 
@@ -46,16 +48,63 @@ function useRoomTournaments(roomId: string | undefined) {
 	}));
 }
 
-export function useCreateSession({ onClose }: { onClose: () => void }) {
+export function useCreateSession({
+	onClose,
+	open = false,
+}: {
+	onClose: () => void;
+	open?: boolean;
+}) {
 	const [selectedRoomId, setSelectedRoomId] = useState<string | undefined>();
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
 
+	// Request the device location when the dialog opens so we can default the
+	// room to whichever one the user is physically nearest.
+	const { coords } = useGeolocation({ enabled: open });
+
+	const roomListKey = trpc.room.list.queryOptions().queryKey;
 	const roomsQuery = useQuery(trpc.room.list.queryOptions());
 	const rooms = (roomsQuery.data ?? []).map((s) => ({
 		id: s.id,
 		name: s.name,
 	}));
+
+	// The geolocation-nearest room (within the default radius), used as the
+	// form's default room selection. `undefined` when location is unavailable or
+	// no room with coordinates is in range.
+	const nearestRoomId = useMemo(() => {
+		if (!coords) {
+			return;
+		}
+		return findNearestRoom(
+			coords,
+			(roomsQuery.data ?? []).map((s) => ({
+				id: s.id,
+				latitude: s.latitude ?? null,
+				longitude: s.longitude ?? null,
+			}))
+		)?.id;
+	}, [coords, roomsQuery.data]);
+
+	// Record the device's coordinates onto the room a session is started at, so
+	// future starts can default to it. Fire-and-forget: a failed location write
+	// must never block starting the session.
+	const recordRoomLocation = (roomId: string | undefined) => {
+		if (!(coords && roomId)) {
+			return;
+		}
+		trpcClient.room.update
+			.mutate({
+				id: roomId,
+				latitude: coords.latitude,
+				longitude: coords.longitude,
+			})
+			.then(() => invalidateTargets(queryClient, [{ queryKey: roomListKey }]))
+			.catch(() => {
+				// Swallow — the session has already started successfully.
+			});
+	};
 
 	const currenciesQuery = useQuery(trpc.currency.list.queryOptions());
 	const currencies = (currenciesQuery.data ?? []).map((c) => ({
@@ -81,7 +130,8 @@ export function useCreateSession({ onClose }: { onClose: () => void }) {
 			ringGameId?: string;
 			roomId?: string;
 		}) => trpcClient.liveCashGameSession.create.mutate(values),
-		onSuccess: async () => {
+		onSuccess: async (_data, variables) => {
+			recordRoomLocation(variables.roomId);
 			await invalidateTargets(queryClient, [
 				{ queryKey: cashListKey },
 				{ queryKey: sessionListKey },
@@ -115,7 +165,8 @@ export function useCreateSession({ onClose }: { onClose: () => void }) {
 			});
 			return result;
 		},
-		onSuccess: async () => {
+		onSuccess: async (_data, variables) => {
+			recordRoomLocation(variables.roomId);
 			await invalidateTargets(queryClient, [
 				{ queryKey: tournamentListKey },
 				{ queryKey: sessionListKey },
@@ -135,6 +186,7 @@ export function useCreateSession({ onClose }: { onClose: () => void }) {
 		tournaments,
 		selectedRoomId,
 		setSelectedRoomId,
+		nearestRoomId,
 		createCash: (values: {
 			currencyId?: string;
 			initialBuyIn: number;

--- a/apps/web/src/features/live-sessions/hooks/use-create-session.ts
+++ b/apps/web/src/features/live-sessions/hooks/use-create-session.ts
@@ -63,7 +63,6 @@ export function useCreateSession({
 	// room to whichever one the user is physically nearest.
 	const { coords } = useGeolocation({ enabled: open });
 
-	const roomListKey = trpc.room.list.queryOptions().queryKey;
 	const roomsQuery = useQuery(trpc.room.list.queryOptions());
 	const rooms = (roomsQuery.data ?? []).map((s) => ({
 		id: s.id,
@@ -86,25 +85,6 @@ export function useCreateSession({
 			}))
 		)?.id;
 	}, [coords, roomsQuery.data]);
-
-	// Record the device's coordinates onto the room a session is started at, so
-	// future starts can default to it. Fire-and-forget: a failed location write
-	// must never block starting the session.
-	const recordRoomLocation = (roomId: string | undefined) => {
-		if (!(coords && roomId)) {
-			return;
-		}
-		trpcClient.room.update
-			.mutate({
-				id: roomId,
-				latitude: coords.latitude,
-				longitude: coords.longitude,
-			})
-			.then(() => invalidateTargets(queryClient, [{ queryKey: roomListKey }]))
-			.catch(() => {
-				// Swallow — the session has already started successfully.
-			});
-	};
 
 	const currenciesQuery = useQuery(trpc.currency.list.queryOptions());
 	const currencies = (currenciesQuery.data ?? []).map((c) => ({
@@ -130,8 +110,7 @@ export function useCreateSession({
 			ringGameId?: string;
 			roomId?: string;
 		}) => trpcClient.liveCashGameSession.create.mutate(values),
-		onSuccess: async (_data, variables) => {
-			recordRoomLocation(variables.roomId);
+		onSuccess: async () => {
 			await invalidateTargets(queryClient, [
 				{ queryKey: cashListKey },
 				{ queryKey: sessionListKey },
@@ -165,8 +144,7 @@ export function useCreateSession({
 			});
 			return result;
 		},
-		onSuccess: async (_data, variables) => {
-			recordRoomLocation(variables.roomId);
+		onSuccess: async () => {
 			await invalidateTargets(queryClient, [
 				{ queryKey: tournamentListKey },
 				{ queryKey: sessionListKey },

--- a/apps/web/src/features/live-sessions/utils/__tests__/geo.test.ts
+++ b/apps/web/src/features/live-sessions/utils/__tests__/geo.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+	type Coords,
+	DEFAULT_NEAREST_RADIUS_METERS,
+	findNearestRoom,
+	haversineMeters,
+} from "../geo";
+
+const TOKYO: Coords = { latitude: 35.6812, longitude: 139.7671 };
+
+describe("haversineMeters", () => {
+	it("returns 0 for identical points", () => {
+		expect(haversineMeters(TOKYO, TOKYO)).toBe(0);
+	});
+
+	it("computes ~111 km for one degree of latitude", () => {
+		const a: Coords = { latitude: 35, longitude: 139 };
+		const b: Coords = { latitude: 36, longitude: 139 };
+		const d = haversineMeters(a, b);
+		// One degree of latitude ≈ 111.19 km; allow 1 km tolerance.
+		expect(d).toBeGreaterThan(110_000);
+		expect(d).toBeLessThan(112_000);
+	});
+
+	it("is symmetric", () => {
+		const a: Coords = { latitude: 35, longitude: 139 };
+		const b: Coords = { latitude: 35.5, longitude: 139.5 };
+		expect(haversineMeters(a, b)).toBeCloseTo(haversineMeters(b, a), 6);
+	});
+
+	it("one degree of longitude shrinks with latitude", () => {
+		const equatorial = haversineMeters(
+			{ latitude: 0, longitude: 0 },
+			{ latitude: 0, longitude: 1 }
+		);
+		const northern = haversineMeters(
+			{ latitude: 60, longitude: 0 },
+			{ latitude: 60, longitude: 1 }
+		);
+		// At 60°N a degree of longitude is roughly half the equatorial distance.
+		expect(northern).toBeLessThan(equatorial);
+		expect(northern).toBeCloseTo(equatorial / 2, -3);
+	});
+});
+
+describe("findNearestRoom", () => {
+	const near: Coords = { latitude: 35.6815, longitude: 139.7675 }; // ~50 m from TOKYO
+	const far: Coords = { latitude: 34.6937, longitude: 135.5023 }; // Osaka, ~400 km
+
+	it("picks the closest room of several within radius", () => {
+		const rooms = [
+			{ id: "osaka", latitude: far.latitude, longitude: far.longitude },
+			{ id: "near", latitude: near.latitude, longitude: near.longitude },
+			{ id: "tokyo", latitude: TOKYO.latitude, longitude: TOKYO.longitude },
+		];
+		// Searching from TOKYO: the exact-match "tokyo" room is closest.
+		expect(findNearestRoom(TOKYO, rooms)?.id).toBe("tokyo");
+	});
+
+	it("ignores rooms with null latitude", () => {
+		const rooms = [
+			{ id: "no-lat", latitude: null, longitude: 139.7671 },
+			{ id: "tokyo", latitude: TOKYO.latitude, longitude: TOKYO.longitude },
+		];
+		expect(findNearestRoom(TOKYO, rooms)?.id).toBe("tokyo");
+	});
+
+	it("ignores rooms with null longitude", () => {
+		const rooms = [
+			{ id: "no-lng", latitude: 35.6812, longitude: null },
+			{ id: "tokyo", latitude: TOKYO.latitude, longitude: TOKYO.longitude },
+		];
+		expect(findNearestRoom(TOKYO, rooms)?.id).toBe("tokyo");
+	});
+
+	it("returns undefined when every room is outside the radius", () => {
+		const rooms = [
+			{ id: "osaka", latitude: far.latitude, longitude: far.longitude },
+		];
+		expect(findNearestRoom(TOKYO, rooms)).toBeUndefined();
+	});
+
+	it("returns undefined for an empty room list", () => {
+		expect(findNearestRoom(TOKYO, [])).toBeUndefined();
+	});
+
+	it("returns undefined when all rooms lack coordinates", () => {
+		const rooms = [
+			{ id: "a", latitude: null, longitude: null },
+			{ id: "b", latitude: null, longitude: null },
+		];
+		expect(findNearestRoom(TOKYO, rooms)).toBeUndefined();
+	});
+
+	it("respects a custom radius", () => {
+		const rooms = [
+			{ id: "near", latitude: near.latitude, longitude: near.longitude },
+		];
+		// ~50 m away: excluded by a 10 m radius, included by a 100 m radius.
+		expect(findNearestRoom(TOKYO, rooms, 10)).toBeUndefined();
+		expect(findNearestRoom(TOKYO, rooms, 100)?.id).toBe("near");
+	});
+
+	it("includes a room exactly at the radius boundary (inclusive)", () => {
+		const oneDegLat: Coords = { latitude: 36, longitude: 139 };
+		const distance = haversineMeters(
+			{ latitude: 35, longitude: 139 },
+			oneDegLat
+		);
+		const rooms = [
+			{
+				id: "edge",
+				latitude: oneDegLat.latitude,
+				longitude: oneDegLat.longitude,
+			},
+		];
+		expect(
+			findNearestRoom({ latitude: 35, longitude: 139 }, rooms, distance)?.id
+		).toBe("edge");
+	});
+
+	it("exposes a sensible default radius", () => {
+		expect(DEFAULT_NEAREST_RADIUS_METERS).toBe(500);
+	});
+});

--- a/apps/web/src/features/live-sessions/utils/geo.ts
+++ b/apps/web/src/features/live-sessions/utils/geo.ts
@@ -1,0 +1,74 @@
+/**
+ * Geographic helpers for defaulting the live-session room to whichever room is
+ * physically nearest the device. Pure functions — no browser APIs — so they run
+ * in the fast web-node test project.
+ */
+
+export interface Coords {
+	latitude: number;
+	longitude: number;
+}
+
+interface RoomLocation {
+	id: string;
+	latitude: number | null;
+	longitude: number | null;
+}
+
+/**
+ * Default "you are at this venue" radius. 500 m comfortably covers a casino /
+ * poker-room footprint plus GPS jitter without matching a different venue
+ * across town.
+ */
+export const DEFAULT_NEAREST_RADIUS_METERS = 500;
+
+const EARTH_RADIUS_METERS = 6_371_000;
+
+function toRadians(degrees: number): number {
+	return (degrees * Math.PI) / 180;
+}
+
+/**
+ * Great-circle distance between two coordinates in meters (haversine formula).
+ */
+export function haversineMeters(a: Coords, b: Coords): number {
+	const dLat = toRadians(b.latitude - a.latitude);
+	const dLng = toRadians(b.longitude - a.longitude);
+	const lat1 = toRadians(a.latitude);
+	const lat2 = toRadians(b.latitude);
+
+	const h =
+		Math.sin(dLat / 2) ** 2 +
+		Math.sin(dLng / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2);
+	return 2 * EARTH_RADIUS_METERS * Math.asin(Math.sqrt(h));
+}
+
+/**
+ * Returns the room closest to `coords` whose distance is within `radiusMeters`
+ * (inclusive), or `undefined` when no room has coordinates or all are out of
+ * range. Rooms missing either coordinate are skipped.
+ */
+export function findNearestRoom<T extends RoomLocation>(
+	coords: Coords,
+	rooms: readonly T[],
+	radiusMeters: number = DEFAULT_NEAREST_RADIUS_METERS
+): T | undefined {
+	let nearest: T | undefined;
+	let nearestDistance = Number.POSITIVE_INFINITY;
+
+	for (const candidate of rooms) {
+		if (candidate.latitude === null || candidate.longitude === null) {
+			continue;
+		}
+		const distance = haversineMeters(coords, {
+			latitude: candidate.latitude,
+			longitude: candidate.longitude,
+		});
+		if (distance <= radiusMeters && distance < nearestDistance) {
+			nearest = candidate;
+			nearestDistance = distance;
+		}
+	}
+
+	return nearest;
+}

--- a/apps/web/src/features/rooms/components/room-form/__tests__/use-room-form.test.ts
+++ b/apps/web/src/features/rooms/components/room-form/__tests__/use-room-form.test.ts
@@ -1,28 +1,87 @@
-import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useRoomForm } from "@/features/rooms/components/room-form/use-room-form";
 
-describe("useRoomForm", () => {
-	it("starts with empty name and memo", () => {
-		const onSubmit = vi.fn();
-		const { result } = renderHook(() => useRoomForm({ onSubmit }));
-		expect(result.current.form.state.values).toEqual({ name: "", memo: "" });
+type SuccessFn = (position: {
+	coords: { latitude: number; longitude: number };
+}) => void;
+type ErrorFn = (error: { code: number; message: string }) => void;
+
+const originalGeo = Object.getOwnPropertyDescriptor(navigator, "geolocation");
+let getCurrentPosition: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+	getCurrentPosition = vi.fn();
+	Object.defineProperty(navigator, "geolocation", {
+		configurable: true,
+		value: { getCurrentPosition },
+	});
+});
+
+afterEach(() => {
+	if (originalGeo) {
+		Object.defineProperty(navigator, "geolocation", originalGeo);
+	} else {
+		// biome-ignore lint/performance/noDelete: restoring jsdom's missing property
+		delete (navigator as { geolocation?: unknown }).geolocation;
+	}
+	vi.restoreAllMocks();
+});
+
+describe("useRoomForm — fields", () => {
+	it("starts with empty name, memo, latitude and longitude", () => {
+		const { result } = renderHook(() => useRoomForm({ onSubmit: vi.fn() }));
+		expect(result.current.form.state.values).toEqual({
+			name: "",
+			memo: "",
+			latitude: "",
+			longitude: "",
+		});
 	});
 
-	it("seeds form from defaultValues", () => {
-		const onSubmit = vi.fn();
+	it("seeds name and memo from defaultValues", () => {
 		const { result } = renderHook(() =>
 			useRoomForm({
-				onSubmit,
+				onSubmit: vi.fn(),
 				defaultValues: { name: "Room A", memo: "hello" },
 			})
 		);
 		expect(result.current.form.state.values).toEqual({
 			name: "Room A",
 			memo: "hello",
+			latitude: "",
+			longitude: "",
 		});
 	});
 
+	it("seeds latitude/longitude from numeric defaultValues as strings", () => {
+		const { result } = renderHook(() =>
+			useRoomForm({
+				onSubmit: vi.fn(),
+				defaultValues: {
+					name: "Room A",
+					latitude: 35.6812,
+					longitude: 139.7671,
+				},
+			})
+		);
+		expect(result.current.form.state.values.latitude).toBe("35.6812");
+		expect(result.current.form.state.values.longitude).toBe("139.7671");
+	});
+
+	it("treats null defaultValue coordinates as empty fields", () => {
+		const { result } = renderHook(() =>
+			useRoomForm({
+				onSubmit: vi.fn(),
+				defaultValues: { name: "Room A", latitude: null, longitude: null },
+			})
+		);
+		expect(result.current.form.state.values.latitude).toBe("");
+		expect(result.current.form.state.values.longitude).toBe("");
+	});
+});
+
+describe("useRoomForm — submit", () => {
 	it("rejects submit with empty name", async () => {
 		const onSubmit = vi.fn();
 		const { result } = renderHook(() => useRoomForm({ onSubmit }));
@@ -32,7 +91,7 @@ describe("useRoomForm", () => {
 		expect(onSubmit).not.toHaveBeenCalled();
 	});
 
-	it("submits with memo=undefined when memo is empty", async () => {
+	it("submits memo and coordinates as undefined when all are empty", async () => {
 		const onSubmit = vi.fn();
 		const { result } = renderHook(() => useRoomForm({ onSubmit }));
 		act(() => {
@@ -41,19 +100,113 @@ describe("useRoomForm", () => {
 		await act(async () => {
 			await result.current.form.handleSubmit();
 		});
-		expect(onSubmit).toHaveBeenCalledWith({ name: "Room", memo: undefined });
+		expect(onSubmit).toHaveBeenCalledWith({
+			name: "Room",
+			memo: undefined,
+			latitude: undefined,
+			longitude: undefined,
+		});
 	});
 
-	it("submits with memo preserved when memo is non-empty", async () => {
+	it("submits typed coordinates as numbers", async () => {
 		const onSubmit = vi.fn();
 		const { result } = renderHook(() => useRoomForm({ onSubmit }));
 		act(() => {
 			result.current.form.setFieldValue("name", "Room");
-			result.current.form.setFieldValue("memo", "hi");
+			result.current.form.setFieldValue("latitude", "35.6812");
+			result.current.form.setFieldValue("longitude", "139.7671");
 		});
 		await act(async () => {
 			await result.current.form.handleSubmit();
 		});
-		expect(onSubmit).toHaveBeenCalledWith({ name: "Room", memo: "hi" });
+		expect(onSubmit).toHaveBeenCalledWith({
+			name: "Room",
+			memo: undefined,
+			latitude: 35.6812,
+			longitude: 139.7671,
+		});
+	});
+
+	it("rejects a latitude outside [-90, 90]", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(() => useRoomForm({ onSubmit }));
+		act(() => {
+			result.current.form.setFieldValue("name", "Room");
+			result.current.form.setFieldValue("latitude", "91");
+			result.current.form.setFieldValue("longitude", "100");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("rejects a longitude outside [-180, 180]", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(() => useRoomForm({ onSubmit }));
+		act(() => {
+			result.current.form.setFieldValue("name", "Room");
+			result.current.form.setFieldValue("latitude", "35");
+			result.current.form.setFieldValue("longitude", "181");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("rejects when only one coordinate is provided", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(() => useRoomForm({ onSubmit }));
+		act(() => {
+			result.current.form.setFieldValue("name", "Room");
+			result.current.form.setFieldValue("latitude", "35.6812");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+});
+
+describe("useRoomForm — capture current location", () => {
+	function fireSuccess(latitude: number, longitude: number) {
+		const success = getCurrentPosition.mock.calls[0][0] as SuccessFn;
+		act(() => {
+			success({ coords: { latitude, longitude } });
+		});
+	}
+
+	it("does not request a position until captureLocation is called", () => {
+		renderHook(() => useRoomForm({ onSubmit: vi.fn() }));
+		expect(getCurrentPosition).not.toHaveBeenCalled();
+	});
+
+	it("writes a captured fix into the latitude/longitude fields", async () => {
+		const { result } = renderHook(() => useRoomForm({ onSubmit: vi.fn() }));
+		act(() => {
+			result.current.captureLocation();
+		});
+		expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+		fireSuccess(35.6812, 139.7671);
+		await waitFor(() => {
+			expect(result.current.form.state.values.latitude).toBe("35.6812");
+			expect(result.current.form.state.values.longitude).toBe("139.7671");
+		});
+		expect(result.current.locationStatus).toBe("granted");
+	});
+
+	it("surfaces a denied status without touching the fields", async () => {
+		const { result } = renderHook(() => useRoomForm({ onSubmit: vi.fn() }));
+		act(() => {
+			result.current.captureLocation();
+		});
+		const errorCb = getCurrentPosition.mock.calls[0][1] as ErrorFn;
+		act(() => {
+			errorCb({ code: 1, message: "denied" });
+		});
+		await waitFor(() => expect(result.current.locationStatus).toBe("denied"));
+		expect(result.current.form.state.values.latitude).toBe("");
+		expect(result.current.form.state.values.longitude).toBe("");
 	});
 });

--- a/apps/web/src/features/rooms/components/room-form/__tests__/use-room-form.test.ts
+++ b/apps/web/src/features/rooms/components/room-form/__tests__/use-room-form.test.ts
@@ -1,32 +1,6 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { useRoomForm } from "@/features/rooms/components/room-form/use-room-form";
-
-type SuccessFn = (position: {
-	coords: { latitude: number; longitude: number };
-}) => void;
-type ErrorFn = (error: { code: number; message: string }) => void;
-
-const originalGeo = Object.getOwnPropertyDescriptor(navigator, "geolocation");
-let getCurrentPosition: ReturnType<typeof vi.fn>;
-
-beforeEach(() => {
-	getCurrentPosition = vi.fn();
-	Object.defineProperty(navigator, "geolocation", {
-		configurable: true,
-		value: { getCurrentPosition },
-	});
-});
-
-afterEach(() => {
-	if (originalGeo) {
-		Object.defineProperty(navigator, "geolocation", originalGeo);
-	} else {
-		// biome-ignore lint/performance/noDelete: restoring jsdom's missing property
-		delete (navigator as { geolocation?: unknown }).geolocation;
-	}
-	vi.restoreAllMocks();
-});
 
 describe("useRoomForm — fields", () => {
 	it("starts with empty name, memo, latitude and longitude", () => {
@@ -81,6 +55,31 @@ describe("useRoomForm — fields", () => {
 	});
 });
 
+describe("useRoomForm — setCoords", () => {
+	it("sets both latitude and longitude fields from a coordinate pair", () => {
+		const { result } = renderHook(() => useRoomForm({ onSubmit: vi.fn() }));
+		act(() => {
+			result.current.setCoords({ latitude: 35.6812, longitude: 139.7671 });
+		});
+		expect(result.current.form.state.values.latitude).toBe("35.6812");
+		expect(result.current.form.state.values.longitude).toBe("139.7671");
+	});
+
+	it("clears both fields when passed null", () => {
+		const { result } = renderHook(() =>
+			useRoomForm({
+				onSubmit: vi.fn(),
+				defaultValues: { name: "Room", latitude: 1, longitude: 2 },
+			})
+		);
+		act(() => {
+			result.current.setCoords(null);
+		});
+		expect(result.current.form.state.values.latitude).toBe("");
+		expect(result.current.form.state.values.longitude).toBe("");
+	});
+});
+
 describe("useRoomForm — submit", () => {
 	it("rejects submit with empty name", async () => {
 		const onSubmit = vi.fn();
@@ -108,13 +107,12 @@ describe("useRoomForm — submit", () => {
 		});
 	});
 
-	it("submits typed coordinates as numbers", async () => {
+	it("submits coordinates set via setCoords as numbers", async () => {
 		const onSubmit = vi.fn();
 		const { result } = renderHook(() => useRoomForm({ onSubmit }));
 		act(() => {
 			result.current.form.setFieldValue("name", "Room");
-			result.current.form.setFieldValue("latitude", "35.6812");
-			result.current.form.setFieldValue("longitude", "139.7671");
+			result.current.setCoords({ latitude: 35.6812, longitude: 139.7671 });
 		});
 		await act(async () => {
 			await result.current.form.handleSubmit();
@@ -127,86 +125,25 @@ describe("useRoomForm — submit", () => {
 		});
 	});
 
-	it("rejects a latitude outside [-90, 90]", async () => {
+	it("submits undefined coordinates after setCoords(null)", async () => {
 		const onSubmit = vi.fn();
-		const { result } = renderHook(() => useRoomForm({ onSubmit }));
+		const { result } = renderHook(() =>
+			useRoomForm({
+				onSubmit,
+				defaultValues: { name: "Room", latitude: 1, longitude: 2 },
+			})
+		);
 		act(() => {
-			result.current.form.setFieldValue("name", "Room");
-			result.current.form.setFieldValue("latitude", "91");
-			result.current.form.setFieldValue("longitude", "100");
+			result.current.setCoords(null);
 		});
 		await act(async () => {
 			await result.current.form.handleSubmit();
 		});
-		expect(onSubmit).not.toHaveBeenCalled();
-	});
-
-	it("rejects a longitude outside [-180, 180]", async () => {
-		const onSubmit = vi.fn();
-		const { result } = renderHook(() => useRoomForm({ onSubmit }));
-		act(() => {
-			result.current.form.setFieldValue("name", "Room");
-			result.current.form.setFieldValue("latitude", "35");
-			result.current.form.setFieldValue("longitude", "181");
+		expect(onSubmit).toHaveBeenCalledWith({
+			name: "Room",
+			memo: undefined,
+			latitude: undefined,
+			longitude: undefined,
 		});
-		await act(async () => {
-			await result.current.form.handleSubmit();
-		});
-		expect(onSubmit).not.toHaveBeenCalled();
-	});
-
-	it("rejects when only one coordinate is provided", async () => {
-		const onSubmit = vi.fn();
-		const { result } = renderHook(() => useRoomForm({ onSubmit }));
-		act(() => {
-			result.current.form.setFieldValue("name", "Room");
-			result.current.form.setFieldValue("latitude", "35.6812");
-		});
-		await act(async () => {
-			await result.current.form.handleSubmit();
-		});
-		expect(onSubmit).not.toHaveBeenCalled();
-	});
-});
-
-describe("useRoomForm — capture current location", () => {
-	function fireSuccess(latitude: number, longitude: number) {
-		const success = getCurrentPosition.mock.calls[0][0] as SuccessFn;
-		act(() => {
-			success({ coords: { latitude, longitude } });
-		});
-	}
-
-	it("does not request a position until captureLocation is called", () => {
-		renderHook(() => useRoomForm({ onSubmit: vi.fn() }));
-		expect(getCurrentPosition).not.toHaveBeenCalled();
-	});
-
-	it("writes a captured fix into the latitude/longitude fields", async () => {
-		const { result } = renderHook(() => useRoomForm({ onSubmit: vi.fn() }));
-		act(() => {
-			result.current.captureLocation();
-		});
-		expect(getCurrentPosition).toHaveBeenCalledTimes(1);
-		fireSuccess(35.6812, 139.7671);
-		await waitFor(() => {
-			expect(result.current.form.state.values.latitude).toBe("35.6812");
-			expect(result.current.form.state.values.longitude).toBe("139.7671");
-		});
-		expect(result.current.locationStatus).toBe("granted");
-	});
-
-	it("surfaces a denied status without touching the fields", async () => {
-		const { result } = renderHook(() => useRoomForm({ onSubmit: vi.fn() }));
-		act(() => {
-			result.current.captureLocation();
-		});
-		const errorCb = getCurrentPosition.mock.calls[0][1] as ErrorFn;
-		act(() => {
-			errorCb({ code: 1, message: "denied" });
-		});
-		await waitFor(() => expect(result.current.locationStatus).toBe("denied"));
-		expect(result.current.form.state.values.latitude).toBe("");
-		expect(result.current.form.state.values.longitude).toBe("");
 	});
 });

--- a/apps/web/src/features/rooms/components/room-form/location-picker/__tests__/maps-url.test.ts
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/__tests__/maps-url.test.ts
@@ -25,6 +25,7 @@ describe("isGoogleMapsUrl", () => {
 	it("rejects lookalike hosts", () => {
 		expect(isGoogleMapsUrl("https://google.com.evil.com/maps")).toBe(false);
 		expect(isGoogleMapsUrl("https://evil-google.com")).toBe(false);
+		expect(isGoogleMapsUrl("https://google.evil.com/maps")).toBe(false);
 	});
 
 	it("rejects non-URL strings", () => {

--- a/apps/web/src/features/rooms/components/room-form/location-picker/__tests__/maps-url.test.ts
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/__tests__/maps-url.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isGoogleMapsUrl } from "../maps-url";
+
+describe("isGoogleMapsUrl", () => {
+	it("accepts full google.com maps URLs", () => {
+		expect(isGoogleMapsUrl("https://www.google.com/maps/@35.6,139.7,17z")).toBe(
+			true
+		);
+	});
+
+	it("accepts country TLDs and maps subdomain", () => {
+		expect(isGoogleMapsUrl("https://maps.google.com/?q=35.6,139.7")).toBe(true);
+		expect(isGoogleMapsUrl("https://www.google.co.jp/maps")).toBe(true);
+	});
+
+	it("accepts short links", () => {
+		expect(isGoogleMapsUrl("https://maps.app.goo.gl/abcd")).toBe(true);
+		expect(isGoogleMapsUrl("https://goo.gl/maps/abcd")).toBe(true);
+	});
+
+	it("rejects non-google hosts", () => {
+		expect(isGoogleMapsUrl("https://example.com/maps")).toBe(false);
+	});
+
+	it("rejects lookalike hosts", () => {
+		expect(isGoogleMapsUrl("https://google.com.evil.com/maps")).toBe(false);
+		expect(isGoogleMapsUrl("https://evil-google.com")).toBe(false);
+	});
+
+	it("rejects non-URL strings", () => {
+		expect(isGoogleMapsUrl("not a url")).toBe(false);
+		expect(isGoogleMapsUrl("")).toBe(false);
+	});
+});

--- a/apps/web/src/features/rooms/components/room-form/location-picker/__tests__/use-location-picker.test.ts
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/__tests__/use-location-picker.test.ts
@@ -51,6 +51,7 @@ function makeWrapper(client: QueryClient) {
 
 function renderPicker(
 	props: {
+		initialQuery?: string;
 		latitude?: number | null;
 		longitude?: number | null;
 		onCoordsChange?: (
@@ -62,6 +63,7 @@ function renderPicker(
 	const utils = renderHook(
 		() =>
 			useLocationPicker({
+				initialQuery: props.initialQuery,
 				latitude: props.latitude ?? null,
 				longitude: props.longitude ?? null,
 				onCoordsChange,
@@ -163,8 +165,36 @@ describe("useLocationPicker", () => {
 			const { result, onCoordsChange } = renderPicker();
 			act(() => result.current.setLink("https://maps.app.goo.gl/x"));
 			act(() => result.current.handleResolveLink());
-			await waitFor(() => expect(result.current.resolveError).toBe("bad link"));
+			await waitFor(() => expect(result.current.linkError).toBe("bad link"));
 			expect(onCoordsChange).not.toHaveBeenCalled();
+		});
+
+		it("marks a non-Google-Maps URL invalid and blocks resolution", () => {
+			const { result } = renderPicker();
+			act(() => result.current.setLink("https://example.com/maps"));
+			expect(result.current.isLinkValid).toBe(false);
+			expect(result.current.linkError).toBe("Enter a valid Google Maps URL");
+			act(() => result.current.handleResolveLink());
+			expect(trpcMocks.resolveLink).not.toHaveBeenCalled();
+		});
+
+		it("accepts a valid Google Maps URL", () => {
+			const { result } = renderPicker();
+			act(() => result.current.setLink("https://maps.app.goo.gl/abc"));
+			expect(result.current.isLinkValid).toBe(true);
+			expect(result.current.linkError).toBeNull();
+		});
+	});
+
+	describe("initial query", () => {
+		it("seeds the search box with the provided initial query", () => {
+			const { result } = renderPicker({ initialQuery: "Casino Tokyo" });
+			expect(result.current.query).toBe("Casino Tokyo");
+		});
+
+		it("defaults to an empty query when none is provided", () => {
+			const { result } = renderPicker();
+			expect(result.current.query).toBe("");
 		});
 	});
 

--- a/apps/web/src/features/rooms/components/room-form/location-picker/__tests__/use-location-picker.test.ts
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/__tests__/use-location-picker.test.ts
@@ -1,0 +1,203 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const trpcMocks = vi.hoisted(() => ({
+	search: vi.fn(),
+	resolveLink: vi.fn(),
+}));
+const geoMock = vi.hoisted(() => ({
+	coords: null as { latitude: number; longitude: number } | null,
+	request: vi.fn(),
+	status: "idle" as string,
+}));
+
+vi.mock("@/utils/trpc", () => ({
+	trpc: {},
+	trpcClient: {
+		location: {
+			search: { mutate: trpcMocks.search },
+			resolveLink: { mutate: trpcMocks.resolveLink },
+		},
+	},
+}));
+
+vi.mock("@/shared/hooks/use-geolocation", () => ({
+	useGeolocation: () => ({
+		coords: geoMock.coords,
+		status: geoMock.status,
+		error: null,
+		request: geoMock.request,
+	}),
+}));
+
+import { useLocationPicker } from "@/features/rooms/components/room-form/location-picker/use-location-picker";
+
+function createClient(): QueryClient {
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0 },
+			mutations: { retry: false },
+		},
+	});
+}
+
+function makeWrapper(client: QueryClient) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return createElement(QueryClientProvider, { client }, children);
+	};
+}
+
+function renderPicker(
+	props: {
+		latitude?: number | null;
+		longitude?: number | null;
+		onCoordsChange?: (
+			c: { latitude: number; longitude: number } | null
+		) => void;
+	} = {}
+) {
+	const onCoordsChange = props.onCoordsChange ?? vi.fn();
+	const utils = renderHook(
+		() =>
+			useLocationPicker({
+				latitude: props.latitude ?? null,
+				longitude: props.longitude ?? null,
+				onCoordsChange,
+			}),
+		{ wrapper: makeWrapper(createClient()) }
+	);
+	return { ...utils, onCoordsChange };
+}
+
+describe("useLocationPicker", () => {
+	beforeEach(() => {
+		trpcMocks.search.mockReset();
+		trpcMocks.resolveLink.mockReset();
+		geoMock.coords = null;
+		geoMock.request.mockReset();
+		geoMock.status = "idle";
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("place search", () => {
+		it("searches with the trimmed query and exposes results", async () => {
+			trpcMocks.search.mockResolvedValue([
+				{ name: "Casino", address: "Tokyo", latitude: 35.6, longitude: 139.7 },
+			]);
+			const { result } = renderPicker();
+			act(() => result.current.setQuery("  casino  "));
+			act(() => result.current.handleSearch());
+			await waitFor(() => expect(result.current.results).toHaveLength(1));
+			expect(trpcMocks.search).toHaveBeenCalledWith({ query: "casino" });
+		});
+
+		it("does not search when the query is blank", () => {
+			const { result } = renderPicker();
+			act(() => result.current.setQuery("   "));
+			act(() => result.current.handleSearch());
+			expect(trpcMocks.search).not.toHaveBeenCalled();
+		});
+
+		it("picking a result reports its coordinates and clears the search", async () => {
+			trpcMocks.search.mockResolvedValue([
+				{ name: "Casino", address: "Tokyo", latitude: 35.6, longitude: 139.7 },
+			]);
+			const { result, onCoordsChange } = renderPicker();
+			act(() => result.current.setQuery("casino"));
+			act(() => result.current.handleSearch());
+			await waitFor(() => expect(result.current.results).toHaveLength(1));
+			act(() => result.current.pickResult(result.current.results[0]));
+			expect(onCoordsChange).toHaveBeenCalledWith({
+				latitude: 35.6,
+				longitude: 139.7,
+			});
+			await waitFor(() => expect(result.current.results).toHaveLength(0));
+			expect(result.current.query).toBe("");
+		});
+
+		it("surfaces a search error", async () => {
+			trpcMocks.search.mockRejectedValue(new Error("search boom"));
+			const { result } = renderPicker();
+			act(() => result.current.setQuery("casino"));
+			act(() => result.current.handleSearch());
+			await waitFor(() =>
+				expect(result.current.searchError).toBe("search boom")
+			);
+		});
+	});
+
+	describe("resolve link", () => {
+		it("resolves a link and reports the coordinates", async () => {
+			trpcMocks.resolveLink.mockResolvedValue({
+				latitude: 35.6812,
+				longitude: 139.7671,
+			});
+			const { result, onCoordsChange } = renderPicker();
+			act(() => result.current.setLink("https://maps.app.goo.gl/abc"));
+			act(() => result.current.handleResolveLink());
+			await waitFor(() =>
+				expect(onCoordsChange).toHaveBeenCalledWith({
+					latitude: 35.6812,
+					longitude: 139.7671,
+				})
+			);
+			expect(trpcMocks.resolveLink).toHaveBeenCalledWith({
+				url: "https://maps.app.goo.gl/abc",
+			});
+			await waitFor(() => expect(result.current.link).toBe(""));
+		});
+
+		it("does not resolve when the link is blank", () => {
+			const { result } = renderPicker();
+			act(() => result.current.setLink("  "));
+			act(() => result.current.handleResolveLink());
+			expect(trpcMocks.resolveLink).not.toHaveBeenCalled();
+		});
+
+		it("surfaces a resolve error and does not report coordinates", async () => {
+			trpcMocks.resolveLink.mockRejectedValue(new Error("bad link"));
+			const { result, onCoordsChange } = renderPicker();
+			act(() => result.current.setLink("https://maps.app.goo.gl/x"));
+			act(() => result.current.handleResolveLink());
+			await waitFor(() => expect(result.current.resolveError).toBe("bad link"));
+			expect(onCoordsChange).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("gps + clear + hasLocation", () => {
+		it("reports a GPS fix through onCoordsChange", () => {
+			geoMock.coords = { latitude: 1.5, longitude: 2.5 };
+			const { onCoordsChange } = renderPicker();
+			expect(onCoordsChange).toHaveBeenCalledWith({
+				latitude: 1.5,
+				longitude: 2.5,
+			});
+		});
+
+		it("captureLocation triggers the geolocation request", () => {
+			const { result } = renderPicker();
+			act(() => result.current.captureLocation());
+			expect(geoMock.request).toHaveBeenCalledTimes(1);
+		});
+
+		it("clearLocation reports null", () => {
+			const { result, onCoordsChange } = renderPicker({
+				latitude: 35.6,
+				longitude: 139.7,
+			});
+			act(() => result.current.clearLocation());
+			expect(onCoordsChange).toHaveBeenCalledWith(null);
+		});
+
+		it("reflects hasLocation from the props", () => {
+			const withCoords = renderPicker({ latitude: 35.6, longitude: 139.7 });
+			expect(withCoords.result.current.hasLocation).toBe(true);
+			const without = renderPicker();
+			expect(without.result.current.hasLocation).toBe(false);
+		});
+	});
+});

--- a/apps/web/src/features/rooms/components/room-form/location-picker/index.ts
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/index.ts
@@ -1,0 +1,2 @@
+export { LocationPicker } from "./location-picker";
+export type { Coords } from "./use-location-picker";

--- a/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.test.tsx
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.test.tsx
@@ -35,7 +35,8 @@ function baseState(overrides: Record<string, unknown> = {}) {
 		pickResult: vi.fn(),
 		handleResolveLink: vi.fn(),
 		isResolving: false,
-		resolveError: null,
+		isLinkValid: false,
+		linkError: null,
 		captureLocation: vi.fn(),
 		gpsStatus: "idle",
 		clearLocation: vi.fn(),
@@ -66,7 +67,7 @@ describe("LocationPicker", () => {
 	it("renders search, link and current-location tabs", () => {
 		renderPicker();
 		expect(screen.getByRole("tab", { name: "Search" })).toBeInTheDocument();
-		expect(screen.getByRole("tab", { name: "Link" })).toBeInTheDocument();
+		expect(screen.getByRole("tab", { name: "URL" })).toBeInTheDocument();
 		expect(screen.getByRole("tab", { name: "Current" })).toBeInTheDocument();
 	});
 

--- a/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.test.tsx
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const hookState = vi.hoisted(() => ({
+	current: {} as Record<string, unknown>,
+}));
+
+vi.mock("./use-location-picker", () => ({
+	useLocationPicker: () => hookState.current,
+}));
+
+import { LocationPicker } from "./location-picker";
+
+const SEARCH_RE = /search/i;
+const CASINO_RE = /casino/i;
+const CLEAR_RE = /clear/i;
+const MAPS_RE = /view on google maps/i;
+const LOCATION_SET_RE = /location set:/i;
+
+function baseState(overrides: Record<string, unknown> = {}) {
+	return {
+		query: "",
+		setQuery: vi.fn(),
+		link: "",
+		setLink: vi.fn(),
+		handleSearch: vi.fn(),
+		results: [] as Array<{
+			name: string;
+			address: string;
+			latitude: number;
+			longitude: number;
+		}>,
+		isSearching: false,
+		searchError: null,
+		pickResult: vi.fn(),
+		handleResolveLink: vi.fn(),
+		isResolving: false,
+		resolveError: null,
+		captureLocation: vi.fn(),
+		gpsStatus: "idle",
+		clearLocation: vi.fn(),
+		hasLocation: false,
+		...overrides,
+	};
+}
+
+function renderPicker(
+	overrides: Record<string, unknown> = {},
+	props: { latitude?: number | null; longitude?: number | null } = {}
+) {
+	hookState.current = baseState(overrides);
+	return render(
+		<LocationPicker
+			latitude={props.latitude ?? null}
+			longitude={props.longitude ?? null}
+			onCoordsChange={vi.fn()}
+		/>
+	);
+}
+
+describe("LocationPicker", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders search, link and current-location tabs", () => {
+		renderPicker();
+		expect(screen.getByRole("tab", { name: "Search" })).toBeInTheDocument();
+		expect(screen.getByRole("tab", { name: "Link" })).toBeInTheDocument();
+		expect(screen.getByRole("tab", { name: "Current" })).toBeInTheDocument();
+	});
+
+	it("triggers handleSearch from the search button", () => {
+		const handleSearch = vi.fn();
+		renderPicker({ query: "casino", handleSearch });
+		fireEvent.click(screen.getByRole("button", { name: SEARCH_RE }));
+		expect(handleSearch).toHaveBeenCalledTimes(1);
+	});
+
+	it("disables the search button when the query is blank", () => {
+		renderPicker({ query: "   " });
+		expect(screen.getByRole("button", { name: SEARCH_RE })).toBeDisabled();
+	});
+
+	it("picks a search result on click", () => {
+		const pickResult = vi.fn();
+		const result = {
+			name: "Casino",
+			address: "Tokyo",
+			latitude: 35.6,
+			longitude: 139.7,
+		};
+		renderPicker({ query: "casino", results: [result], pickResult });
+		fireEvent.click(screen.getByRole("button", { name: CASINO_RE }));
+		expect(pickResult).toHaveBeenCalledWith(result);
+	});
+
+	it("shows the confirmation link and clear button when a location is set", () => {
+		const clearLocation = vi.fn();
+		renderPicker(
+			{ hasLocation: true, clearLocation },
+			{ latitude: 35.6812, longitude: 139.7671 }
+		);
+		const link = screen.getByRole("link", { name: MAPS_RE });
+		expect(link).toHaveAttribute(
+			"href",
+			"https://www.google.com/maps/search/?api=1&query=35.6812,139.7671"
+		);
+		fireEvent.click(screen.getByRole("button", { name: CLEAR_RE }));
+		expect(clearLocation).toHaveBeenCalledTimes(1);
+	});
+
+	it("hides the confirmation when no location is set", () => {
+		renderPicker({ hasLocation: false });
+		expect(screen.queryByText(LOCATION_SET_RE)).not.toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.tsx
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.tsx
@@ -16,6 +16,7 @@ import type { Coords } from "./use-location-picker";
 import { useLocationPicker } from "./use-location-picker";
 
 interface LocationPickerProps {
+	initialQuery?: string;
 	latitude: number | null;
 	longitude: number | null;
 	onCoordsChange: (coords: Coords | null) => void;
@@ -28,6 +29,7 @@ const GPS_STATUS_MESSAGE: Partial<Record<string, string>> = {
 };
 
 export function LocationPicker({
+	initialQuery,
 	latitude,
 	longitude,
 	onCoordsChange,
@@ -44,12 +46,13 @@ export function LocationPicker({
 		pickResult,
 		handleResolveLink,
 		isResolving,
-		resolveError,
+		isLinkValid,
+		linkError,
 		captureLocation,
 		gpsStatus,
 		clearLocation,
 		hasLocation,
-	} = useLocationPicker({ latitude, longitude, onCoordsChange });
+	} = useLocationPicker({ initialQuery, latitude, longitude, onCoordsChange });
 
 	const gpsMessage = GPS_STATUS_MESSAGE[gpsStatus];
 
@@ -59,7 +62,7 @@ export function LocationPicker({
 			<Tabs defaultValue="search">
 				<TabsList className="w-full">
 					<TabsTrigger value="search">Search</TabsTrigger>
-					<TabsTrigger value="link">Link</TabsTrigger>
+					<TabsTrigger value="link">URL</TabsTrigger>
 					<TabsTrigger value="gps">Current</TabsTrigger>
 				</TabsList>
 
@@ -114,13 +117,13 @@ export function LocationPicker({
 				<TabsContent className="flex flex-col gap-2 pt-1" value="link">
 					<div className="flex gap-2">
 						<Input
-							aria-label="Google Maps link"
+							aria-label="Google Maps URL"
 							inputMode="url"
 							onChange={(e) => setLink(e.target.value)}
 							value={link}
 						/>
 						<Button
-							disabled={isResolving || link.trim() === ""}
+							disabled={isResolving || !isLinkValid}
 							onClick={handleResolveLink}
 							type="button"
 							variant="outline"
@@ -129,9 +132,7 @@ export function LocationPicker({
 							Set
 						</Button>
 					</div>
-					{resolveError && (
-						<p className="text-destructive text-sm">{resolveError}</p>
-					)}
+					{linkError && <p className="text-destructive text-sm">{linkError}</p>}
 				</TabsContent>
 
 				<TabsContent

--- a/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.tsx
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.tsx
@@ -5,8 +5,13 @@ import {
 	IconX,
 } from "@tabler/icons-react";
 import { Button } from "@/shared/components/ui/button";
-import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
+import {
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
+} from "@/shared/components/ui/tabs";
 import type { Coords } from "./use-location-picker";
 import { useLocationPicker } from "./use-location-picker";
 
@@ -50,95 +55,111 @@ export function LocationPicker({
 
 	return (
 		<div className="flex flex-col gap-3">
-			<Field label="Search a place">
-				<div className="flex gap-2">
-					<Input
-						onChange={(e) => setQuery(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === "Enter") {
-								e.preventDefault();
-								handleSearch();
-							}
-						}}
-						value={query}
-					/>
-					<Button
-						disabled={isSearching || query.trim() === ""}
-						onClick={handleSearch}
-						type="button"
-						variant="outline"
-					>
-						<IconSearch size={16} />
-						Search
-					</Button>
-				</div>
-			</Field>
-			{searchError && <p className="text-destructive text-sm">{searchError}</p>}
-			{results.length > 0 && (
-				<ul className="flex flex-col gap-1">
-					{results.map((result) => (
-						<li key={`${result.latitude},${result.longitude}`}>
-							<button
-								className="flex w-full flex-col items-start rounded-md border border-border px-3 py-2 text-left hover:bg-muted"
-								onClick={() => pickResult(result)}
-								type="button"
-							>
-								<span className="t-body-sm font-medium">{result.name}</span>
-								{result.address && (
-									<span className="text-muted-foreground text-xs">
-										{result.address}
-									</span>
-								)}
-							</button>
-						</li>
-					))}
-				</ul>
-			)}
+			<span className="t-label text-muted-foreground">Location</span>
+			<Tabs defaultValue="search">
+				<TabsList className="w-full">
+					<TabsTrigger value="search">Search</TabsTrigger>
+					<TabsTrigger value="link">Link</TabsTrigger>
+					<TabsTrigger value="gps">Current</TabsTrigger>
+				</TabsList>
 
-			<Field label="Google Maps link">
-				<div className="flex gap-2">
-					<Input
-						inputMode="url"
-						onChange={(e) => setLink(e.target.value)}
-						value={link}
-					/>
-					<Button
-						disabled={isResolving || link.trim() === ""}
-						onClick={handleResolveLink}
-						type="button"
-						variant="outline"
-					>
-						<IconMapPin size={16} />
-						Set from link
-					</Button>
-				</div>
-			</Field>
-			{resolveError && (
-				<p className="text-destructive text-sm">{resolveError}</p>
-			)}
+				<TabsContent className="flex flex-col gap-2 pt-1" value="search">
+					<div className="flex gap-2">
+						<Input
+							aria-label="Search a place"
+							onChange={(e) => setQuery(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									e.preventDefault();
+									handleSearch();
+								}
+							}}
+							value={query}
+						/>
+						<Button
+							disabled={isSearching || query.trim() === ""}
+							onClick={handleSearch}
+							type="button"
+							variant="outline"
+						>
+							<IconSearch size={16} />
+							Search
+						</Button>
+					</div>
+					{searchError && (
+						<p className="text-destructive text-sm">{searchError}</p>
+					)}
+					{results.length > 0 && (
+						<ul className="flex flex-col gap-1">
+							{results.map((result) => (
+								<li key={`${result.latitude},${result.longitude}`}>
+									<button
+										className="flex w-full flex-col items-start rounded-md border border-border px-3 py-2 text-left hover:bg-muted"
+										onClick={() => pickResult(result)}
+										type="button"
+									>
+										<span className="t-body-sm font-medium">{result.name}</span>
+										{result.address && (
+											<span className="text-muted-foreground text-xs">
+												{result.address}
+											</span>
+										)}
+									</button>
+								</li>
+							))}
+						</ul>
+					)}
+				</TabsContent>
 
-			<div className="flex flex-wrap items-center gap-2">
-				<Button
-					onClick={captureLocation}
-					size="sm"
-					type="button"
-					variant="outline"
+				<TabsContent className="flex flex-col gap-2 pt-1" value="link">
+					<div className="flex gap-2">
+						<Input
+							aria-label="Google Maps link"
+							inputMode="url"
+							onChange={(e) => setLink(e.target.value)}
+							value={link}
+						/>
+						<Button
+							disabled={isResolving || link.trim() === ""}
+							onClick={handleResolveLink}
+							type="button"
+							variant="outline"
+						>
+							<IconMapPin size={16} />
+							Set
+						</Button>
+					</div>
+					{resolveError && (
+						<p className="text-destructive text-sm">{resolveError}</p>
+					)}
+				</TabsContent>
+
+				<TabsContent
+					className="flex flex-wrap items-center gap-2 pt-1"
+					value="gps"
 				>
-					<IconCurrentLocation size={16} />
-					Use current location
-				</Button>
-				{gpsMessage && (
-					<span
-						className={
-							gpsStatus === "prompting"
-								? "text-muted-foreground text-sm"
-								: "text-destructive text-sm"
-						}
+					<Button
+						onClick={captureLocation}
+						size="sm"
+						type="button"
+						variant="outline"
 					>
-						{gpsMessage}
-					</span>
-				)}
-			</div>
+						<IconCurrentLocation size={16} />
+						Use current location
+					</Button>
+					{gpsMessage && (
+						<span
+							className={
+								gpsStatus === "prompting"
+									? "text-muted-foreground text-sm"
+									: "text-destructive text-sm"
+							}
+						>
+							{gpsMessage}
+						</span>
+					)}
+				</TabsContent>
+			</Tabs>
 
 			{hasLocation && latitude !== null && longitude !== null && (
 				<div className="flex flex-wrap items-center gap-2 text-sm">

--- a/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.tsx
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.tsx
@@ -1,0 +1,169 @@
+import {
+	IconCurrentLocation,
+	IconMapPin,
+	IconSearch,
+	IconX,
+} from "@tabler/icons-react";
+import { Button } from "@/shared/components/ui/button";
+import { Field } from "@/shared/components/ui/field";
+import { Input } from "@/shared/components/ui/input";
+import type { Coords } from "./use-location-picker";
+import { useLocationPicker } from "./use-location-picker";
+
+interface LocationPickerProps {
+	latitude: number | null;
+	longitude: number | null;
+	onCoordsChange: (coords: Coords | null) => void;
+}
+
+const GPS_STATUS_MESSAGE: Partial<Record<string, string>> = {
+	prompting: "Getting current location",
+	denied: "Location permission denied",
+	unavailable: "Location unavailable",
+};
+
+export function LocationPicker({
+	latitude,
+	longitude,
+	onCoordsChange,
+}: LocationPickerProps) {
+	const {
+		query,
+		setQuery,
+		link,
+		setLink,
+		handleSearch,
+		results,
+		isSearching,
+		searchError,
+		pickResult,
+		handleResolveLink,
+		isResolving,
+		resolveError,
+		captureLocation,
+		gpsStatus,
+		clearLocation,
+		hasLocation,
+	} = useLocationPicker({ latitude, longitude, onCoordsChange });
+
+	const gpsMessage = GPS_STATUS_MESSAGE[gpsStatus];
+
+	return (
+		<div className="flex flex-col gap-3">
+			<Field label="Search a place">
+				<div className="flex gap-2">
+					<Input
+						onChange={(e) => setQuery(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") {
+								e.preventDefault();
+								handleSearch();
+							}
+						}}
+						value={query}
+					/>
+					<Button
+						disabled={isSearching || query.trim() === ""}
+						onClick={handleSearch}
+						type="button"
+						variant="outline"
+					>
+						<IconSearch size={16} />
+						Search
+					</Button>
+				</div>
+			</Field>
+			{searchError && <p className="text-destructive text-sm">{searchError}</p>}
+			{results.length > 0 && (
+				<ul className="flex flex-col gap-1">
+					{results.map((result) => (
+						<li key={`${result.latitude},${result.longitude}`}>
+							<button
+								className="flex w-full flex-col items-start rounded-md border border-border px-3 py-2 text-left hover:bg-muted"
+								onClick={() => pickResult(result)}
+								type="button"
+							>
+								<span className="t-body-sm font-medium">{result.name}</span>
+								{result.address && (
+									<span className="text-muted-foreground text-xs">
+										{result.address}
+									</span>
+								)}
+							</button>
+						</li>
+					))}
+				</ul>
+			)}
+
+			<Field label="Google Maps link">
+				<div className="flex gap-2">
+					<Input
+						inputMode="url"
+						onChange={(e) => setLink(e.target.value)}
+						value={link}
+					/>
+					<Button
+						disabled={isResolving || link.trim() === ""}
+						onClick={handleResolveLink}
+						type="button"
+						variant="outline"
+					>
+						<IconMapPin size={16} />
+						Set from link
+					</Button>
+				</div>
+			</Field>
+			{resolveError && (
+				<p className="text-destructive text-sm">{resolveError}</p>
+			)}
+
+			<div className="flex flex-wrap items-center gap-2">
+				<Button
+					onClick={captureLocation}
+					size="sm"
+					type="button"
+					variant="outline"
+				>
+					<IconCurrentLocation size={16} />
+					Use current location
+				</Button>
+				{gpsMessage && (
+					<span
+						className={
+							gpsStatus === "prompting"
+								? "text-muted-foreground text-sm"
+								: "text-destructive text-sm"
+						}
+					>
+						{gpsMessage}
+					</span>
+				)}
+			</div>
+
+			{hasLocation && latitude !== null && longitude !== null && (
+				<div className="flex flex-wrap items-center gap-2 text-sm">
+					<span className="text-muted-foreground">
+						Location set: {latitude.toFixed(5)}, {longitude.toFixed(5)}
+					</span>
+					<a
+						className="text-primary underline-offset-4 hover:underline"
+						href={`https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}`}
+						rel="noreferrer"
+						target="_blank"
+					>
+						View on Google Maps
+					</a>
+					<Button
+						onClick={clearLocation}
+						size="xs"
+						type="button"
+						variant="ghost"
+					>
+						<IconX size={14} />
+						Clear
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/features/rooms/components/room-form/location-picker/maps-url.ts
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/maps-url.ts
@@ -1,8 +1,10 @@
-// Short-link hosts + `google.<tld>` / `*.google.<tld>` (incl. `google.co.jp`).
-// Mirrors the server-side allowlist in `packages/api/src/routers/location.ts`
-// so the URL tab can validate before hitting the network.
+// Short-link hosts + `google.<tld>` / `*.google.<tld>` (incl. `google.co.jp`),
+// where `google` is the registrable label immediately followed by the TLD so
+// lookalikes like `google.evil.com` are rejected. Mirrors the server-side
+// allowlist in `packages/api/src/routers/location.ts`.
 const MAPS_HOSTS = new Set(["maps.app.goo.gl", "goo.gl"]);
-const GOOGLE_HOST_RE = /^([a-z0-9-]+\.)*google\.[a-z]{2,}(\.[a-z]{2,})?$/;
+const GOOGLE_HOST_RE =
+	/^([a-z0-9-]+\.)*google\.(com|[a-z]{2}|(?:co|com)\.[a-z]{2})$/;
 
 export function isGoogleMapsUrl(rawUrl: string): boolean {
 	let host: string;

--- a/apps/web/src/features/rooms/components/room-form/location-picker/maps-url.ts
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/maps-url.ts
@@ -1,0 +1,15 @@
+// Short-link hosts + `google.<tld>` / `*.google.<tld>` (incl. `google.co.jp`).
+// Mirrors the server-side allowlist in `packages/api/src/routers/location.ts`
+// so the URL tab can validate before hitting the network.
+const MAPS_HOSTS = new Set(["maps.app.goo.gl", "goo.gl"]);
+const GOOGLE_HOST_RE = /^([a-z0-9-]+\.)*google\.[a-z]{2,}(\.[a-z]{2,})?$/;
+
+export function isGoogleMapsUrl(rawUrl: string): boolean {
+	let host: string;
+	try {
+		host = new URL(rawUrl).hostname.toLowerCase();
+	} catch {
+		return false;
+	}
+	return MAPS_HOSTS.has(host) || GOOGLE_HOST_RE.test(host);
+}

--- a/apps/web/src/features/rooms/components/room-form/location-picker/use-location-picker.ts
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/use-location-picker.ts
@@ -2,6 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { useGeolocation } from "@/shared/hooks/use-geolocation";
 import { trpcClient } from "@/utils/trpc";
+import { isGoogleMapsUrl } from "./maps-url";
 
 export interface Coords {
 	latitude: number;
@@ -16,22 +17,25 @@ interface PlaceResult {
 }
 
 interface UseLocationPickerArgs {
+	initialQuery?: string;
 	latitude: number | null;
 	longitude: number | null;
 	onCoordsChange: (coords: Coords | null) => void;
 }
 
 /**
- * Drives the room location picker: place-name search, Google Maps link paste
+ * Drives the room location picker: place-name search, Google Maps URL paste
  * and device GPS, all funnelling into a single `onCoordsChange`. The canonical
  * coordinates live in the parent form; this hook only sets them.
  */
 export function useLocationPicker({
+	initialQuery,
 	latitude,
 	longitude,
 	onCoordsChange,
 }: UseLocationPickerArgs) {
-	const [query, setQuery] = useState("");
+	// Seed the search box with the room name so the user can search in one tap.
+	const [query, setQuery] = useState(initialQuery ?? "");
 	const [link, setLink] = useState("");
 
 	// Keep the latest callback in a ref so the GPS effect fires only on a new
@@ -77,16 +81,24 @@ export function useLocationPicker({
 		setQuery("");
 	};
 
+	const linkTrimmed = link.trim();
+	const isLinkValid = linkTrimmed !== "" && isGoogleMapsUrl(linkTrimmed);
+	// Client-side validation first (invalid URL), then any server rejection.
+	const linkError =
+		linkTrimmed !== "" && !isGoogleMapsUrl(linkTrimmed)
+			? "Enter a valid Google Maps URL"
+			: (resolveMutation.error?.message ?? null);
+
 	const handleResolveLink = () => {
-		const trimmed = link.trim();
-		if (trimmed) {
-			resolveMutation.mutate(trimmed, {
-				onSuccess: (coords) => {
-					onCoordsChange(coords);
-					setLink("");
-				},
-			});
+		if (!isLinkValid) {
+			return;
 		}
+		resolveMutation.mutate(linkTrimmed, {
+			onSuccess: (coords) => {
+				onCoordsChange(coords);
+				setLink("");
+			},
+		});
 	};
 
 	const clearLocation = () => {
@@ -105,7 +117,8 @@ export function useLocationPicker({
 		pickResult,
 		handleResolveLink,
 		isResolving: resolveMutation.isPending,
-		resolveError: resolveMutation.error?.message ?? null,
+		isLinkValid,
+		linkError,
 		captureLocation,
 		gpsStatus,
 		clearLocation,

--- a/apps/web/src/features/rooms/components/room-form/location-picker/use-location-picker.ts
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/use-location-picker.ts
@@ -1,0 +1,116 @@
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+import { useGeolocation } from "@/shared/hooks/use-geolocation";
+import { trpcClient } from "@/utils/trpc";
+
+export interface Coords {
+	latitude: number;
+	longitude: number;
+}
+
+interface PlaceResult {
+	address: string;
+	latitude: number;
+	longitude: number;
+	name: string;
+}
+
+interface UseLocationPickerArgs {
+	latitude: number | null;
+	longitude: number | null;
+	onCoordsChange: (coords: Coords | null) => void;
+}
+
+/**
+ * Drives the room location picker: place-name search, Google Maps link paste
+ * and device GPS, all funnelling into a single `onCoordsChange`. The canonical
+ * coordinates live in the parent form; this hook only sets them.
+ */
+export function useLocationPicker({
+	latitude,
+	longitude,
+	onCoordsChange,
+}: UseLocationPickerArgs) {
+	const [query, setQuery] = useState("");
+	const [link, setLink] = useState("");
+
+	// Keep the latest callback in a ref so the GPS effect fires only on a new
+	// fix, not whenever the parent re-creates onCoordsChange.
+	const onCoordsChangeRef = useRef(onCoordsChange);
+	onCoordsChangeRef.current = onCoordsChange;
+
+	const {
+		request: captureLocation,
+		coords: gpsCoords,
+		status: gpsStatus,
+	} = useGeolocation({ enabled: false });
+
+	useEffect(() => {
+		if (gpsCoords) {
+			onCoordsChangeRef.current(gpsCoords);
+		}
+	}, [gpsCoords]);
+
+	const searchMutation = useMutation({
+		mutationFn: (q: string): Promise<PlaceResult[]> =>
+			trpcClient.location.search.mutate({ query: q }),
+	});
+
+	const resolveMutation = useMutation({
+		mutationFn: (url: string): Promise<Coords> =>
+			trpcClient.location.resolveLink.mutate({ url }),
+	});
+
+	const handleSearch = () => {
+		const trimmed = query.trim();
+		if (trimmed) {
+			searchMutation.mutate(trimmed);
+		}
+	};
+
+	const pickResult = (result: PlaceResult) => {
+		onCoordsChange({
+			latitude: result.latitude,
+			longitude: result.longitude,
+		});
+		searchMutation.reset();
+		setQuery("");
+	};
+
+	const handleResolveLink = () => {
+		const trimmed = link.trim();
+		if (trimmed) {
+			resolveMutation.mutate(trimmed, {
+				onSuccess: (coords) => {
+					onCoordsChange(coords);
+					setLink("");
+				},
+			});
+		}
+	};
+
+	const clearLocation = () => {
+		onCoordsChange(null);
+	};
+
+	return {
+		query,
+		setQuery,
+		link,
+		setLink,
+		handleSearch,
+		results: searchMutation.data ?? [],
+		isSearching: searchMutation.isPending,
+		searchError: searchMutation.error?.message ?? null,
+		pickResult,
+		handleResolveLink,
+		isResolving: resolveMutation.isPending,
+		resolveError: resolveMutation.error?.message ?? null,
+		captureLocation,
+		gpsStatus,
+		clearLocation,
+		hasLocation: latitude !== null && longitude !== null,
+		latitude,
+		longitude,
+	};
+}

--- a/apps/web/src/features/rooms/components/room-form/room-form.tsx
+++ b/apps/web/src/features/rooms/components/room-form/room-form.tsx
@@ -1,8 +1,7 @@
-import { IconCurrentLocation } from "@tabler/icons-react";
-import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
 import { Textarea } from "@/shared/components/ui/textarea";
+import { LocationPicker } from "./location-picker";
 import type { RoomFormValues } from "./use-room-form";
 import { useRoomForm } from "./use-room-form";
 
@@ -22,19 +21,12 @@ interface RoomFormProps {
 	onSubmit: (values: RoomFormValues) => void;
 }
 
-const LOCATION_STATUS_MESSAGE: Partial<Record<string, string>> = {
-	prompting: "Getting current location",
-	denied: "Location permission denied",
-	unavailable: "Location unavailable",
-};
+function fieldToCoord(value: string): number | null {
+	return value.trim() === "" ? null : Number(value);
+}
 
 export function RoomForm({ onSubmit, defaultValues, formId }: RoomFormProps) {
-	const { form, captureLocation, locationStatus } = useRoomForm({
-		onSubmit,
-		defaultValues,
-	});
-
-	const statusMessage = LOCATION_STATUS_MESSAGE[locationStatus];
+	const { form, setCoords } = useRoomForm({ onSubmit, defaultValues });
 
 	return (
 		<form
@@ -77,66 +69,20 @@ export function RoomForm({ onSubmit, defaultValues, formId }: RoomFormProps) {
 					</Field>
 				)}
 			</form.Field>
-			<div className="grid grid-cols-2 gap-4">
-				<form.Field name="latitude">
-					{(field) => (
-						<Field
-							error={field.state.meta.errors[0]?.message}
-							htmlFor={field.name}
-							label="Latitude"
-						>
-							<Input
-								id={field.name}
-								inputMode="decimal"
-								name={field.name}
-								onBlur={field.handleBlur}
-								onChange={(e) => field.handleChange(e.target.value)}
-								value={field.state.value}
-							/>
-						</Field>
-					)}
-				</form.Field>
-				<form.Field name="longitude">
-					{(field) => (
-						<Field
-							error={field.state.meta.errors[0]?.message}
-							htmlFor={field.name}
-							label="Longitude"
-						>
-							<Input
-								id={field.name}
-								inputMode="decimal"
-								name={field.name}
-								onBlur={field.handleBlur}
-								onChange={(e) => field.handleChange(e.target.value)}
-								value={field.state.value}
-							/>
-						</Field>
-					)}
-				</form.Field>
-			</div>
-			<div className="flex items-center gap-3">
-				<Button
-					onClick={captureLocation}
-					size="sm"
-					type="button"
-					variant="outline"
-				>
-					<IconCurrentLocation size={16} />
-					Use current location
-				</Button>
-				{statusMessage && (
-					<span
-						className={
-							locationStatus === "prompting"
-								? "text-muted-foreground text-sm"
-								: "text-destructive text-sm"
-						}
-					>
-						{statusMessage}
-					</span>
+			<form.Subscribe
+				selector={(state) => ({
+					latitude: state.values.latitude,
+					longitude: state.values.longitude,
+				})}
+			>
+				{({ latitude, longitude }) => (
+					<LocationPicker
+						latitude={fieldToCoord(latitude)}
+						longitude={fieldToCoord(longitude)}
+						onCoordsChange={setCoords}
+					/>
 				)}
-			</div>
+			</form.Subscribe>
 		</form>
 	);
 }

--- a/apps/web/src/features/rooms/components/room-form/room-form.tsx
+++ b/apps/web/src/features/rooms/components/room-form/room-form.tsx
@@ -1,3 +1,5 @@
+import { IconCurrentLocation } from "@tabler/icons-react";
+import { Button } from "@/shared/components/ui/button";
 import { Field } from "@/shared/components/ui/field";
 import { Input } from "@/shared/components/ui/input";
 import { Textarea } from "@/shared/components/ui/textarea";
@@ -5,7 +7,12 @@ import type { RoomFormValues } from "./use-room-form";
 import { useRoomForm } from "./use-room-form";
 
 interface RoomFormProps {
-	defaultValues?: RoomFormValues;
+	defaultValues?: {
+		latitude?: number | null;
+		longitude?: number | null;
+		memo?: string;
+		name: string;
+	};
 	/**
 	 * Stable id assigned to the `<form>` element so an external Save button
 	 * (rendered by the surrounding FormSheet toolbar) can submit it via the
@@ -15,8 +22,19 @@ interface RoomFormProps {
 	onSubmit: (values: RoomFormValues) => void;
 }
 
+const LOCATION_STATUS_MESSAGE: Partial<Record<string, string>> = {
+	prompting: "Getting current location",
+	denied: "Location permission denied",
+	unavailable: "Location unavailable",
+};
+
 export function RoomForm({ onSubmit, defaultValues, formId }: RoomFormProps) {
-	const { form } = useRoomForm({ onSubmit, defaultValues });
+	const { form, captureLocation, locationStatus } = useRoomForm({
+		onSubmit,
+		defaultValues,
+	});
+
+	const statusMessage = LOCATION_STATUS_MESSAGE[locationStatus];
 
 	return (
 		<form
@@ -59,6 +77,66 @@ export function RoomForm({ onSubmit, defaultValues, formId }: RoomFormProps) {
 					</Field>
 				)}
 			</form.Field>
+			<div className="grid grid-cols-2 gap-4">
+				<form.Field name="latitude">
+					{(field) => (
+						<Field
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label="Latitude"
+						>
+							<Input
+								id={field.name}
+								inputMode="decimal"
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) => field.handleChange(e.target.value)}
+								value={field.state.value}
+							/>
+						</Field>
+					)}
+				</form.Field>
+				<form.Field name="longitude">
+					{(field) => (
+						<Field
+							error={field.state.meta.errors[0]?.message}
+							htmlFor={field.name}
+							label="Longitude"
+						>
+							<Input
+								id={field.name}
+								inputMode="decimal"
+								name={field.name}
+								onBlur={field.handleBlur}
+								onChange={(e) => field.handleChange(e.target.value)}
+								value={field.state.value}
+							/>
+						</Field>
+					)}
+				</form.Field>
+			</div>
+			<div className="flex items-center gap-3">
+				<Button
+					onClick={captureLocation}
+					size="sm"
+					type="button"
+					variant="outline"
+				>
+					<IconCurrentLocation size={16} />
+					Use current location
+				</Button>
+				{statusMessage && (
+					<span
+						className={
+							locationStatus === "prompting"
+								? "text-muted-foreground text-sm"
+								: "text-destructive text-sm"
+						}
+					>
+						{statusMessage}
+					</span>
+				)}
+			</div>
 		</form>
 	);
 }

--- a/apps/web/src/features/rooms/components/room-form/room-form.tsx
+++ b/apps/web/src/features/rooms/components/room-form/room-form.tsx
@@ -77,6 +77,7 @@ export function RoomForm({ onSubmit, defaultValues, formId }: RoomFormProps) {
 			>
 				{({ latitude, longitude }) => (
 					<LocationPicker
+						initialQuery={defaultValues?.name}
 						latitude={fieldToCoord(latitude)}
 						longitude={fieldToCoord(longitude)}
 						onCoordsChange={setCoords}

--- a/apps/web/src/features/rooms/components/room-form/use-room-form.ts
+++ b/apps/web/src/features/rooms/components/room-form/use-room-form.ts
@@ -1,31 +1,67 @@
 import { useForm } from "@tanstack/react-form";
+import { useEffect } from "react";
 import z from "zod";
+import { useGeolocation } from "@/shared/hooks/use-geolocation";
+import {
+	optionalNumericString,
+	parseOptionalNumber,
+} from "@/shared/lib/form-fields";
 
 export interface RoomFormValues {
+	latitude?: number;
+	longitude?: number;
 	memo?: string;
 	name: string;
 }
 
-const roomFormSchema = z.object({
-	name: z.string().min(1, "Room name is required"),
-	memo: z.string(),
-});
+interface RoomFormDefaults {
+	latitude?: number | null;
+	longitude?: number | null;
+	memo?: string;
+	name: string;
+}
+
+const roomFormSchema = z
+	.object({
+		name: z.string().min(1, "Room name is required"),
+		memo: z.string(),
+		latitude: optionalNumericString({ min: -90, max: 90 }),
+		longitude: optionalNumericString({ min: -180, max: 180 }),
+	})
+	.refine(
+		(value) =>
+			(value.latitude.trim() === "") === (value.longitude.trim() === ""),
+		{
+			message: "Both latitude and longitude are required",
+			path: ["longitude"],
+		}
+	);
 
 interface UseRoomFormOptions {
-	defaultValues?: RoomFormValues;
+	defaultValues?: RoomFormDefaults;
 	onSubmit: (values: RoomFormValues) => void;
 }
 
+function coordToField(value: number | null | undefined): string {
+	return value === null || value === undefined ? "" : String(value);
+}
+
 export function useRoomForm({ onSubmit, defaultValues }: UseRoomFormOptions) {
+	const { request, coords, status } = useGeolocation({ enabled: false });
+
 	const form = useForm({
 		defaultValues: {
 			name: defaultValues?.name ?? "",
 			memo: defaultValues?.memo ?? "",
+			latitude: coordToField(defaultValues?.latitude),
+			longitude: coordToField(defaultValues?.longitude),
 		},
 		onSubmit: ({ value }) => {
 			onSubmit({
 				name: value.name,
 				memo: value.memo ? value.memo : undefined,
+				latitude: parseOptionalNumber(value.latitude),
+				longitude: parseOptionalNumber(value.longitude),
 			});
 		},
 		validators: {
@@ -33,5 +69,14 @@ export function useRoomForm({ onSubmit, defaultValues }: UseRoomFormOptions) {
 		},
 	});
 
-	return { form };
+	// A captured GPS fix lands asynchronously; mirror it into the editable
+	// lat/lng fields so the user sees (and can adjust) the captured coordinates.
+	useEffect(() => {
+		if (coords) {
+			form.setFieldValue("latitude", String(coords.latitude));
+			form.setFieldValue("longitude", String(coords.longitude));
+		}
+	}, [coords, form]);
+
+	return { form, captureLocation: request, locationStatus: status };
 }

--- a/apps/web/src/features/rooms/components/room-form/use-room-form.ts
+++ b/apps/web/src/features/rooms/components/room-form/use-room-form.ts
@@ -1,7 +1,5 @@
 import { useForm } from "@tanstack/react-form";
-import { useEffect } from "react";
 import z from "zod";
-import { useGeolocation } from "@/shared/hooks/use-geolocation";
 import {
 	optionalNumericString,
 	parseOptionalNumber,
@@ -47,8 +45,6 @@ function coordToField(value: number | null | undefined): string {
 }
 
 export function useRoomForm({ onSubmit, defaultValues }: UseRoomFormOptions) {
-	const { request, coords, status } = useGeolocation({ enabled: false });
-
 	const form = useForm({
 		defaultValues: {
 			name: defaultValues?.name ?? "",
@@ -69,14 +65,14 @@ export function useRoomForm({ onSubmit, defaultValues }: UseRoomFormOptions) {
 		},
 	});
 
-	// A captured GPS fix lands asynchronously; mirror it into the editable
-	// lat/lng fields so the user sees (and can adjust) the captured coordinates.
-	useEffect(() => {
-		if (coords) {
-			form.setFieldValue("latitude", String(coords.latitude));
-			form.setFieldValue("longitude", String(coords.longitude));
-		}
-	}, [coords, form]);
+	// Coordinates are set as a pair from the LocationPicker (search / link / GPS),
+	// never typed by hand. `null` clears both.
+	const setCoords = (
+		coords: { latitude: number; longitude: number } | null
+	) => {
+		form.setFieldValue("latitude", coords ? String(coords.latitude) : "");
+		form.setFieldValue("longitude", coords ? String(coords.longitude) : "");
+	};
 
-	return { form, captureLocation: request, locationStatus: status };
+	return { form, setCoords };
 }

--- a/apps/web/src/features/rooms/hooks/__tests__/use-rooms.test.ts
+++ b/apps/web/src/features/rooms/hooks/__tests__/use-rooms.test.ts
@@ -158,6 +158,49 @@ describe("useRooms", () => {
 			}
 		});
 
+		it("forwards latitude/longitude to the server and the optimistic row", async () => {
+			const qc = createClient();
+			qc.setQueryData(STORE_KEY, [
+				{ id: "s1", name: "Main", memo: null, latitude: null, longitude: null },
+			]);
+			let resolve: ((v: unknown) => void) | undefined;
+			trpcMocks.create.mockImplementation(
+				() =>
+					new Promise((r) => {
+						resolve = r;
+					})
+			);
+			const { result } = renderHook(() => useRooms(), {
+				wrapper: makeWrapper(qc),
+			});
+			act(() => {
+				result.current.create({
+					name: "Geo Room",
+					latitude: 35.6812,
+					longitude: 139.7671,
+				});
+			});
+			await waitFor(() => {
+				const list =
+					qc.getQueryData<
+						Array<{
+							id: string;
+							latitude: number | null;
+							longitude: number | null;
+						}>
+					>(STORE_KEY);
+				const temp = list?.find((s) => s.id.startsWith("temp-"));
+				expect(temp?.latitude).toBe(35.6812);
+				expect(temp?.longitude).toBe(139.7671);
+			});
+			expect(trpcMocks.create).toHaveBeenCalledWith({
+				name: "Geo Room",
+				latitude: 35.6812,
+				longitude: 139.7671,
+			});
+			resolve?.({ id: "s2" });
+		});
+
 		it("flips isCreatePending to true while the mutation is in-flight", async () => {
 			const qc = createClient();
 			qc.setQueryData(STORE_KEY, []);
@@ -263,6 +306,8 @@ describe("useRooms", () => {
 				id: "s1",
 				name: "Main",
 				memo: null,
+				latitude: null,
+				longitude: null,
 			});
 		});
 
@@ -280,6 +325,34 @@ describe("useRooms", () => {
 				id: "s1",
 				name: "Main",
 				memo: "kept",
+				latitude: null,
+				longitude: null,
+			});
+		});
+
+		it("forwards updated coordinates to the server", async () => {
+			const qc = createClient();
+			qc.setQueryData(STORE_KEY, [
+				{ id: "s1", name: "Main", memo: null, latitude: null, longitude: null },
+			]);
+			trpcMocks.update.mockResolvedValue({ id: "s1" });
+			const { result } = renderHook(() => useRooms(), {
+				wrapper: makeWrapper(qc),
+			});
+			await act(async () => {
+				await result.current.update({
+					id: "s1",
+					name: "Main",
+					latitude: 12.5,
+					longitude: -34.25,
+				});
+			});
+			expect(trpcMocks.update).toHaveBeenCalledWith({
+				id: "s1",
+				name: "Main",
+				memo: null,
+				latitude: 12.5,
+				longitude: -34.25,
 			});
 		});
 

--- a/apps/web/src/features/rooms/hooks/use-rooms.ts
+++ b/apps/web/src/features/rooms/hooks/use-rooms.ts
@@ -8,6 +8,8 @@ import {
 import { trpc, trpcClient } from "@/utils/trpc";
 
 export interface RoomValues {
+	latitude?: number;
+	longitude?: number;
 	memo?: string;
 	name: string;
 }
@@ -16,6 +18,8 @@ export interface RoomItem {
 	createdAt: Date | string;
 	id: string;
 	isFavorite: boolean;
+	latitude?: number | null;
+	longitude?: number | null;
 	memo?: string | null;
 	name: string;
 	ringGameCount: number;
@@ -46,6 +50,8 @@ export function useRooms() {
 						id: `temp-${Date.now()}`,
 						name: newRoom.name,
 						memo: newRoom.memo ?? null,
+						latitude: newRoom.latitude ?? null,
+						longitude: newRoom.longitude ?? null,
 						isFavorite: false,
 						createdAt: new Date().toISOString(),
 						ringGameCount: 0,
@@ -64,13 +70,15 @@ export function useRooms() {
 	});
 
 	const updateMutation = useMutation({
-		// Send an explicit `null` for a cleared memo so the server overwrites it
+		// Send an explicit `null` for cleared fields so the server overwrites them
 		// rather than treating the omitted (undefined) key as "leave unchanged".
 		mutationFn: (values: RoomValues & { id: string }) =>
 			trpcClient.room.update.mutate({
 				id: values.id,
 				name: values.name,
 				memo: values.memo ?? null,
+				latitude: values.latitude ?? null,
+				longitude: values.longitude ?? null,
 			}),
 		onMutate: async (updated) => {
 			await cancelTargets(queryClient, [{ queryKey: roomListKey }]);

--- a/apps/web/src/features/rooms/pages/room-detail-page/room-detail-page.tsx
+++ b/apps/web/src/features/rooms/pages/room-detail-page/room-detail-page.tsx
@@ -3,6 +3,7 @@ import { RoomForm } from "@/features/rooms/components/room-form";
 import { DeleteRoomDialog } from "@/features/rooms/pages/room-detail-page/delete-room-dialog";
 import { RingGameTab } from "@/features/rooms/pages/room-detail-page/ring-game-tab";
 import { RoomActionsDrawer } from "@/features/rooms/pages/room-detail-page/room-actions-drawer";
+import { RoomLocationLink } from "@/features/rooms/pages/room-detail-page/room-location-link";
 import { TournamentTab } from "@/features/rooms/pages/room-detail-page/tournament-tab";
 import { FormSheet } from "@/shared/components/form-sheet";
 import { PageHeader } from "@/shared/components/page-header";
@@ -90,6 +91,8 @@ export function RoomDetailPage({ roomId }: RoomDetailPageProps) {
 						</span>
 					}
 				/>
+
+				<RoomLocationLink latitude={room.latitude} longitude={room.longitude} />
 
 				<Tabs defaultValue="ring-games">
 					<TabsList className="w-full">

--- a/apps/web/src/features/rooms/pages/room-detail-page/room-detail-page.tsx
+++ b/apps/web/src/features/rooms/pages/room-detail-page/room-detail-page.tsx
@@ -124,6 +124,8 @@ export function RoomDetailPage({ roomId }: RoomDetailPageProps) {
 						defaultValues={{
 							name: room.name,
 							memo: room.memo ?? undefined,
+							latitude: room.latitude,
+							longitude: room.longitude,
 						}}
 						formId={EDIT_STORE_FORM_ID}
 						onSubmit={handleEdit}

--- a/apps/web/src/features/rooms/pages/room-detail-page/room-location-link/__tests__/room-location-link.test.tsx
+++ b/apps/web/src/features/rooms/pages/room-detail-page/room-location-link/__tests__/room-location-link.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RoomLocationLink } from "@/features/rooms/pages/room-detail-page/room-location-link";
+
+const MAPS_RE = /view on google maps/i;
+
+describe("RoomLocationLink", () => {
+	it("renders a Google Maps link with the coordinates as the query", () => {
+		render(<RoomLocationLink latitude={35.6812} longitude={139.7671} />);
+		const link = screen.getByRole("link", { name: MAPS_RE });
+		expect(link).toHaveAttribute(
+			"href",
+			"https://www.google.com/maps/search/?api=1&query=35.6812,139.7671"
+		);
+		expect(link).toHaveAttribute("target", "_blank");
+		expect(link).toHaveAttribute("rel", "noreferrer");
+	});
+
+	it("renders nothing when latitude is null", () => {
+		const { container } = render(
+			<RoomLocationLink latitude={null} longitude={139.7671} />
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders nothing when longitude is undefined", () => {
+		const { container } = render(
+			<RoomLocationLink latitude={35.6812} longitude={undefined} />
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+});

--- a/apps/web/src/features/rooms/pages/room-detail-page/room-location-link/index.ts
+++ b/apps/web/src/features/rooms/pages/room-detail-page/room-location-link/index.ts
@@ -1,0 +1,1 @@
+export { RoomLocationLink } from "./room-location-link";

--- a/apps/web/src/features/rooms/pages/room-detail-page/room-location-link/room-location-link.tsx
+++ b/apps/web/src/features/rooms/pages/room-detail-page/room-location-link/room-location-link.tsx
@@ -1,0 +1,38 @@
+import { IconMapPin } from "@tabler/icons-react";
+
+interface RoomLocationLinkProps {
+	latitude: number | null | undefined;
+	longitude: number | null | undefined;
+}
+
+/**
+ * "View on Google Maps" link shown on the room detail page when the room has
+ * coordinates. Uses the key-free Maps search URL so no API key is needed.
+ */
+export function RoomLocationLink({
+	latitude,
+	longitude,
+}: RoomLocationLinkProps) {
+	if (
+		latitude === null ||
+		latitude === undefined ||
+		longitude === null ||
+		longitude === undefined
+	) {
+		return null;
+	}
+
+	return (
+		<div className="mt-1 mb-3">
+			<a
+				className="inline-flex items-center gap-1 text-primary text-sm underline-offset-4 hover:underline"
+				href={`https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}`}
+				rel="noreferrer"
+				target="_blank"
+			>
+				<IconMapPin size={16} />
+				View on Google Maps
+			</a>
+		</div>
+	);
+}

--- a/apps/web/src/features/sessions/components/session-wizard/use-session-form-state.ts
+++ b/apps/web/src/features/sessions/components/session-wizard/use-session-form-state.ts
@@ -1,5 +1,5 @@
 import { useForm } from "@tanstack/react-form";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ChipPurchaseRow } from "@/features/rooms/components/chip-purchases-editor";
 import type { BlindLevelRow } from "@/features/rooms/hooks/use-blind-levels";
 import {
@@ -20,6 +20,13 @@ import {
 } from "./chip-purchase-rows";
 
 interface UseSessionFormStateArgs {
+	/**
+	 * Room to pre-select as the default (e.g. the geolocation-nearest room).
+	 * Applied only while the user hasn't picked a room — never overrides a
+	 * manual choice. Resolves asynchronously, so it seeds via an effect rather
+	 * than `defaultValues`.
+	 */
+	defaultRoomId?: string;
 	defaultValues?: SessionFormDefaults;
 	onRoomChange?: (roomId: string | undefined) => void;
 	onSubmit: (values: SessionFormValues) => void;
@@ -40,6 +47,7 @@ function timerStringToUnix(value: string): number | undefined {
 }
 
 export function useSessionFormState({
+	defaultRoomId,
 	defaultValues,
 	onRoomChange,
 	onSubmit,
@@ -248,11 +256,29 @@ export function useSessionFormState({
 		setChipPurchaseCounts((prev) => ({ ...prev, [uid]: count }));
 	};
 
+	// Tracks whether the user has actively chosen a room. Once true, the
+	// geolocation default must not override their choice.
+	const userPickedRoomRef = useRef(false);
+
 	const handleRoomChange = (value: string | undefined) => {
+		userPickedRoomRef.current = true;
 		setSelectedRoomId(value);
 		setSelectedGameId(undefined);
 		onRoomChange?.(value);
 	};
+
+	// Seed the geolocation-suggested room as the default. Fires only while the
+	// user hasn't picked a room and none is selected yet, so a manual choice (or
+	// an explicit clear) always wins, and a later suggestion never yanks the
+	// current selection.
+	useEffect(() => {
+		if (!defaultRoomId || userPickedRoomRef.current || selectedRoomId) {
+			return;
+		}
+		setSelectedRoomId(defaultRoomId);
+		setSelectedGameId(undefined);
+		onRoomChange?.(defaultRoomId);
+	}, [defaultRoomId, selectedRoomId, onRoomChange]);
 
 	const handleGameChange = (value: string | undefined) => {
 		setSelectedGameId(value);

--- a/apps/web/src/features/sessions/components/session-wizard/use-session-wizard.ts
+++ b/apps/web/src/features/sessions/components/session-wizard/use-session-wizard.ts
@@ -32,6 +32,7 @@ export function wizardStepsForMode(
 export const WIZARD_STEPS = WIZARD_STEPS_MANUAL;
 
 interface UseSessionWizardArgs {
+	defaultRoomId?: string;
 	defaultValues?: SessionFormDefaults;
 	mode?: WizardMode;
 	onRoomChange?: (roomId: string | undefined) => void;

--- a/apps/web/src/shared/components/ui/tabs/tabs.test.tsx
+++ b/apps/web/src/shared/components/ui/tabs/tabs.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
+
+function renderTabs(values: string[]) {
+	return render(
+		<Tabs defaultValue={values[0]}>
+			<TabsList>
+				{values.map((v) => (
+					<TabsTrigger key={v} value={v}>
+						{v}
+					</TabsTrigger>
+				))}
+			</TabsList>
+			{values.map((v) => (
+				<TabsContent key={v} value={v}>
+					{`content-${v}`}
+				</TabsContent>
+			))}
+		</Tabs>
+	);
+}
+
+describe("Tabs", () => {
+	it("sets --tabs-count from the number of triggers (2)", () => {
+		renderTabs(["a", "b"]);
+		expect(
+			screen.getByRole("tablist").style.getPropertyValue("--tabs-count")
+		).toBe("2");
+	});
+
+	it("sets --tabs-count for three tabs", () => {
+		renderTabs(["a", "b", "c"]);
+		expect(
+			screen.getByRole("tablist").style.getPropertyValue("--tabs-count")
+		).toBe("3");
+	});
+
+	it("sets --tabs-count for four tabs", () => {
+		renderTabs(["a", "b", "c", "d"]);
+		expect(
+			screen.getByRole("tablist").style.getPropertyValue("--tabs-count")
+		).toBe("4");
+	});
+
+	it("renders every trigger for a three-tab list", () => {
+		renderTabs(["a", "b", "c"]);
+		expect(screen.getAllByRole("tab")).toHaveLength(3);
+	});
+});

--- a/apps/web/src/shared/components/ui/tabs/tabs.tsx
+++ b/apps/web/src/shared/components/ui/tabs/tabs.tsx
@@ -1,6 +1,7 @@
 import { cva, type VariantProps } from "class-variance-authority";
 import { Tabs as TabsPrimitive } from "radix-ui";
 import type * as React from "react";
+import { Children } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -29,10 +30,12 @@ const tabsListVariants = cva(
 			variant: {
 				// The active state is a single `::after` "pill" that slides to the
 				// active trigger (translateX) rather than cross-fading per trigger.
-				// Tuned for the app's two equal-width tabs (every default TabsList is
-				// `w-full` / `grid-cols-2`). Hidden in the vertical orientation.
+				// Works for any tab count: `TabsList` sets `--tabs-count` from its
+				// child count, so the pill width is `1 / N` and each active trigger
+				// shifts it by whole multiples of its own width. Hidden in the
+				// vertical orientation.
 				default:
-					"relative bg-muted after:absolute after:inset-y-[3px] after:left-[3px] after:z-0 after:w-[calc((100%-6px)/2)] after:rounded-md after:border after:border-foreground/20 after:bg-background after:shadow-sm after:transition-transform after:duration-200 after:ease-out after:content-[''] has-[>[data-slot=tabs-trigger]:nth-child(2)[data-state=active]]:after:translate-x-full group-data-vertical/tabs:after:hidden dark:after:bg-foreground/15",
+					"relative bg-muted after:absolute after:inset-y-[3px] after:left-[3px] after:z-0 after:w-[calc((100%-6px)/var(--tabs-count,2))] after:rounded-md after:border after:border-foreground/20 after:bg-background after:shadow-sm after:transition-transform after:duration-200 after:ease-out after:content-[''] has-[>[data-slot=tabs-trigger]:nth-child(2)[data-state=active]]:after:translate-x-full has-[>[data-slot=tabs-trigger]:nth-child(3)[data-state=active]]:after:translate-x-[200%] has-[>[data-slot=tabs-trigger]:nth-child(4)[data-state=active]]:after:translate-x-[300%] has-[>[data-slot=tabs-trigger]:nth-child(5)[data-state=active]]:after:translate-x-[400%] group-data-vertical/tabs:after:hidden dark:after:bg-foreground/15",
 				line: "gap-1 bg-transparent",
 			},
 		},
@@ -45,16 +48,24 @@ const tabsListVariants = cva(
 function TabsList({
 	className,
 	variant = "default",
+	children,
+	style,
 	...props
 }: React.ComponentProps<typeof TabsPrimitive.List> &
 	VariantProps<typeof tabsListVariants>) {
+	// Drives the sliding-pill width (`1 / N`) so the default variant renders
+	// correctly for any number of tabs, not just two.
+	const count = Children.toArray(children).length;
 	return (
 		<TabsPrimitive.List
 			className={cn(tabsListVariants({ variant }), className)}
 			data-slot="tabs-list"
 			data-variant={variant}
+			style={{ ...style, "--tabs-count": count } as React.CSSProperties}
 			{...props}
-		/>
+		>
+			{children}
+		</TabsPrimitive.List>
 	);
 }
 

--- a/apps/web/src/shared/components/ui/tabs/tabs.tsx
+++ b/apps/web/src/shared/components/ui/tabs/tabs.tsx
@@ -30,9 +30,10 @@ const tabsListVariants = cva(
 			variant: {
 				// The active state is a single `::after` "pill" that slides to the
 				// active trigger (translateX) rather than cross-fading per trigger.
-				// Works for any tab count: `TabsList` sets `--tabs-count` from its
-				// child count, so the pill width is `1 / N` and each active trigger
-				// shifts it by whole multiples of its own width. Hidden in the
+				// `TabsList` sets `--tabs-count` from its child count so the pill
+				// width is `1 / N`; the per-child translate offsets are enumerated up
+				// to the 5th tab (enough for every current TabsList — extend the
+				// `nth-child` rules if a 6+ tab list is ever added). Hidden in the
 				// vertical orientation.
 				default:
 					"relative bg-muted after:absolute after:inset-y-[3px] after:left-[3px] after:z-0 after:w-[calc((100%-6px)/var(--tabs-count,2))] after:rounded-md after:border after:border-foreground/20 after:bg-background after:shadow-sm after:transition-transform after:duration-200 after:ease-out after:content-[''] has-[>[data-slot=tabs-trigger]:nth-child(2)[data-state=active]]:after:translate-x-full has-[>[data-slot=tabs-trigger]:nth-child(3)[data-state=active]]:after:translate-x-[200%] has-[>[data-slot=tabs-trigger]:nth-child(4)[data-state=active]]:after:translate-x-[300%] has-[>[data-slot=tabs-trigger]:nth-child(5)[data-state=active]]:after:translate-x-[400%] group-data-vertical/tabs:after:hidden dark:after:bg-foreground/15",

--- a/apps/web/src/shared/hooks/__tests__/use-geolocation.test.ts
+++ b/apps/web/src/shared/hooks/__tests__/use-geolocation.test.ts
@@ -1,0 +1,134 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useGeolocation } from "@/shared/hooks/use-geolocation";
+
+type SuccessFn = (position: {
+	coords: { latitude: number; longitude: number };
+}) => void;
+type ErrorFn = (error: { code: number; message: string }) => void;
+
+const originalGeo = Object.getOwnPropertyDescriptor(navigator, "geolocation");
+let getCurrentPosition: ReturnType<typeof vi.fn>;
+
+function setGeolocation(value: unknown) {
+	Object.defineProperty(navigator, "geolocation", {
+		configurable: true,
+		value,
+	});
+}
+
+function fireSuccess(latitude: number, longitude: number) {
+	const success = getCurrentPosition.mock.calls[0][0] as SuccessFn;
+	act(() => {
+		success({ coords: { latitude, longitude } });
+	});
+}
+
+function fireError(code: number, message = "geo error") {
+	const errorCb = getCurrentPosition.mock.calls[0][1] as ErrorFn;
+	act(() => {
+		errorCb({ code, message });
+	});
+}
+
+beforeEach(() => {
+	getCurrentPosition = vi.fn();
+	setGeolocation({ getCurrentPosition });
+});
+
+afterEach(() => {
+	if (originalGeo) {
+		Object.defineProperty(navigator, "geolocation", originalGeo);
+	} else {
+		// biome-ignore lint/performance/noDelete: restoring jsdom's missing property
+		delete (navigator as { geolocation?: unknown }).geolocation;
+	}
+	vi.restoreAllMocks();
+});
+
+describe("useGeolocation", () => {
+	it("stays idle and does not request when disabled", () => {
+		const { result } = renderHook(() => useGeolocation({ enabled: false }));
+		expect(result.current.status).toBe("idle");
+		expect(result.current.coords).toBeNull();
+		expect(getCurrentPosition).not.toHaveBeenCalled();
+	});
+
+	it("requests a position once when enabled", () => {
+		const { result } = renderHook(() => useGeolocation({ enabled: true }));
+		expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+		expect(result.current.status).toBe("prompting");
+	});
+
+	it("sets coords and granted status on success", () => {
+		const { result } = renderHook(() => useGeolocation({ enabled: true }));
+		fireSuccess(35.6812, 139.7671);
+		expect(result.current.status).toBe("granted");
+		expect(result.current.coords).toEqual({
+			latitude: 35.6812,
+			longitude: 139.7671,
+		});
+		expect(result.current.error).toBeNull();
+	});
+
+	it("maps permission-denied (code 1) to denied with no coords", () => {
+		const { result } = renderHook(() => useGeolocation({ enabled: true }));
+		fireError(1, "User denied Geolocation");
+		expect(result.current.status).toBe("denied");
+		expect(result.current.coords).toBeNull();
+		expect(result.current.error).toBe("User denied Geolocation");
+	});
+
+	it("maps position-unavailable (code 2) to unavailable", () => {
+		const { result } = renderHook(() => useGeolocation({ enabled: true }));
+		fireError(2);
+		expect(result.current.status).toBe("unavailable");
+		expect(result.current.coords).toBeNull();
+	});
+
+	it("maps timeout (code 3) to unavailable", () => {
+		const { result } = renderHook(() => useGeolocation({ enabled: true }));
+		fireError(3);
+		expect(result.current.status).toBe("unavailable");
+	});
+
+	it("reports unavailable without throwing when geolocation is absent", () => {
+		setGeolocation(undefined);
+		const { result } = renderHook(() => useGeolocation({ enabled: true }));
+		expect(result.current.status).toBe("unavailable");
+		expect(result.current.coords).toBeNull();
+	});
+
+	it("does not re-request on re-render while enabled stays true", () => {
+		const { rerender } = renderHook(
+			({ enabled }) => useGeolocation({ enabled }),
+			{ initialProps: { enabled: true } }
+		);
+		rerender({ enabled: true });
+		rerender({ enabled: true });
+		expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+	});
+
+	it("re-requests after the dialog is closed and reopened", () => {
+		const { rerender } = renderHook(
+			({ enabled }) => useGeolocation({ enabled }),
+			{ initialProps: { enabled: true } }
+		);
+		expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+		rerender({ enabled: false });
+		rerender({ enabled: true });
+		expect(getCurrentPosition).toHaveBeenCalledTimes(2);
+	});
+
+	it("requests imperatively via request() even when disabled", () => {
+		const { result } = renderHook(() => useGeolocation({ enabled: false }));
+		expect(getCurrentPosition).not.toHaveBeenCalled();
+		act(() => {
+			result.current.request();
+		});
+		expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+		fireSuccess(10, 20);
+		expect(result.current.coords).toEqual({ latitude: 10, longitude: 20 });
+		expect(result.current.status).toBe("granted");
+	});
+});

--- a/apps/web/src/shared/hooks/use-geolocation.ts
+++ b/apps/web/src/shared/hooks/use-geolocation.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface GeolocationCoords {
+	latitude: number;
+	longitude: number;
+}
+
+export type GeolocationStatus =
+	| "idle"
+	| "prompting"
+	| "granted"
+	| "denied"
+	| "unavailable";
+
+interface UseGeolocationOptions {
+	/** When it flips to true, a one-shot position request fires automatically. */
+	enabled: boolean;
+}
+
+interface UseGeolocationResult {
+	coords: GeolocationCoords | null;
+	error: string | null;
+	request: () => void;
+	status: GeolocationStatus;
+}
+
+const POSITION_OPTIONS: PositionOptions = {
+	enableHighAccuracy: true,
+	timeout: 10_000,
+	// Reuse a recent fix (≤1 min) so reopening the dialog is instant.
+	maximumAge: 60_000,
+};
+
+// GeolocationPositionError.PERMISSION_DENIED === 1.
+const PERMISSION_DENIED = 1;
+
+/**
+ * Wraps `navigator.geolocation.getCurrentPosition` as a one-shot request. Pass
+ * `enabled` to auto-request when (for example) a dialog opens; call `request()`
+ * to fetch on demand (e.g. a "use current location" button). Re-requests on a
+ * fresh `enabled` false→true transition, but never twice for the same one.
+ */
+export function useGeolocation({
+	enabled,
+}: UseGeolocationOptions): UseGeolocationResult {
+	const [coords, setCoords] = useState<GeolocationCoords | null>(null);
+	const [status, setStatus] = useState<GeolocationStatus>("idle");
+	const [error, setError] = useState<string | null>(null);
+	const autoRequestedRef = useRef(false);
+
+	const request = useCallback(() => {
+		if (!navigator.geolocation) {
+			setStatus("unavailable");
+			setError("Geolocation is not supported");
+			return;
+		}
+		setStatus("prompting");
+		setError(null);
+		navigator.geolocation.getCurrentPosition(
+			(position) => {
+				setCoords({
+					latitude: position.coords.latitude,
+					longitude: position.coords.longitude,
+				});
+				setStatus("granted");
+				setError(null);
+			},
+			(positionError) => {
+				setStatus(
+					positionError.code === PERMISSION_DENIED ? "denied" : "unavailable"
+				);
+				setError(positionError.message);
+			},
+			POSITION_OPTIONS
+		);
+	}, []);
+
+	useEffect(() => {
+		if (!enabled) {
+			// Reset so the next open re-requests a fresh fix.
+			autoRequestedRef.current = false;
+			return;
+		}
+		if (autoRequestedRef.current) {
+			return;
+		}
+		autoRequestedRef.current = true;
+		request();
+	}, [enabled, request]);
+
+	return { coords, status, error, request };
+}

--- a/packages/api/src/__tests__/location.test.ts
+++ b/packages/api/src/__tests__/location.test.ts
@@ -96,6 +96,14 @@ describe("isGoogleMapsUrl", () => {
 	it("rejects lookalike hosts", () => {
 		expect(isGoogleMapsUrl("https://google.com.evil.com/maps")).toBe(false);
 		expect(isGoogleMapsUrl("https://evil-google.com/maps")).toBe(false);
+		// `google` as a subdomain of another registrable domain.
+		expect(isGoogleMapsUrl("https://google.evil.com/maps")).toBe(false);
+		expect(isGoogleMapsUrl("https://google.evil.co/maps")).toBe(false);
+	});
+
+	it("accepts co / com second-level ccTLDs", () => {
+		expect(isGoogleMapsUrl("https://www.google.com.au/maps")).toBe(true);
+		expect(isGoogleMapsUrl("https://google.de/maps")).toBe(true);
 	});
 
 	it("rejects malformed urls", () => {

--- a/packages/api/src/__tests__/location.test.ts
+++ b/packages/api/src/__tests__/location.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { appRouter } from "../routers";
+import {
+	extractCoordsFromMapsUrl,
+	isGoogleMapsUrl,
+	isShortMapsUrl,
+} from "../routers/location";
+import {
+	expectAccepts,
+	expectProtected,
+	expectRejects,
+	expectType,
+} from "./test-utils";
+
+describe("location router", () => {
+	it("appRouter has location namespace", () => {
+		expect(appRouter.location).toBeDefined();
+	});
+
+	it("exposes exactly search and resolveLink", () => {
+		expect(Object.keys(appRouter.location).sort()).toEqual([
+			"resolveLink",
+			"search",
+		]);
+	});
+
+	it("search and resolveLink are protected mutations", () => {
+		expectProtected(appRouter.location.search);
+		expectType(appRouter.location.search, "mutation");
+		expectProtected(appRouter.location.resolveLink);
+		expectType(appRouter.location.resolveLink, "mutation");
+	});
+});
+
+describe("location.search input validation", () => {
+	it("accepts a non-empty query", () => {
+		expectAccepts(appRouter.location.search, { query: "casino tokyo" });
+	});
+
+	it("rejects an empty query", () => {
+		expectRejects(appRouter.location.search, { query: "" });
+	});
+
+	it("accepts a 200-char query (upper boundary)", () => {
+		expectAccepts(appRouter.location.search, { query: "x".repeat(200) });
+	});
+
+	it("rejects a query over 200 chars", () => {
+		expectRejects(appRouter.location.search, { query: "x".repeat(201) });
+	});
+
+	it("rejects a missing query", () => {
+		expectRejects(appRouter.location.search, {});
+	});
+});
+
+describe("location.resolveLink input validation", () => {
+	it("accepts a valid url", () => {
+		expectAccepts(appRouter.location.resolveLink, {
+			url: "https://maps.app.goo.gl/abc",
+		});
+	});
+
+	it("rejects a malformed url", () => {
+		expectRejects(appRouter.location.resolveLink, { url: "not a url" });
+	});
+
+	it("rejects a missing url", () => {
+		expectRejects(appRouter.location.resolveLink, {});
+	});
+});
+
+describe("isGoogleMapsUrl", () => {
+	it("accepts google.com maps URLs", () => {
+		expect(
+			isGoogleMapsUrl("https://www.google.com/maps/place/x/@35.6,139.7,17z")
+		).toBe(true);
+	});
+
+	it("accepts maps.google.com and country TLDs", () => {
+		expect(isGoogleMapsUrl("https://maps.google.com/?q=35.6,139.7")).toBe(true);
+		expect(
+			isGoogleMapsUrl("https://www.google.co.jp/maps/@35.6,139.7,17z")
+		).toBe(true);
+	});
+
+	it("accepts short links", () => {
+		expect(isGoogleMapsUrl("https://maps.app.goo.gl/abcd")).toBe(true);
+		expect(isGoogleMapsUrl("https://goo.gl/maps/abcd")).toBe(true);
+	});
+
+	it("rejects non-google hosts", () => {
+		expect(isGoogleMapsUrl("https://example.com/maps")).toBe(false);
+	});
+
+	it("rejects lookalike hosts", () => {
+		expect(isGoogleMapsUrl("https://google.com.evil.com/maps")).toBe(false);
+		expect(isGoogleMapsUrl("https://evil-google.com/maps")).toBe(false);
+	});
+
+	it("rejects malformed urls", () => {
+		expect(isGoogleMapsUrl("not a url")).toBe(false);
+	});
+});
+
+describe("isShortMapsUrl", () => {
+	it("detects short link hosts", () => {
+		expect(isShortMapsUrl("https://maps.app.goo.gl/abcd")).toBe(true);
+		expect(isShortMapsUrl("https://goo.gl/maps/abcd")).toBe(true);
+	});
+
+	it("is false for full google maps URLs", () => {
+		expect(isShortMapsUrl("https://www.google.com/maps/@35.6,139.7,17z")).toBe(
+			false
+		);
+	});
+});
+
+describe("extractCoordsFromMapsUrl", () => {
+	it("prefers the place !3d!4d coordinates over the @ map center", () => {
+		const url =
+			"https://www.google.com/maps/place/X/@35.0,139.0,17z/data=!3d35.6812!4d139.7671";
+		expect(extractCoordsFromMapsUrl(url)).toEqual({
+			latitude: 35.6812,
+			longitude: 139.7671,
+		});
+	});
+
+	it("falls back to the @lat,lng map center", () => {
+		expect(
+			extractCoordsFromMapsUrl(
+				"https://www.google.com/maps/@35.6812,139.7671,17z"
+			)
+		).toEqual({ latitude: 35.6812, longitude: 139.7671 });
+	});
+
+	it("falls back to a q= query parameter", () => {
+		expect(
+			extractCoordsFromMapsUrl("https://maps.google.com/?q=35.6812,139.7671")
+		).toEqual({ latitude: 35.6812, longitude: 139.7671 });
+	});
+
+	it("handles negative coordinates", () => {
+		expect(
+			extractCoordsFromMapsUrl(
+				"https://www.google.com/maps/@-33.8688,151.2093,17z"
+			)
+		).toEqual({ latitude: -33.8688, longitude: 151.2093 });
+	});
+
+	it("returns null when no coordinates are present", () => {
+		expect(
+			extractCoordsFromMapsUrl("https://www.google.com/maps/place/SomePlace")
+		).toBeNull();
+	});
+
+	it("returns null when coordinates are out of range", () => {
+		expect(
+			extractCoordsFromMapsUrl("https://www.google.com/maps/@95.0,200.0,17z")
+		).toBeNull();
+	});
+});

--- a/packages/api/src/__tests__/room.test.ts
+++ b/packages/api/src/__tests__/room.test.ts
@@ -94,6 +94,19 @@ describe("room.create input validation", () => {
 			memo: 123,
 		});
 	});
+
+	it("accepts name + coordinates", () => {
+		expectAccepts(appRouter.room.create, {
+			name: "Casino Tokyo",
+			latitude: 35.6812,
+			longitude: 139.7671,
+		});
+	});
+
+	it("rejects out-of-range coordinates", () => {
+		expectRejects(appRouter.room.create, { name: "x", latitude: 91 });
+		expectRejects(appRouter.room.create, { name: "x", longitude: -181 });
+	});
 });
 
 describe("room.update input validation", () => {
@@ -119,6 +132,59 @@ describe("room.update input validation", () => {
 
 	it("rejects missing id", () => {
 		expectRejects(appRouter.room.update, { name: "x" });
+	});
+
+	it("accepts latitude + longitude", () => {
+		expectAccepts(appRouter.room.update, {
+			id: "r1",
+			latitude: 35.6812,
+			longitude: 139.7671,
+		});
+	});
+
+	it("accepts latitude/longitude cleared to null", () => {
+		expectAccepts(appRouter.room.update, {
+			id: "r1",
+			latitude: null,
+			longitude: null,
+		});
+	});
+
+	it("accepts boundary coordinates", () => {
+		expectAccepts(appRouter.room.update, {
+			id: "r1",
+			latitude: -90,
+			longitude: -180,
+		});
+		expectAccepts(appRouter.room.update, {
+			id: "r1",
+			latitude: 90,
+			longitude: 180,
+		});
+	});
+
+	it("rejects latitude above 90", () => {
+		expectRejects(appRouter.room.update, { id: "r1", latitude: 90.1 });
+	});
+
+	it("rejects latitude below -90", () => {
+		expectRejects(appRouter.room.update, { id: "r1", latitude: -90.1 });
+	});
+
+	it("rejects longitude above 180", () => {
+		expectRejects(appRouter.room.update, { id: "r1", longitude: 180.1 });
+	});
+
+	it("rejects longitude below -180", () => {
+		expectRejects(appRouter.room.update, { id: "r1", longitude: -180.1 });
+	});
+
+	it("rejects non-numeric latitude", () => {
+		expectRejects(appRouter.room.update, { id: "r1", latitude: "35.6" });
+	});
+
+	it("rejects non-numeric longitude", () => {
+		expectRejects(appRouter.room.update, { id: "r1", longitude: "139.7" });
 	});
 });
 

--- a/packages/api/src/__tests__/room.test.ts
+++ b/packages/api/src/__tests__/room.test.ts
@@ -107,6 +107,11 @@ describe("room.create input validation", () => {
 		expectRejects(appRouter.room.create, { name: "x", latitude: 91 });
 		expectRejects(appRouter.room.create, { name: "x", longitude: -181 });
 	});
+
+	it("rejects a single coordinate without its pair", () => {
+		expectRejects(appRouter.room.create, { name: "x", latitude: 35.6 });
+		expectRejects(appRouter.room.create, { name: "x", longitude: 139.7 });
+	});
 });
 
 describe("room.update input validation", () => {
@@ -185,6 +190,19 @@ describe("room.update input validation", () => {
 
 	it("rejects non-numeric longitude", () => {
 		expectRejects(appRouter.room.update, { id: "r1", longitude: "139.7" });
+	});
+
+	it("rejects a single coordinate without its pair", () => {
+		expectRejects(appRouter.room.update, { id: "r1", latitude: 35.6 });
+		expectRejects(appRouter.room.update, { id: "r1", longitude: 139.7 });
+	});
+
+	it("rejects one coordinate cleared while the other is set", () => {
+		expectRejects(appRouter.room.update, {
+			id: "r1",
+			latitude: 35.6,
+			longitude: null,
+		});
 	});
 });
 

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -11,13 +11,14 @@ type AuthInstance = ReturnType<typeof createAuth>;
 export function createContextFactory(
 	authInstance: AuthInstance,
 	dbInstance: Database,
-	anthropicApiKey?: string
+	anthropicApiKey?: string,
+	googleMapsApiKey?: string
 ) {
 	return async ({ context }: CreateContextOptions) => {
 		const session = await authInstance.api.getSession({
 			headers: context.req.raw.headers,
 		});
-		return { session, db: dbInstance, anthropicApiKey };
+		return { session, db: dbInstance, anthropicApiKey, googleMapsApiKey };
 	};
 }
 

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -5,6 +5,7 @@ import { currencyRouter } from "./currency";
 import { currencyTransactionRouter } from "./currency-transaction";
 import { liveCashGameSessionRouter } from "./live-cash-game-session";
 import { liveTournamentSessionRouter } from "./live-tournament-session";
+import { locationRouter } from "./location";
 import { playerRouter } from "./player";
 import { playerTagRouter } from "./player-tag";
 import { ringGameRouter } from "./ring-game";
@@ -30,6 +31,7 @@ export const appRouter = router({
 		};
 	}),
 	aiExtract: aiExtractRouter,
+	location: locationRouter,
 	room: roomRouter,
 	transactionType: transactionTypeRouter,
 	currency: currencyRouter,

--- a/packages/api/src/routers/location.ts
+++ b/packages/api/src/routers/location.ts
@@ -1,0 +1,184 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { protectedProcedure, router } from "../index";
+
+// Short-link hosts are the only URLs we ever fetch server-side (to follow the
+// redirect), so they are an exact allowlist — this bounds the SSRF surface.
+const SHORT_MAPS_HOSTS = new Set(["maps.app.goo.gl", "goo.gl"]);
+
+// `google.<tld>` or `*.google.<tld>` (incl. `google.co.jp`). The label before
+// the TLD must be exactly `google`, anchored at both ends, so lookalikes like
+// `google.com.evil.com` or `evil-google.com` are rejected.
+const GOOGLE_HOST_RE = /^([a-z0-9-]+\.)*google\.[a-z]{2,}(\.[a-z]{2,})?$/;
+
+function hostnameOf(rawUrl: string): string | null {
+	try {
+		return new URL(rawUrl).hostname.toLowerCase();
+	} catch {
+		return null;
+	}
+}
+
+export function isShortMapsUrl(rawUrl: string): boolean {
+	const host = hostnameOf(rawUrl);
+	return host !== null && SHORT_MAPS_HOSTS.has(host);
+}
+
+export function isGoogleMapsUrl(rawUrl: string): boolean {
+	const host = hostnameOf(rawUrl);
+	if (host === null) {
+		return false;
+	}
+	return SHORT_MAPS_HOSTS.has(host) || GOOGLE_HOST_RE.test(host);
+}
+
+function safeDecode(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
+}
+
+function inRange(latitude: number, longitude: number): boolean {
+	return (
+		latitude >= -90 && latitude <= 90 && longitude >= -180 && longitude <= 180
+	);
+}
+
+// Ordered by specificity: `!3d!4d` is the place's actual location, `@lat,lng`
+// is the map viewport center, and `q=`/`ll=`/etc. cover share/query links.
+const COORD_PATTERNS = [
+	/!3d(-?\d+(?:\.\d+)?)!4d(-?\d+(?:\.\d+)?)/,
+	/@(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)/,
+	/[?&](?:q|query|ll|center|destination|daddr)=(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)/,
+];
+
+export function extractCoordsFromMapsUrl(
+	url: string
+): { latitude: number; longitude: number } | null {
+	for (const candidate of [url, safeDecode(url)]) {
+		for (const pattern of COORD_PATTERNS) {
+			const match = candidate.match(pattern);
+			if (!(match?.[1] && match[2])) {
+				continue;
+			}
+			const latitude = Number.parseFloat(match[1]);
+			const longitude = Number.parseFloat(match[2]);
+			if (
+				Number.isFinite(latitude) &&
+				Number.isFinite(longitude) &&
+				inRange(latitude, longitude)
+			) {
+				return { latitude, longitude };
+			}
+		}
+	}
+	return null;
+}
+
+interface PlacesTextSearchResponse {
+	places?: Array<{
+		displayName?: { text?: string };
+		formattedAddress?: string;
+		location?: { latitude?: number; longitude?: number };
+	}>;
+}
+
+export const locationRouter = router({
+	// Place name search via Google Places API (New) Text Search. Triggered by an
+	// explicit search action (not per keystroke) to bound API cost.
+	search: protectedProcedure
+		.input(z.object({ query: z.string().min(1).max(200) }))
+		.mutation(async ({ ctx, input }) => {
+			if (!ctx.googleMapsApiKey) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message:
+						"Place search is not configured (missing GOOGLE_MAPS_API_KEY)",
+				});
+			}
+
+			const res = await fetch(
+				"https://places.googleapis.com/v1/places:searchText",
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"X-Goog-Api-Key": ctx.googleMapsApiKey,
+						"X-Goog-FieldMask":
+							"places.displayName,places.formattedAddress,places.location",
+					},
+					body: JSON.stringify({
+						textQuery: input.query,
+						languageCode: "ja",
+						regionCode: "JP",
+					}),
+				}
+			);
+
+			if (!res.ok) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Place search failed",
+				});
+			}
+
+			const data = (await res.json()) as PlacesTextSearchResponse;
+			return (data.places ?? [])
+				.filter(
+					(p) =>
+						typeof p.location?.latitude === "number" &&
+						typeof p.location?.longitude === "number"
+				)
+				.slice(0, 5)
+				.map((p) => ({
+					name: p.displayName?.text ?? "",
+					address: p.formattedAddress ?? "",
+					latitude: p.location?.latitude as number,
+					longitude: p.location?.longitude as number,
+				}));
+		}),
+
+	// Extract coordinates from a pasted Google Maps link. Full URLs are parsed
+	// directly; short links are resolved by following the redirect server-side
+	// (the only outbound fetch, restricted to the short-link host allowlist).
+	resolveLink: protectedProcedure
+		.input(z.object({ url: z.string().url() }))
+		.mutation(async ({ input }) => {
+			if (!isGoogleMapsUrl(input.url)) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Not a Google Maps link",
+				});
+			}
+
+			let finalUrl = input.url;
+			if (isShortMapsUrl(input.url)) {
+				let res: Response;
+				try {
+					res = await fetch(input.url, {
+						redirect: "follow",
+						headers: {
+							"User-Agent": "Mozilla/5.0 (compatible; Sapphire2/1.0)",
+						},
+					});
+				} catch {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "Could not resolve the link",
+					});
+				}
+				finalUrl = res.url || input.url;
+			}
+
+			const coords = extractCoordsFromMapsUrl(finalUrl);
+			if (!coords) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Could not find coordinates in the link",
+				});
+			}
+			return coords;
+		}),
+});

--- a/packages/api/src/routers/location.ts
+++ b/packages/api/src/routers/location.ts
@@ -6,10 +6,13 @@ import { protectedProcedure, router } from "../index";
 // redirect), so they are an exact allowlist — this bounds the SSRF surface.
 const SHORT_MAPS_HOSTS = new Set(["maps.app.goo.gl", "goo.gl"]);
 
-// `google.<tld>` or `*.google.<tld>` (incl. `google.co.jp`). The label before
-// the TLD must be exactly `google`, anchored at both ends, so lookalikes like
-// `google.com.evil.com` or `evil-google.com` are rejected.
-const GOOGLE_HOST_RE = /^([a-z0-9-]+\.)*google\.[a-z]{2,}(\.[a-z]{2,})?$/;
+// `google.<tld>` or `*.google.<tld>`, where `google` is the registrable label
+// immediately followed by the TLD: a gTLD (`com`), a 2-letter ccTLD (`google.de`)
+// or a `co`/`com` second-level ccTLD (`google.co.jp`, `google.com.au`). This
+// rejects lookalikes such as `evil-google.com`, `google.com.evil.com` AND
+// `google.evil.com` (where `google` would be a subdomain of `evil.com`).
+const GOOGLE_HOST_RE =
+	/^([a-z0-9-]+\.)*google\.(com|[a-z]{2}|(?:co|com)\.[a-z]{2})$/;
 
 function hostnameOf(rawUrl: string): string | null {
 	try {

--- a/packages/api/src/routers/room.ts
+++ b/packages/api/src/routers/room.ts
@@ -22,6 +22,8 @@ export const roomRouter = router({
 				isFavorite: room.isFavorite,
 				createdAt: room.createdAt,
 				updatedAt: room.updatedAt,
+				latitude: room.latitude,
+				longitude: room.longitude,
 				ringGameCount: sql<number>`(SELECT COUNT(*) FROM ring_game WHERE ring_game.room_id = room.id AND ring_game.archived_at IS NULL)`,
 				tournamentCount: sql<number>`(SELECT COUNT(*) FROM tournament WHERE tournament.room_id = room.id AND tournament.archived_at IS NULL)`,
 			})
@@ -54,7 +56,14 @@ export const roomRouter = router({
 		}),
 
 	create: protectedProcedure
-		.input(z.object({ name: z.string().min(1), memo: z.string().optional() }))
+		.input(
+			z.object({
+				name: z.string().min(1),
+				memo: z.string().optional(),
+				latitude: z.number().min(-90).max(90).nullable().optional(),
+				longitude: z.number().min(-180).max(180).nullable().optional(),
+			})
+		)
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
 			const id = crypto.randomUUID();
@@ -63,6 +72,8 @@ export const roomRouter = router({
 				userId,
 				name: input.name,
 				memo: input.memo ?? null,
+				latitude: input.latitude ?? null,
+				longitude: input.longitude ?? null,
 				updatedAt: new Date(),
 			});
 			const [created] = await ctx.db.select().from(room).where(eq(room.id, id));
@@ -77,6 +88,10 @@ export const roomRouter = router({
 				// Nullable so an explicit `null` clears the memo. `undefined`
 				// (key omitted) still means "leave unchanged".
 				memo: z.string().nullable().optional(),
+				// Geographic coordinates. Nullable so an explicit `null` clears the
+				// location; `undefined` leaves it unchanged (same pattern as memo).
+				latitude: z.number().min(-90).max(90).nullable().optional(),
+				longitude: z.number().min(-180).max(180).nullable().optional(),
 			})
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -102,6 +117,10 @@ export const roomRouter = router({
 				.set({
 					...(input.name === undefined ? {} : { name: input.name }),
 					...(input.memo === undefined ? {} : { memo: input.memo }),
+					...(input.latitude === undefined ? {} : { latitude: input.latitude }),
+					...(input.longitude === undefined
+						? {}
+						: { longitude: input.longitude }),
 					updatedAt: new Date(),
 				})
 				.where(eq(room.id, input.id));

--- a/packages/api/src/routers/room.ts
+++ b/packages/api/src/routers/room.ts
@@ -4,6 +4,24 @@ import { asc, desc, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
 
+// Coordinates move as a pair: latitude and longitude must both be omitted
+// (leave unchanged), both `null` (cleared) or both numbers (set). Mirrors the
+// web form's `.refine`, so a direct tRPC call can't persist a half-set location.
+function coordinatesPaired(value: {
+	latitude?: number | null;
+	longitude?: number | null;
+}): boolean {
+	return (
+		(value.latitude === undefined) === (value.longitude === undefined) &&
+		(value.latitude === null) === (value.longitude === null)
+	);
+}
+
+const COORDINATES_PAIRED_ISSUE = {
+	message: "latitude and longitude must be set or cleared together",
+	path: ["longitude"],
+};
+
 export const roomRouter = router({
 	list: protectedProcedure.query(({ ctx }) => {
 		const userId = ctx.session.user.id;
@@ -57,12 +75,14 @@ export const roomRouter = router({
 
 	create: protectedProcedure
 		.input(
-			z.object({
-				name: z.string().min(1),
-				memo: z.string().optional(),
-				latitude: z.number().min(-90).max(90).nullable().optional(),
-				longitude: z.number().min(-180).max(180).nullable().optional(),
-			})
+			z
+				.object({
+					name: z.string().min(1),
+					memo: z.string().optional(),
+					latitude: z.number().min(-90).max(90).nullable().optional(),
+					longitude: z.number().min(-180).max(180).nullable().optional(),
+				})
+				.refine(coordinatesPaired, COORDINATES_PAIRED_ISSUE)
 		)
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
@@ -82,17 +102,19 @@ export const roomRouter = router({
 
 	update: protectedProcedure
 		.input(
-			z.object({
-				id: z.string(),
-				name: z.string().min(1).optional(),
-				// Nullable so an explicit `null` clears the memo. `undefined`
-				// (key omitted) still means "leave unchanged".
-				memo: z.string().nullable().optional(),
-				// Geographic coordinates. Nullable so an explicit `null` clears the
-				// location; `undefined` leaves it unchanged (same pattern as memo).
-				latitude: z.number().min(-90).max(90).nullable().optional(),
-				longitude: z.number().min(-180).max(180).nullable().optional(),
-			})
+			z
+				.object({
+					id: z.string(),
+					name: z.string().min(1).optional(),
+					// Nullable so an explicit `null` clears the memo. `undefined`
+					// (key omitted) still means "leave unchanged".
+					memo: z.string().nullable().optional(),
+					// Geographic coordinates. Nullable so an explicit `null` clears the
+					// location; `undefined` leaves it unchanged (same pattern as memo).
+					latitude: z.number().min(-90).max(90).nullable().optional(),
+					longitude: z.number().min(-180).max(180).nullable().optional(),
+				})
+				.refine(coordinatesPaired, COORDINATES_PAIRED_ISSUE)
 		)
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;

--- a/packages/db/src/__tests__/room.test.ts
+++ b/packages/db/src/__tests__/room.test.ts
@@ -96,3 +96,30 @@ describe("Room schema — constraints", () => {
 		expect(columns.memo.dataType).toBe("string");
 	});
 });
+
+describe("Room schema — location", () => {
+	it("defines latitude and longitude columns", () => {
+		const columns = getTableColumns(room);
+		expect(columns.latitude).toBeDefined();
+		expect(columns.longitude).toBeDefined();
+	});
+
+	it("latitude and longitude are nullable", () => {
+		const columns = getTableColumns(room);
+		expect(columns.latitude.notNull).toBe(false);
+		expect(columns.longitude.notNull).toBe(false);
+	});
+
+	it("latitude and longitude are stored as real (number) columns", () => {
+		const columns = getTableColumns(room);
+		// drizzle `real()` reports its dataType as "number", not "real".
+		expect(columns.latitude.dataType).toBe("number");
+		expect(columns.longitude.dataType).toBe("number");
+	});
+
+	it("latitude and longitude have no default (unset stays null)", () => {
+		const columns = getTableColumns(room);
+		expect(columns.latitude.hasDefault).toBe(false);
+		expect(columns.longitude.hasDefault).toBe(false);
+	});
+});

--- a/packages/db/src/migrations/0032_room_add_location.sql
+++ b/packages/db/src/migrations/0032_room_add_location.sql
@@ -1,0 +1,5 @@
+-- SA2-41: 緯度・経度を room テーブルに追加。ライブセッション開始時に位置情報から
+-- 最寄りの room をデフォルト選択するために使用する。NULL 許容（既存行・未設定の
+-- room は位置情報なし。(0, 0) は有効な座標なので「未設定」には使えないため）。
+ALTER TABLE room ADD COLUMN latitude REAL;--> statement-breakpoint
+ALTER TABLE room ADD COLUMN longitude REAL;

--- a/packages/db/src/schema/room.ts
+++ b/packages/db/src/schema/room.ts
@@ -1,5 +1,11 @@
 import { relations, sql } from "drizzle-orm";
-import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import {
+	index,
+	integer,
+	real,
+	sqliteTable,
+	text,
+} from "drizzle-orm/sqlite-core";
 import { user } from "./auth";
 
 export const room = sqliteTable(
@@ -14,6 +20,11 @@ export const room = sqliteTable(
 		isFavorite: integer("is_favorite", { mode: "boolean" })
 			.notNull()
 			.default(false),
+		// Geographic coordinates of the room, used to default-select the nearest
+		// room when starting a live session. Nullable: existing/unset rooms have
+		// no location, and (0, 0) is a valid coordinate so it can't mean "unset".
+		latitude: real("latitude"),
+		longitude: real("longitude"),
 		createdAt: integer("created_at", { mode: "timestamp" })
 			.default(sql`(unixepoch())`)
 			.notNull(),


### PR DESCRIPTION
## 概要

Linear [SA2-41](https://linear.app/sapphire2/issue/SA2-41) / #305

ライブセッション開始時に、ブラウザの位置情報から**最寄りの Room（旧称 Store）を自動でデフォルト選択**できるようにする。あわせて Room の座標を **地名検索 / Google Maps URL / 現在地(GPS)** で手軽に設定できるようにし、Store ページから地図を開けるようにした。

## 主な変更

### ライブセッション開始
- 開始ダイアログを開いたとき位置情報を要求し、**半径 500m 以内の最寄り Room を自動選択**（`DEFAULT_NEAREST_RADIUS_METERS`）。圏内に座標付き Room が無ければ未選択のまま
- ユーザーが手動で選択・クリアした場合は自動選択で**上書きしない**（ref ガード）

### Room の座標設定（フォーム）
- 位置入力を **タブ（Search / URL / Current）** に整理
  - **Search**: Google Places API (New) Text Search で地名検索 → 候補から選択（検索ボックスは Room 名で初期化）
  - **URL**: Google Maps の URL 貼り付け → 座標抽出。短縮リンク(`maps.app.goo.gl`)はサーバーでリダイレクト追跡。クライアント側で Google ドメインを厳密バリデーション
  - **Current**: 現在地(GPS)
- 解決した座標は読み取り専用で確認表示（座標 + "View on Google Maps" + Clear）

### Store（Room 詳細）ページ
- 座標が設定済みのとき「View on Google Maps」リンクを表示（キー不要の Maps 検索 URL）

### DB / API
- `room` に `latitude`/`longitude`（nullable `real`）を追加（migration `0032`）。未設定は `NULL`（`(0,0)` は有効座標のため）
- `room.create`/`update` が座標を授受（範囲＋**両方 or どちらも空**の対称制約）、`list` が座標を返却
- 新規 `location` ルーター: `search`（Places Text Search）/ `resolveLink`（URL→座標）。**SSRF 対策**として実 fetch は短縮リンクの固定ホスト allowlist のみ

### 共通コンポーネント
- shared `Tabs` を **3+ タブ対応**化（`TabsList` が子数から `--tabs-count` を算出、スライドピル幅 `1/N`。既存2タブ挙動は不変）

### 環境変数 / デプロイ
- `GOOGLE_MAPS_API_KEY` を `context.ts` / `worker.ts` / `.dev.vars.example` と各デプロイワークフローに配線
- **キー未設定でも URL 解決 / GPS は動作**、地名検索のみ無効（`GOOGLE_MAPS_API_KEY` を GitHub リポジトリシークレットに登録すると有効）

## テスト

すべて TDD。全 288 ファイル / 3921 テスト green。DB スキーマ / API ルーター（範囲・対称制約・URL 検証・座標抽出・ホスト allowlist）/ geo 純関数 / `useGeolocation` / 最寄り自動選択 / LocationPicker / Tabs / Room フォームをブランチ網羅・境界値・エラーパスまでカバー。

## 動作確認

1. Room 編集 → Search で地名検索 → 選択 → 座標確認表示
2. URL タブに Google Maps 共有リンク貼付 → 座標設定（不正 URL はエラー）
3. Current で現在地取得 / Clear で解除 / 保存して再編集で復元
4. 開始ダイアログ → 位置許可後、最寄り Room が自動選択（半径外/拒否時は従来動作、手動選択は上書きされない）
5. Store ページの「View on Google Maps」で地図を開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)
