### PR TITLE
fix(live-sessions): ライブP/L表示にチップ回収額を反映 (SA2-124)

### DIFF
--- a/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-compact-summary/__tests__/use-cash-game-compact-summary.test.ts
+++ b/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-compact-summary/__tests__/use-cash-game-compact-summary.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/shared/hooks/use-elapsed-time", () => ({
 import { useCashGameCompactSummary } from "@/features/live-sessions/pages/active-session-page/cash-game-compact-summary/use-cash-game-compact-summary";
 
 const BASE_INPUT = {
+	chipRemoveTotal: 0,
 	currentStack: 0,
 	evDiff: 0,
 	startedAt: new Date("2026-01-01T00:00:00Z"),
@@ -73,6 +74,7 @@ describe("useCashGameCompactSummary", () => {
 	it("computes evPL separately from displayPL when evDiff != 0 and shows when different", () => {
 		const { result } = renderHook(() =>
 			useCashGameCompactSummary({
+				chipRemoveTotal: 0,
 				currentStack: 12_000,
 				evDiff: 500,
 				startedAt: new Date(),
@@ -89,6 +91,7 @@ describe("useCashGameCompactSummary", () => {
 	it("hides evPL when evDiff is 0 (computation branch gates)", () => {
 		const { result } = renderHook(() =>
 			useCashGameCompactSummary({
+				chipRemoveTotal: 0,
 				currentStack: 12_000,
 				evDiff: 0,
 				startedAt: new Date(),
@@ -108,6 +111,7 @@ describe("useCashGameCompactSummary", () => {
 		// So when evDiff != 0 and evPL is not null, showEvPL must be true.
 		const { result } = renderHook(() =>
 			useCashGameCompactSummary({
+				chipRemoveTotal: 0,
 				currentStack: 1,
 				evDiff: 1,
 				startedAt: new Date(),
@@ -115,6 +119,64 @@ describe("useCashGameCompactSummary", () => {
 			})
 		);
 		expect(result.current.showEvPL).toBe(true);
+	});
+
+	it("adds chipRemoveTotal to displayPL (issue scenario: 400 + 300 - 500 = 200)", () => {
+		// SA2-124: header P/L must match the server / chart formula
+		// stack + chipRemoveTotal - totalBuyIn. Without chipRemoveTotal the
+		// header would show 400 - 500 = -100, contradicting the chart's +200.
+		const { result } = renderHook(() =>
+			useCashGameCompactSummary({
+				...BASE_INPUT,
+				chipRemoveTotal: 300,
+				currentStack: 400,
+				evDiff: 0,
+				totalBuyIn: 500,
+			})
+		);
+		expect(result.current.displayPL).toBe(200);
+	});
+
+	it("adds chipRemoveTotal to evPL as well (400 + 300 + 100 - 500 = 300)", () => {
+		const { result } = renderHook(() =>
+			useCashGameCompactSummary({
+				...BASE_INPUT,
+				chipRemoveTotal: 300,
+				currentStack: 400,
+				evDiff: 100,
+				totalBuyIn: 500,
+			})
+		);
+		expect(result.current.displayPL).toBe(200);
+		expect(result.current.evPL).toBe(300);
+		expect(result.current.showEvPL).toBe(true);
+	});
+
+	it("keeps displayPL as currentStack - totalBuyIn when chipRemoveTotal is 0", () => {
+		const { result } = renderHook(() =>
+			useCashGameCompactSummary({
+				...BASE_INPUT,
+				chipRemoveTotal: 0,
+				currentStack: 400,
+				evDiff: 0,
+				totalBuyIn: 500,
+			})
+		);
+		expect(result.current.displayPL).toBe(-100);
+	});
+
+	it("returns null displayPL even when chipRemoveTotal is positive but currentStack is null", () => {
+		const { result } = renderHook(() =>
+			useCashGameCompactSummary({
+				...BASE_INPUT,
+				chipRemoveTotal: 300,
+				currentStack: null,
+				evDiff: 200,
+				totalBuyIn: 500,
+			})
+		);
+		expect(result.current.displayPL).toBeNull();
+		expect(result.current.evPL).toBeNull();
 	});
 
 	it("formats totalBuyIn via formatCompactNumber (0 → '0')", () => {

--- a/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-compact-summary/use-cash-game-compact-summary.ts
+++ b/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-compact-summary/use-cash-game-compact-summary.ts
@@ -6,6 +6,7 @@ import {
 } from "@/utils/format-profit-loss";
 
 interface CashGameCompactSummaryInput {
+	chipRemoveTotal: number;
 	currentStack: number | null;
 	evDiff: number;
 	startedAt: Date | string | number;
@@ -29,14 +30,20 @@ export function useCashGameCompactSummary(
 ): CashGameCompactSummaryViewModel {
 	const duration = useElapsedTime(summary.startedAt);
 
+	// SA2-124: P/L must match the server (`live-session-pl.ts`) and the session
+	// chart (`session-timeline.ts`): stack + chipRemoveTotal - totalBuyIn.
+	// Chips racked off the table are already-pocketed value, not a loss.
 	const displayPL =
 		summary.currentStack === null
 			? null
-			: summary.currentStack - summary.totalBuyIn;
+			: summary.currentStack + summary.chipRemoveTotal - summary.totalBuyIn;
 
 	const evPL =
 		summary.currentStack !== null && summary.evDiff !== 0
-			? summary.currentStack + summary.evDiff - summary.totalBuyIn
+			? summary.currentStack +
+				summary.chipRemoveTotal +
+				summary.evDiff -
+				summary.totalBuyIn
 			: null;
 	const showEvPL = evPL !== null && evPL !== displayPL;
 

--- a/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-session/__tests__/use-cash-game-session-view.test.ts
+++ b/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-session/__tests__/use-cash-game-session-view.test.ts
@@ -61,7 +61,12 @@ function makeSession(
 		memo: null,
 		ringGameId: null,
 		startedAt: new Date("2026-06-01T10:00:00Z"),
-		summary: { currentStack: 1500, evDiff: 50, totalBuyIn: 1000 },
+		summary: {
+			chipRemoveTotal: 0,
+			currentStack: 1500,
+			evDiff: 50,
+			totalBuyIn: 1000,
+		},
 		...overrides,
 	};
 }
@@ -140,6 +145,7 @@ describe("useCashGameSessionView", () => {
 			mocks.session = makeSession({ startedAt });
 			const { result } = renderHook(() => useCashGameSessionView("cg-1"));
 			expect(result.current.summary).toEqual({
+				chipRemoveTotal: 0,
 				currentStack: 1500,
 				evDiff: 50,
 				startedAt,
@@ -153,6 +159,32 @@ describe("useCashGameSessionView", () => {
 			});
 			const { result } = renderHook(() => useCashGameSessionView("cg-1"));
 			expect(result.current.summary?.evDiff).toBe(0);
+		});
+
+		it("threads chipRemoveTotal from the session summary (SA2-124)", () => {
+			mocks.session = makeSession({
+				summary: {
+					chipRemoveTotal: 300,
+					currentStack: 400,
+					evDiff: 0,
+					totalBuyIn: 500,
+				},
+			});
+			const { result } = renderHook(() => useCashGameSessionView("cg-1"));
+			expect(result.current.summary?.chipRemoveTotal).toBe(300);
+		});
+
+		it("coerces a non-numeric chipRemoveTotal to 0", () => {
+			mocks.session = makeSession({
+				summary: {
+					chipRemoveTotal: undefined,
+					currentStack: 1500,
+					evDiff: 0,
+					totalBuyIn: 1000,
+				},
+			});
+			const { result } = renderHook(() => useCashGameSessionView("cg-1"));
+			expect(result.current.summary?.chipRemoveTotal).toBe(0);
 		});
 
 		it("falls back to now when startedAt is missing", () => {

--- a/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-session/use-cash-game-session-view.ts
+++ b/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-session/use-cash-game-session-view.ts
@@ -11,6 +11,7 @@ import { useCashGameSession } from "@/features/live-sessions/hooks/use-cash-game
 import { useCashGameStack } from "@/features/live-sessions/hooks/use-cash-game-stack";
 
 export interface CashGameCompactSummaryData {
+	chipRemoveTotal: number;
 	currentStack: number | null;
 	evDiff: number;
 	startedAt: Date | string | number;
@@ -45,6 +46,10 @@ export function useCashGameSessionView(sessionId: string) {
 
 	const summary: CashGameCompactSummaryData | null = session
 		? {
+				chipRemoveTotal:
+					typeof session.summary.chipRemoveTotal === "number"
+						? session.summary.chipRemoveTotal
+						: 0,
 				currentStack: session.summary.currentStack,
 				evDiff:
 					typeof session.summary.evDiff === "number"

--- a/apps/web/src/features/live-sessions/utils/__tests__/optimistic-session-event.test.ts
+++ b/apps/web/src/features/live-sessions/utils/__tests__/optimistic-session-event.test.ts
@@ -191,6 +191,34 @@ describe("buildOptimisticSessionSummary", () => {
 			expect(result.cashOut).toBeUndefined();
 			expect(result.profitLoss).toBeUndefined();
 		});
+
+		it("includes chipRemoveTotal in profitLoss (SA2-124: 400 + 300 - 500 = 200)", () => {
+			const result = buildOptimisticSessionSummary(
+				{ chipRemoveTotal: 300, totalBuyIn: 500 },
+				"session_end",
+				{ cashOutAmount: 400 }
+			);
+			expect(result.cashOut).toBe(400);
+			expect(result.profitLoss).toBe(200);
+		});
+
+		it("treats missing chipRemoveTotal as 0 when computing profitLoss", () => {
+			const result = buildOptimisticSessionSummary(
+				{ totalBuyIn: 500 },
+				"session_end",
+				{ cashOutAmount: 400 }
+			);
+			expect(result.profitLoss).toBe(-100);
+		});
+
+		it("treats non-numeric chipRemoveTotal as 0 when computing profitLoss", () => {
+			const result = buildOptimisticSessionSummary(
+				{ chipRemoveTotal: "nope", totalBuyIn: 500 },
+				"session_end",
+				{ cashOutAmount: 400 }
+			);
+			expect(result.profitLoss).toBe(-100);
+		});
 	});
 
 	describe("session_end — tournament branch (beforeDeadline=false)", () => {

--- a/apps/web/src/features/live-sessions/utils/optimistic-session-event.ts
+++ b/apps/web/src/features/live-sessions/utils/optimistic-session-event.ts
@@ -80,17 +80,29 @@ function applySessionStartSummary(
 	}
 }
 
+function applyCashSessionEndSummary(
+	summary: Record<string, unknown>,
+	payload: Record<string, unknown>
+) {
+	// Cash game end: cashOutAmount drives profitLoss. SA2-124: mirror the
+	// server / chart formula cashOut + chipRemoveTotal - totalBuyIn so racked-off
+	// chips are counted, not treated as a loss.
+	if (typeof payload.cashOutAmount !== "number") {
+		return;
+	}
+	summary.cashOut = payload.cashOutAmount;
+	const totalBuyIn =
+		typeof summary.totalBuyIn === "number" ? summary.totalBuyIn : 0;
+	const chipRemoveTotal =
+		typeof summary.chipRemoveTotal === "number" ? summary.chipRemoveTotal : 0;
+	summary.profitLoss = payload.cashOutAmount + chipRemoveTotal - totalBuyIn;
+}
+
 function applySessionEndSummary(
 	summary: Record<string, unknown>,
 	payload: Record<string, unknown>
 ) {
-	// Cash game end: cashOutAmount drives profitLoss
-	if (typeof payload.cashOutAmount === "number") {
-		summary.cashOut = payload.cashOutAmount;
-		const totalBuyIn =
-			typeof summary.totalBuyIn === "number" ? summary.totalBuyIn : 0;
-		summary.profitLoss = payload.cashOutAmount - totalBuyIn;
-	}
+	applyCashSessionEndSummary(summary, payload);
 
 	// Tournament end (not before deadline): placement + prizes
 	if (payload.beforeDeadline === false) {

--- a/packages/api/src/__tests__/live-session-pl.test.ts
+++ b/packages/api/src/__tests__/live-session-pl.test.ts
@@ -403,6 +403,77 @@ describe("computeCashGamePLFromEvents", () => {
 		expect(result.profitLoss).toBe(150);
 	});
 
+	it("exposes chipRemoveTotal from negative chips_add_remove events (SA2-124)", () => {
+		// buyIn 500, chip removal 300, cashOut 400 =>
+		// profitLoss = 400 + 300 - 500 = 200, and chipRemoveTotal is surfaced
+		// so the live header can mirror the chart's stack + chipRemoveTotal - buyIn.
+		const events = [
+			{
+				eventType: "session_start",
+				payload: JSON.stringify({ buyInAmount: 500 }),
+			},
+			{
+				eventType: "chips_add_remove",
+				payload: JSON.stringify({ amount: -300, type: "remove" }),
+			},
+			{
+				eventType: "session_end",
+				payload: JSON.stringify({ cashOutAmount: 400 }),
+			},
+		];
+		const result = computeCashGamePLFromEvents(events);
+		expect(result.chipRemoveTotal).toBe(300);
+		expect(result.totalBuyIn).toBe(500);
+		expect(result.profitLoss).toBe(200);
+	});
+
+	it("reports chipRemoveTotal as 0 when there are no chip removals", () => {
+		const events = [
+			{
+				eventType: "session_start",
+				payload: JSON.stringify({ buyInAmount: 500 }),
+			},
+			{
+				eventType: "session_end",
+				payload: JSON.stringify({ cashOutAmount: 400 }),
+			},
+		];
+		const result = computeCashGamePLFromEvents(events);
+		expect(result.chipRemoveTotal).toBe(0);
+		expect(result.profitLoss).toBe(-100);
+	});
+
+	it("accumulates chipRemoveTotal across multiple removals without touching addonTotal", () => {
+		const events = [
+			{
+				eventType: "session_start",
+				payload: JSON.stringify({ buyInAmount: 1000 }),
+			},
+			{
+				eventType: "chips_add_remove",
+				payload: JSON.stringify({ amount: -200, type: "remove" }),
+			},
+			{
+				eventType: "chips_add_remove",
+				payload: JSON.stringify({ amount: 300, type: "add" }),
+			},
+			{
+				eventType: "chips_add_remove",
+				payload: JSON.stringify({ amount: -100, type: "remove" }),
+			},
+			{
+				eventType: "session_end",
+				payload: JSON.stringify({ cashOutAmount: 900 }),
+			},
+		];
+		const result = computeCashGamePLFromEvents(events);
+		expect(result.chipRemoveTotal).toBe(300);
+		expect(result.addonTotal).toBe(300);
+		expect(result.totalBuyIn).toBe(1300);
+		// profitLoss = 900 + 300 - 1300 = -100
+		expect(result.profitLoss).toBe(-100);
+	});
+
 	it("computes evCashOut correctly using all_in events", () => {
 		// EV diff = potSize * (equity / 100) - (potSize / trials) * wins
 		// potSize=400, equity=75, trials=1, wins=0 => 400 * 0.75 - (400 / 1) * 0 = 300

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -296,6 +296,7 @@ export const liveCashGameSessionRouter = router({
 			const summary = {
 				totalBuyIn: s.totalBuyIn,
 				cashOut: s.cashOut,
+				chipRemoveTotal: pl.chipRemoveTotal,
 				profitLoss: pl.profitLoss,
 				evCashOut: pl.evCashOut,
 				evDiff: pl.evDiff,

--- a/packages/api/src/services/live-session-pl.ts
+++ b/packages/api/src/services/live-session-pl.ts
@@ -30,6 +30,9 @@ type DbInstance = Parameters<
 interface CashGamePLResult {
 	addonTotal: number;
 	cashOut: number | null;
+	/** Σ of chips racked off the table (positive amount of every negative
+	 * chips_add_remove). Added back into P/L as already-pocketed chips. */
+	chipRemoveTotal: number;
 	evCashOut: number | null;
 	evDiff: number;
 	profitLoss: number | null;
@@ -154,6 +157,7 @@ export function computeCashGamePLFromEvents(
 	return {
 		totalBuyIn,
 		cashOut,
+		chipRemoveTotal,
 		profitLoss,
 		evCashOut,
 		evDiff: totalEvDiff,


### PR DESCRIPTION
## 概要

SA2-124 / Closes #441

ライブ・キャッシュゲームのヘッダー表示（`displayPL` / `evPL`）が、チップ回収額（`chipRemoveTotal`）を計算に含めておらず、サーバー側の正しいP/L計算やセッションチャートと矛盾する値を表示していた。

例: バイイン `500`・チップ回収 `300`・現在スタック `400` のとき、本来 `+200` であるべきP/Lがヘッダー上では `-100` と表示され、同一画面のチャート（`+200`）と食い違っていた。

## 誤 vs 正の計算式

| | 修正前（誤） | 修正後（正） |
|---|---|---|
| `displayPL` | `currentStack - totalBuyIn` | `currentStack + chipRemoveTotal - totalBuyIn` |
| `evPL` | `currentStack + evDiff - totalBuyIn` | `currentStack + chipRemoveTotal + evDiff - totalBuyIn` |
| 楽観更新 `profitLoss` | `cashOut - totalBuyIn` | `cashOut + chipRemoveTotal - totalBuyIn` |

正の式は、サーバーの正式な計算（`live-session-pl.ts`: `cashOut + chipRemoveTotal - totalBuyIn`）およびチャート（`session-timeline.ts`: `stack + chipRemoveTotal - totalBuyIn`）と一致する。チップの回収・早期ラックオフはロスではなく「持ち出し済みチップ」として加算される。

## 変更内容

- **`packages/api/src/services/live-session-pl.ts`**: `computeCashGamePLFromEvents` が既に集計している `chipRemoveTotal` を `CashGamePLResult` に公開。
- **`packages/api/src/routers/live-cash-game-session.ts`**: `getById` の `summary` に `chipRemoveTotal` を追加し、フロントへ渡るようにした。
- **`use-cash-game-compact-summary.ts`**: `displayPL` / `evPL` を `chipRemoveTotal` を含む式に修正。
- **`use-cash-game-session-view.ts`**: `session.summary.chipRemoveTotal` を透過（非数値は `0` にフォールバック）。
- **`optimistic-session-event.ts`**: `session_end` の楽観更新後P/Lにも `chipRemoveTotal` を反映（複雑度回避のためキャッシュ終了分岐を `applyCashSessionEndSummary` に抽出）。

なお、DBに永続化される最終P/Lはサーバー側の正しい式で保存されるため、これは表示上の不整合の修正であり、データ破損ではない。

## テスト（TDD）

RED → GREEN で実施。

- `packages/api/src/__tests__/live-session-pl.test.ts`: `chipRemoveTotal` の公開・0時・複数回回収の累積を検証。
- `use-cash-game-compact-summary.test.ts`: 課題の `400 + 300 - 500 = 200` シナリオ、`evPL` への反映、`chipRemoveTotal 0`、`currentStack null` の各分岐。
- `use-cash-game-session-view.test.ts`: `chipRemoveTotal` の透過と非数値 `0` フォールバック。
- `optimistic-session-event.test.ts`: `session_end` 楽観更新の `chipRemoveTotal` 反映・欠落/非数値フォールバック。

スコープ実行結果:
- `web-dom`: 40 passed
- `api` (`live-session-pl` + `live-cash-game-session`): 104 passed

`bun x ultracite check`（変更ファイル）クリーン、`bun run check-types`（web / server）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ)_