### PR TITLE
fix(web): PWAのstart_urlを削除済み/dashboardから/へ修正 (SA2-163)

### DIFF
--- a/apps/web/src/shared/lib/__tests__/pwa-manifest.test.ts
+++ b/apps/web/src/shared/lib/__tests__/pwa-manifest.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { pwaManifest } from "../pwa-manifest";
+
+/**
+ * Regression guard for SA2-163: the PWA manifest `start_url` must resolve to a
+ * route that actually exists in the generated route tree. The bug was
+ * `start_url: "/dashboard"`, a route removed in PR #341/#363 — launching the
+ * installed PWA landed on TanStack Router's not-found shell.
+ *
+ * Instead of hard-coding the expected path we derive the set of real routes
+ * from `src/routeTree.gen.ts` (the generated source of truth) so this test
+ * keeps working as routes come and go, and fails the moment `start_url` points
+ * anywhere the router can't serve.
+ */
+function readGeneratedRoutePaths(): Set<string> {
+	const routeTreePath = path.resolve(
+		import.meta.dirname,
+		"../../../routeTree.gen.ts"
+	);
+	const source = readFileSync(routeTreePath, "utf8");
+	const paths = new Set<string>();
+	const pathLiteral = /(?:full)?[Pp]ath:\s*'([^']+)'/g;
+	let match = pathLiteral.exec(source);
+	while (match !== null) {
+		paths.add(match[1]);
+		match = pathLiteral.exec(source);
+	}
+	return paths;
+}
+
+describe("pwaManifest", () => {
+	const routePaths = readGeneratedRoutePaths();
+
+	it("derives a non-empty route-path set from the generated route tree", () => {
+		// Sanity: the regex must actually find routes, otherwise the guard below
+		// would pass vacuously.
+		expect(routePaths.size).toBeGreaterThan(0);
+		expect(routePaths.has("/")).toBe(true);
+	});
+
+	it("points start_url at a route that exists in the generated route tree", () => {
+		expect(routePaths.has(pwaManifest.start_url as string)).toBe(true);
+	});
+
+	it("uses '/' — the only always-reachable entry point after the dashboard removal", () => {
+		expect(pwaManifest.start_url).toBe("/");
+	});
+
+	it("does not point start_url at the removed /dashboard route", () => {
+		// Documents the SA2-163 root cause: /dashboard is no longer in the tree,
+		// so it must never be the launch target again.
+		expect(routePaths.has("/dashboard")).toBe(false);
+		expect(pwaManifest.start_url).not.toBe("/dashboard");
+	});
+});

--- a/apps/web/src/shared/lib/pwa-manifest.ts
+++ b/apps/web/src/shared/lib/pwa-manifest.ts
@@ -1,0 +1,21 @@
+import type { ManifestOptions } from "vite-plugin-pwa";
+
+/**
+ * PWA manifest, extracted into its own module so it can be unit-tested
+ * independently of `vite.config.ts` (importing the config would pull in the
+ * whole Vite plugin graph).
+ *
+ * `start_url` MUST reference a route that actually exists in the generated
+ * route tree (`src/routeTree.gen.ts`). The previous value `"/dashboard"`
+ * pointed at a route removed in PR #341 (and cleanup #363), so a PWA launched
+ * from the home screen landed on TanStack Router's not-found shell (blank/404).
+ * `"/"` is the only always-reachable entry point: the index route dispatches
+ * signed-in users to `/statistics` and everyone else to `/login`.
+ */
+export const pwaManifest: Partial<ManifestOptions> = {
+	name: "sapphire2",
+	short_name: "sapphire2",
+	description: "sapphire2 - PWA Application",
+	theme_color: "#0c0c0c",
+	start_url: "/",
+};

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,6 +5,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { githubReleasesPlugin } from "./src/plugins/vite-plugin-github-releases";
+import { pwaManifest } from "./src/shared/lib/pwa-manifest";
 
 export default defineConfig({
 	plugins: [
@@ -14,13 +15,7 @@ export default defineConfig({
 		react(),
 		VitePWA({
 			registerType: "autoUpdate",
-			manifest: {
-				name: "sapphire2",
-				short_name: "sapphire2",
-				description: "sapphire2 - PWA Application",
-				theme_color: "#0c0c0c",
-				start_url: "/dashboard",
-			},
+			manifest: pwaManifest,
 			pwaAssets: { disabled: false, config: true },
 			devOptions: { enabled: true },
 		}),

--- a/apps/web/vitest.dom.config.ts
+++ b/apps/web/vitest.dom.config.ts
@@ -28,7 +28,6 @@ export default defineConfig({
 			"src/features/**/components/**/__tests__/*.test.ts",
 			"src/features/**/pages/**/__tests__/*.test.ts",
 			"src/features/**/hooks/__tests__/*.test.ts",
-			"src/features/dashboard/widgets/**/__tests__/*.test.ts",
 			"src/features/sessions/utils/__tests__/share-session.test.ts",
 			"src/routes/**/__tests__/*.test.ts",
 		],


### PR DESCRIPTION
## 概要

SA2-163 / Closes #480

PWAマニフェストの `start_url` が削除済みの `/dashboard` を指していた問題を修正する。

## なぜ `/dashboard` が壊れているか

`dashboard` 機能とそのルートは PR #341（および後続クリーンアップ #363）で削除済み。`apps/web/src/routes` 配下に dashboard ルートは存在せず、`routeTree.gen.ts` にも一切参照がない。そのため、ホーム画面からインストール済みPWAを起動すると SPA は `/dashboard` で開始され、TanStack Router の not-found 状態（空白/404相当）に着地してしまう。

## 選んだルートと根拠

`start_url` を `"/"` に変更する。

`apps/web/src/routes/index.tsx` の index ルートは、サインイン済みユーザーを `/statistics` へ、未サインインユーザーを `/login` へリダイレクトする。オフライン時は `getSession` ガードも失敗するため、常に成立するエントリポイントは `/` のみ。よって `/` が唯一正しい認証後ランディングルートであり、既存のリダイレクトにより適切なタブへ振り分けられる。

## 変更点

- `apps/web/vite.config.ts` — インラインのマニフェストを切り出したモジュール参照に変更。
- `apps/web/src/shared/lib/pwa-manifest.ts`（新規）— PWAマニフェストを独立モジュール化。`vite.config.ts` を import するとViteプラグイングラフ全体を巻き込むため、単体テスト可能にする目的で切り出し。`start_url: "/"`。
- `apps/web/src/shared/lib/__tests__/pwa-manifest.test.ts`（新規）— リグレッションガードテスト。

## ガードテスト

生成済みの `src/routeTree.gen.ts` から実ルートのパス集合を実行時に導出し、`start_url` がその集合に含まれることを検証する（`web-node` プロジェクト、Node環境で `fs` 読み取り）。パスをハードコードせず生成物を真実の源とするため、ルートの増減に追従する。

- `/dashboard` では RED（ルート集合に存在しない）、`/` では GREEN になることを確認済み。
- スコープテスト結果: `Test Files 1 passed (1) / Tests 4 passed (4)`。

`bun x ultracite check` / `tsc --noEmit`（web）ともにクリーン。


---
_Generated by [Claude Code](https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ)_