### PR TITLE
fix(statistics): sort P&amp;L graph points by actual start time

### DIFF
--- a/apps/web/src/features/statistics/pages/statistics-page/pnl-graph/__tests__/use-pnl-graph.test.ts
+++ b/apps/web/src/features/statistics/pages/statistics-page/pnl-graph/__tests__/use-pnl-graph.test.ts
@@ -35,6 +35,7 @@ function seriesPoint(
 		evProfitLoss: null,
 		playMinutes: null,
 		type: "cash_game",
+		sortKey: overrides.sessionDate,
 		...overrides,
 	};
 }
@@ -220,6 +221,32 @@ describe("usePnlGraph", () => {
 		act(() => result.current.setShowEvCash(true));
 		const last = result.current.points.at(-1);
 		expect(last?.evCashCumulative).toBeUndefined();
+	});
+
+	it("orders same-day sessions by sortKey (actual start time), not id (SA2-98)", async () => {
+		const morning = day1 + 3 * 60 * 60;
+		const evening = day1 + 22 * 60 * 60;
+		trpcMocks.seriesQueryFn.mockResolvedValue({
+			points: [
+				seriesPoint({
+					id: "z",
+					profitLoss: 100,
+					sessionDate: day1,
+					sortKey: morning,
+				}),
+				seriesPoint({
+					id: "a",
+					profitLoss: -30,
+					sessionDate: day1,
+					sortKey: evening,
+				}),
+			],
+		});
+		const result = await renderLoaded(ctx());
+		act(() => result.current.setXAxis("sessionCount"));
+		expect(result.current.points.map((p) => p.cumulative)).toEqual([
+			0, 100, 70,
+		]);
 	});
 
 	it("reports an empty graph when the series has no usable points", async () => {

--- a/apps/web/src/features/statistics/utils/__tests__/aggregate-pnl-points.test.ts
+++ b/apps/web/src/features/statistics/utils/__tests__/aggregate-pnl-points.test.ts
@@ -17,6 +17,7 @@ function point(
 		evProfitLoss: null,
 		playMinutes: null,
 		type: "cash_game",
+		sortKey: overrides.sessionDate,
 		...overrides,
 	};
 }
@@ -92,6 +93,41 @@ describe("aggregatePnlPoints", () => {
 				],
 			});
 			expect(result.points.map((p) => p.cumulative)).toEqual([0, 100, 150]);
+		});
+
+		it("orders same-day sessions by sortKey (actual start time), not by id (SA2-98)", () => {
+			// sessionDate is date-only, so both sessions share the same calendar
+			// day; "z" sorts after "a" lexically but started first chronologically.
+			const day = Math.floor(new Date("2026-04-01T00:00:00Z").getTime() / 1000);
+			const morning = Math.floor(
+				new Date("2026-04-01T03:00:00Z").getTime() / 1000
+			);
+			const evening = Math.floor(
+				new Date("2026-04-01T22:00:00Z").getTime() / 1000
+			);
+			const result = aggregatePnlPoints({
+				...baseOptions,
+				xAxis: "sessionCount",
+				rawPoints: [
+					point({
+						id: "z",
+						profitLoss: 100,
+						sessionDate: day,
+						sortKey: morning,
+					}),
+					point({
+						id: "a",
+						profitLoss: -30,
+						sessionDate: day,
+						sortKey: evening,
+					}),
+				],
+			});
+			expect(result.points).toEqual([
+				{ x: 0, cumulative: 0 },
+				{ x: 1, cumulative: 100 },
+				{ x: 2, cumulative: 70 },
+			]);
 		});
 	});
 

--- a/apps/web/src/features/statistics/utils/aggregate-pnl-points.ts
+++ b/apps/web/src/features/statistics/utils/aggregate-pnl-points.ts
@@ -13,6 +13,14 @@ export interface PnlSeriesPoint {
 	playMinutes: number | null;
 	profitLoss: number;
 	sessionDate: number;
+	/**
+	 * Chronological order key (unix seconds) — the session's actual start time
+	 * when known, falling back to the date-only `sessionDate`. `sessionDate`
+	 * itself has no time component, so same-day sessions all share the same
+	 * value; sorting by it alone left same-day ordering to fall back to `id`
+	 * (effectively random) instead of actual play order (SA2-98).
+	 */
+	sortKey: number;
 	type: "cash_game" | "tournament";
 }
 
@@ -108,7 +116,7 @@ function originX(
 
 function sortPoints(points: PnlSeriesPoint[]): PnlSeriesPoint[] {
 	return [...points].sort(
-		(a, b) => a.sessionDate - b.sessionDate || a.id.localeCompare(b.id)
+		(a, b) => a.sortKey - b.sortKey || a.id.localeCompare(b.id)
 	);
 }
 

--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -5,7 +5,9 @@ import {
 	assertNoLiveLinkedRestrictedEdits,
 	computeTournamentPL,
 	encodeSessionCursor,
+	type ProfitLossSeriesRow,
 	parseSessionCursor,
+	toProfitLossSeriesPoint,
 } from "../routers/session";
 
 const DERIVED_FIELDS_RE = /Cannot edit fields derived from live session events/;
@@ -254,6 +256,56 @@ describe("session router input validation", () => {
 
 		it("returns null for an empty id", () => {
 			expect(parseSessionCursor("1000_")).toBeNull();
+		});
+	});
+
+	describe("toProfitLossSeriesPoint sortKey (SA2-98)", () => {
+		function row(overrides: Partial<ProfitLossSeriesRow>): ProfitLossSeriesRow {
+			return {
+				bountyPrizes: null,
+				breakMinutes: null,
+				buyIn: null,
+				cashOut: null,
+				chipPurchaseCost: 0,
+				endedAt: null,
+				entryFee: null,
+				evCashOut: null,
+				id: "s1",
+				prizeMoney: null,
+				ringGameBlind2: null,
+				sessionDate: new Date(1_700_000_000_000),
+				startedAt: null,
+				tournamentBuyIn: null,
+				type: "cash_game",
+				...overrides,
+			};
+		}
+
+		it("uses startedAt (in seconds) as sortKey when present", () => {
+			const point = toProfitLossSeriesPoint(
+				row({
+					sessionDate: new Date(1_700_000_000_000),
+					startedAt: new Date(1_700_003_600_000),
+				})
+			);
+			expect(point.sortKey).toBe(1_700_003_600);
+		});
+
+		it("falls back to sessionDate (in seconds) as sortKey when startedAt is null", () => {
+			const point = toProfitLossSeriesPoint(
+				row({ sessionDate: new Date(1_700_000_000_000), startedAt: null })
+			);
+			expect(point.sortKey).toBe(1_700_000_000);
+		});
+
+		it("keeps sessionDate (date-only) unchanged even when startedAt differs", () => {
+			const point = toProfitLossSeriesPoint(
+				row({
+					sessionDate: new Date(1_700_000_000_000),
+					startedAt: new Date(1_700_003_600_000),
+				})
+			);
+			expect(point.sessionDate).toBe(1_700_000_000);
 		});
 	});
 

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -931,7 +931,7 @@ interface ListItemRaw {
 	type: string;
 }
 
-interface ProfitLossSeriesRow {
+export interface ProfitLossSeriesRow {
 	bountyPrizes: number | null;
 	breakMinutes: number | null;
 	buyIn: number | null;
@@ -1083,7 +1083,7 @@ export async function fetchProfitLossSeries(
 	return { points };
 }
 
-function toProfitLossSeriesPoint(r: ProfitLossSeriesRow) {
+export function toProfitLossSeriesPoint(r: ProfitLossSeriesRow) {
 	const cashStats =
 		r.type === "cash_game"
 			? computeCashStats(r)
@@ -1104,6 +1104,10 @@ function toProfitLossSeriesPoint(r: ProfitLossSeriesRow) {
 		id: r.id,
 		type: r.type as "cash_game" | "tournament",
 		sessionDate: Math.floor(r.sessionDate.getTime() / 1000),
+		// Chronological order key: sessionDate has no time component, so same-day
+		// sessions need startedAt to sort by actual play order (SA2-98). Mirrors
+		// the DB query's own `sessionOrderKeySql()` ordering.
+		sortKey: Math.floor((r.startedAt ?? r.sessionDate).getTime() / 1000),
 		profitLoss,
 		evProfitLoss: cashStats.evProfitLoss,
 		playMinutes: computePlayMinutes(r),


### PR DESCRIPTION
## Summary

- Fixes [SA2-98](https://linear.app/sapphire2/issue/SA2-98/statisticsのグラフにおいて時系列がおかしい): the statistics P&L graph ordered same-day sessions incorrectly.
- Root cause: `sessionDate` is a date-only column (no time component), so all sessions on the same calendar day share one value. The client-side aggregator (`aggregatePnlPoints`) sorted by `sessionDate` and tie-broke on `id`, which is effectively random — not actual play order. The server query itself already ordered rows correctly by `coalesce(startedAt, sessionDate)` (the same pattern used by the session list, see `sessionOrderKeySql()`), but that ordering was discarded once the client re-sorted.
- Adds a `sortKey` field (unix seconds: `startedAt ?? sessionDate`) to the point shape returned by `toProfitLossSeriesPoint` in `packages/api/src/routers/session.ts`, and updates the client's `sortPoints` in `apps/web/src/features/statistics/utils/aggregate-pnl-points.ts` to sort by `sortKey` instead of `sessionDate`. The date-only `sessionDate` field is unchanged and still drives day-bucketing for the "date" x-axis mode.

## Test plan

- [x] `bunx vitest run --project web-node apps/web/src/features/statistics/utils/__tests__/aggregate-pnl-points.test.ts` — added a regression case for same-day ordering.
- [x] `bunx vitest run --project web-dom apps/web/src/features/statistics/pages/statistics-page/pnl-graph/__tests__/use-pnl-graph.test.ts` — added an end-to-end hook regression case.
- [x] `bunx vitest run --project api packages/api/src/__tests__/session.test.ts` — added unit tests for `toProfitLossSeriesPoint`'s new `sortKey`.
- [x] `bun run lint && bun run check-types`
- [x] `bunx vitest run --changed HEAD` (644 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7Ndr2b4EWYxnB9xxc3a6c

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7Ndr2b4EWYxnB9xxc3a6c)_