### PR TITLE
fix(api): ライブセッションのroomId/currencyId所有権検証を追加 (SA2-102)

### DIFF
--- a/packages/api/src/__tests__/live-cash-game-session.test.ts
+++ b/packages/api/src/__tests__/live-cash-game-session.test.ts
@@ -1,3 +1,7 @@
+import { currency } from "@sapphire2/db/schema/currency";
+import { room } from "@sapphire2/db/schema/room";
+import { gameSession } from "@sapphire2/db/schema/session";
+import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -7,6 +11,238 @@ import {
 	expectType,
 	getInputSchema,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+
+/**
+ * Minimal drizzle-shaped mock db: `select().from(t).where().limit()` chains
+ * resolve to the rows registered for table `t`; `insert`/`update`/`delete`
+ * resolve to no-ops. Keyed by the imported schema object reference so the
+ * ownership `select().from(room|currency)` reads the seeded owner rows.
+ */
+type ChainablePromise = Promise<Rows> & Record<string, () => ChainablePromise>;
+
+function createMockDb(tableRows: Map<unknown, Rows>) {
+	const makeResult = (table: unknown): ChainablePromise => {
+		const promise = Promise.resolve(
+			tableRows.get(table) ?? []
+		) as ChainablePromise;
+		const same = () => promise;
+		for (const method of [
+			"where",
+			"limit",
+			"orderBy",
+			"groupBy",
+			"innerJoin",
+			"leftJoin",
+		]) {
+			promise[method] = same;
+		}
+		return promise;
+	};
+	return {
+		select: () => ({ from: (table: unknown) => makeResult(table) }),
+		insert: () => ({ values: () => Promise.resolve(undefined) }),
+		update: () => ({
+			set: () => ({ where: () => Promise.resolve(undefined) }),
+		}),
+		delete: () => ({ where: () => Promise.resolve(undefined) }),
+	};
+}
+
+function makeCaller(userId: string, tableRows: Map<unknown, Rows>) {
+	return appRouter.createCaller({
+		session: { user: { id: userId } },
+		db: createMockDb(tableRows),
+	} as unknown as Parameters<typeof appRouter.createCaller>[0])
+		.liveCashGameSession;
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+const OWNER = "user-1";
+const OTHER = "user-2";
+
+const ownedSession = {
+	id: "s1",
+	userId: OWNER,
+	kind: "cash_game",
+	status: "active",
+	source: "live",
+	roomId: null,
+	currencyId: null,
+};
+
+describe("liveCashGameSession.create ownership validation (SA2-102)", () => {
+	it("accepts a room and currency owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, [{ id: "room-1", userId: OWNER }]],
+			[currency, [{ id: "cur-1", userId: OWNER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).create({
+				initialBuyIn: 1000,
+				roomId: "room-1",
+				currencyId: "cur-1",
+			})
+		).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
+	});
+
+	it("rejects a room owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, [{ id: "room-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, roomId: "room-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a currency owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a non-existent room with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, roomId: "room-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("rejects a non-existent currency with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[currency, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, currencyId: "cur-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("does not validate ownership when room/currency are omitted", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0 })
+		).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
+	});
+});
+
+describe("liveCashGameSession.update ownership validation (SA2-102)", () => {
+	it("accepts a room and currency owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OWNER }]],
+			[currency, [{ id: "cur-1", userId: OWNER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({
+				id: "s1",
+				roomId: "room-1",
+				currencyId: "cur-1",
+			})
+		).resolves.toBeDefined();
+	});
+
+	it("rejects a room owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", roomId: "room-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a currency owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a non-existent room with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", roomId: "room-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("rejects a non-existent currency with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[currency, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", currencyId: "cur-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("clears roomId/currencyId with null without an ownership error", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({
+				id: "s1",
+				roomId: null,
+				currencyId: null,
+			})
+		).resolves.toBeDefined();
+	});
+
+	it("does not validate ownership when room/currency are omitted", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({ id: "s1", memo: "note" })
+		).resolves.toBeDefined();
+	});
+});
 
 describe("liveCashGameSession router", () => {
 	it("appRouter has liveCashGameSession namespace", () => {

--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -1,3 +1,7 @@
+import { currency } from "@sapphire2/db/schema/currency";
+import { room } from "@sapphire2/db/schema/room";
+import { gameSession } from "@sapphire2/db/schema/session";
+import { TRPCError } from "@trpc/server";
 import { describe, expect, it, vi } from "vitest";
 import { t } from "../index";
 import { appRouter } from "../routers";
@@ -65,6 +69,234 @@ function callerFor(db: unknown, userId: string) {
 		db,
 	} as never);
 }
+
+type Rows = Record<string, unknown>[];
+
+/**
+ * Minimal drizzle-shaped mock db: `select().from(t).where().limit()` chains
+ * resolve to the rows registered for table `t`; `insert`/`update`/`delete`
+ * resolve to no-ops. Keyed by the imported schema object reference so the
+ * ownership `select().from(room|currency)` reads the seeded owner rows.
+ */
+type ChainablePromise = Promise<Rows> & Record<string, () => ChainablePromise>;
+
+function createMockDb(tableRows: Map<unknown, Rows>) {
+	const makeResult = (table: unknown): ChainablePromise => {
+		const promise = Promise.resolve(
+			tableRows.get(table) ?? []
+		) as ChainablePromise;
+		const same = () => promise;
+		for (const method of [
+			"where",
+			"limit",
+			"orderBy",
+			"groupBy",
+			"innerJoin",
+			"leftJoin",
+		]) {
+			promise[method] = same;
+		}
+		return promise;
+	};
+	return {
+		select: () => ({ from: (table: unknown) => makeResult(table) }),
+		insert: () => ({ values: () => Promise.resolve(undefined) }),
+		update: () => ({
+			set: () => ({ where: () => Promise.resolve(undefined) }),
+		}),
+		delete: () => ({ where: () => Promise.resolve(undefined) }),
+	};
+}
+
+function makeCaller(userId: string, tableRows: Map<unknown, Rows>) {
+	return appRouter.createCaller({
+		session: { user: { id: userId } },
+		db: createMockDb(tableRows),
+	} as unknown as Parameters<typeof appRouter.createCaller>[0])
+		.liveTournamentSession;
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+const OWNER = "user-1";
+const OTHER = "user-2";
+
+const ownedSession = {
+	id: "s1",
+	userId: OWNER,
+	kind: "tournament",
+	status: "active",
+	source: "live",
+	roomId: null,
+	currencyId: null,
+};
+
+describe("liveTournamentSession.create ownership validation (SA2-102)", () => {
+	it("accepts a room and currency owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, [{ id: "room-1", userId: OWNER }]],
+			[currency, [{ id: "cur-1", userId: OWNER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).create({ roomId: "room-1", currencyId: "cur-1" })
+		).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
+	});
+
+	it("rejects a room owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, [{ id: "room-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ roomId: "room-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a currency owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a non-existent room with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ roomId: "room-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("rejects a non-existent currency with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[currency, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ currencyId: "cur-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("does not validate ownership when room/currency are omitted", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expect(makeCaller(OWNER, rows).create({})).resolves.toEqual(
+			expect.objectContaining({ id: expect.any(String) })
+		);
+	});
+});
+
+describe("liveTournamentSession.update ownership validation (SA2-102)", () => {
+	it("accepts a room and currency owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OWNER }]],
+			[currency, [{ id: "cur-1", userId: OWNER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({
+				id: "s1",
+				roomId: "room-1",
+				currencyId: "cur-1",
+			})
+		).resolves.toBeDefined();
+	});
+
+	it("rejects a room owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", roomId: "room-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a currency owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a non-existent room with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", roomId: "room-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("rejects a non-existent currency with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[currency, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", currencyId: "cur-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("clears roomId/currencyId with null without an ownership error", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({
+				id: "s1",
+				roomId: null,
+				currencyId: null,
+			})
+		).resolves.toBeDefined();
+	});
+
+	it("does not validate ownership when room/currency are omitted", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({ id: "s1", memo: "note" })
+		).resolves.toBeDefined();
+	});
+});
 
 describe("liveTournamentSession router", () => {
 	it("appRouter has liveTournamentSession namespace", () => {

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -21,7 +21,7 @@ import {
 	recalculateCashGameSession,
 } from "../services/live-session-pl";
 import { floorToMinute } from "../utils/session-event-time";
-import { resolveCashRuleSnapshot } from "./session";
+import { resolveCashRuleSnapshot, validateLiveLinkOwnership } from "./session";
 
 const DEFAULT_LIMIT = 20;
 
@@ -395,6 +395,8 @@ export const liveCashGameSessionRouter = router({
 				}
 			}
 
+			await validateLiveLinkOwnership(ctx.db, input, userId);
+
 			const id = crypto.randomUUID();
 
 			await ctx.db.insert(gameSession).values({
@@ -464,6 +466,8 @@ export const liveCashGameSessionRouter = router({
 			const updateData: Partial<typeof gameSession.$inferInsert> = {
 				updatedAt: new Date(),
 			};
+
+			await validateLiveLinkOwnership(ctx.db, input, userId);
 
 			if (input.memo !== undefined) {
 				updateData.memo = input.memo;

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -28,6 +28,7 @@ import {
 	resolveTournamentRuleSnapshot,
 	snapshotTournamentStructure,
 	validateEntityOwnership,
+	validateLiveLinkOwnership,
 } from "./session";
 
 const DEFAULT_LIMIT = 20;
@@ -667,6 +668,7 @@ export const liveTournamentSessionRouter = router({
 
 			await assertNoActiveSession(ctx.db, userId);
 
+			await validateLiveLinkOwnership(ctx.db, input, userId);
 			// Validate tournament ownership before reading its structure so a
 			// caller cannot snapshot another user's blind levels / chip purchases
 			// via snapshotTournamentStructure (IDOR).
@@ -759,6 +761,8 @@ export const liveTournamentSessionRouter = router({
 				.select()
 				.from(sessionTournamentDetail)
 				.where(eq(sessionTournamentDetail.sessionId, input.id));
+
+			await validateLiveLinkOwnership(ctx.db, input, userId);
 
 			const baseUpdateData = buildLiveSessionUpdateData(input);
 			const { detailUpdate, patchedUpdateData } = await resolveDetailUpdate(

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -918,6 +918,26 @@ async function validateCreateLinks(
 	}
 }
 
+/**
+ * Ownership guard for the room / currency links shared by the live cash-game
+ * and live-tournament routers. A falsy value (undefined = omitted, null =
+ * clear, "" = empty) skips validation; a provided id must exist AND belong to
+ * the caller, else validateEntityOwnership throws NOT_FOUND / FORBIDDEN.
+ * Prevents IDOR on the money-ledger links (SA2-102).
+ */
+export async function validateLiveLinkOwnership(
+	db: DbInstance,
+	input: { currencyId?: string | null; roomId?: string | null },
+	userId: string
+) {
+	if (input.roomId) {
+		await validateEntityOwnership(db, "room", input.roomId, userId);
+	}
+	if (input.currencyId) {
+		await validateEntityOwnership(db, "currency", input.currencyId, userId);
+	}
+}
+
 // ---------------------------------------------------------------------------
 // create helpers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要 (SA2-102)

Closes #420

ライブキャッシュゲーム / ライブトーナメントの create・update API が、`currencyId` と `roomId` を **所有権チェックなしに** 永続化していた。通常の `session.ts` では `validateEntityOwnership`（currency / room が存在し、かつ `userId === callerId` であることを検証。それ以外は FORBIDDEN / NOT_FOUND）で検証しているが、ライブ系ルーターはこれをスキップしていた。

その結果、認証済みの攻撃者が **他ユーザーが所有する currency / room を参照** でき、money-ledger への書き込みに対する IDOR（Insecure Direct Object Reference）が成立していた。緊急度: Urgent。

## 修正内容

- `packages/api/src/routers/session.ts` に共有ヘルパー `validateLiveLinkOwnership(db, input, userId)` を追加。既存の `validateEntityOwnership` を再利用し、`roomId` / `currencyId` が指定されている場合のみ room / currency の所有権を検証する（falsy = 省略 / null クリア / 空文字はスキップ）。
- `live-cash-game-session.ts` の create（insert 前）と update（`updateData` 書き込み前）で呼び出し。
- `live-tournament-session.ts` の create（insert 前）と update（`buildLiveSessionUpdateData` 前）で呼び出し。

エラーセマンティクスは通常の `session.ts` と一致:
- 存在しない ID → `NOT_FOUND`
- 他ユーザー所有 → `FORBIDDEN`
- `null`（フィールドのクリア）→ 検証をスキップ
- フィールド省略 → 検証しない

## テスト

TDD で実装（先にテストを追加し RED を確認 → 実装で GREEN）。`createCaller` + ドライバ形状のモック db を用い、両ルーターの create / update について以下を網羅:

- 呼び出し元が所有する room / currency を受理（throw しない）
- 他ユーザー所有の room → `FORBIDDEN`
- 他ユーザー所有の currency → `FORBIDDEN`
- 存在しない room / currency → `NOT_FOUND`
- update で `roomId: null` / `currencyId: null` は所有権エラーなくクリア
- フィールド省略時は所有権検証をトリガーしない

### 検証結果

- `bunx vitest run --project api packages/api/src/__tests__/live-cash-game-session.test.ts packages/api/src/__tests__/live-tournament-session.test.ts` → `Test Files 2 passed (2) / Tests 108 passed (108)`
- api プロジェクト全体 → `Test Files 24 passed (24) / Tests 775 passed (775)`
- `ultracite check`（変更ファイル）→ クリーン
- `bun run check-types` → server / web ともに exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ)_