### PR TITLE
fix(sessions): リンク中のゲームをリネームしたときセッション一覧の表示名も追随させる (SA2-95)

### DIFF
--- a/apps/web/src/features/rooms/hooks/__tests__/use-ring-games.test.ts
+++ b/apps/web/src/features/rooms/hooks/__tests__/use-ring-games.test.ts
@@ -35,6 +35,19 @@ vi.mock("@/utils/trpc", () => ({
 				}),
 			},
 		},
+		session: {
+			list: {
+				queryKey: () => buildKey("session", "list", undefined),
+			},
+		},
+		liveCashGameSession: {
+			list: {
+				queryOptions: (input: unknown) => ({
+					queryKey: buildKey("liveCashGameSession", "list", input),
+					queryFn: () => Promise.resolve([]),
+				}),
+			},
+		},
 	},
 	trpcClient: {
 		ringGame: {
@@ -300,6 +313,31 @@ describe("useRingGames", () => {
 					memo: null,
 				})
 			);
+		});
+
+		it("invalidates session.list and liveCashGameSession.list so a rename shows up there (SA2-95)", async () => {
+			const qc = createClient();
+			qc.setQueryData(activeKey, [makeGame({ id: "r1" })]);
+			qc.setQueryData(archivedKey, []);
+			const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+			trpcMocks.update.mockResolvedValue({ id: "r1" });
+			const { result } = renderHook(
+				() => useRingGames({ roomId: STORE_ID, showArchived: false }),
+				{ wrapper: makeWrapper(qc) }
+			);
+			await act(async () => {
+				await result.current.update({
+					id: "r1",
+					name: "Renamed",
+					variant: "nlh",
+				});
+			});
+			expect(invalidateSpy).toHaveBeenCalledWith({
+				queryKey: ["session", "list"],
+			});
+			expect(invalidateSpy).toHaveBeenCalledWith({
+				queryKey: ["liveCashGameSession", "list", {}],
+			});
 		});
 	});
 

--- a/apps/web/src/features/rooms/hooks/use-ring-games.ts
+++ b/apps/web/src/features/rooms/hooks/use-ring-games.ts
@@ -196,7 +196,15 @@ export function useRingGames({ roomId, showArchived }: UseRingGamesOptions) {
 				context?.previousArchived,
 			]);
 		},
-		onSettled: invalidateBoth,
+		onSettled: () => {
+			invalidateBoth();
+			// A rename cascades to already-linked sessions' displayed name
+			// server-side (SA2-95); refresh the lists that show it.
+			invalidateTargets(queryClient, [
+				{ queryKey: trpc.session.list.queryKey() },
+				{ queryKey: trpc.liveCashGameSession.list.queryOptions({}).queryKey },
+			]);
+		},
 	});
 
 	const archiveMutation = useMutation({

--- a/apps/web/src/features/rooms/pages/room-detail-page/tournament-tab/__tests__/use-tournament-tab.test.ts
+++ b/apps/web/src/features/rooms/pages/room-detail-page/tournament-tab/__tests__/use-tournament-tab.test.ts
@@ -40,6 +40,19 @@ vi.mock("@/utils/trpc", () => ({
 				}),
 			},
 		},
+		session: {
+			list: {
+				queryKey: () => buildKey("session", "list", undefined),
+			},
+		},
+		liveTournamentSession: {
+			list: {
+				queryOptions: (input: unknown) => ({
+					queryKey: buildKey("liveTournamentSession", "list", input),
+					queryFn: () => Promise.resolve([]),
+				}),
+			},
+		},
 	},
 	trpcClient: {
 		tournament: {
@@ -213,6 +226,30 @@ describe("useTournamentTab", () => {
 			expect.objectContaining({ id: "t1", name: "New" })
 		);
 		expect(result.current.editingTournament).toBeNull();
+	});
+
+	it("handleUpdate invalidates session.list and liveTournamentSession.list so a rename shows up there (SA2-95)", async () => {
+		hoisted.updateWithLevels.mockResolvedValue(undefined);
+		const qc = createClient();
+		const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+		const { result } = renderHook(() => useTournamentTab({ roomId: "s1" }), {
+			wrapper: wrapper(qc),
+		});
+		act(() => {
+			result.current.setEditingTournament(TOURNAMENT);
+		});
+		await act(async () => {
+			await result.current.handleUpdate(
+				{ name: "New", variant: "nlh", chipPurchases: [] },
+				[]
+			);
+		});
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: ["session", "list"],
+		});
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: ["liveTournamentSession", "list", {}],
+		});
 	});
 
 	it("toggleArchived flips showArchived back and forth", () => {

--- a/apps/web/src/features/rooms/pages/room-detail-page/tournament-tab/use-tournament-tab.ts
+++ b/apps/web/src/features/rooms/pages/room-detail-page/tournament-tab/use-tournament-tab.ts
@@ -153,6 +153,12 @@ export function useTournamentTab({ roomId }: UseTournamentTabOptions) {
 							tournamentId: editingTournament.id,
 						}).queryKey,
 					},
+					// A rename cascades to already-linked sessions' displayed
+					// name server-side (SA2-95); refresh the lists that show it.
+					{ queryKey: trpc.session.list.queryKey() },
+					{
+						queryKey: trpc.liveTournamentSession.list.queryOptions({}).queryKey,
+					},
 				]),
 			]);
 			setEditingTournament(null);

--- a/apps/web/src/features/sessions/utils/session-display.ts
+++ b/apps/web/src/features/sessions/utils/session-display.ts
@@ -24,9 +24,10 @@ interface GameNameInput {
 }
 
 /**
- * Resolves the display name for a session, preferring the frozen rule name and
- * falling back to a generic label per game type. Sentence case per the v2
- * design contract.
+ * Resolves the display name for a session, preferring the session's rule name
+ * (kept in sync with the linked ring_game / tournament's name on rename; see
+ * SA2-95) and falling back to a generic label per game type. Sentence case
+ * per the v2 design contract.
  */
 export function getSessionGameName(session: GameNameInput): string {
 	if (session.type === "tournament" && session.tournamentName) {

--- a/packages/api/src/routers/ring-game.ts
+++ b/packages/api/src/routers/ring-game.ts
@@ -1,5 +1,6 @@
 import { ringGame } from "@sapphire2/db/schema/ring-game";
 import { room } from "@sapphire2/db/schema/room";
+import { sessionCashDetail } from "@sapphire2/db/schema/session-cash-detail";
 import { TRPCError } from "@trpc/server";
 import { and, eq, isNotNull, isNull } from "drizzle-orm";
 import { z } from "zod";
@@ -188,6 +189,16 @@ export const ringGameRouter = router({
 				.update(ringGame)
 				.set(updateData)
 				.where(eq(ringGame.id, input.id));
+
+			// A rename must keep already-linked sessions' displayed name in
+			// sync (SA2-95); other frozen snapshot fields (blinds, variant,
+			// ...) intentionally stay untouched.
+			if (input.name !== undefined) {
+				await ctx.db
+					.update(sessionCashDetail)
+					.set({ ruleName: input.name })
+					.where(eq(sessionCashDetail.ringGameId, input.id));
+			}
 
 			const [updated] = await ctx.db
 				.select()

--- a/packages/api/src/routers/tournament.ts
+++ b/packages/api/src/routers/tournament.ts
@@ -1,4 +1,5 @@
 import { room } from "@sapphire2/db/schema/room";
+import { sessionTournamentDetail } from "@sapphire2/db/schema/session-tournament-detail";
 import {
 	blindLevel,
 	tournament,
@@ -233,6 +234,16 @@ export const tournamentRouter = router({
 				.set(updateData)
 				.where(eq(tournament.id, input.id));
 
+			// A rename must keep already-linked sessions' displayed name in
+			// sync (SA2-95); other frozen snapshot fields (blinds, variant,
+			// ...) intentionally stay untouched.
+			if (input.name !== undefined) {
+				await ctx.db
+					.update(sessionTournamentDetail)
+					.set({ ruleName: input.name })
+					.where(eq(sessionTournamentDetail.tournamentId, input.id));
+			}
+
 			const [updated] = await ctx.db
 				.select()
 				.from(tournament)
@@ -453,6 +464,16 @@ export const tournamentRouter = router({
 				.update(tournament)
 				.set(updateData)
 				.where(eq(tournament.id, input.id));
+
+			// A rename must keep already-linked sessions' displayed name in
+			// sync (SA2-95); other frozen snapshot fields (blinds, variant,
+			// ...) intentionally stay untouched.
+			if (input.name !== undefined) {
+				await ctx.db
+					.update(sessionTournamentDetail)
+					.set({ ruleName: input.name })
+					.where(eq(sessionTournamentDetail.tournamentId, input.id));
+			}
 
 			if (input.tags !== undefined) {
 				await ctx.db

--- a/packages/db/src/schema/session-cash-detail.ts
+++ b/packages/db/src/schema/session-cash-detail.ts
@@ -15,8 +15,10 @@ export const sessionCashDetail = sqliteTable(
 		buyIn: integer("buy_in"),
 		cashOut: integer("cash_out"),
 		evCashOut: integer("ev_cash_out"),
-		// Snapshot fields — copied from ring_game at session create time and
-		// frozen thereafter. Parent rename / blind change does not propagate.
+		// Snapshot fields — copied from ring_game at session create time.
+		// Blind / rule changes on the parent stay frozen (SA2-95), but
+		// `ruleName` is cascade-updated by ringGame.update whenever the
+		// parent is still linked, so a rename does propagate.
 		ruleName: text("rule_name").notNull().default("Untitled"),
 		variant: text("variant").notNull().default("nlh"),
 		blind1: integer("blind1"),

--- a/packages/db/src/schema/session-tournament-detail.ts
+++ b/packages/db/src/schema/session-tournament-detail.ts
@@ -20,8 +20,11 @@ export const sessionTournamentDetail = sqliteTable(
 		prizeMoney: integer("prize_money"),
 		bountyPrizes: integer("bounty_prizes"),
 		timerStartedAt: integer("timer_started_at", { mode: "timestamp" }),
-		// Snapshot fields — copied from tournament at session create time and
-		// frozen thereafter. Parent rename / config change does not propagate.
+		// Snapshot fields — copied from tournament at session create time.
+		// Blind / rule changes on the parent stay frozen (SA2-95), but
+		// `ruleName` is cascade-updated by tournament.update /
+		// updateWithLevels whenever the parent is still linked, so a rename
+		// does propagate.
 		ruleName: text("rule_name").notNull().default("Untitled"),
 		variant: text("variant").notNull().default("nlh"),
 		startingStack: integer("starting_stack"),


### PR DESCRIPTION
## Summary

- `session_cash_detail.ruleName` / `session_tournament_detail.ruleName` はセッション作成時に `ring_game` / `tournament` から名前をコピーして以降凍結される仕様（PR #271 / migration `0024_freeze_session_rule_snapshot.sql`）だったため、リンク済みのゲームを後からリネームしても、セッション一覧・詳細の表示名が古いままになっていた（SA2-95）。
- `ringGame.update` / `tournament.update` / `tournament.updateWithLevels` で `name` が変更された場合に、まだそのゲームにリンクされているセッションの `ruleName` もカスケード更新するようにした。blind / variant / buy-in などの他のスナップショット項目は引き続き凍結のまま（意図的な仕様を維持）。
- ゲームのリネーム操作（`use-ring-games.ts` の rename mutation, `use-tournament-tab.ts` の `handleUpdate`）で `session.list` / `liveCashGameSession.list` / `liveTournamentSession.list` のクエリキャッシュも無効化し、画面遷移なしでも一覧に反映されるようにした。

## Test plan

- [x] `bunx vitest run --project api packages/api/src` — 689 tests pass
- [x] `bunx vitest run --project web-dom apps/web/src/features/rooms apps/web/src/features/sessions apps/web/src/features/live-sessions` — 1113 tests pass
- [x] `bunx vitest run --project web-node apps/web/src/features/sessions` — 103 tests pass
- [x] `bunx vitest run --project db` — 364 tests pass
- [x] `bun run check-types`
- [x] `bunx ultracite check` on all changed files
- [ ] 手動確認: rooms 管理画面でリングゲーム / トーナメントをリネームし、セッション一覧・ライブセッション一覧の表示名が追随することを確認（DB統合テストのハーネスが本リポジトリに存在しないため、mutation ハンドラ内のカスケード更新自体は自動テスト対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xyg4dfMETTqKgeCKEMeXSY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xyg4dfMETTqKgeCKEMeXSY)_