### PR TITLE
fix(session): D1のバインドパラメータ上限超えでチップ購入バッチ取得が失敗する不具合を修正

### DIFF
--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -8,6 +8,7 @@ import {
 	encodeSessionCursor,
 	type ProfitLossSeriesRow,
 	parseSessionCursor,
+	selectInChunks,
 	toProfitLossSeriesPoint,
 } from "../routers/session";
 
@@ -52,6 +53,66 @@ describe("chunkForInsert", () => {
 	it("falls back to one row per chunk when a single row already fills the cap", () => {
 		const rows = [1, 2, 3];
 		expect(chunkForInsert(rows, 200)).toEqual([[1], [2], [3]]);
+	});
+});
+
+describe("selectInChunks", () => {
+	it("splits an id list over D1's cap so every WHERE IN stays <=100 params", async () => {
+		// 101 session ids in a single `inArray` binds 101 params — over D1's cap
+		// of 100 — and D1 rejects the statement at runtime (the SA2 chip-purchase
+		// batched lookup outage). The lookup must run in <=100-id chunks.
+		const ids = Array.from({ length: 101 }, (_, i) => `s${i}`);
+		const chunkSizes: number[] = [];
+		const rows = await selectInChunks(ids, (chunk) => {
+			chunkSizes.push(chunk.length);
+			return Promise.resolve(chunk.map((id) => ({ id })));
+		});
+		expect(chunkSizes).toEqual([100, 1]);
+		for (const size of chunkSizes) {
+			expect(size).toBeLessThanOrEqual(100);
+		}
+		// Rows are concatenated across chunks, preserving order.
+		expect(rows).toHaveLength(101);
+		expect(rows[0]).toEqual({ id: "s0" });
+		expect(rows.at(-1)).toEqual({ id: "s100" });
+	});
+
+	it("runs a single query when the id list fits under the cap", async () => {
+		const ids = Array.from({ length: 100 }, (_, i) => `s${i}`);
+		let calls = 0;
+		const rows = await selectInChunks(ids, (chunk) => {
+			calls += 1;
+			return Promise.resolve(chunk.map((id) => ({ id })));
+		});
+		expect(calls).toBe(1);
+		expect(rows).toHaveLength(100);
+	});
+
+	it("never issues a query for an empty id list", async () => {
+		let calls = 0;
+		const rows = await selectInChunks<string, { id: string }>([], (chunk) => {
+			calls += 1;
+			return Promise.resolve(chunk.map((id) => ({ id })));
+		});
+		expect(calls).toBe(0);
+		expect(rows).toEqual([]);
+	});
+
+	it("flattens multi-row results from each chunk in chunk order", async () => {
+		const ids = Array.from({ length: 150 }, (_, i) => i);
+		const rows = await selectInChunks(ids, (chunk) =>
+			Promise.resolve(
+				chunk.flatMap((id) => [
+					{ id, n: 0 },
+					{ id, n: 1 },
+				])
+			)
+		);
+		// 2 rows per id, chunked as [100, 50], concatenated in order.
+		expect(rows).toHaveLength(300);
+		expect(rows[0]).toEqual({ id: 0, n: 0 });
+		expect(rows[1]).toEqual({ id: 0, n: 1 });
+		expect(rows.at(-1)).toEqual({ id: 149, n: 1 });
 	});
 });
 

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -92,6 +92,26 @@ export function chunkForInsert<T>(rows: T[], columnsPerRow: number): T[][] {
 	return chunks;
 }
 
+/**
+ * Run a `WHERE ... IN (ids)` SELECT in chunks so no single statement exceeds
+ * D1's 100 bound-parameter cap. A one-column `IN` binds one param per id, so a
+ * batched lookup across >100 sessions (e.g. the chip-purchase / blind-level
+ * maps below) overflows exactly like a wide multi-row INSERT — hence the reuse
+ * of {@link chunkForInsert} with a single "column". Rows from every chunk are
+ * concatenated in chunk order; callers bucket by id afterward, and because each
+ * id lands in exactly one chunk, per-id ordering (sortOrder / level) survives.
+ */
+export async function selectInChunks<Id, Row>(
+	ids: Id[],
+	run: (chunk: Id[]) => Promise<Row[]>
+): Promise<Row[]> {
+	const rows: Row[] = [];
+	for (const chunk of chunkForInsert(ids, 1)) {
+		rows.push(...(await run(chunk)));
+	}
+	return rows;
+}
+
 interface SessionChipPurchaseWithCount {
 	chips: number;
 	cost: number;
@@ -121,26 +141,28 @@ async function getSessionChipPurchaseMap(
 	if (sessionIds.length === 0) {
 		return map;
 	}
-	const rows = await db
-		.select({
-			sessionId: sessionChipPurchase.sessionId,
-			id: sessionChipPurchase.id,
-			name: sessionChipPurchase.name,
-			cost: sessionChipPurchase.cost,
-			chips: sessionChipPurchase.chips,
-			sortOrder: sessionChipPurchase.sortOrder,
-			count: sessionChipPurchaseResult.count,
-		})
-		.from(sessionChipPurchase)
-		.leftJoin(
-			sessionChipPurchaseResult,
-			eq(
-				sessionChipPurchaseResult.sessionChipPurchaseId,
-				sessionChipPurchase.id
+	const rows = await selectInChunks(sessionIds, (chunk) =>
+		db
+			.select({
+				sessionId: sessionChipPurchase.sessionId,
+				id: sessionChipPurchase.id,
+				name: sessionChipPurchase.name,
+				cost: sessionChipPurchase.cost,
+				chips: sessionChipPurchase.chips,
+				sortOrder: sessionChipPurchase.sortOrder,
+				count: sessionChipPurchaseResult.count,
+			})
+			.from(sessionChipPurchase)
+			.leftJoin(
+				sessionChipPurchaseResult,
+				eq(
+					sessionChipPurchaseResult.sessionChipPurchaseId,
+					sessionChipPurchase.id
+				)
 			)
-		)
-		.where(inArray(sessionChipPurchase.sessionId, sessionIds))
-		.orderBy(asc(sessionChipPurchase.sortOrder));
+			.where(inArray(sessionChipPurchase.sessionId, chunk))
+			.orderBy(asc(sessionChipPurchase.sortOrder))
+	);
 	for (const r of rows) {
 		const entry: SessionChipPurchaseWithCount = {
 			id: r.id,
@@ -183,19 +205,21 @@ async function getSessionBlindLevelMap(
 	if (sessionIds.length === 0) {
 		return map;
 	}
-	const rows = await db
-		.select({
-			sessionId: sessionBlindLevel.sessionId,
-			isBreak: sessionBlindLevel.isBreak,
-			blind1: sessionBlindLevel.blind1,
-			blind2: sessionBlindLevel.blind2,
-			blind3: sessionBlindLevel.blind3,
-			ante: sessionBlindLevel.ante,
-			minutes: sessionBlindLevel.minutes,
-		})
-		.from(sessionBlindLevel)
-		.where(inArray(sessionBlindLevel.sessionId, sessionIds))
-		.orderBy(asc(sessionBlindLevel.level));
+	const rows = await selectInChunks(sessionIds, (chunk) =>
+		db
+			.select({
+				sessionId: sessionBlindLevel.sessionId,
+				isBreak: sessionBlindLevel.isBreak,
+				blind1: sessionBlindLevel.blind1,
+				blind2: sessionBlindLevel.blind2,
+				blind3: sessionBlindLevel.blind3,
+				ante: sessionBlindLevel.ante,
+				minutes: sessionBlindLevel.minutes,
+			})
+			.from(sessionBlindLevel)
+			.where(inArray(sessionBlindLevel.sessionId, chunk))
+			.orderBy(asc(sessionBlindLevel.level))
+	);
 	for (const r of rows) {
 		const entry: SessionBlindLevelRow = {
 			isBreak: r.isBreak,
@@ -1331,21 +1355,20 @@ async function enrichSessionRows<
 	const withPL = withChipPurchases.map(enrichItemWithPL);
 
 	const sessionIds = withPL.map((item) => item.id);
-	const tagLinks =
-		sessionIds.length > 0
-			? await db
-					.select({
-						sessionId: sessionToSessionTag.sessionId,
-						tagId: sessionTag.id,
-						tagName: sessionTag.name,
-					})
-					.from(sessionToSessionTag)
-					.innerJoin(
-						sessionTag,
-						eq(sessionTag.id, sessionToSessionTag.sessionTagId)
-					)
-					.where(inArray(sessionToSessionTag.sessionId, sessionIds))
-			: [];
+	const tagLinks = await selectInChunks(sessionIds, (chunk) =>
+		db
+			.select({
+				sessionId: sessionToSessionTag.sessionId,
+				tagId: sessionTag.id,
+				tagName: sessionTag.name,
+			})
+			.from(sessionToSessionTag)
+			.innerJoin(
+				sessionTag,
+				eq(sessionTag.id, sessionToSessionTag.sessionTagId)
+			)
+			.where(inArray(sessionToSessionTag.sessionId, chunk))
+	);
 
 	return withPL.map((item) => ({
 		...item,


### PR DESCRIPTION
## 概要

セッション一覧・`getById`・stats で使われるチップ購入 / ブラインドレベル / タグ紐付けのバッチ取得が、`sessionIds` をそのまま `inArray(...)` に渡していたため、**101 件以上のセッションを持つユーザー**では `WHERE ... IN (?, ?, ...)` のバインドパラメータが D1 の上限 **100** を超え、実行時にクエリが失敗していました。

報告されたエラーは `session_chip_purchase` × `session_chip_purchase_result` の JOIN クエリで、`session_id` のプレースホルダが **101 個**（上限 100 超）だったことが原因です。

```
Failed query: select ... from "session_chip_purchase"
  left join "session_chip_purchase_result" on ...
  where "session_chip_purchase"."session_id" in (?, ?, ... ×101)
```

インサート側は既に `chunkForInsert` で 100 パラメータ以下に分割していましたが、これらのバッチ `SELECT` は分割されていませんでした。

## 変更内容

- `selectInChunks` ヘルパーを追加（`packages/api/src/routers/session.ts`）
  - id リストを 100 件ずつに分割し、`WHERE IN` クエリを複数回実行して結果を連結する。
  - 1 カラムの `IN` は id 1 件につき 1 パラメータをバインドするため、既存の `chunkForInsert(ids, 1)` をそのまま流用（多列 INSERT と同じパラメータ計算）。
  - 各 id は必ず 1 つのチャンクに収まるため、`sortOrder` / `level` による session 単位の並び順は維持される。
- 上限を超えていた 3 箇所のバッチ取得を `selectInChunks` に通す：
  - `getSessionChipPurchaseMap`（チップ購入 + 結果カウント）
  - `getSessionBlindLevelMap`（ブラインドレベル）
  - `enrichSessionRows` 内のタグ紐付け取得

`stats.ts` など他の呼び出し元は `getSessionChipPurchaseMap` を経由するため、修正元で自動的にカバーされます。

## テスト

`selectInChunks` に対する単体テストを追加（`packages/api/src/__tests__/session.test.ts`）：

- 101 件 → チャンクサイズ `[100, 1]`、各チャンク ≤ 100、結果はチャンク順に連結
- 100 件（境界値）→ 1 クエリのみ
- 空リスト → クエリを一切発行せず `[]` を返す
- 1 id 複数行の結果をチャンク順に flatten

`bunx vitest run --project api packages/api/src/__tests__/session.test.ts` → 75 passed。`bun run check-types` / `ultracite check` もパス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnNKtmTbWV6Uoq39LDk6Jn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnNKtmTbWV6Uoq39LDk6Jn)_