### PR TITLE
fix(release): 本番デプロイを release.yml から明示的にトリガーする

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -3,6 +3,14 @@ name: Production Deploy
 on:
   release:
     types: [published]
+  # Manual / programmatic trigger. release.yml dispatches this after publishing
+  # the Release, because a Release published with the default GITHUB_TOKEN does
+  # NOT emit a `release: published` event that can start another workflow
+  # (GitHub's recursive-run guard). workflow_dispatch is exempt from that guard,
+  # so it fires even when invoked with GITHUB_TOKEN. Checkout uses the dispatched
+  # ref (github.ref), so `gh workflow run production-deploy.yml --ref <tag|main>`
+  # deploys that ref — this is also the "Run workflow" button for manual redeploys.
+  workflow_dispatch:
 
 concurrency:
   group: production-deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,3 +110,18 @@ jobs:
           RELEASE_URL=$(gh release view "$RELEASE_VERSION" --repo "$REPO" --json url --jq .url)
           gh pr comment "$PR_NUMBER" --repo "$REPO" \
             --body "Released as **$RELEASE_VERSION** → $RELEASE_URL"
+
+      # A Release published with the default GITHUB_TOKEN does not emit a
+      # `release: published` event that starts production-deploy.yml (GitHub's
+      # recursive-run guard). workflow_dispatch is exempt from that guard, so we
+      # explicitly kick the production deploy here. Deploy the tag we just cut so
+      # the deployed tree matches the Release exactly.
+      - name: Trigger production deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh workflow run production-deploy.yml \
+            --repo "$REPO" \
+            --ref "$RELEASE_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-      actions: read
+      # write (includes read) — the "Trigger production deploy" step dispatches
+      # production-deploy.yml via `gh workflow run`, which needs actions: write.
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## 背景

v3.2.0 のリリースで **本番デプロイ（`production-deploy.yml`）が自動起動しなかった**。

`production-deploy.yml` は `on: release: [published]` で発火する設計だが、`release.yml` の `gh release create` がデフォルトの `GITHUB_TOKEN`（`github-actions[bot]`）で Release を publish している。GitHub の recursive-run guard により、**デフォルト `GITHUB_TOKEN` が発行したイベントは他ワークフローを起動しない**ため、`release: published` が飛ばずデプロイが走らなかった。

過去は Release 作成者がユーザー / GitHub App だったため発火していたが、リリースフロー刷新（#367）で `github-actions[bot]` 発行になり顕在化した。

## 変更

- **`production-deploy.yml`**: `workflow_dispatch` トリガーを追加。recursive-run guard の**対象外**イベントなので `GITHUB_TOKEN` から呼んでも発火する。checkout は `github.ref`（dispatch した ref）を使うため、タグ指定でその内容をデプロイできる。手動再デプロイ用の「Run workflow」ボタンも兼ねる。
- **`release.yml`**: Release publish 後に `gh workflow run production-deploy.yml --ref <version-tag>` を実行し、本番デプロイを明示的にキックするステップを追加。新規シークレット不要。

## 影響

次回リリース以降、Release 公開後に本番デプロイが自動で起動する。ワークフロー定義のみの変更で、アプリのコード・テストへの影響はなし（YAML パース検証済み）。

> なお本 PR がマージ→`main` に載るのは次回リリース時。**既に公開済みの v3.2.0 の本番反映は別途手動トリガーが必要**（PR コメント／チャットで手順を案内済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SveG3DGEdWM7vreUwAfN6h)_