### PR TITLE
fix(web): サインアウト時にReact Queryキャッシュと永続化データを削除 (SA2-159)

### DIFF
--- a/apps/web/src/__tests__/settings-route.test.tsx
+++ b/apps/web/src/__tests__/settings-route.test.tsx
@@ -41,6 +41,7 @@ describe("SettingsComponent", () => {
 		mocks.navigate.mockReset();
 		mocks.signOut.mockReset();
 		mocks.clearPersistedQueryCache.mockReset();
+		mocks.clearPersistedQueryCache.mockResolvedValue(undefined);
 		mocks.signOut.mockImplementation(
 			(options?: { fetchOptions?: { onSuccess?: () => void } }) => {
 				options?.fetchOptions?.onSuccess?.();

--- a/apps/web/src/__tests__/settings-route.test.tsx
+++ b/apps/web/src/__tests__/settings-route.test.tsx
@@ -6,6 +6,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
 	navigate: vi.fn(),
 	signOut: vi.fn(),
+	clearPersistedQueryCache: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -25,6 +26,10 @@ vi.mock("@/lib/auth-client", () => ({
 	},
 }));
 
+vi.mock("@/utils/trpc", () => ({
+	clearPersistedQueryCache: mocks.clearPersistedQueryCache,
+}));
+
 let routeModule: typeof import("@/routes/settings");
 
 describe("SettingsComponent", () => {
@@ -35,6 +40,7 @@ describe("SettingsComponent", () => {
 	beforeEach(() => {
 		mocks.navigate.mockReset();
 		mocks.signOut.mockReset();
+		mocks.clearPersistedQueryCache.mockReset();
 		mocks.signOut.mockImplementation(
 			(options?: { fetchOptions?: { onSuccess?: () => void } }) => {
 				options?.fetchOptions?.onSuccess?.();
@@ -62,7 +68,11 @@ describe("SettingsComponent", () => {
 		await user.click(screen.getByRole("button", { name: "Sign out" }));
 
 		expect(mocks.signOut).toHaveBeenCalledOnce();
+		expect(mocks.clearPersistedQueryCache).toHaveBeenCalledTimes(1);
 		expect(mocks.navigate).toHaveBeenCalledWith({ to: "/" });
+		expect(
+			mocks.clearPersistedQueryCache.mock.invocationCallOrder[0]
+		).toBeLessThan(mocks.navigate.mock.invocationCallOrder[0]);
 	});
 
 	it("does not navigate when signOut does not call onSuccess", async () => {

--- a/apps/web/src/features/settings/pages/settings-page/__tests__/use-settings-page.test.ts
+++ b/apps/web/src/features/settings/pages/settings-page/__tests__/use-settings-page.test.ts
@@ -2,48 +2,32 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-	navigate: vi.fn(),
-	signOut: vi.fn(),
+	onSignOut: vi.fn(),
+	useSignOut: vi.fn(),
 }));
 
-vi.mock("@tanstack/react-router", () => ({
-	useNavigate: () => mocks.navigate,
-}));
-
-vi.mock("@/lib/auth-client", () => ({
-	authClient: {
-		signOut: mocks.signOut,
-	},
+vi.mock("@/shared/hooks/use-sign-out", () => ({
+	useSignOut: mocks.useSignOut,
 }));
 
 import { useSettingsPage } from "@/features/settings/pages/settings-page/use-settings-page";
 
 describe("useSettingsPage", () => {
 	beforeEach(() => {
-		mocks.navigate.mockReset();
-		mocks.signOut.mockReset();
+		mocks.onSignOut.mockReset();
+		mocks.useSignOut.mockReset();
+		mocks.useSignOut.mockReturnValue({ onSignOut: mocks.onSignOut });
 	});
 
-	it("onSignOut calls authClient.signOut exactly once", () => {
+	it("delegates sign-out to the shared useSignOut hook", () => {
 		const { result } = renderHook(() => useSettingsPage());
-		result.current.onSignOut();
-		expect(mocks.signOut).toHaveBeenCalledTimes(1);
+		expect(mocks.useSignOut).toHaveBeenCalledTimes(1);
+		expect(result.current.onSignOut).toBe(mocks.onSignOut);
 	});
 
-	it("does not navigate before sign-out succeeds", () => {
+	it("invokes the shared handler when onSignOut is called", () => {
 		const { result } = renderHook(() => useSettingsPage());
 		result.current.onSignOut();
-		expect(mocks.navigate).not.toHaveBeenCalled();
-	});
-
-	it("navigates to the public home page when sign-out succeeds", () => {
-		const { result } = renderHook(() => useSettingsPage());
-		result.current.onSignOut();
-		const fetchOptions = mocks.signOut.mock.calls[0][0]?.fetchOptions as {
-			onSuccess: () => void;
-		};
-		fetchOptions.onSuccess();
-		expect(mocks.navigate).toHaveBeenCalledTimes(1);
-		expect(mocks.navigate).toHaveBeenNthCalledWith(1, { to: "/" });
+		expect(mocks.onSignOut).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/web/src/features/settings/pages/settings-page/use-settings-page.ts
+++ b/apps/web/src/features/settings/pages/settings-page/use-settings-page.ts
@@ -1,18 +1,7 @@
-import { useNavigate } from "@tanstack/react-router";
-import { authClient } from "@/lib/auth-client";
+import { useSignOut } from "@/shared/hooks/use-sign-out";
 
 export function useSettingsPage() {
-	const navigate = useNavigate();
-
-	const onSignOut = () => {
-		authClient.signOut({
-			fetchOptions: {
-				onSuccess: () => {
-					navigate({ to: "/" });
-				},
-			},
-		});
-	};
+	const { onSignOut } = useSignOut();
 
 	return { onSignOut };
 }

--- a/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/__tests__/use-user-menu.test.ts
+++ b/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/__tests__/use-user-menu.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	useSession: vi.fn(),
+	updateNotesSheet: {
+		isOpen: false,
+		open: vi.fn(),
+		close: vi.fn(),
+		setIsOpen: vi.fn(),
+	},
+	onSignOut: vi.fn(),
+	useSignOut: vi.fn(),
+	useUpdateNotesSheet: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+	authClient: {
+		useSession: mocks.useSession,
+	},
+}));
+
+vi.mock("@/features/update-notes/components/update-notes-sheet", () => ({
+	useUpdateNotesSheet: mocks.useUpdateNotesSheet,
+}));
+
+vi.mock("@/shared/hooks/use-sign-out", () => ({
+	useSignOut: mocks.useSignOut,
+}));
+
+import { useUserMenu } from "@/shared/components/authenticated-shell/sidebar-nav/user-menu/use-user-menu";
+
+describe("useUserMenu", () => {
+	beforeEach(() => {
+		mocks.useSession.mockReset();
+		mocks.onSignOut.mockReset();
+		mocks.useSignOut.mockReset();
+		mocks.useUpdateNotesSheet.mockReset();
+		mocks.useSignOut.mockReturnValue({ onSignOut: mocks.onSignOut });
+		mocks.useUpdateNotesSheet.mockReturnValue(mocks.updateNotesSheet);
+	});
+
+	it("exposes the authenticated session and update-notes controls", () => {
+		const session = {
+			data: { user: { email: "hero@example.com", name: "Hero User" } },
+			isPending: false,
+		};
+		mocks.useSession.mockReturnValue(session);
+
+		const { result } = renderHook(() => useUserMenu());
+
+		expect(result.current.session).toBe(session.data);
+		expect(result.current.isPending).toBe(false);
+		expect(result.current.updateNotesSheet).toBe(mocks.updateNotesSheet);
+	});
+
+	it("surfaces isPending while the session is loading", () => {
+		mocks.useSession.mockReturnValue({ data: null, isPending: true });
+
+		const { result } = renderHook(() => useUserMenu());
+
+		expect(result.current.isPending).toBe(true);
+		expect(result.current.session).toBeNull();
+	});
+
+	it("delegates sign-out to the shared useSignOut hook", () => {
+		mocks.useSession.mockReturnValue({ data: null, isPending: false });
+
+		const { result } = renderHook(() => useUserMenu());
+		result.current.onSignOut();
+
+		expect(mocks.useSignOut).toHaveBeenCalledTimes(1);
+		expect(result.current.onSignOut).toBe(mocks.onSignOut);
+		expect(mocks.onSignOut).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/use-user-menu.ts
+++ b/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/use-user-menu.ts
@@ -1,0 +1,11 @@
+import { useUpdateNotesSheet } from "@/features/update-notes/components/update-notes-sheet";
+import { authClient } from "@/lib/auth-client";
+import { useSignOut } from "@/shared/hooks/use-sign-out";
+
+export function useUserMenu() {
+	const { data: session, isPending } = authClient.useSession();
+	const updateNotesSheet = useUpdateNotesSheet();
+	const { onSignOut } = useSignOut();
+
+	return { session, isPending, updateNotesSheet, onSignOut };
+}

--- a/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/user-menu.test.tsx
+++ b/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/user-menu.test.tsx
@@ -1,50 +1,44 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UserMenu } from "./user-menu";
 
 const mocks = vi.hoisted(() => ({
-	navigate: vi.fn(),
-	sessionState: {
-		data: null as null | {
-			user: {
-				email: string;
-				name: string;
-			};
-		},
+	menuState: {
+		session: null as null | { user: { email: string; name: string } },
 		isPending: false,
+		updateNotesSheet: {
+			isOpen: false,
+			open: vi.fn(),
+			close: vi.fn(),
+			setIsOpen: vi.fn(),
+		},
+		onSignOut: vi.fn(),
 	},
-	signOut: vi.fn(),
-	updateNotesSheet: {
-		isOpen: false,
-		open: vi.fn(),
-		close: vi.fn(),
-		setIsOpen: vi.fn(),
-	},
+	useUserMenu: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-router", () => ({
 	Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
 		<a href={to}>{children}</a>
 	),
-	useNavigate: () => mocks.navigate,
 }));
 
-vi.mock("@/lib/auth-client", () => ({
-	authClient: {
-		signOut: mocks.signOut,
-		useSession: () => mocks.sessionState,
-	},
-}));
-
-vi.mock("@/features/update-notes/components/update-notes-sheet", () => ({
-	useUpdateNotesSheet: () => mocks.updateNotesSheet,
+vi.mock("./use-user-menu", () => ({
+	useUserMenu: mocks.useUserMenu,
 }));
 
 describe("UserMenu", () => {
+	beforeEach(() => {
+		mocks.menuState.updateNotesSheet.open.mockReset();
+		mocks.menuState.onSignOut.mockReset();
+		mocks.useUserMenu.mockReset();
+		mocks.useUserMenu.mockImplementation(() => mocks.menuState);
+	});
+
 	it("shows the loading skeleton", () => {
-		mocks.sessionState.isPending = true;
-		mocks.sessionState.data = null;
+		mocks.menuState.isPending = true;
+		mocks.menuState.session = null;
 
 		const { container } = render(<UserMenu />);
 
@@ -52,8 +46,8 @@ describe("UserMenu", () => {
 	});
 
 	it("renders sign in when there is no session", () => {
-		mocks.sessionState.isPending = false;
-		mocks.sessionState.data = null;
+		mocks.menuState.isPending = false;
+		mocks.menuState.session = null;
 
 		render(<UserMenu />);
 
@@ -63,20 +57,12 @@ describe("UserMenu", () => {
 		);
 	});
 
-	it("renders the user trigger and signs out to home", async () => {
+	it("renders the user trigger and calls onSignOut", async () => {
 		const user = userEvent.setup();
-		mocks.sessionState.isPending = false;
-		mocks.sessionState.data = {
-			user: {
-				email: "hero@example.com",
-				name: "Hero User",
-			},
+		mocks.menuState.isPending = false;
+		mocks.menuState.session = {
+			user: { email: "hero@example.com", name: "Hero User" },
 		};
-		mocks.signOut.mockImplementation(
-			({ fetchOptions }: { fetchOptions: { onSuccess: () => void } }) => {
-				fetchOptions.onSuccess();
-			}
-		);
 
 		render(<UserMenu />);
 
@@ -84,7 +70,6 @@ describe("UserMenu", () => {
 		expect(screen.getByText("hero@example.com")).toBeInTheDocument();
 		await user.click(screen.getByText("Sign Out"));
 
-		expect(mocks.signOut).toHaveBeenCalled();
-		expect(mocks.navigate).toHaveBeenCalledWith({ to: "/" });
+		expect(mocks.menuState.onSignOut).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/user-menu.tsx
+++ b/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/user-menu.tsx
@@ -1,6 +1,4 @@
-import { Link, useNavigate } from "@tanstack/react-router";
-import { useUpdateNotesSheet } from "@/features/update-notes/components/update-notes-sheet";
-import { authClient } from "@/lib/auth-client";
+import { Link } from "@tanstack/react-router";
 import { Button } from "@/shared/components/ui/button";
 import {
 	DropdownMenu,
@@ -12,11 +10,10 @@ import {
 	DropdownMenuTrigger,
 } from "@/shared/components/ui/dropdown-menu";
 import { Skeleton } from "@/shared/components/ui/skeleton";
+import { useUserMenu } from "./use-user-menu";
 
 export function UserMenu() {
-	const navigate = useNavigate();
-	const { data: session, isPending } = authClient.useSession();
-	const updateNotesSheet = useUpdateNotesSheet();
+	const { session, isPending, updateNotesSheet, onSignOut } = useUserMenu();
 
 	if (isPending) {
 		return <Skeleton className="h-8 w-24" />;
@@ -47,20 +44,7 @@ export function UserMenu() {
 					<DropdownMenuItem onClick={updateNotesSheet.open}>
 						Update Notes
 					</DropdownMenuItem>
-					<DropdownMenuItem
-						onClick={() => {
-							authClient.signOut({
-								fetchOptions: {
-									onSuccess: () => {
-										navigate({
-											to: "/",
-										});
-									},
-								},
-							});
-						}}
-						variant="destructive"
-					>
+					<DropdownMenuItem onClick={onSignOut} variant="destructive">
 						Sign Out
 					</DropdownMenuItem>
 				</DropdownMenuGroup>

--- a/apps/web/src/shared/hooks/__tests__/use-sign-out.test.ts
+++ b/apps/web/src/shared/hooks/__tests__/use-sign-out.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	navigate: vi.fn(),
+	signOut: vi.fn(),
+	clearPersistedQueryCache: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+	useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+	authClient: {
+		signOut: mocks.signOut,
+	},
+}));
+
+vi.mock("@/utils/trpc", () => ({
+	clearPersistedQueryCache: mocks.clearPersistedQueryCache,
+}));
+
+import { useSignOut } from "@/shared/hooks/use-sign-out";
+
+interface FetchOptions {
+	onError: () => void;
+	onSuccess: () => void;
+}
+
+function getFetchOptions(): FetchOptions {
+	return mocks.signOut.mock.calls[0][0].fetchOptions as FetchOptions;
+}
+
+describe("useSignOut", () => {
+	beforeEach(() => {
+		mocks.navigate.mockReset();
+		mocks.signOut.mockReset();
+		mocks.clearPersistedQueryCache.mockReset();
+	});
+
+	it("onSignOut calls authClient.signOut exactly once", () => {
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+		expect(mocks.signOut).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not clear the cache or navigate before sign-out resolves", () => {
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+		expect(mocks.clearPersistedQueryCache).not.toHaveBeenCalled();
+		expect(mocks.navigate).not.toHaveBeenCalled();
+	});
+
+	it("on success clears the persisted cache before navigating home", () => {
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+
+		getFetchOptions().onSuccess();
+
+		expect(mocks.clearPersistedQueryCache).toHaveBeenCalledTimes(1);
+		expect(mocks.navigate).toHaveBeenCalledTimes(1);
+		expect(mocks.navigate).toHaveBeenNthCalledWith(1, { to: "/" });
+		expect(
+			mocks.clearPersistedQueryCache.mock.invocationCallOrder[0]
+		).toBeLessThan(mocks.navigate.mock.invocationCallOrder[0]);
+	});
+
+	it("on error still clears the persisted cache and does not navigate", () => {
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+
+		getFetchOptions().onError();
+
+		expect(mocks.clearPersistedQueryCache).toHaveBeenCalledTimes(1);
+		expect(mocks.navigate).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/shared/hooks/__tests__/use-sign-out.test.ts
+++ b/apps/web/src/shared/hooks/__tests__/use-sign-out.test.ts
@@ -52,11 +52,12 @@ describe("useSignOut", () => {
 		expect(mocks.navigate).not.toHaveBeenCalled();
 	});
 
-	it("on success clears the persisted cache before navigating home", () => {
+	it("on success clears the persisted cache before navigating home", async () => {
+		mocks.clearPersistedQueryCache.mockResolvedValue(undefined);
 		const { result } = renderHook(() => useSignOut());
 		result.current.onSignOut();
 
-		getFetchOptions().onSuccess();
+		await getFetchOptions().onSuccess();
 
 		expect(mocks.clearPersistedQueryCache).toHaveBeenCalledTimes(1);
 		expect(mocks.navigate).toHaveBeenCalledTimes(1);
@@ -66,13 +67,58 @@ describe("useSignOut", () => {
 		).toBeLessThan(mocks.navigate.mock.invocationCallOrder[0]);
 	});
 
+	it("does not navigate until the persisted cache clear resolves", async () => {
+		let resolveClear: () => void = () => {
+			// overwritten synchronously below
+		};
+		mocks.clearPersistedQueryCache.mockReturnValue(
+			new Promise<void>((resolve) => {
+				resolveClear = resolve;
+			})
+		);
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+
+		const pendingSuccess = getFetchOptions().onSuccess();
+		await Promise.resolve();
+		expect(mocks.navigate).not.toHaveBeenCalled();
+
+		resolveClear();
+		await pendingSuccess;
+
+		expect(mocks.navigate).toHaveBeenCalledTimes(1);
+	});
+
+	it("still navigates home when the persisted cache clear rejects on success", async () => {
+		mocks.clearPersistedQueryCache.mockRejectedValue(new Error("idb error"));
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+
+		await expect(getFetchOptions().onSuccess()).resolves.toBeUndefined();
+
+		expect(mocks.navigate).toHaveBeenCalledTimes(1);
+	});
+
 	it("on error still clears the persisted cache and does not navigate", () => {
+		mocks.clearPersistedQueryCache.mockResolvedValue(undefined);
 		const { result } = renderHook(() => useSignOut());
 		result.current.onSignOut();
 
 		getFetchOptions().onError();
 
 		expect(mocks.clearPersistedQueryCache).toHaveBeenCalledTimes(1);
+		expect(mocks.navigate).not.toHaveBeenCalled();
+	});
+
+	it("does not throw when the persisted cache clear rejects on error", async () => {
+		mocks.clearPersistedQueryCache.mockRejectedValue(new Error("idb error"));
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+
+		expect(() => getFetchOptions().onError()).not.toThrow();
+		await Promise.resolve();
+		await Promise.resolve();
+
 		expect(mocks.navigate).not.toHaveBeenCalled();
 	});
 });

--- a/apps/web/src/shared/hooks/use-sign-out.ts
+++ b/apps/web/src/shared/hooks/use-sign-out.ts
@@ -17,12 +17,17 @@ export function useSignOut() {
 	const onSignOut = () => {
 		authClient.signOut({
 			fetchOptions: {
-				onSuccess: () => {
-					clearPersistedQueryCache();
+				onSuccess: async () => {
+					await clearPersistedQueryCache().catch(() => {
+						// Clearing the cache is best-effort: a failed IndexedDB delete
+						// must not block the user from being navigated away.
+					});
 					navigate({ to: "/" });
 				},
 				onError: () => {
-					clearPersistedQueryCache();
+					clearPersistedQueryCache().catch(() => {
+						// Same best-effort rationale as the success path above.
+					});
 				},
 			},
 		});

--- a/apps/web/src/shared/hooks/use-sign-out.ts
+++ b/apps/web/src/shared/hooks/use-sign-out.ts
@@ -1,0 +1,32 @@
+import { useNavigate } from "@tanstack/react-router";
+import { authClient } from "@/lib/auth-client";
+import { clearPersistedQueryCache } from "@/utils/trpc";
+
+/**
+ * Shared sign-out handler for every sign-out entry point (user menu, settings).
+ *
+ * After Better Auth's `signOut`, the React Query cache and its persisted
+ * IndexedDB store are cleared before navigating home so the previous user's
+ * financial data can never leak to the next account on a shared device
+ * (SA2-159). The cache is cleared on `onError` too so a failed request never
+ * leaves stale data behind.
+ */
+export function useSignOut() {
+	const navigate = useNavigate();
+
+	const onSignOut = () => {
+		authClient.signOut({
+			fetchOptions: {
+				onSuccess: () => {
+					clearPersistedQueryCache();
+					navigate({ to: "/" });
+				},
+				onError: () => {
+					clearPersistedQueryCache();
+				},
+			},
+		});
+	};
+
+	return { onSignOut };
+}

--- a/apps/web/src/utils/trpc.ts
+++ b/apps/web/src/utils/trpc.ts
@@ -45,6 +45,21 @@ export const persister = createAsyncStoragePersister({
 	key: "sapphire2-query-cache",
 });
 
+/**
+ * Wipe every trace of the signed-in user's data on sign-out.
+ *
+ * The whole tRPC query cache is persisted to IndexedDB keyed only by procedure
+ * name (not per-user), so on a shared device the next account would briefly see
+ * the previous user's financial data (SA2-159). Clearing the in-memory cache
+ * (`queryClient.clear()`) removes what is currently rendered, and
+ * `persister.removeClient()` deletes the persisted `sapphire2-query-cache` store
+ * so nothing can be rehydrated on the next load.
+ */
+export function clearPersistedQueryCache() {
+	queryClient.clear();
+	return persister.removeClient();
+}
+
 export const trpcClient = createTRPCClient<AppRouter>({
 	links: [
 		httpBatchLink({

--- a/apps/web/src/utils/trpc.ts
+++ b/apps/web/src/utils/trpc.ts
@@ -55,9 +55,9 @@ export const persister = createAsyncStoragePersister({
  * `persister.removeClient()` deletes the persisted `sapphire2-query-cache` store
  * so nothing can be rehydrated on the next load.
  */
-export function clearPersistedQueryCache() {
+export function clearPersistedQueryCache(): Promise<void> {
 	queryClient.clear();
-	return persister.removeClient();
+	return Promise.resolve(persister.removeClient());
 }
 
 export const trpcClient = createTRPCClient<AppRouter>({


### PR DESCRIPTION
## 対応Issue

- SA2-159
- Closes #476

## 問題(情報漏洩の根本原因)

tRPCのクエリキャッシュ全体が `PersistQueryClientProvider` により IndexedDB(キー `sapphire2-query-cache`、`maxAge` 24時間)へ永続化されているが、キーはtRPCプロシージャ名のみで**ユーザーごとに区別されていない**。加えて、両方のサインアウト経路(`user-menu` と `settings`)は Better Auth の `signOut` 後に `navigate` するだけで、React Query のメモリキャッシュや永続化ストアを一切消去していなかった。

その結果、共有デバイスで User A がサインアウトし同じブラウザで User B がログインすると、起動時に persister が User A のキャッシュを rehydrate し、`staleTime: 0` による再取得が完了するまでの間 User A の players / sessions / statistics などの**財務データが一時的に表示される**(セキュリティ: High)。

## 修正内容

- **`apps/web/src/utils/trpc.ts`**: `clearPersistedQueryCache()` を追加。
  - `queryClient.clear()` でメモリ上のキャッシュを消去(現在の描画内容を除去)。
  - `persister.removeClient()` で永続化された `sapphire2-query-cache` ストアを削除し、次回ロード時の rehydrate を防止。
- **`apps/web/src/shared/hooks/use-sign-out.ts`(新規)**: 両経路のサインアウト処理を集約した共有フック。`onSuccess` で `clearPersistedQueryCache()` → `navigate({ to: "/" })` の順で実行し、`onError` でも**キャッシュを消去して失敗時もデータを残さない**(データ漏洩を防ぐため常にクリア)。
- **user-menu**: ロジックを `use-user-menu.ts` に分離し、コンポーネントからの直接フック呼び出しを排除(hooks-separation 準拠)。`settings` も `use-settings-page` 経由で `use-sign-out` を利用。

なおIssueの恒久対策案(`persistOptions.buster` をユーザーIDに紐付け)は本PRのスコープ外とし、まずサインアウト時の確実な消去で漏洩経路を塞ぐ最小構成とした。

## テスト(TDD, project `web-dom`)

- `use-sign-out.test.ts`(新規): signOut 1回呼び出し / 成功時はキャッシュ消去→navigate の順序と回数 / 失敗時もキャッシュ消去し navigate しない / 解決前は何もしない。
- `use-user-menu.test.ts`(新規): セッション・update-notes・onSignOut の受け渡し、loading 状態、sign-out 委譲。
- `use-settings-page.test.ts` / `user-menu.test.tsx` / `settings-route.test.tsx`: 共有フックへの委譲と、実経路でのキャッシュ消去→navigate 順序を検証。

結果: `Test Files 5 passed (5) / Tests 17 passed (17)`、`ultracite check` クリーン、`tsc --noEmit` パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ)_