### PR TITLE
fix(statistics): surface sessions excluded from normalized BB/BI totals

### DIFF
--- a/apps/web/src/features/statistics/pages/statistics-page/kpi-cards/__tests__/use-kpi-cards.test.ts
+++ b/apps/web/src/features/statistics/pages/statistics-page/kpi-cards/__tests__/use-kpi-cards.test.ts
@@ -28,6 +28,7 @@ interface Summary {
 	bbPerHour: number | null;
 	cashEvDiffNormalized: number | null;
 	cashNormalizedProfitLoss: number | null;
+	cashUnnormalizedSessions: number;
 	hourlyRate: number | null;
 	itmRate: number | null;
 	roi: number | null;
@@ -38,6 +39,7 @@ interface Summary {
 	totalProfitLoss: number;
 	totalSessions: number;
 	tournamentNormalizedProfitLoss: number | null;
+	tournamentUnnormalizedSessions: number;
 	winRate: number;
 }
 
@@ -46,8 +48,10 @@ function summary(overrides: Partial<Summary> = {}): Summary {
 		totalSessions: 10,
 		totalProfitLoss: 1500,
 		cashNormalizedProfitLoss: 30,
+		cashUnnormalizedSessions: 0,
 		cashEvDiffNormalized: 6,
 		tournamentNormalizedProfitLoss: 5,
+		tournamentUnnormalizedSessions: 0,
 		totalEvProfitLoss: 1800,
 		totalEvDiff: 300,
 		winRate: 60,
@@ -214,5 +218,63 @@ describe("useKpiCards", () => {
 		const net = result.current.cards.find((c) => c.key === "net");
 		expect(net?.value).toBe("-500 USD");
 		expect(net?.trend).toBe("down");
+	});
+
+	it("leaves the sessions card without a hint when nothing is unnormalized", async () => {
+		trpcMocks.summaryQueryFn.mockResolvedValue(summary());
+		const result = await renderLoadedKpi(
+			ctx({ type: "all", normalized: true, currencyUnit: null })
+		);
+		const sessions = result.current.cards.find((c) => c.key === "sessions");
+		expect(sessions?.hint).toBeUndefined();
+	});
+
+	it("does not add a hint when normalization is off, even with unnormalized sessions", async () => {
+		trpcMocks.summaryQueryFn.mockResolvedValue(
+			summary({ cashUnnormalizedSessions: 2 })
+		);
+		const result = await renderLoadedKpi(
+			ctx({ type: "all", normalized: false })
+		);
+		const sessions = result.current.cards.find((c) => c.key === "sessions");
+		expect(sessions?.hint).toBeUndefined();
+	});
+
+	it("hints at cash sessions missing stakes when normalized for cash", async () => {
+		trpcMocks.summaryQueryFn.mockResolvedValue(
+			summary({ cashUnnormalizedSessions: 2 })
+		);
+		const result = await renderLoadedKpi(
+			ctx({ type: "cash_game", normalized: true, currencyUnit: null })
+		);
+		const sessions = result.current.cards.find((c) => c.key === "sessions");
+		expect(sessions?.hint).toBe("2 excluded from BB total (no stakes)");
+	});
+
+	it("hints at tournaments missing buy-in when normalized for tournament", async () => {
+		trpcMocks.summaryQueryFn.mockResolvedValue(
+			summary({ tournamentUnnormalizedSessions: 1 })
+		);
+		const result = await renderLoadedKpi(
+			ctx({ type: "tournament", normalized: true, currencyUnit: null })
+		);
+		const sessions = result.current.cards.find((c) => c.key === "sessions");
+		expect(sessions?.hint).toBe("1 excluded from BI total (no buy-in)");
+	});
+
+	it("combines cash and tournament hints for the 'all' type", async () => {
+		trpcMocks.summaryQueryFn.mockResolvedValue(
+			summary({
+				cashUnnormalizedSessions: 2,
+				tournamentUnnormalizedSessions: 1,
+			})
+		);
+		const result = await renderLoadedKpi(
+			ctx({ type: "all", normalized: true, currencyUnit: null })
+		);
+		const sessions = result.current.cards.find((c) => c.key === "sessions");
+		expect(sessions?.hint).toBe(
+			"2 excluded from BB total (no stakes), 1 excluded from BI total (no buy-in)"
+		);
 	});
 });

--- a/apps/web/src/features/statistics/pages/statistics-page/kpi-cards/kpi-cards.tsx
+++ b/apps/web/src/features/statistics/pages/statistics-page/kpi-cards/kpi-cards.tsx
@@ -22,6 +22,9 @@ function KpiCardItem({ card }: { card: KpiCard }) {
 			>
 				{card.value}
 			</span>
+			{card.hint && (
+				<span className="t-meta text-muted-foreground">{card.hint}</span>
+			)}
 		</Card>
 	);
 }

--- a/apps/web/src/features/statistics/pages/statistics-page/kpi-cards/use-kpi-cards.ts
+++ b/apps/web/src/features/statistics/pages/statistics-page/kpi-cards/use-kpi-cards.ts
@@ -13,6 +13,8 @@ import { formatProfitLoss } from "@/utils/format-profit-loss";
 import { trpc } from "@/utils/trpc";
 
 export interface KpiCard {
+	/** Small muted note under the value — e.g. sessions excluded from a normalized total. */
+	hint?: string;
 	key: string;
 	label: string;
 	trend: TrendDirection;
@@ -100,6 +102,38 @@ function buildNetCards(
 	];
 }
 
+interface UnnormalizedSummary {
+	cashUnnormalizedSessions: number;
+	tournamentUnnormalizedSessions: number;
+}
+
+/**
+ * Note for the "Sessions" card when some sessions can't be converted to bb /
+ * bi units (e.g. a manually logged session with no stakes or buy-in
+ * recorded) — otherwise they'd silently disappear from the normalized Net /
+ * BB-per-hour figures while still counting toward the session total.
+ */
+function unnormalizedHint(
+	ctx: StatsSectionContext,
+	summary: UnnormalizedSummary
+): string | undefined {
+	if (!ctx.normalized) {
+		return undefined;
+	}
+	const parts: string[] = [];
+	if (ctx.type !== "tournament" && summary.cashUnnormalizedSessions > 0) {
+		parts.push(
+			`${summary.cashUnnormalizedSessions} excluded from BB total (no stakes)`
+		);
+	}
+	if (ctx.type !== "cash_game" && summary.tournamentUnnormalizedSessions > 0) {
+		parts.push(
+			`${summary.tournamentUnnormalizedSessions} excluded from BI total (no buy-in)`
+		);
+	}
+	return parts.length > 0 ? parts.join(", ") : undefined;
+}
+
 interface TournamentSummary {
 	avgPlacement: number | null;
 	avgRoi: number | null;
@@ -176,6 +210,7 @@ export function useKpiCards(ctx: StatsSectionContext): UseKpiCardsResult {
 			label: "Sessions",
 			value: String(summary.totalSessions),
 			trend: null,
+			hint: unnormalizedHint(ctx, summary),
 		},
 		{
 			key: "playTime",

--- a/apps/web/src/features/statistics/pages/statistics-page/pnl-graph/__tests__/use-pnl-graph.test.ts
+++ b/apps/web/src/features/statistics/pages/statistics-page/pnl-graph/__tests__/use-pnl-graph.test.ts
@@ -244,4 +244,57 @@ describe("usePnlGraph", () => {
 		expect(result.current.isEmpty).toBe(true);
 		expect(trpcMocks.seriesQueryFn).not.toHaveBeenCalled();
 	});
+
+	it("reports skippedCount as 0 when every point is normalizable", async () => {
+		trpcMocks.seriesQueryFn.mockResolvedValue({
+			points: [
+				seriesPoint({
+					id: "a",
+					profitLoss: 100,
+					sessionDate: day1,
+					bigBlind: 2,
+				}),
+			],
+		});
+		const result = await renderLoaded(ctx({ normalized: true }));
+		expect(result.current.skippedCount).toBe(0);
+	});
+
+	it("reports skippedCount for cash points with no big blind when normalized", async () => {
+		trpcMocks.seriesQueryFn.mockResolvedValue({
+			points: [
+				seriesPoint({
+					id: "a",
+					profitLoss: 100,
+					sessionDate: day1,
+					bigBlind: null,
+				}),
+				seriesPoint({
+					id: "b",
+					profitLoss: 50,
+					sessionDate: day2,
+					bigBlind: 2,
+				}),
+			],
+		});
+		const result = await renderLoaded(
+			ctx({ normalized: true, type: "cash_game" })
+		);
+		expect(result.current.skippedCount).toBe(1);
+	});
+
+	it("keeps skippedCount at 0 in currency mode since every point has a profitLoss", async () => {
+		trpcMocks.seriesQueryFn.mockResolvedValue({
+			points: [
+				seriesPoint({
+					id: "a",
+					profitLoss: 100,
+					sessionDate: day1,
+					bigBlind: null,
+				}),
+			],
+		});
+		const result = await renderLoaded(ctx({ normalized: false }));
+		expect(result.current.skippedCount).toBe(0);
+	});
 });

--- a/apps/web/src/features/statistics/pages/statistics-page/pnl-graph/pnl-graph.tsx
+++ b/apps/web/src/features/statistics/pages/statistics-page/pnl-graph/pnl-graph.tsx
@@ -20,6 +20,7 @@ export function PnlGraph({ ctx }: { ctx: StatsSectionContext }) {
 		setShowEvCash,
 		evToggleAvailable,
 		points,
+		skippedCount,
 		dual,
 		isPending,
 	} = usePnlGraph(ctx);
@@ -68,6 +69,12 @@ export function PnlGraph({ ctx }: { ctx: StatsSectionContext }) {
 					xAxisType={xAxis}
 				/>
 			</div>
+			{skippedCount > 0 && (
+				<p className="t-meta text-muted-foreground">
+					{skippedCount} session{skippedCount === 1 ? "" : "s"} not shown (no
+					stakes / buy-in recorded)
+				</p>
+			)}
 		</div>
 	);
 }

--- a/apps/web/src/features/statistics/pages/statistics-page/pnl-graph/use-pnl-graph.ts
+++ b/apps/web/src/features/statistics/pages/statistics-page/pnl-graph/use-pnl-graph.ts
@@ -19,6 +19,10 @@ export interface UsePnlGraphResult {
 	setShowEvCash: (value: boolean) => void;
 	setXAxis: (value: PnlGraphXAxis) => void;
 	showEvCash: boolean;
+	/** Sessions dropped from the chart because they can't be normalized (no
+	 * stakes / buy-in recorded) — 0 in currency mode, since raw P&L never
+	 * requires a denominator. */
+	skippedCount: number;
 	unit: PnlGraphUnit;
 	xAxis: PnlGraphXAxis;
 }
@@ -48,7 +52,7 @@ export function usePnlGraph(ctx: StatsSectionContext): UsePnlGraphResult {
 	);
 	const rawPoints = query.data?.points ?? [];
 
-	const { points } = aggregatePnlPoints({
+	const { points, skippedCount } = aggregatePnlPoints({
 		rawPoints,
 		xAxis,
 		unit,
@@ -69,6 +73,7 @@ export function usePnlGraph(ctx: StatsSectionContext): UsePnlGraphResult {
 		setShowEvCash,
 		evToggleAvailable,
 		points,
+		skippedCount,
 		dual,
 		unit,
 		isPending: ctx.enabled && query.isPending,

--- a/packages/api/src/__tests__/stats.test.ts
+++ b/packages/api/src/__tests__/stats.test.ts
@@ -574,6 +574,8 @@ describe("summarizeStats", () => {
 		expect(summary.itmRate).toBeNull();
 		expect(summary.avgPlacement).toBeNull();
 		expect(summary.totalPrizeMoney).toBeNull();
+		expect(summary.cashUnnormalizedSessions).toBe(0);
+		expect(summary.tournamentUnnormalizedSessions).toBe(0);
 	});
 
 	it("computes totals, winRate and avg for a set of cash rows", () => {
@@ -606,6 +608,36 @@ describe("summarizeStats", () => {
 		]);
 		expect(summary.cashNormalizedProfitLoss).toBeNull();
 		expect(summary.tournamentNormalizedProfitLoss).toBeNull();
+	});
+
+	it("counts cash rows missing bigBlind as cashUnnormalizedSessions", () => {
+		const rows = [
+			cashRow({ id: "a", bigBlind: 2 }),
+			cashRow({ id: "b", bigBlind: null }),
+			cashRow({ id: "c", bigBlind: 0 }),
+		];
+		const summary = summarizeStats(rows);
+		expect(summary.cashUnnormalizedSessions).toBe(2);
+		expect(summary.tournamentUnnormalizedSessions).toBe(0);
+	});
+
+	it("counts tournament rows missing buyInTotal as tournamentUnnormalizedSessions", () => {
+		const rows = [
+			tournamentRow({ id: "a", buyInTotal: 100 }),
+			tournamentRow({ id: "b", buyInTotal: null }),
+			tournamentRow({ id: "c", buyInTotal: 0 }),
+		];
+		const summary = summarizeStats(rows);
+		expect(summary.tournamentUnnormalizedSessions).toBe(2);
+		expect(summary.cashUnnormalizedSessions).toBe(0);
+	});
+
+	it("keeps cashUnnormalizedSessions at 0 when every cash row is normalizable", () => {
+		const rows = [
+			cashRow({ id: "a", bigBlind: 2 }),
+			cashRow({ id: "b", bigBlind: 5 }),
+		];
+		expect(summarizeStats(rows).cashUnnormalizedSessions).toBe(0);
 	});
 
 	it("computes cash hourlyRate from cash play time", () => {

--- a/packages/api/src/routers/stats.ts
+++ b/packages/api/src/routers/stats.ts
@@ -317,6 +317,12 @@ export interface StatsSummary {
 	// cash sessions. Never combined with the tournament (bi) figure — the two
 	// units live on different scales.
 	cashNormalizedProfitLoss: number | null;
+	// Count of cash sessions with no recorded big blind (e.g. a manually
+	// logged session with no stakes entered) — excluded from
+	// `cashNormalizedProfitLoss` / `bbPerHour` because their P&L can't be
+	// converted to bb units. Lets the UI flag when the bb figure undercounts
+	// `totalSessions`.
+	cashUnnormalizedSessions: number;
 	hourlyRate: number | null;
 	itmRate: number | null;
 	roi: number | null;
@@ -328,6 +334,11 @@ export interface StatsSummary {
 	totalSessions: number;
 	// Tournament sessions normalized to buy-ins (bi). Null when none.
 	tournamentNormalizedProfitLoss: number | null;
+	// Count of tournament sessions with no recorded investment (buy-in +
+	// entry fee + chip purchases all zero) — excluded from
+	// `tournamentNormalizedProfitLoss` for the same reason as
+	// `cashUnnormalizedSessions`.
+	tournamentUnnormalizedSessions: number;
 	winRate: number;
 }
 
@@ -335,8 +346,10 @@ const EMPTY_SUMMARY: StatsSummary = {
 	totalSessions: 0,
 	totalProfitLoss: 0,
 	cashNormalizedProfitLoss: null,
+	cashUnnormalizedSessions: 0,
 	cashEvDiffNormalized: null,
 	tournamentNormalizedProfitLoss: null,
+	tournamentUnnormalizedSessions: 0,
 	totalEvProfitLoss: null,
 	totalEvDiff: null,
 	winRate: 0,
@@ -358,6 +371,7 @@ interface SummaryAccumulator {
 	cashEvDiffBbSum: number;
 	cashPL: number;
 	cashPlayMinutes: number;
+	cashUnnormalizedSessions: number;
 	evCount: number;
 	evDiffSum: number;
 	evSum: number;
@@ -374,6 +388,7 @@ interface SummaryAccumulator {
 	tournamentInvested: number;
 	tournamentPrize: number;
 	tournamentPrizeMoneyAndBounty: number;
+	tournamentUnnormalizedSessions: number;
 	winCount: number;
 }
 
@@ -394,7 +409,9 @@ function accumulateCash(row: StatsSessionRow, acc: SummaryAccumulator): void {
 		}
 	}
 	const bb = normalizedSessionValue(row);
-	if (bb !== null) {
+	if (bb === null) {
+		acc.cashUnnormalizedSessions += 1;
+	} else {
 		acc.cashBbSum += bb;
 		acc.cashBbCount += 1;
 	}
@@ -423,7 +440,9 @@ function accumulateTournament(
 		acc.placementCount += 1;
 	}
 	const bi = normalizedSessionValue(row);
-	if (bi !== null) {
+	if (bi === null) {
+		acc.tournamentUnnormalizedSessions += 1;
+	} else {
 		acc.tournamentBiSum += bi;
 		acc.tournamentBiCount += 1;
 	}
@@ -440,10 +459,12 @@ function buildSummary(
 		totalSessions,
 		totalProfitLoss: acc.totalProfitLoss,
 		cashNormalizedProfitLoss: acc.cashBbCount > 0 ? acc.cashBbSum : null,
+		cashUnnormalizedSessions: acc.cashUnnormalizedSessions,
 		cashEvDiffNormalized:
 			acc.cashEvDiffBbCount > 0 ? acc.cashEvDiffBbSum : null,
 		tournamentNormalizedProfitLoss:
 			acc.tournamentBiCount > 0 ? acc.tournamentBiSum : null,
+		tournamentUnnormalizedSessions: acc.tournamentUnnormalizedSessions,
 		totalEvProfitLoss: acc.evCount > 0 ? acc.evSum : null,
 		totalEvDiff: acc.evCount > 0 ? acc.evDiffSum : null,
 		winRate: (acc.winCount / totalSessions) * 100,
@@ -486,10 +507,12 @@ export function summarizeStats(rows: StatsSessionRow[]): StatsSummary {
 		cashPlayMinutes: 0,
 		cashBbSum: 0,
 		cashBbCount: 0,
+		cashUnnormalizedSessions: 0,
 		cashEvDiffBbSum: 0,
 		cashEvDiffBbCount: 0,
 		tournamentBiSum: 0,
 		tournamentBiCount: 0,
+		tournamentUnnormalizedSessions: 0,
 		tournamentCount: 0,
 		tournamentInvested: 0,
 		tournamentPrize: 0,


### PR DESCRIPTION
## Summary

Closes SA2-98 / #405.

Root cause: the Statistics page defaults to the **normalized (BB/BI)** view. `normalizedSessionValue` (cash → P&L / big blind, tournament → P&L / total invested) returns `null` when a session has no recorded stakes or investment — which manually-logged sessions often don't have, since blind1/blind2 (cash) and the tournament buy-in fields are optional in the manual entry form and aren't auto-filled the way live-tracked sessions are from a linked ring game / tournament.

Those non-normalizable sessions were silently dropped from every BB/BI aggregate (`cashNormalizedProfitLoss`, `tournamentNormalizedProfitLoss`, `bbPerHour`, the breakdown table's normalized columns, and the P&L graph's cumulative series) while still being counted in `totalSessions` / play time — so a manually recorded session could contribute to the session count but never show up in the headline Net P&L, giving the impression that manual sessions "aren't included in statistics."

This PR does **not** change the normalization math itself (bb/bi units must never be summed together — that design is intentional and already covered by tests). Instead it makes the exclusion visible:

- `stats.summary` now also returns `cashUnnormalizedSessions` / `tournamentUnnormalizedSessions` — counts of sessions dropped from the normalized totals.
- The KPI "Sessions" card shows a hint (e.g. "2 excluded from BB total (no stakes)") when normalization is on and some sessions couldn't be converted.
- The P&L graph already computed a `skippedCount` for the same reason but discarded it — it's now wired through and shown as a caption under the chart.

## Test plan

- [x] `bunx vitest run --project api packages/api/src/__tests__/stats.test.ts` — new + existing tests pass
- [x] `bunx vitest run --project web-dom apps/web/src/features/statistics` — new + existing tests pass
- [x] `bun run check-types`
- [x] `bunx ultracite check` on changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_01WLkZoFcf8KPs5yHVbz3gh9)_