### PR TITLE
ci(preview-deploy): concurrencyガード追加とd1-setup id解決の堅牢化 (SA2-138)

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -89,9 +89,20 @@ jobs:
               IS_NEW=true
               echo "Created D1 database: $DB_ID"
             else
-              # Create returned no id — most likely the DB already exists but the
-              # list lookup raced/paginated past it. Re-resolve after a delay.
-              echo "Create returned no id; re-resolving. Response: $CREATE_RESP"
+              # Create returned no id. Distinguish the cause so the downstream
+              # seed step (gated on is_new_db) still runs when appropriate:
+              #   - duplicate-name (7502): the DB already existed -> not new,
+              #     the seed was already applied on its first deploy, skip it.
+              #   - any other transient failure: the DB may have just been
+              #     created but the response was unparseable -> treat as new so
+              #     the seed runs and the preview DB is not left empty.
+              if echo "$CREATE_RESP" | jq -e '.errors[]? | select(.code == 7502)' >/dev/null 2>&1; then
+                echo "DB already exists (7502); re-resolving id. Response: $CREATE_RESP"
+                IS_NEW=false
+              else
+                echo "Create returned no id (transient?); re-resolving id, treating as new. Response: $CREATE_RESP"
+                IS_NEW=true
+              fi
               sleep 3
               DB_ID=$(resolve_id || true)
             fi

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: preview-deploy-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -56,29 +60,52 @@ jobs:
         id: resolve
         run: |
           DB_NAME="${{ needs.setup.outputs.d1_db_name }}"
+          API="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/d1/database"
 
-          # Check if database already exists
-          EXISTING_ID=$(curl -sf \
-            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/d1/database" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            | jq -r ".result[] | select(.name == \"${DB_NAME}\") | .uuid")
+          # Resolve an existing DB id by exact name. The list endpoint is
+          # paginated and also accepts a `name` filter, so pass a large per_page
+          # plus the name filter, then still select by exact name to guard
+          # against prefix matches.
+          resolve_id() {
+            curl -sf "${API}?per_page=1000&name=${DB_NAME}" \
+              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              | jq -r ".result[] | select(.name == \"${DB_NAME}\") | .uuid" \
+              | head -n1
+          }
 
-          if [ -n "$EXISTING_ID" ]; then
-            echo "Reusing existing D1 database: $EXISTING_ID"
-            echo "d1_database_id=${EXISTING_ID}" >> "$GITHUB_OUTPUT"
-            echo "is_new_db=false" >> "$GITHUB_OUTPUT"
-          else
-            # Create new database
-            NEW_ID=$(curl -sf -X POST \
-              "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/d1/database" \
+          DB_ID=$(resolve_id || true)
+          IS_NEW=false
+
+          if [ -z "$DB_ID" ]; then
+            # No existing DB found — create it. Capture the full response so a
+            # duplicate-name error (7502) or an empty uuid does not silently
+            # leave DB_ID blank and break the migrate job downstream.
+            CREATE_RESP=$(curl -s -X POST "${API}" \
               -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
               -H "Content-Type: application/json" \
-              -d "{\"name\": \"${DB_NAME}\"}" \
-              | jq -r '.result.uuid')
-            echo "Created D1 database: $NEW_ID"
-            echo "d1_database_id=${NEW_ID}" >> "$GITHUB_OUTPUT"
-            echo "is_new_db=true" >> "$GITHUB_OUTPUT"
+              -d "{\"name\": \"${DB_NAME}\"}")
+            DB_ID=$(echo "$CREATE_RESP" | jq -r '.result.uuid // empty')
+            if [ -n "$DB_ID" ]; then
+              IS_NEW=true
+              echo "Created D1 database: $DB_ID"
+            else
+              # Create returned no id — most likely the DB already exists but the
+              # list lookup raced/paginated past it. Re-resolve after a delay.
+              echo "Create returned no id; re-resolving. Response: $CREATE_RESP"
+              sleep 3
+              DB_ID=$(resolve_id || true)
+            fi
+          else
+            echo "Reusing existing D1 database: $DB_ID"
           fi
+
+          if [ -z "$DB_ID" ]; then
+            echo "::error::Could not resolve or create D1 database ${DB_NAME}"
+            exit 1
+          fi
+
+          echo "d1_database_id=${DB_ID}" >> "$GITHUB_OUTPUT"
+          echo "is_new_db=${IS_NEW}" >> "$GITHUB_OUTPUT"
 
   db-migrate:
     needs: [setup, d1-setup]


### PR DESCRIPTION
## 概要 (SA2-138)

`preview-deploy.yml` に `concurrency:` ブロックが無く、同一PRへの連続pushで preview-deploy が並行実行され、`d1-setup`（per-PR D1 データベースの check-then-create）が競合しうる問題を修正する。

さらに調査の結果、実際のCI失敗（複数PR同時デプロイ時の `db-migrate` 失敗）の**真因は d1-setup の id 解決バグ**であることが判明したため、あわせて堅牢化する。

## 真因

`d1-setup` の「Resolve or create」ステップで、既存DB検索（LIST）が対象を取りこぼすと再作成に進むが、重複作成は `curl -sf` がエラーを飲み込んで `d1_database_id` を**空**にする。d1-setup 自体は「成功」扱いのまま、後続の `db-migrate` が `database_id = ""` を書き込み、`Found a database ... but it is missing a database_id` で失敗する（ジョブログに `Created D1 database:`＝uuid空 として現れる）。

## 修正内容

- **concurrencyブロック追加**（`dev-deploy.yml` / `production-deploy.yml` と同じidiom、`cancel-in-progress: false` で進行中のマイグレーションを中断しない）。
- **d1-setup の id 解決を堅牢化**:
  - LIST を `?per_page=1000&name=<db>` で確実に既存DBを解決（ページネーション/取りこぼし対策）。
  - 新規作成のレスポンスから `uuid` を取得できなかった場合（重複7502等）は、待機後に id を**再解決**する。
  - 最終的に id が空なら `::error::` を出して**ジョブを fail**させ、空idのまま db-migrate に進ませない。

## テスト / 検証

- ワークフローYAMLは `yaml.safe_load` でパース確認済み。
- ユニットテスト対象外（YAML）。既存の他ワークフローのidiomに合わせて最小差分。

## 補足

`pull_request` は head ブランチのワークフローで実行されるため、本修正がdevにマージされるまでは既存PRには反映されない。既に赤い preview PR には本コミットを個別に取り込んで再実行し green 化する運用で対応する。

_Generated by [Claude Code](https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ)_