### PR TITLE
fix(api): ライブトーナメントのブラインド更新INSERTをチャンク化してデータ消失を防止 (SA2-115)

### DIFF
--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -1,11 +1,59 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { appRouter } from "../routers";
+import { persistSessionBlindLevels } from "../routers/session";
 import {
 	expectAccepts,
 	expectProtected,
 	expectRejects,
 	expectType,
 } from "./test-utils";
+
+const BLIND_LEVEL_COLUMNS = 9;
+const MAX_ROWS_PER_INSERT = Math.floor(100 / BLIND_LEVEL_COLUMNS); // 11
+
+interface BlindLevelInput {
+	ante?: number | null;
+	blind1?: number | null;
+	blind2?: number | null;
+	blind3?: number | null;
+	isBreak: boolean;
+	minutes?: number | null;
+}
+
+interface InsertedRow {
+	level: number;
+	sessionId: string;
+}
+
+function makeBlindLevels(count: number): BlindLevelInput[] {
+	return Array.from({ length: count }, (_, i) => ({
+		isBreak: false,
+		blind1: (i + 1) * 100,
+		blind2: (i + 1) * 200,
+		blind3: null,
+		ante: null,
+		minutes: 15,
+	}));
+}
+
+function createBlindLevelMockDb() {
+	const deleteWhere = vi.fn().mockResolvedValue(undefined);
+	const del = vi.fn(() => ({ where: deleteWhere }));
+	const values = vi.fn().mockResolvedValue(undefined);
+	const insert = vi.fn(() => ({ values }));
+	return {
+		db: { delete: del, insert } as never,
+		del,
+		deleteWhere,
+		insert,
+		values,
+	};
+}
+
+/** The row array passed to each `.values()` call, in call order. */
+function insertedChunks(values: ReturnType<typeof vi.fn>): InsertedRow[][] {
+	return values.mock.calls.map((call) => call[0] as InsertedRow[]);
+}
 
 describe("liveTournamentSession router", () => {
 	it("appRouter has liveTournamentSession namespace", () => {
@@ -315,5 +363,89 @@ describe("liveTournamentSession.updateSnapshot input validation", () => {
 			id: "s1",
 			blindLevels: [{ blind1: 100 }],
 		});
+	});
+});
+
+// Regression guard for SA2-115: updateSnapshot re-seeds blind levels via the
+// shared persistSessionBlindLevels helper, which DELETEs then re-INSERTs. D1
+// rejects any statement binding >100 params, so a 9-column blind row must be
+// chunked at 11 rows/INSERT. A single unchunked INSERT of >=12 levels (>=108
+// params) would throw at runtime AFTER the DELETE already committed, wiping the
+// session's blind structure permanently.
+describe("persistSessionBlindLevels chunking (SA2-115)", () => {
+	it("splits >11 blind levels into multiple INSERTs each within D1's 100-param cap", async () => {
+		const { db, del, deleteWhere, insert, values } = createBlindLevelMockDb();
+
+		await persistSessionBlindLevels(db, "sess-1", makeBlindLevels(12));
+
+		// DELETE runs exactly once before any INSERT.
+		expect(del).toHaveBeenCalledTimes(1);
+		expect(deleteWhere).toHaveBeenCalledTimes(1);
+		// 12 rows -> 11 + 1 => two INSERT statements.
+		expect(insert).toHaveBeenCalledTimes(2);
+		expect(values).toHaveBeenCalledTimes(2);
+		const [firstChunk, secondChunk] = insertedChunks(values);
+		expect(firstChunk).toHaveLength(MAX_ROWS_PER_INSERT);
+		expect(secondChunk).toHaveLength(12 - MAX_ROWS_PER_INSERT);
+		// Every INSERT stays under the 100 bound-parameter cap.
+		for (const chunk of insertedChunks(values)) {
+			expect(chunk.length * BLIND_LEVEL_COLUMNS).toBeLessThanOrEqual(100);
+		}
+	});
+
+	it("inserts every level exactly once, in ascending level order across chunks", async () => {
+		const { db, values } = createBlindLevelMockDb();
+
+		await persistSessionBlindLevels(db, "sess-1", makeBlindLevels(23));
+
+		const allRows = insertedChunks(values).flat();
+		expect(allRows).toHaveLength(23);
+		expect(allRows.map((r) => r.level)).toEqual(
+			Array.from({ length: 23 }, (_, i) => i + 1)
+		);
+		for (const row of allRows) {
+			expect(row.sessionId).toBe("sess-1");
+		}
+	});
+
+	it("keeps a single INSERT for exactly 11 levels (chunk boundary)", async () => {
+		const { db, insert, values } = createBlindLevelMockDb();
+
+		await persistSessionBlindLevels(db, "sess-1", makeBlindLevels(11));
+
+		expect(insert).toHaveBeenCalledTimes(1);
+		expect(values).toHaveBeenCalledTimes(1);
+		expect(insertedChunks(values).flat()).toHaveLength(11);
+	});
+
+	it("splits into two INSERTs for 12 levels (one over the boundary)", async () => {
+		const { db, insert, values } = createBlindLevelMockDb();
+
+		await persistSessionBlindLevels(db, "sess-1", makeBlindLevels(12));
+
+		expect(insert).toHaveBeenCalledTimes(2);
+		expect(values).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps a single INSERT for the small-N case (behavior unchanged)", async () => {
+		const { db, del, insert, values } = createBlindLevelMockDb();
+
+		await persistSessionBlindLevels(db, "sess-1", makeBlindLevels(5));
+
+		expect(del).toHaveBeenCalledTimes(1);
+		expect(insert).toHaveBeenCalledTimes(1);
+		expect(values).toHaveBeenCalledTimes(1);
+		expect(insertedChunks(values).flat()).toHaveLength(5);
+	});
+
+	it("DELETEs only and issues no INSERT for an empty blind-level list", async () => {
+		const { db, del, deleteWhere, insert, values } = createBlindLevelMockDb();
+
+		await persistSessionBlindLevels(db, "sess-1", []);
+
+		expect(del).toHaveBeenCalledTimes(1);
+		expect(deleteWhere).toHaveBeenCalledTimes(1);
+		expect(insert).not.toHaveBeenCalled();
+		expect(values).not.toHaveBeenCalled();
 	});
 });

--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -383,6 +383,9 @@ describe("persistSessionBlindLevels chunking (SA2-115)", () => {
 		expect(deleteWhere).toHaveBeenCalledTimes(1);
 		// 12 rows -> 11 + 1 => two INSERT statements.
 		expect(insert).toHaveBeenCalledTimes(2);
+		expect(del.mock.invocationCallOrder[0]).toBeLessThan(
+			insert.mock.invocationCallOrder[0]
+		);
 		expect(values).toHaveBeenCalledTimes(2);
 		const [firstChunk, secondChunk] = insertedChunks(values);
 		expect(firstChunk).toHaveLength(MAX_ROWS_PER_INSERT);

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -21,6 +21,7 @@ import {
 } from "../services/live-session-pl";
 import { floorToMinute } from "../utils/session-event-time";
 import {
+	persistSessionBlindLevels,
 	persistSessionChipPurchases,
 	resnapshotTournamentStructure,
 	resolveTournamentRuleSnapshot,
@@ -871,24 +872,12 @@ export const liveTournamentSessionRouter = router({
 			}
 
 			if (input.blindLevels !== undefined) {
-				await ctx.db
-					.delete(sessionBlindLevel)
-					.where(eq(sessionBlindLevel.sessionId, input.id));
-				if (input.blindLevels.length > 0) {
-					await ctx.db.insert(sessionBlindLevel).values(
-						input.blindLevels.map((l, idx) => ({
-							id: crypto.randomUUID(),
-							sessionId: input.id,
-							level: idx + 1,
-							isBreak: l.isBreak,
-							blind1: l.blind1 ?? null,
-							blind2: l.blind2 ?? null,
-							blind3: l.blind3 ?? null,
-							ante: l.ante ?? null,
-							minutes: l.minutes ?? null,
-						}))
-					);
-				}
+				// Reuse the shared helper so the DELETE + re-INSERT is chunked
+				// under D1's 100 bound-parameter cap (9 columns/row => 11 rows
+				// max per INSERT). A single unchunked INSERT of >=12 levels
+				// overflows and throws AFTER the DELETE commits, permanently
+				// wiping the session's blind structure (SA2-115).
+				await persistSessionBlindLevels(ctx.db, input.id, input.blindLevels);
 			}
 
 			if (input.chipPurchases !== undefined) {

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -286,7 +286,7 @@ async function persistSessionChipPurchases(
  * (explicit override of the master snapshot) and update (session-wizard edits
  * to a session's own blind structure) so the array is always written fresh.
  */
-async function persistSessionBlindLevels(
+export async function persistSessionBlindLevels(
 	db: DbInstance,
 	sessionId: string,
 	blindLevels: {


### PR DESCRIPTION
## 概要

SA2-115 / Closes #432

`liveTournamentSession.updateSnapshot`(`packages/api/src/routers/live-tournament-session.ts`)で、ブラインドレベル更新時に既存レコードを DELETE した後、新レベル一覧を **1回の** `.insert().values()` でまとめて INSERT していた。これを既存の共通ヘルパーによるチャンク分割へ置き換え、データ消失バグを修正する。

## 根本原因(D1 のバインドパラメータ上限)

Cloudflare D1 は **1ステートメントあたりバインドパラメータ数の上限が100**。`session_blind_level` は1行あたり9カラムを bind するため、`9 × 12 = 108 > 100` となり **12レベル以上**の構造体を保存しようとすると INSERT が実行時に失敗する。

さらに直前の DELETE(旧873-876行)は独立したステートメントとして既にコミット済みのため、INSERT が失敗した時点で新旧どちらのブラインドレベルも失われ、セッションのブラインド構造が **ゼロ件のまま復旧不能** になる。一般的なトーナメントは15〜30レベルあり通常利用で発生しうる、Urgent なデータ消失バグ。

## 修正内容

- `packages/api/src/routers/session.ts` の `persistSessionBlindLevels`(DELETE + `chunkForInsert(rows, 9)` によるチャンク化済み)を **export** し、`updateSnapshot` から再利用。既に同ファイルの `persistSessionChipPurchases` を再利用している流儀にそのまま揃えた(並行実装を新設しない)。
- インライン実装(DELETE + 未チャンク INSERT)を削除し、`await persistSessionBlindLevels(ctx.db, input.id, input.blindLevels)` の1行に集約。小さい N の挙動は不変。

### チャンクサイズの導出

マジックナンバーではなく既存 `chunkForInsert` が計算する:

```ts
const perChunk = Math.max(1, Math.floor(D1_MAX_BOUND_PARAMS / columnsPerRow)); // = floor(100 / 9) = 11
```

9カラム/行 → **最大11行/INSERT**(11×9=99 ≤ 100)。

## テスト(TDD)

`packages/api/src/__tests__/live-tournament-session.test.ts` に、mock db で `persistSessionBlindLevels` を駆動する回帰テスト群を追加(RED→GREEN 確認済み)。`toHaveBeenCalledTimes` + 引数アサーションで検証:

- 12レベル → INSERT が **2回**(11 + 1)、各チャンク ≤ 100 params、DELETE は INSERT より前に1回
- 23レベル → 全レベルが `level` 昇順で **ちょうど1回ずつ** 挿入され、`sessionId` が正しい
- 11レベル(チャンク境界)→ INSERT **1回**
- 12レベル(境界+1)→ INSERT **2回**
- 5レベル(小 N)→ INSERT **1回**、挙動不変
- 0レベル → **DELETE のみ**、INSERT なし

スコープ実行: `bunx vitest run --project api packages/api/src/__tests__/live-tournament-session.test.ts` → 45 passed。

## 部分失敗 / トランザクションについて

D1 の Workers バインディングでも DELETE と INSERT を1つのアトミックなトランザクションでは括っていない(Drizzle の `db.transaction` は D1 環境では利用していない現状に合わせた)。本修正はチャンク化により **INSERT 自体が失敗しなくなる**ことでデータ消失を解消するが、複数チャンクの途中失敗に対する原子性は導入していない。スコープを最小に保つ判断で、トランザクション化は本 PR の対象外(必要なら別 issue で対応)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ)_