### PR TITLE
fix(sessions): セッション日付をUTC暦日として一貫処理し一日ずれを解消 (SA2-145)

### DIFF
--- a/apps/web/src/__tests__/tz.ts
+++ b/apps/web/src/__tests__/tz.ts
@@ -1,0 +1,32 @@
+// Deterministic time-zone control for date-formatting tests. Node/Bun re-reads
+// `process.env.TZ` on every Date operation, so wrapping an assertion in `withTz`
+// exercises a specific zone regardless of the host machine's local time.
+//
+// The pristine host zone is captured once at module load and restored in a
+// `finally`, so a test can never leak a zone into sibling files that share the
+// same project under vitest's `isolate: false` (both `web-node` and `web-dom`
+// run this way). When the host had no `TZ` set, the restore must `delete` the
+// var — assigning `undefined` coerces to the string `"undefined"`, which Node
+// treats as an invalid zone and silently falls back to UTC (SA2-145).
+const ORIGINAL_TZ = process.env.TZ;
+
+/** Common zones used by the date tests: west of / east of / at UTC. */
+export const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the off-by-one bug
+export const TZ_EAST = "Asia/Tokyo"; // UTC+9
+
+export function withTz<T>(tz: string, fn: () => T): T {
+	process.env.TZ = tz;
+	try {
+		return fn();
+	} finally {
+		if (ORIGINAL_TZ === undefined) {
+			// Truly unset it: `process.env.TZ = undefined` coerces to the string
+			// "undefined" (an invalid zone Node silently reads as UTC), which would
+			// leak instead of restoring the pristine "no TZ" state. Reflect avoids
+			// the `delete` operator that lint/performance/noDelete forbids.
+			Reflect.deleteProperty(process.env, "TZ");
+		} else {
+			process.env.TZ = ORIGINAL_TZ;
+		}
+	}
+}

--- a/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
+++ b/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
@@ -102,6 +102,27 @@ const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const TIME_HH_MM_PATTERN = /^\d{2}:\d{2}$/;
 const TEMP_ID_PATTERN = /^temp-/;
 
+// SA2-145: sessionDate must round-trip as a UTC calendar date regardless of
+// the machine's local time zone. Node/Bun re-reads `process.env.TZ` on every
+// Date operation, so we can drive a west-of-UTC and an east-of-UTC zone
+// deterministically. Always restore the original TZ so this file cannot leak
+// into sibling test files that share the worker.
+const ORIGINAL_TZ = process.env.TZ;
+const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the bug
+const TZ_EAST = "Asia/Tokyo"; // UTC+9 — the primary user base
+function withTz<T>(tz: string, fn: () => T): T {
+	process.env.TZ = tz;
+	try {
+		return fn();
+	} finally {
+		if (ORIGINAL_TZ === undefined) {
+			process.env.TZ = undefined;
+		} else {
+			process.env.TZ = ORIGINAL_TZ;
+		}
+	}
+}
+
 function createClient(): QueryClient {
 	return new QueryClient({
 		defaultOptions: {
@@ -219,7 +240,7 @@ function baseSessionItem(overrides: Partial<SessionItem> = {}): SessionItem {
 
 describe("pure helpers", () => {
 	describe("formatDateForInput", () => {
-		it("formats ISO strings to YYYY-MM-DD (local time zone safe for midday)", () => {
+		it("formats ISO strings to YYYY-MM-DD", () => {
 			expect(formatDateForInput("2026-04-23T12:00:00Z")).toMatch(
 				ISO_DATE_PATTERN
 			);
@@ -230,6 +251,87 @@ describe("pure helpers", () => {
 			const [, month, day] = result.split("-");
 			expect(month).toHaveLength(2);
 			expect(day).toHaveLength(2);
+		});
+
+		// SA2-145: the API returns sessionDate as a UTC-midnight ISO string.
+		// The edit form must echo back the SAME calendar day the user saved,
+		// otherwise opening + saving an edit shifts the stored date one day
+		// earlier for every user west of UTC.
+		it("keeps the UTC calendar day at the exact UTC-midnight boundary west of UTC", () => {
+			expect(
+				withTz(TZ_WEST, () => formatDateForInput("2026-07-04T00:00:00Z"))
+			).toBe("2026-07-04");
+		});
+
+		it("keeps the UTC calendar day at the exact UTC-midnight boundary east of UTC", () => {
+			expect(
+				withTz(TZ_EAST, () => formatDateForInput("2026-07-04T00:00:00Z"))
+			).toBe("2026-07-04");
+		});
+
+		it("produces the same calendar day in west-of-UTC, east-of-UTC, and UTC zones", () => {
+			const iso = "2026-01-01T00:00:00Z";
+			const west = withTz(TZ_WEST, () => formatDateForInput(iso));
+			const east = withTz(TZ_EAST, () => formatDateForInput(iso));
+			const utc = withTz("UTC", () => formatDateForInput(iso));
+			expect(west).toBe("2026-01-01");
+			expect(east).toBe("2026-01-01");
+			expect(utc).toBe("2026-01-01");
+		});
+
+		it("does not roll back across a year boundary west of UTC", () => {
+			expect(
+				withTz(TZ_WEST, () => formatDateForInput("2026-01-01T00:00:00Z"))
+			).toBe("2026-01-01");
+		});
+	});
+
+	// SA2-145: round-trip stability. Rendering a saved session into the edit
+	// form and saving it unchanged must reproduce the original UTC-midnight
+	// epoch. Before the fix, a west-of-UTC formatter shifted the day back one,
+	// so each edit-save drifted the stored date earlier (cumulative).
+	describe("sessionDate round-trip stability (UTC calendar date)", () => {
+		it("buildCreatePayload stores UTC-midnight epoch seconds regardless of local zone", () => {
+			const expected = Math.floor(Date.UTC(2026, 3, 1) / 1000);
+			const west = withTz(
+				TZ_WEST,
+				() =>
+					buildCreatePayload(cashValues({ sessionDate: "2026-04-01" }))
+						.sessionDate
+			);
+			const east = withTz(
+				TZ_EAST,
+				() =>
+					buildCreatePayload(cashValues({ sessionDate: "2026-04-01" }))
+						.sessionDate
+			);
+			expect(west).toBe(expected);
+			expect(east).toBe(expected);
+		});
+
+		it("format → save reproduces the original epoch and is stable on re-save (west of UTC)", () => {
+			withTz(TZ_WEST, () => {
+				const apiIso = "2026-07-04T00:00:00Z";
+				const originalEpoch = Math.floor(Date.UTC(2026, 6, 4) / 1000);
+
+				// First edit cycle: hydrate the form from the API row, save unchanged.
+				const formValue = formatDateForInput(apiIso);
+				expect(formValue).toBe("2026-07-04");
+				const firstSave = buildUpdatePayload({
+					...cashValues({ sessionDate: formValue }),
+					id: "s1",
+				}).sessionDate;
+				expect(firstSave).toBe(originalEpoch);
+
+				// Second edit cycle: re-render the just-saved epoch and save again.
+				const roundTripIso = new Date(firstSave * 1000).toISOString();
+				const secondForm = formatDateForInput(roundTripIso);
+				const secondSave = buildUpdatePayload({
+					...cashValues({ sessionDate: secondForm }),
+					id: "s1",
+				}).sessionDate;
+				expect(secondSave).toBe(originalEpoch);
+			});
 		});
 	});
 

--- a/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
+++ b/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TZ_EAST, TZ_WEST, withTz } from "@/__tests__/tz";
 import type {
 	SessionFormValues,
 	SessionItem,
@@ -102,26 +103,9 @@ const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const TIME_HH_MM_PATTERN = /^\d{2}:\d{2}$/;
 const TEMP_ID_PATTERN = /^temp-/;
 
-// SA2-145: sessionDate must round-trip as a UTC calendar date regardless of
-// the machine's local time zone. Node/Bun re-reads `process.env.TZ` on every
-// Date operation, so we can drive a west-of-UTC and an east-of-UTC zone
-// deterministically. Always restore the original TZ so this file cannot leak
-// into sibling test files that share the worker.
-const ORIGINAL_TZ = process.env.TZ;
-const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the bug
-const TZ_EAST = "Asia/Tokyo"; // UTC+9 — the primary user base
-function withTz<T>(tz: string, fn: () => T): T {
-	process.env.TZ = tz;
-	try {
-		return fn();
-	} finally {
-		if (ORIGINAL_TZ === undefined) {
-			process.env.TZ = undefined;
-		} else {
-			process.env.TZ = ORIGINAL_TZ;
-		}
-	}
-}
+// SA2-145: sessionDate must round-trip as a UTC calendar date regardless of the
+// machine's local time zone. `withTz` (shared helper) drives a west-of-UTC and
+// an east-of-UTC zone deterministically and restores the host zone afterwards.
 
 function createClient(): QueryClient {
 	return new QueryClient({

--- a/apps/web/src/features/sessions/hooks/use-sessions.ts
+++ b/apps/web/src/features/sessions/hooks/use-sessions.ts
@@ -393,11 +393,16 @@ export function filtersToListInput(filters: SessionFilterValues) {
 	};
 }
 
+// sessionDate is stored/returned as UTC midnight and the create/update payloads
+// re-encode a date-only string as UTC midnight, so the edit form must read back
+// the UTC calendar day. Local getters shift the day back one for users west of
+// UTC, and saving that value drifts the stored date one day earlier on every
+// edit (SA2-145).
 export function formatDateForInput(date: string): string {
 	const d = new Date(date);
-	const year = d.getFullYear();
-	const month = String(d.getMonth() + 1).padStart(2, "0");
-	const day = String(d.getDate()).padStart(2, "0");
+	const year = d.getUTCFullYear();
+	const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+	const day = String(d.getUTCDate()).padStart(2, "0");
 	return `${year}-${month}-${day}`;
 }
 

--- a/apps/web/src/features/sessions/utils/__tests__/share-session.test.ts
+++ b/apps/web/src/features/sessions/utils/__tests__/share-session.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TZ_EAST, TZ_WEST, withTz } from "@/__tests__/tz";
 import {
 	createSessionShareText,
 	type ShareableSession,
@@ -10,23 +11,8 @@ const ANY_DURATION = /\d+\.\dh/;
 const COMPACT_500 = /📈 \+500 \n/;
 
 // SA2-145: the shared text's 📅 line must show the UTC calendar day the user
-// saved (sessionDate is a UTC-midnight ISO string). Node/Bun re-reads
-// process.env.TZ on each Date op; restore the original zone after each case.
-const ORIGINAL_TZ = process.env.TZ;
-const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the bug
-const TZ_EAST = "Asia/Tokyo"; // UTC+9
-function withTz<T>(tz: string, fn: () => T): T {
-	process.env.TZ = tz;
-	try {
-		return fn();
-	} finally {
-		if (ORIGINAL_TZ === undefined) {
-			process.env.TZ = undefined;
-		} else {
-			process.env.TZ = ORIGINAL_TZ;
-		}
-	}
-}
+// saved (sessionDate is a UTC-midnight ISO string). `withTz` (shared helper)
+// drives a deterministic zone per case and restores the host zone afterwards.
 
 function cashSession(
 	overrides: Partial<ShareableSession> = {}

--- a/apps/web/src/features/sessions/utils/__tests__/share-session.test.ts
+++ b/apps/web/src/features/sessions/utils/__tests__/share-session.test.ts
@@ -9,6 +9,25 @@ const DURATION_3_5H = /\/ 3\.5h/;
 const ANY_DURATION = /\d+\.\dh/;
 const COMPACT_500 = /📈 \+500 \n/;
 
+// SA2-145: the shared text's 📅 line must show the UTC calendar day the user
+// saved (sessionDate is a UTC-midnight ISO string). Node/Bun re-reads
+// process.env.TZ on each Date op; restore the original zone after each case.
+const ORIGINAL_TZ = process.env.TZ;
+const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the bug
+const TZ_EAST = "Asia/Tokyo"; // UTC+9
+function withTz<T>(tz: string, fn: () => T): T {
+	process.env.TZ = tz;
+	try {
+		return fn();
+	} finally {
+		if (ORIGINAL_TZ === undefined) {
+			process.env.TZ = undefined;
+		} else {
+			process.env.TZ = ORIGINAL_TZ;
+		}
+	}
+}
+
 function cashSession(
 	overrides: Partial<ShareableSession> = {}
 ): ShareableSession {
@@ -60,6 +79,25 @@ describe("createSessionShareText", () => {
 			expect(text).toContain("📍 Downtown");
 			expect(text).toContain("💲 NL2k/5k");
 			expect(text).toContain("📈 +5.0K JPY");
+		});
+
+		// SA2-145: the 📅 date must not roll back a day west of UTC.
+		it("renders the UTC calendar day west of UTC (no off-by-one)", () => {
+			const text = withTz(TZ_WEST, () =>
+				createSessionShareText(
+					cashSession({ sessionDate: "2026-04-22T00:00:00Z" })
+				)
+			);
+			expect(text).toContain("📅 2026/4/22");
+		});
+
+		it("renders the same UTC calendar day east of UTC", () => {
+			const text = withTz(TZ_EAST, () =>
+				createSessionShareText(
+					cashSession({ sessionDate: "2026-04-22T00:00:00Z" })
+				)
+			);
+			expect(text).toContain("📅 2026/4/22");
 		});
 
 		it("omits room line when roomName is null", () => {

--- a/apps/web/src/features/sessions/utils/share-session.ts
+++ b/apps/web/src/features/sessions/utils/share-session.ts
@@ -88,7 +88,11 @@ export function createSessionShareText(session: ShareableSession): string {
 	const plIcon = profitLoss >= 0 ? "📈" : "📉";
 	const plSign = profitLoss >= 0 ? "+" : "";
 	const currencyUnit = session.currencyUnit ?? "";
-	const date = new Date(session.sessionDate).toLocaleDateString("ja-JP");
+	// sessionDate is UTC midnight; force UTC so the shared date is the calendar
+	// day the user saved rather than its local rendering (SA2-145).
+	const date = new Date(session.sessionDate).toLocaleDateString("ja-JP", {
+		timeZone: "UTC",
+	});
 	const gameIcon = isTournament ? "🏆" : "💲";
 
 	let text = "📊 Poker Session Result\n";

--- a/apps/web/src/utils/__tests__/format-number.test.ts
+++ b/apps/web/src/utils/__tests__/format-number.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { TZ_EAST, TZ_WEST, withTz } from "@/__tests__/tz";
 import {
 	createGroupFormatter,
 	formatCompactNumber,
@@ -8,24 +9,8 @@ import {
 const B_SUFFIX = /B$/;
 
 // SA2-145: sessionDate is a UTC-midnight ISO string, so formatYmdSlash must
-// read UTC calendar fields. Node/Bun re-reads process.env.TZ on every Date
-// operation; restore the original TZ so this file (web-node, isolate:false)
-// cannot leak a zone into sibling pure-util test files.
-const ORIGINAL_TZ = process.env.TZ;
-const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the bug
-const TZ_EAST = "Asia/Tokyo"; // UTC+9
-function withTz<T>(tz: string, fn: () => T): T {
-	process.env.TZ = tz;
-	try {
-		return fn();
-	} finally {
-		if (ORIGINAL_TZ === undefined) {
-			process.env.TZ = undefined;
-		} else {
-			process.env.TZ = ORIGINAL_TZ;
-		}
-	}
-}
+// read UTC calendar fields. `withTz` (shared helper) drives a deterministic
+// zone per assertion and restores the host zone afterwards.
 
 describe("formatCompactNumber", () => {
 	describe("below the 10k threshold", () => {

--- a/apps/web/src/utils/__tests__/format-number.test.ts
+++ b/apps/web/src/utils/__tests__/format-number.test.ts
@@ -6,7 +6,26 @@ import {
 } from "@/utils/format-number";
 
 const B_SUFFIX = /B$/;
-const YMD_SHAPE = /^2026\/06\/1[45]$/;
+
+// SA2-145: sessionDate is a UTC-midnight ISO string, so formatYmdSlash must
+// read UTC calendar fields. Node/Bun re-reads process.env.TZ on every Date
+// operation; restore the original TZ so this file (web-node, isolate:false)
+// cannot leak a zone into sibling pure-util test files.
+const ORIGINAL_TZ = process.env.TZ;
+const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the bug
+const TZ_EAST = "Asia/Tokyo"; // UTC+9
+function withTz<T>(tz: string, fn: () => T): T {
+	process.env.TZ = tz;
+	try {
+		return fn();
+	} finally {
+		if (ORIGINAL_TZ === undefined) {
+			process.env.TZ = undefined;
+		} else {
+			process.env.TZ = ORIGINAL_TZ;
+		}
+	}
+}
 
 describe("formatCompactNumber", () => {
 	describe("below the 10k threshold", () => {
@@ -188,28 +207,45 @@ describe("createGroupFormatter", () => {
 });
 
 describe("formatYmdSlash", () => {
-	it("formats a Date as Y/MM/DD", () => {
-		expect(formatYmdSlash(new Date(2026, 3, 5))).toBe("2026/04/05");
+	it("formats a UTC Date as Y/MM/DD", () => {
+		expect(formatYmdSlash(new Date(Date.UTC(2026, 3, 5)))).toBe("2026/04/05");
 	});
 
 	it("zero-pads single-digit months and days", () => {
-		expect(formatYmdSlash(new Date(2026, 0, 1))).toBe("2026/01/01");
-		expect(formatYmdSlash(new Date(2026, 8, 9))).toBe("2026/09/09");
+		expect(formatYmdSlash(new Date(Date.UTC(2026, 0, 1)))).toBe("2026/01/01");
+		expect(formatYmdSlash(new Date(Date.UTC(2026, 8, 9)))).toBe("2026/09/09");
 	});
 
-	it("parses a YYYY-MM-DD string (local interpretation)", () => {
-		// JS Date parses 'YYYY-MM-DD' as UTC, but we output local date fields.
-		// Pin to a value that resolves the same in any timezone we run in:
-		const iso = "2026-06-15T09:00:00";
-		const result = formatYmdSlash(iso);
-		expect(result).toMatch(YMD_SHAPE);
+	it("parses a UTC-midnight ISO string to its UTC calendar day", () => {
+		expect(formatYmdSlash("2026-06-15T00:00:00Z")).toBe("2026/06/15");
 	});
 
 	it("formats December 31 without off-by-one", () => {
-		expect(formatYmdSlash(new Date(2026, 11, 31))).toBe("2026/12/31");
+		expect(formatYmdSlash(new Date(Date.UTC(2026, 11, 31)))).toBe("2026/12/31");
 	});
 
 	it("handles a pre-epoch date", () => {
-		expect(formatYmdSlash(new Date(1969, 6, 20))).toBe("1969/07/20");
+		expect(formatYmdSlash(new Date(Date.UTC(1969, 6, 20)))).toBe("1969/07/20");
+	});
+
+	// SA2-145: the session-list card and detail meta row must show the UTC
+	// calendar day the user saved, not the local rendering of UTC midnight.
+	it("keeps the UTC calendar day at the UTC-midnight boundary west of UTC", () => {
+		expect(withTz(TZ_WEST, () => formatYmdSlash("2026-04-22T00:00:00Z"))).toBe(
+			"2026/04/22"
+		);
+	});
+
+	it("keeps the UTC calendar day at the UTC-midnight boundary east of UTC", () => {
+		expect(withTz(TZ_EAST, () => formatYmdSlash("2026-04-22T00:00:00Z"))).toBe(
+			"2026/04/22"
+		);
+	});
+
+	it("renders the same day west-of-UTC, east-of-UTC, and in UTC", () => {
+		const iso = "2026-01-01T00:00:00Z";
+		expect(withTz(TZ_WEST, () => formatYmdSlash(iso))).toBe("2026/01/01");
+		expect(withTz(TZ_EAST, () => formatYmdSlash(iso))).toBe("2026/01/01");
+		expect(withTz("UTC", () => formatYmdSlash(iso))).toBe("2026/01/01");
 	});
 });

--- a/apps/web/src/utils/format-number.ts
+++ b/apps/web/src/utils/format-number.ts
@@ -57,10 +57,13 @@ export function createGroupFormatter(
 	return (value: number) => formatWithTier(value, tier);
 }
 
+// sessionDate is stored/returned as UTC midnight, so read UTC calendar fields
+// to render the day the user actually saved. Using local getters shifts the
+// day back one for users west of UTC (SA2-145).
 export function formatYmdSlash(input: string | Date): string {
 	const d = typeof input === "string" ? new Date(input) : input;
-	const y = d.getFullYear();
-	const m = String(d.getMonth() + 1).padStart(2, "0");
-	const day = String(d.getDate()).padStart(2, "0");
+	const y = d.getUTCFullYear();
+	const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+	const day = String(d.getUTCDate()).padStart(2, "0");
 	return `${y}/${m}/${day}`;
 }


### PR DESCRIPTION
## 概要

SA2-145 / Closes #462

`sessionDate` はUTC深夜0時のepoch秒として保存され、APIからもUTCのISO文字列としてそのまま返る一方、表示・編集用のフォーマッタがローカルタイムのDate getter（`getFullYear`/`getMonth`/`getDate`）を使用していた。このため **UTCより西のタイムゾーン** のユーザーで日付がずれていた。

## 原因（ドリフトの根本）

1. APIは `sessionDate` を `2026-07-04T00:00:00Z`（UTC深夜0時）として返す。
2. UTC-8 のユーザーでは、ローカルgetterがこれを **2026-07-03** と解釈する。
3. 一覧カード・詳細メタ行・共有テキストがすべて1日前で表示される。
4. さらに編集フォームの初期値も `formatDateForInput`（ローカルgetter）で生成されるため、編集画面を開くだけで 07-03 が入り、そのまま保存すると `07-03T00:00Z` として上書きされ、**編集のたびに1日ずつ前方向へ累積的にずれる**。

なお統計グラフ（`pnl-graph-chart.tsx`）はUTC getterを使っており、画面間で日付が食い違っていた。

## 修正

`sessionDate` をアプリ全体で「UTCの暦日」として一貫して扱うよう、ローカルgetterを排除した。

- `apps/web/src/features/sessions/hooks/use-sessions.ts` — `formatDateForInput` を `getUTCFullYear`/`getUTCMonth`/`getUTCDate` に変更。
- `apps/web/src/utils/format-number.ts` — `formatYmdSlash`（`session-list-card` / `session-display` から呼び出し）を同様にUTC getterへ変更。
- `apps/web/src/features/sessions/utils/share-session.ts` — `toLocaleDateString("ja-JP")` に `{ timeZone: "UTC" }` を付与。

保存経路（`buildCreatePayload` / `buildUpdatePayload`）は date-only 文字列を `new Date("YYYY-MM-DD")` で **UTC深夜0時** としてパースしており元々正しいため変更していない。表示側をUTCに揃えたことで、**表示 → 編集 → 保存の往復が安定**し、どのローカルTZでもoff-by-oneが起きなくなった。

## テスト（TZ決定的）

`process.env.TZ` を切り替えて West（`America/Los_Angeles`, UTC-8）・East（`Asia/Tokyo`, UTC+9）・UTC を再現し、各テスト後に元のTZへ復元（web-node は `isolate:false` のため他ファイルへのリークを防止）。`T00:00:00Z` の境界値を明示的に検証。

- `formatDateForInput` — UTC深夜0時境界でWest/East/UTCとも同一暦日を返すこと、年跨ぎでロールバックしないこと。
- **往復安定性** — API ISO → `formatDateForInput` → `buildUpdatePayload` が元の `Date.UTC(...)` epochを再現し、再保存でもドリフトしないこと（West）。`buildCreatePayload` がTZに依らずUTC深夜0時のepochを返すこと。
- `formatYmdSlash` — UTC境界でWest/East/UTCとも同一暦日。既存のローカル構築テストはUTC構築（`Date.UTC`）へ更新。
- `createSessionShareText` — 📅 行がWest/EastでUTC暦日（`2026/4/22`）を表示すること。

スコープ済みテスト結果: `web-node` 40 passed / `web-dom`（use-sessions + share-session）79 passed。`ultracite check` クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ)_