### PR TITLE
feat(SA2-100): 位置情報なしのRoomでライブセッション開始時に現在地保存を確認

### DIFF
--- a/apps/web/src/features/live-sessions/components/create-session-dialog/__tests__/create-session-dialog.test.tsx
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/__tests__/create-session-dialog.test.tsx
@@ -32,6 +32,13 @@ function setup() {
 		tournaments: [],
 		setSelectedRoomId: vi.fn(),
 		handleSubmit: vi.fn(),
+		locationPrompt: {
+			open: false,
+			roomName: "",
+			onSave: vi.fn(),
+			onSkip: vi.fn(),
+			onOpenChange: vi.fn(),
+		},
 		isLoading: false,
 		handleReset: vi.fn(),
 	});

--- a/apps/web/src/features/live-sessions/components/create-session-dialog/__tests__/use-create-session-dialog.test.ts
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/__tests__/use-create-session-dialog.test.ts
@@ -24,6 +24,13 @@ function setupImpl(overrides: Record<string, unknown> = {}) {
 		setSelectedRoomId,
 		createCash,
 		createTournament,
+		locationPrompt: {
+			open: false,
+			roomName: "",
+			onSave: vi.fn(),
+			onSkip: vi.fn(),
+			onOpenChange: vi.fn(),
+		},
 		isLoading: false,
 		...overrides,
 	}));
@@ -49,6 +56,21 @@ describe("useCreateSessionDialog", () => {
 		expect(lastArgs).toBeDefined();
 		lastArgs?.onClose();
 		expect(onOpenChange).toHaveBeenCalledWith(false);
+	});
+
+	it("propagates the underlying hook's locationPrompt", () => {
+		const locationPrompt = {
+			open: true,
+			roomName: "Room 1",
+			onSave: vi.fn(),
+			onSkip: vi.fn(),
+			onOpenChange: vi.fn(),
+		};
+		setupImpl({ locationPrompt });
+		const { result } = renderHook(() =>
+			useCreateSessionDialog({ onOpenChange: vi.fn() })
+		);
+		expect(result.current.locationPrompt).toBe(locationPrompt);
 	});
 
 	it("propagates isLoading from the underlying hook", () => {

--- a/apps/web/src/features/live-sessions/components/create-session-dialog/create-session-dialog.tsx
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/create-session-dialog.tsx
@@ -1,5 +1,6 @@
 import { FormSheet } from "@/shared/components/form-sheet";
 import { LiveSessionForm } from "./live-session-form";
+import { SetRoomLocationDialog } from "./set-room-location-dialog";
 import { useCreateSessionDialog } from "./use-create-session-dialog";
 
 const LIVE_SESSION_FORM_ID = "live-session-form";
@@ -27,33 +28,43 @@ export function CreateSessionDialog({
 		setSelectedRoomId,
 		defaultRoomId,
 		handleSubmit,
+		locationPrompt,
 		isLoading,
 		handleReset,
 	} = useCreateSessionDialog({ onOpenChange, open });
 
 	return (
-		<FormSheet
-			formId={LIVE_SESSION_FORM_ID}
-			isLoading={isLoading}
-			onOpenChange={(o) => {
-				onOpenChange(o);
-				if (!o) {
-					handleReset();
-				}
-			}}
-			open={open}
-			title="Start Live Session"
-		>
-			<LiveSessionForm
-				currencies={currencies}
-				defaultRoomId={defaultRoomId}
+		<>
+			<FormSheet
 				formId={LIVE_SESSION_FORM_ID}
-				onRoomChange={setSelectedRoomId}
-				onSubmit={handleSubmit}
-				ringGames={ringGames}
-				rooms={rooms}
-				tournaments={tournaments}
+				isLoading={isLoading}
+				onOpenChange={(o) => {
+					onOpenChange(o);
+					if (!o) {
+						handleReset();
+					}
+				}}
+				open={open}
+				title="Start Live Session"
+			>
+				<LiveSessionForm
+					currencies={currencies}
+					defaultRoomId={defaultRoomId}
+					formId={LIVE_SESSION_FORM_ID}
+					onRoomChange={setSelectedRoomId}
+					onSubmit={handleSubmit}
+					ringGames={ringGames}
+					rooms={rooms}
+					tournaments={tournaments}
+				/>
+			</FormSheet>
+			<SetRoomLocationDialog
+				onOpenChange={locationPrompt.onOpenChange}
+				onSave={locationPrompt.onSave}
+				onSkip={locationPrompt.onSkip}
+				open={locationPrompt.open}
+				roomName={locationPrompt.roomName}
 			/>
-		</FormSheet>
+		</>
 	);
 }

--- a/apps/web/src/features/live-sessions/components/create-session-dialog/set-room-location-dialog/index.ts
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/set-room-location-dialog/index.ts
@@ -1,0 +1,1 @@
+export { SetRoomLocationDialog } from "./set-room-location-dialog";

--- a/apps/web/src/features/live-sessions/components/create-session-dialog/set-room-location-dialog/set-room-location-dialog.test.tsx
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/set-room-location-dialog/set-room-location-dialog.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SetRoomLocationDialog } from "./set-room-location-dialog";
+
+const ROOM_NAME_PATTERN = /Casino X/;
+
+function setup(
+	overrides: Partial<Parameters<typeof SetRoomLocationDialog>[0]> = {}
+) {
+	const props = {
+		onOpenChange: vi.fn(),
+		onSave: vi.fn(),
+		onSkip: vi.fn(),
+		open: true,
+		roomName: "Room 1",
+		...overrides,
+	};
+	render(<SetRoomLocationDialog {...props} />);
+	return props;
+}
+
+describe("SetRoomLocationDialog", () => {
+	it("shows the room name in the body copy when open", () => {
+		setup({ roomName: "Casino X" });
+		expect(screen.getByText(ROOM_NAME_PATTERN)).toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", { name: "Save this room's location?" })
+		).toBeInTheDocument();
+	});
+
+	it("renders nothing while closed", () => {
+		setup({ open: false });
+		expect(
+			screen.queryByText("Save this room's location?")
+		).not.toBeInTheDocument();
+	});
+
+	it("calls onSave when the save button is pressed", async () => {
+		const user = userEvent.setup();
+		const { onSave, onSkip } = setup();
+		await user.click(screen.getByRole("button", { name: "Save location" }));
+		expect(onSave).toHaveBeenCalledTimes(1);
+		expect(onSkip).not.toHaveBeenCalled();
+	});
+
+	it("calls onSkip when the not-now button is pressed", async () => {
+		const user = userEvent.setup();
+		const { onSave, onSkip } = setup();
+		await user.click(screen.getByRole("button", { name: "Not now" }));
+		expect(onSkip).toHaveBeenCalledTimes(1);
+		expect(onSave).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/features/live-sessions/components/create-session-dialog/set-room-location-dialog/set-room-location-dialog.tsx
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/set-room-location-dialog/set-room-location-dialog.tsx
@@ -1,0 +1,53 @@
+import { Button } from "@/shared/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/shared/components/ui/dialog";
+
+interface SetRoomLocationDialogProps {
+	onOpenChange: (open: boolean) => void;
+	onSave: () => void;
+	onSkip: () => void;
+	open: boolean;
+	roomName: string;
+}
+
+/**
+ * Centered prompt shown when a live session starts in a room that has no saved
+ * location (SA2-100). Offers to stamp the device's current location onto the
+ * room so it can be auto-selected next time. Dismissing or "Not now" starts the
+ * session without touching the room; "Save location" saves then starts.
+ */
+export function SetRoomLocationDialog({
+	onOpenChange,
+	onSave,
+	onSkip,
+	open,
+	roomName,
+}: SetRoomLocationDialogProps) {
+	return (
+		<Dialog onOpenChange={onOpenChange} open={open}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Save this room's location?</DialogTitle>
+					<DialogDescription>
+						{roomName} has no saved location. Save your current location to it
+						so it can be auto-selected next time you start a session here.
+					</DialogDescription>
+				</DialogHeader>
+				<DialogFooter className="flex-row justify-end gap-2">
+					<Button onClick={onSkip} type="button" variant="outline">
+						Not now
+					</Button>
+					<Button onClick={onSave} type="button">
+						Save location
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/features/live-sessions/components/create-session-dialog/use-create-session-dialog.ts
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/use-create-session-dialog.ts
@@ -23,6 +23,7 @@ export function useCreateSessionDialog({
 		nearestRoomId,
 		createCash,
 		createTournament,
+		locationPrompt,
 		isLoading,
 	} = useCreateSession({ onClose: () => onOpenChange(false), open });
 
@@ -65,6 +66,7 @@ export function useCreateSessionDialog({
 		setSelectedRoomId,
 		defaultRoomId: nearestRoomId,
 		handleSubmit,
+		locationPrompt,
 		isLoading,
 		handleReset,
 	};

--- a/apps/web/src/features/live-sessions/hooks/__tests__/use-create-session.test.ts
+++ b/apps/web/src/features/live-sessions/hooks/__tests__/use-create-session.test.ts
@@ -553,7 +553,9 @@ describe("useCreateSession", () => {
 
 			expect(result.current.locationPrompt.open).toBe(false);
 			expect(trpcMocks.roomUpdate).not.toHaveBeenCalled();
-			await waitFor(() => expect(trpcMocks.createCash).toHaveBeenCalledTimes(1));
+			await waitFor(() =>
+				expect(trpcMocks.createCash).toHaveBeenCalledTimes(1)
+			);
 		});
 
 		it("does not open the prompt when the room already has coordinates", async () => {
@@ -569,7 +571,9 @@ describe("useCreateSession", () => {
 			});
 
 			expect(result.current.locationPrompt.open).toBe(false);
-			await waitFor(() => expect(trpcMocks.createCash).toHaveBeenCalledTimes(1));
+			await waitFor(() =>
+				expect(trpcMocks.createCash).toHaveBeenCalledTimes(1)
+			);
 		});
 
 		it("does not open the prompt when no device fix is available", async () => {
@@ -585,7 +589,9 @@ describe("useCreateSession", () => {
 			});
 
 			expect(result.current.locationPrompt.open).toBe(false);
-			await waitFor(() => expect(trpcMocks.createCash).toHaveBeenCalledTimes(1));
+			await waitFor(() =>
+				expect(trpcMocks.createCash).toHaveBeenCalledTimes(1)
+			);
 		});
 
 		it("does not open the prompt when the chosen room is not in the list", async () => {
@@ -601,7 +607,9 @@ describe("useCreateSession", () => {
 			});
 
 			expect(result.current.locationPrompt.open).toBe(false);
-			await waitFor(() => expect(trpcMocks.createCash).toHaveBeenCalledTimes(1));
+			await waitFor(() =>
+				expect(trpcMocks.createCash).toHaveBeenCalledTimes(1)
+			);
 		});
 
 		it("prompts for a tournament start too, then saves before starting", async () => {

--- a/apps/web/src/features/live-sessions/hooks/__tests__/use-create-session.test.ts
+++ b/apps/web/src/features/live-sessions/hooks/__tests__/use-create-session.test.ts
@@ -19,6 +19,12 @@ const trpcMocks = vi.hoisted(() => ({
 const geoMock = vi.hoisted(() => ({
 	coords: null as { latitude: number; longitude: number } | null,
 }));
+const toastMock = vi.hoisted(() => ({
+	success: vi.fn(),
+	error: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: toastMock }));
 
 vi.mock("@tanstack/react-router", () => ({
 	useNavigate: () => navigateMock,
@@ -131,6 +137,8 @@ describe("useCreateSession", () => {
 		for (const m of Object.values(trpcMocks)) {
 			m.mockReset();
 		}
+		toastMock.success.mockReset();
+		toastMock.error.mockReset();
 		geoMock.coords = null;
 	});
 	afterEach(() => {
@@ -534,6 +542,64 @@ describe("useCreateSession", () => {
 					roomId: "s1",
 				})
 			);
+			await waitFor(() =>
+				expect(toastMock.success).toHaveBeenCalledWith("Room location saved")
+			);
+			expect(toastMock.success).toHaveBeenCalledTimes(1);
+			expect(toastMock.error).not.toHaveBeenCalled();
+		});
+
+		it("toasts an error but still starts the session when the location save fails", async () => {
+			geoMock.coords = COORDS;
+			const qc = createClient();
+			seedRoom(qc, { latitude: null, longitude: null });
+			trpcMocks.createCash.mockResolvedValue({ id: "c-1" });
+			trpcMocks.roomUpdate.mockRejectedValue(new Error("network"));
+			const { result } = renderReady(qc);
+			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
+
+			act(() => {
+				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
+			});
+			act(() => {
+				result.current.locationPrompt.onSave();
+			});
+
+			await waitFor(() =>
+				expect(toastMock.error).toHaveBeenCalledWith(
+					"Couldn't save room location"
+				)
+			);
+			expect(toastMock.error).toHaveBeenCalledTimes(1);
+			expect(toastMock.success).not.toHaveBeenCalled();
+			await waitFor(() =>
+				expect(trpcMocks.createCash).toHaveBeenCalledWith({
+					initialBuyIn: 5000,
+					roomId: "s1",
+				})
+			);
+		});
+
+		it("does not toast when the prompt is skipped without saving", async () => {
+			geoMock.coords = COORDS;
+			const qc = createClient();
+			seedRoom(qc, { latitude: null, longitude: null });
+			trpcMocks.createCash.mockResolvedValue({ id: "c-1" });
+			const { result } = renderReady(qc);
+			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
+
+			act(() => {
+				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
+			});
+			act(() => {
+				result.current.locationPrompt.onSkip();
+			});
+
+			await waitFor(() =>
+				expect(trpcMocks.createCash).toHaveBeenCalledTimes(1)
+			);
+			expect(toastMock.success).not.toHaveBeenCalled();
+			expect(toastMock.error).not.toHaveBeenCalled();
 		});
 
 		it("treats a dismissal (onOpenChange false) as a skip", async () => {

--- a/apps/web/src/features/live-sessions/hooks/__tests__/use-create-session.test.ts
+++ b/apps/web/src/features/live-sessions/hooks/__tests__/use-create-session.test.ts
@@ -14,6 +14,7 @@ const trpcMocks = vi.hoisted(() => ({
 	createCash: vi.fn(),
 	createTournament: vi.fn(),
 	sessionEventCreate: vi.fn(),
+	roomUpdate: vi.fn(),
 }));
 const geoMock = vi.hoisted(() => ({
 	coords: null as { latitude: number; longitude: number } | null,
@@ -100,6 +101,9 @@ vi.mock("@/utils/trpc", () => ({
 		},
 		sessionEvent: {
 			create: { mutate: trpcMocks.sessionEventCreate },
+		},
+		room: {
+			update: { mutate: trpcMocks.roomUpdate },
 		},
 	},
 }));
@@ -429,6 +433,213 @@ describe("useCreateSession", () => {
 			);
 			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
 			expect(result.current.nearestRoomId).toBeUndefined();
+		});
+	});
+
+	describe("locationPrompt (SA2-100 save room location)", () => {
+		const COORDS = { latitude: 35.6812, longitude: 139.7671 };
+
+		function seedRoom(
+			qc: QueryClient,
+			room: { latitude: number | null; longitude: number | null }
+		) {
+			qc.setQueryData(
+				["room", "list"],
+				[{ id: "s1", name: "Room 1", ...room }]
+			);
+		}
+
+		function renderReady(qc: QueryClient, onClose = vi.fn()) {
+			const view = renderHook(() => useCreateSession({ onClose, open: true }), {
+				wrapper: makeWrapper(qc),
+			});
+			return view;
+		}
+
+		it("is closed with an empty room name by default", () => {
+			const qc = createClient();
+			const { result } = renderReady(qc);
+			expect(result.current.locationPrompt.open).toBe(false);
+			expect(result.current.locationPrompt.roomName).toBe("");
+		});
+
+		it("opens the prompt instead of starting when the room has no coordinates and a fix is available", async () => {
+			geoMock.coords = COORDS;
+			const qc = createClient();
+			seedRoom(qc, { latitude: null, longitude: null });
+			const { result } = renderReady(qc);
+			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
+
+			act(() => {
+				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
+			});
+
+			expect(result.current.locationPrompt.open).toBe(true);
+			expect(result.current.locationPrompt.roomName).toBe("Room 1");
+			expect(trpcMocks.createCash).not.toHaveBeenCalled();
+		});
+
+		it("starts the session without saving when the prompt is skipped", async () => {
+			geoMock.coords = COORDS;
+			const qc = createClient();
+			seedRoom(qc, { latitude: null, longitude: null });
+			trpcMocks.createCash.mockResolvedValue({ id: "c-1" });
+			const { result } = renderReady(qc);
+			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
+
+			act(() => {
+				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
+			});
+			act(() => {
+				result.current.locationPrompt.onSkip();
+			});
+
+			expect(result.current.locationPrompt.open).toBe(false);
+			expect(trpcMocks.roomUpdate).not.toHaveBeenCalled();
+			await waitFor(() =>
+				expect(trpcMocks.createCash).toHaveBeenCalledWith({
+					initialBuyIn: 5000,
+					roomId: "s1",
+				})
+			);
+		});
+
+		it("saves the current location to the room then starts the session", async () => {
+			geoMock.coords = COORDS;
+			const qc = createClient();
+			seedRoom(qc, { latitude: null, longitude: null });
+			trpcMocks.createCash.mockResolvedValue({ id: "c-1" });
+			trpcMocks.roomUpdate.mockResolvedValue({ id: "s1" });
+			const { result } = renderReady(qc);
+			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
+
+			act(() => {
+				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
+			});
+			act(() => {
+				result.current.locationPrompt.onSave();
+			});
+
+			expect(result.current.locationPrompt.open).toBe(false);
+			await waitFor(() =>
+				expect(trpcMocks.roomUpdate).toHaveBeenCalledWith({
+					id: "s1",
+					latitude: COORDS.latitude,
+					longitude: COORDS.longitude,
+				})
+			);
+			await waitFor(() =>
+				expect(trpcMocks.createCash).toHaveBeenCalledWith({
+					initialBuyIn: 5000,
+					roomId: "s1",
+				})
+			);
+		});
+
+		it("treats a dismissal (onOpenChange false) as a skip", async () => {
+			geoMock.coords = COORDS;
+			const qc = createClient();
+			seedRoom(qc, { latitude: null, longitude: null });
+			trpcMocks.createCash.mockResolvedValue({ id: "c-1" });
+			const { result } = renderReady(qc);
+			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
+
+			act(() => {
+				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
+			});
+			act(() => {
+				result.current.locationPrompt.onOpenChange(false);
+			});
+
+			expect(result.current.locationPrompt.open).toBe(false);
+			expect(trpcMocks.roomUpdate).not.toHaveBeenCalled();
+			await waitFor(() => expect(trpcMocks.createCash).toHaveBeenCalledTimes(1));
+		});
+
+		it("does not open the prompt when the room already has coordinates", async () => {
+			geoMock.coords = COORDS;
+			const qc = createClient();
+			seedRoom(qc, { latitude: 35.68, longitude: 139.76 });
+			trpcMocks.createCash.mockResolvedValue({ id: "c-1" });
+			const { result } = renderReady(qc);
+			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
+
+			act(() => {
+				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
+			});
+
+			expect(result.current.locationPrompt.open).toBe(false);
+			await waitFor(() => expect(trpcMocks.createCash).toHaveBeenCalledTimes(1));
+		});
+
+		it("does not open the prompt when no device fix is available", async () => {
+			geoMock.coords = null;
+			const qc = createClient();
+			seedRoom(qc, { latitude: null, longitude: null });
+			trpcMocks.createCash.mockResolvedValue({ id: "c-1" });
+			const { result } = renderReady(qc);
+			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
+
+			act(() => {
+				result.current.createCash({ initialBuyIn: 5000, roomId: "s1" });
+			});
+
+			expect(result.current.locationPrompt.open).toBe(false);
+			await waitFor(() => expect(trpcMocks.createCash).toHaveBeenCalledTimes(1));
+		});
+
+		it("does not open the prompt when the chosen room is not in the list", async () => {
+			geoMock.coords = COORDS;
+			const qc = createClient();
+			seedRoom(qc, { latitude: null, longitude: null });
+			trpcMocks.createCash.mockResolvedValue({ id: "c-1" });
+			const { result } = renderReady(qc);
+			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
+
+			act(() => {
+				result.current.createCash({ initialBuyIn: 5000, roomId: "missing" });
+			});
+
+			expect(result.current.locationPrompt.open).toBe(false);
+			await waitFor(() => expect(trpcMocks.createCash).toHaveBeenCalledTimes(1));
+		});
+
+		it("prompts for a tournament start too, then saves before starting", async () => {
+			geoMock.coords = COORDS;
+			const qc = createClient();
+			seedRoom(qc, { latitude: null, longitude: null });
+			trpcMocks.createTournament.mockResolvedValue({ id: "t-1" });
+			trpcMocks.sessionEventCreate.mockResolvedValue({ id: "ev-1" });
+			trpcMocks.roomUpdate.mockResolvedValue({ id: "s1" });
+			const { result } = renderReady(qc);
+			await waitFor(() => expect(result.current.rooms).toHaveLength(1));
+
+			act(() => {
+				result.current.createTournament({
+					buyIn: 10_000,
+					startingStack: 20_000,
+					roomId: "s1",
+				});
+			});
+			expect(result.current.locationPrompt.open).toBe(true);
+			expect(trpcMocks.createTournament).not.toHaveBeenCalled();
+
+			act(() => {
+				result.current.locationPrompt.onSave();
+			});
+			await waitFor(() =>
+				expect(trpcMocks.roomUpdate).toHaveBeenCalledWith({
+					id: "s1",
+					latitude: COORDS.latitude,
+					longitude: COORDS.longitude,
+				})
+			);
+			await waitFor(() =>
+				expect(trpcMocks.createTournament).toHaveBeenCalledWith({
+					buyIn: 10_000,
+					roomId: "s1",
+				})
+			);
 		});
 	});
 });

--- a/apps/web/src/features/live-sessions/hooks/use-create-session.ts
+++ b/apps/web/src/features/live-sessions/hooks/use-create-session.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
+import { toast } from "sonner";
 import { findNearestRoom } from "@/features/live-sessions/utils/geo";
 import { useGeolocation } from "@/shared/hooks/use-geolocation";
 import { invalidateTargets } from "@/utils/optimistic-update";
@@ -102,8 +103,15 @@ export function useCreateSession({
 	const updateRoomLocationMutation = useMutation({
 		mutationFn: (vars: { id: string; latitude: number; longitude: number }) =>
 			trpcClient.room.update.mutate(vars),
-		onSuccess: () =>
-			invalidateTargets(queryClient, [{ queryKey: roomListKey }]),
+		onSuccess: async () => {
+			await invalidateTargets(queryClient, [{ queryKey: roomListKey }]);
+			toast.success("Room location saved");
+		},
+		// The save is fire-and-forget so the session start stays snappy; surface a
+		// toast on failure so a persistently failing save isn't silently swallowed.
+		onError: () => {
+			toast.error("Couldn't save room location");
+		},
 	});
 
 	// Runs the session starter now, or — when the target room lacks coordinates

--- a/apps/web/src/features/live-sessions/hooks/use-create-session.ts
+++ b/apps/web/src/features/live-sessions/hooks/use-create-session.ts
@@ -27,6 +27,25 @@ function useRoomRingGames(roomId: string | undefined) {
 	}));
 }
 
+interface CreateCashValues {
+	currencyId?: string;
+	initialBuyIn: number;
+	memo?: string;
+	ringGameId?: string;
+	roomId?: string;
+}
+
+interface CreateTournamentValues {
+	buyIn: number;
+	currencyId?: string;
+	entryFee?: number;
+	memo?: string;
+	roomId?: string;
+	startingStack: number;
+	timerStartedAt?: number;
+	tournamentId?: string;
+}
+
 function useRoomTournaments(roomId: string | undefined) {
 	const tournamentsQuery = useQuery({
 		...trpc.tournament.listByRoom.queryOptions({
@@ -68,6 +87,69 @@ export function useCreateSession({
 		id: s.id,
 		name: s.name,
 	}));
+
+	const roomListKey = trpc.room.list.queryOptions().queryKey;
+
+	// When the chosen room has no saved coordinates, we offer to stamp the
+	// device's current location onto it (SA2-100). Hold the pending session
+	// starter and the target room while the confirmation prompt is open.
+	const [pendingStart, setPendingStart] = useState<(() => void) | null>(null);
+	const [promptRoom, setPromptRoom] = useState<{
+		id: string;
+		name: string;
+	} | null>(null);
+
+	const updateRoomLocationMutation = useMutation({
+		mutationFn: (vars: { id: string; latitude: number; longitude: number }) =>
+			trpcClient.room.update.mutate(vars),
+		onSuccess: () =>
+			invalidateTargets(queryClient, [{ queryKey: roomListKey }]),
+	});
+
+	// Runs the session starter now, or — when the target room lacks coordinates
+	// and we have a device fix — defers it behind the "save location?" prompt.
+	const startOrPrompt = (roomId: string | undefined, run: () => void) => {
+		const targetRoom = (roomsQuery.data ?? []).find((r) => r.id === roomId);
+		if (
+			coords &&
+			targetRoom &&
+			targetRoom.latitude == null &&
+			targetRoom.longitude == null
+		) {
+			setPendingStart(() => run);
+			setPromptRoom({ id: targetRoom.id, name: targetRoom.name });
+			return;
+		}
+		run();
+	};
+
+	const closePrompt = () => {
+		setPromptRoom(null);
+		setPendingStart(null);
+	};
+
+	// Dismiss / "Not now": start the session without touching the room.
+	const handleLocationSkip = () => {
+		const run = pendingStart;
+		closePrompt();
+		run?.();
+	};
+
+	// "Save location": fire-and-forget the room update so session start stays
+	// snappy, then start the session immediately.
+	const handleLocationSave = () => {
+		const run = pendingStart;
+		const target = promptRoom;
+		closePrompt();
+		if (target && coords) {
+			updateRoomLocationMutation.mutate({
+				id: target.id,
+				latitude: coords.latitude,
+				longitude: coords.longitude,
+			});
+		}
+		run?.();
+	};
 
 	// The geolocation-nearest room (within the default radius), used as the
 	// form's default room selection. `undefined` when location is unavailable or
@@ -165,23 +247,23 @@ export function useCreateSession({
 		selectedRoomId,
 		setSelectedRoomId,
 		nearestRoomId,
-		createCash: (values: {
-			currencyId?: string;
-			initialBuyIn: number;
-			memo?: string;
-			ringGameId?: string;
-			roomId?: string;
-		}) => createCashMutation.mutate(values),
-		createTournament: (values: {
-			buyIn: number;
-			currencyId?: string;
-			entryFee?: number;
-			memo?: string;
-			startingStack: number;
-			roomId?: string;
-			timerStartedAt?: number;
-			tournamentId?: string;
-		}) => createTournamentMutation.mutate(values),
+		createCash: (values: CreateCashValues) =>
+			startOrPrompt(values.roomId, () => createCashMutation.mutate(values)),
+		createTournament: (values: CreateTournamentValues) =>
+			startOrPrompt(values.roomId, () =>
+				createTournamentMutation.mutate(values)
+			),
+		locationPrompt: {
+			open: promptRoom !== null,
+			roomName: promptRoom?.name ?? "",
+			onSave: handleLocationSave,
+			onSkip: handleLocationSkip,
+			onOpenChange: (nextOpen: boolean) => {
+				if (!nextOpen) {
+					handleLocationSkip();
+				}
+			},
+		},
 		isLoading,
 	};
 }

--- a/apps/web/src/features/live-sessions/hooks/use-create-session.ts
+++ b/apps/web/src/features/live-sessions/hooks/use-create-session.ts
@@ -185,13 +185,8 @@ export function useCreateSession({
 	const sessionListKey = trpc.session.list.queryOptions({}).queryKey;
 
 	const createCashMutation = useMutation({
-		mutationFn: (values: {
-			currencyId?: string;
-			initialBuyIn: number;
-			memo?: string;
-			ringGameId?: string;
-			roomId?: string;
-		}) => trpcClient.liveCashGameSession.create.mutate(values),
+		mutationFn: (values: CreateCashValues) =>
+			trpcClient.liveCashGameSession.create.mutate(values),
 		onSuccess: async () => {
 			await invalidateTargets(queryClient, [
 				{ queryKey: cashListKey },
@@ -203,16 +198,7 @@ export function useCreateSession({
 	});
 
 	const createTournamentMutation = useMutation({
-		mutationFn: async (values: {
-			buyIn: number;
-			currencyId?: string;
-			entryFee?: number;
-			memo?: string;
-			startingStack: number;
-			roomId?: string;
-			timerStartedAt?: number;
-			tournamentId?: string;
-		}) => {
+		mutationFn: async (values: CreateTournamentValues) => {
 			const { startingStack, ...createValues } = values;
 			const result =
 				await trpcClient.liveTournamentSession.create.mutate(createValues);


### PR DESCRIPTION
## 概要

位置情報が未設定のポーカールームでライブセッションを開始したとき、そのルームの位置情報を現在地に設定するかを確認するようにしました（SA2-100）。一度設定すれば、SA2-41 で入った「現在地から最寄りRoomを自動選択」が次回以降効くようになります。

## 背景

SA2-41 で Room に緯度/経度を持たせて最寄りRoomの自動選択を導入しましたが、既存の（座標未設定の）Roomは自動選択の対象外のままでした。ライブセッションを始めるのは大抵「今いる店」なので、そのタイミングで座標を保存できると次回から自動選択が効くようになります。

## 変更内容

- `useCreateSession` に `startOrPrompt` ガードを追加。開始対象Roomが座標を持たず、かつ端末の現在地が取得できている場合のみ、セッション開始を確認プロンプトの背後に遅延させます。
  - 座標あり／現在地なし／対象Room不明のときは従来どおり即開始（挙動不変）。
- **Save location**: `room.update` に現在地を fire-and-forget で書き込み、即座にセッションを開始（開始のもたつきを避ける）。完了時に `room.list` を invalidate。
- **Not now** ・プロンプト外への離脱（`onOpenChange=false`）はスキップ扱いで、Roomに触れずセッションを開始。
- 確認用に `SetRoomLocationDialog`（中央モーダル、`web-theme` の確認ダイアログ規約に準拠）を新設し、`CreateSessionDialog` から `FormSheet` と併置してレンダリング。

## UIコピー

英語のみ（`Save this room's location?` / `Not now` / `Save location`）。

## テスト

- `use-create-session`: 分岐（座標あり/なし・現在地あり/なし・対象Room不明）、保存/スキップ/離脱、cash / tournament 双方を網羅。
- `use-create-session-dialog`: `locationPrompt` の透過を確認。
- `SetRoomLocationDialog`: 開閉・Room名表示・保存/スキップのハンドラ発火。
- `bunx vitest run --project web-dom`（対象6ファイル・46件）green、`bun run check-types` green、`bunx ultracite check` clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVf4aYLZf54qnbkPaAgaba

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVf4aYLZf54qnbkPaAgaba)_