### PR TITLE
fix(session): トーナメントセッション編集時のブラインドストラクチャー保存不具合を修正 (SA2-96)

### DIFF
--- a/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
+++ b/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
@@ -361,6 +361,34 @@ describe("pure helpers", () => {
 			expect(out.roomId).toBe("room-1");
 			expect(out.currencyId).toBe("cur-1");
 		});
+
+		it("includes tournament snapshot overrides and blind levels", () => {
+			const blindLevels = [
+				{
+					ante: null,
+					blind1: 100,
+					blind2: 200,
+					blind3: null,
+					isBreak: false,
+					minutes: 15,
+				},
+			];
+			const out = buildUpdatePayload({
+				...tournamentValues({
+					variant: "nlh",
+					startingStack: 20_000,
+					bountyAmount: 500,
+					tableSize: 9,
+					blindLevels,
+				}),
+				id: "s1",
+			}) as Record<string, unknown>;
+			expect(out.variant).toBe("nlh");
+			expect(out.startingStack).toBe(20_000);
+			expect(out.bountyAmount).toBe(500);
+			expect(out.tableSize).toBe(9);
+			expect(out.blindLevels).toEqual(blindLevels);
+		});
 	});
 
 	describe("buildLiveLinkedUpdatePayload", () => {

--- a/apps/web/src/features/sessions/hooks/use-sessions.ts
+++ b/apps/web/src/features/sessions/hooks/use-sessions.ts
@@ -201,6 +201,11 @@ export function buildUpdatePayload(values: SessionFormValues & { id: string }) {
 		totalEntries: values.totalEntries ?? null,
 		prizeMoney: values.prizeMoney,
 		bountyPrizes: values.bountyPrizes,
+		variant: values.variant,
+		startingStack: values.startingStack ?? null,
+		bountyAmount: values.bountyAmount ?? null,
+		tableSize: values.tableSize ?? null,
+		blindLevels: values.blindLevels,
 		chipPurchases: values.chipPurchases,
 		tournamentId: values.tournamentId ?? null,
 	};

--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -427,6 +427,56 @@ describe("session router input validation", () => {
 		).toBe(true);
 	});
 
+	it("update accepts and retains tournament snapshot override fields and blind level structure", () => {
+		const schema = (
+			appRouter.session.update as unknown as {
+				_def: { inputs: unknown[] };
+			}
+		)._def.inputs[0] as {
+			safeParse: (v: unknown) => {
+				data?: Record<string, unknown>;
+				success: boolean;
+			};
+		};
+		const input = {
+			id: "s1",
+			variant: "nlh",
+			startingStack: 20_000,
+			bountyAmount: 500,
+			tableSize: 9,
+			blindLevels: [
+				{
+					isBreak: false,
+					blind1: 100,
+					blind2: 200,
+					blind3: null,
+					ante: null,
+					minutes: 15,
+				},
+			],
+		};
+		const parsed = schema.safeParse(input);
+		expect(parsed.success).toBe(true);
+		// Guards against Zod silently stripping these as unknown keys.
+		expect(parsed.data?.startingStack).toBe(20_000);
+		expect(parsed.data?.bountyAmount).toBe(500);
+		expect(parsed.data?.blindLevels).toEqual(input.blindLevels);
+	});
+
+	it("update rejects a blind level missing isBreak", () => {
+		const schema = (
+			appRouter.session.update as unknown as {
+				_def: { inputs: unknown[] };
+			}
+		)._def.inputs[0] as { safeParse: (v: unknown) => { success: boolean } };
+		expect(
+			schema.safeParse({
+				id: "s1",
+				blindLevels: [{ blind1: 100 }],
+			}).success
+		).toBe(false);
+	});
+
 	it("delete rejects missing id", () => {
 		const schema = (
 			appRouter.session.delete as unknown as {
@@ -515,6 +565,27 @@ describe("assertNoLiveLinkedRestrictedEdits", () => {
 				tournamentId: "some-other-tournament",
 			})
 		).toThrow(TOURNAMENT_ID_RE);
+	});
+
+	it("rejects rule-snapshot / blind-structure edits on live-linked tournament session", () => {
+		expect(() =>
+			assertNoLiveLinkedRestrictedEdits(liveTournamentSession, {
+				variant: "plo",
+				startingStack: 20_000,
+				bountyAmount: 500,
+				tableSize: 9,
+				blindLevels: [
+					{
+						isBreak: false,
+						blind1: 100,
+						blind2: 200,
+						blind3: null,
+						ante: null,
+						minutes: 15,
+					},
+				],
+			})
+		).toThrow(TRPCError);
 	});
 
 	it("allows memo edit on live-linked session", () => {

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -181,6 +181,44 @@ async function persistSessionChipPurchases(
 	);
 }
 
+/**
+ * Delete + reinsert a session's blind level structure. Used by both create
+ * (explicit override of the master snapshot) and update (session-wizard edits
+ * to a session's own blind structure) so the array is always written fresh.
+ */
+async function persistSessionBlindLevels(
+	db: DbInstance,
+	sessionId: string,
+	blindLevels: {
+		ante?: number | null;
+		blind1?: number | null;
+		blind2?: number | null;
+		blind3?: number | null;
+		isBreak: boolean;
+		minutes?: number | null;
+	}[]
+): Promise<void> {
+	await db
+		.delete(sessionBlindLevel)
+		.where(eq(sessionBlindLevel.sessionId, sessionId));
+	if (blindLevels.length === 0) {
+		return;
+	}
+	await db.insert(sessionBlindLevel).values(
+		blindLevels.map((l, idx) => ({
+			id: crypto.randomUUID(),
+			sessionId,
+			level: idx + 1,
+			isBreak: l.isBreak,
+			blind1: l.blind1 ?? null,
+			blind2: l.blind2 ?? null,
+			blind3: l.blind3 ?? null,
+			ante: l.ante ?? null,
+			minutes: l.minutes ?? null,
+		}))
+	);
+}
+
 async function validateEntityOwnership(
 	db: DbInstance,
 	entityType: "currency" | "ringGame" | "room" | "tournament",
@@ -374,6 +412,11 @@ const TOURNAMENT_LIVE_LINKED_RESTRICTED_FIELDS = [
 	"breakMinutes",
 	"sessionDate",
 	"tournamentId",
+	"variant",
+	"startingStack",
+	"bountyAmount",
+	"tableSize",
+	"blindLevels",
 ] as const;
 
 export function assertNoLiveLinkedRestrictedEdits(
@@ -1362,6 +1405,15 @@ async function applyCashDetailUpdate(
 
 interface TournamentUpdateInput {
 	beforeDeadline?: boolean | null;
+	blindLevels?: {
+		ante?: number | null;
+		blind1?: number | null;
+		blind2?: number | null;
+		blind3?: number | null;
+		isBreak: boolean;
+		minutes?: number | null;
+	}[];
+	bountyAmount?: number | null;
 	bountyPrizes?: number | null;
 	chipPurchases?: {
 		chips: number;
@@ -1372,9 +1424,12 @@ interface TournamentUpdateInput {
 	entryFee?: number;
 	placement?: number | null;
 	prizeMoney?: number | null;
+	startingStack?: number | null;
+	tableSize?: number | null;
 	totalEntries?: number | null;
 	tournamentBuyIn?: number;
 	tournamentId?: string | null;
+	variant?: string;
 }
 
 async function applyTournamentSnapshotUpdate(
@@ -1393,6 +1448,10 @@ async function applyTournamentSnapshotUpdate(
 		tournamentId: input.tournamentId,
 		tournamentBuyIn: input.tournamentBuyIn,
 		entryFee: input.entryFee,
+		variant: input.variant,
+		startingStack: input.startingStack,
+		bountyAmount: input.bountyAmount,
+		tableSize: input.tableSize,
 	});
 	tournUpdate.ruleName = snapshot.ruleName;
 	tournUpdate.variant = snapshot.variant;
@@ -1423,6 +1482,22 @@ function applyTournamentScalarUpdates(
 		if (input[key] !== undefined) {
 			tournUpdate[key] = input[key];
 		}
+	}
+	// Snapshot field overrides — written to detail, never propagated to
+	// parent. Assigned individually (rather than via `scalarKeys`) since
+	// `variant` is a string while the rest are nullable numbers, which the
+	// generic keyed loop above can't type-check across.
+	if (input.variant !== undefined) {
+		tournUpdate.variant = input.variant;
+	}
+	if (input.startingStack !== undefined) {
+		tournUpdate.startingStack = input.startingStack;
+	}
+	if (input.bountyAmount !== undefined) {
+		tournUpdate.bountyAmount = input.bountyAmount;
+	}
+	if (input.tableSize !== undefined) {
+		tournUpdate.tableSize = input.tableSize;
 	}
 	if (input.beforeDeadline !== undefined) {
 		tournUpdate.beforeDeadline = input.beforeDeadline;
@@ -1465,8 +1540,12 @@ async function applyTournamentDetailUpdate(
 		await resnapshotTournamentStructure(db, sessionId, input.tournamentId);
 	}
 
-	// Explicit chip purchases (with result counts) override the snapshot.
-	// Runs after the re-snapshot so the explicit array wins when both apply.
+	// Explicit blind levels / chip purchases (with result counts) override the
+	// snapshot. Runs after the re-snapshot so the explicit arrays win when both
+	// apply.
+	if (input.blindLevels !== undefined) {
+		await persistSessionBlindLevels(db, sessionId, input.blindLevels);
+	}
 	if (input.chipPurchases !== undefined) {
 		await persistSessionChipPurchases(db, sessionId, input.chipPurchases);
 	}
@@ -1700,24 +1779,7 @@ async function insertTournamentSessionDetail(
 	// blind levels / chip purchases. This runs after the parent copy so
 	// the explicit arrays win when both are supplied.
 	if (input.blindLevels !== undefined) {
-		await db
-			.delete(sessionBlindLevel)
-			.where(eq(sessionBlindLevel.sessionId, sessionId));
-		if (input.blindLevels.length > 0) {
-			await db.insert(sessionBlindLevel).values(
-				input.blindLevels.map((l, idx) => ({
-					id: crypto.randomUUID(),
-					sessionId,
-					level: idx + 1,
-					isBreak: l.isBreak,
-					blind1: l.blind1 ?? null,
-					blind2: l.blind2 ?? null,
-					blind3: l.blind3 ?? null,
-					ante: l.ante ?? null,
-					minutes: l.minutes ?? null,
-				}))
-			);
-		}
+		await persistSessionBlindLevels(db, sessionId, input.blindLevels);
 	}
 	if (input.chipPurchases !== undefined) {
 		await persistSessionChipPurchases(db, sessionId, input.chipPurchases);
@@ -2013,6 +2075,20 @@ export const sessionRouter = router({
 				beforeDeadline: z.boolean().nullable().optional(),
 				prizeMoney: z.number().int().min(0).nullable().optional(),
 				bountyPrizes: z.number().int().min(0).nullable().optional(),
+				startingStack: z.number().int().nullable().optional(),
+				bountyAmount: z.number().int().nullable().optional(),
+				blindLevels: z
+					.array(
+						z.object({
+							isBreak: z.boolean(),
+							blind1: z.number().int().nullable().optional(),
+							blind2: z.number().int().nullable().optional(),
+							blind3: z.number().int().nullable().optional(),
+							ante: z.number().int().nullable().optional(),
+							minutes: z.number().int().nullable().optional(),
+						})
+					)
+					.optional(),
 				chipPurchases: z.array(chipPurchaseInputSchema).optional(),
 				startedAt: z.number().nullable().optional(),
 				endedAt: z.number().nullable().optional(),


### PR DESCRIPTION
## Summary

- `session.update` の入力スキーマに `blindLevels` / `startingStack` / `bountyAmount` が存在せず、既存のトーナメントセッションを編集した際にブラインドストラクチャーの変更が Zod によって未知キーとして黙って strip され、保存されない不具合を修正 (SA2-96)。
- `TournamentUpdateInput` 型・`applyTournamentScalarUpdates` / `applyTournamentSnapshotUpdate` / `applyTournamentDetailUpdate` に `variant` / `startingStack` / `bountyAmount` / `tableSize` / `blindLevels` の永続化ロジックを追加し、`session.create` (`insertTournamentSessionDetail`) と対称になるよう修正。ブラインドレベルの delete+reinsert ロジックは `persistSessionBlindLevels` として共通化。
- クライアント側 `buildUpdatePayload` (tournament 分岐) にも同フィールドを追加し、`buildCreatePayload` と対称にした。
- ライブ連携セッションではこれらのフィールドを直接編集できないよう `TOURNAMENT_LIVE_LINKED_RESTRICTED_FIELDS` にも追加 (cash 側の既存の制限と対称)。

## Root cause

トーナメントセッションの編集フォーム(session-wizard の Rules ステップ)は `blindLevels` / `variant` / `startingStack` / `bountyAmount` を常に送信していたが、`session.update` の Zod スキーマにこれらのフィールドが定義されておらず、送信されたデータが検証時に静かに破棄されていた。そのため保存処理自体はエラーなく成功するように見えるが、実際にはブラインドストラクチャーなどの変更が一切反映されていなかった。

## Test plan

- [x] `packages/api/src/__tests__/session.test.ts` — `session.update` スキーマが `blindLevels` / `startingStack` / `bountyAmount` を受理・保持することを確認するテスト、および不正な `blindLevels`(`isBreak` 欠落)を拒否するテストを追加。
- [x] `packages/api/src/__tests__/session.test.ts` — ライブ連携トーナメントセッションでこれらのフィールドの編集が拒否されることを確認するテストを追加。
- [x] `apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts` — `buildUpdatePayload` が tournament 種別でこれらのフィールドを含むことを確認するテストを追加。
- [x] 追加したテストが修正前は red になることを確認し、実装後に green になることを確認済み。
- [x] `bunx vitest run --project api packages/api/src/__tests__/session.test.ts packages/api/src/__tests__/tournament.test.ts packages/api/src/__tests__/blind-level.test.ts` — 125 tests passed
- [x] `bunx vitest run --project web-dom apps/web/src/features/sessions apps/web/src/features/rooms` — 594 tests passed
- [x] `bunx tsc --noEmit` (api / web) — 差分に起因する型エラーなし
- [x] `bunx ultracite check` — 変更ファイルに指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBD3UQMDMjqYuk4RFKhDSF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBD3UQMDMjqYuk4RFKhDSF)_