### PR TITLE
fix(rooms): align location picker label with other input labels (SA2-101)

### DIFF
--- a/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.test.tsx
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.test.tsx
@@ -71,6 +71,16 @@ describe("LocationPicker", () => {
 		expect(screen.getByRole("tab", { name: "Current" })).toBeInTheDocument();
 	});
 
+	it("renders the Location label with the shared field-label style", () => {
+		renderPicker();
+		const label = screen.getByText("Location");
+		// Aligns with the other room-form inputs, whose labels render through the
+		// shared Field/Label component as a <label> with `font-medium text-sm`.
+		expect(label.tagName).toBe("LABEL");
+		expect(label).toHaveClass("font-medium", "text-sm");
+		expect(label).not.toHaveClass("text-muted-foreground");
+	});
+
 	it("triggers handleSearch from the search button", () => {
 		const handleSearch = vi.fn();
 		renderPicker({ query: "casino", handleSearch });

--- a/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.tsx
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tabler/icons-react";
 import { Button } from "@/shared/components/ui/button";
 import { Input } from "@/shared/components/ui/input";
+import { Label } from "@/shared/components/ui/label";
 import {
 	Tabs,
 	TabsContent,
@@ -58,7 +59,7 @@ export function LocationPicker({
 
 	return (
 		<div className="flex flex-col gap-3">
-			<span className="t-label text-muted-foreground">Location</span>
+			<Label>Location</Label>
 			<Tabs defaultValue="search">
 				<TabsList className="w-full">
 					<TabsTrigger value="search">Search</TabsTrigger>


### PR DESCRIPTION
## 概要

`auto-fix` ラベルの付いた Todo issue を自動修正するタスクの成果です。対象条件（Todo・`auto-fix` ラベル・修正 PR 未作成）を満たす issue は現時点で **SA2-101 の 1 件のみ** でした。

## 対応 issue

- **SA2-101** ([#412](https://github.com/HIRO15254/sapphire2/issues/412)) — ルーム編集モーダルのロケーションインプットのラベルが他の Input Label と異なるスタイルなので揃える

## 変更内容

`LocationPicker` の "Location" ラベルだけが `<span className="t-label text-muted-foreground">` で描画されており、他の入力ラベル（Room name / Memo は共有 `Field` → `Label` 経由）と字面・色が異なっていた。

共有の `Label` コンポーネントに置き換え、他ラベルと同じ `font-medium` / `text-sm` / foreground 色へ統一した。

## テスト

- `location-picker.test.tsx` に、"Location" ラベルが共有ラベルスタイル（`LABEL` 要素・`font-medium text-sm`・非 `text-muted-foreground`）で描画されることを検証するテストを追加（TDD: red → green を確認）。
- `bunx vitest run --project web-dom` / `bun run check-types` / `ultracite` いずれもグリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8BvABuibes1mXXgi19Uud

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8BvABuibes1mXXgi19Uud)_