### PR TITLE
fix(api): ライブトーナメント作成のtournamentId所有権検証を追加 (SA2-172)

### DIFF
--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import { t } from "../index";
 import { appRouter } from "../routers";
 import { persistSessionBlindLevels } from "../routers/session";
 import {
+	createChainableMockDb,
 	expectAccepts,
 	expectProtected,
 	expectRejects,
@@ -53,6 +55,15 @@ function createBlindLevelMockDb() {
 /** The row array passed to each `.values()` call, in call order. */
 function insertedChunks(values: ReturnType<typeof vi.fn>): InsertedRow[][] {
 	return values.mock.calls.map((call) => call[0] as InsertedRow[]);
+}
+
+const createCaller = t.createCallerFactory(appRouter);
+
+function callerFor(db: unknown, userId: string) {
+	return createCaller({
+		session: { user: { id: userId } },
+		db,
+	} as never);
 }
 
 describe("liveTournamentSession router", () => {
@@ -373,6 +384,7 @@ describe("liveTournamentSession.updateSnapshot input validation", () => {
 	});
 });
 
+<<<<<<< HEAD
 // Regression guard for SA2-115: updateSnapshot re-seeds blind levels via the
 // shared persistSessionBlindLevels helper, which DELETEs then re-INSERTs. D1
 // rejects any statement binding >100 params, so a 9-column blind row must be
@@ -457,5 +469,111 @@ describe("persistSessionBlindLevels chunking (SA2-115)", () => {
 		expect(deleteWhere).toHaveBeenCalledTimes(1);
 		expect(insert).not.toHaveBeenCalled();
 		expect(values).not.toHaveBeenCalled();
+	});
+});
+
+describe("liveTournamentSession.create tournament ownership (IDOR guard)", () => {
+	const CALLER = "user-1";
+	const OTHER = "user-2";
+	const TOURNAMENT_ID = "tn-1";
+	const ROOM_ID = "room-1";
+
+	function mockDb(opts: {
+		tournament?: Record<string, unknown>[];
+		room?: Record<string, unknown>[];
+		blindLevels?: Record<string, unknown>[];
+		chipPurchases?: Record<string, unknown>[];
+	}) {
+		return createChainableMockDb({
+			select: {
+				// no session is currently active
+				game_session: [],
+				tournament: opts.tournament ?? [],
+				room: opts.room ?? [],
+				blind_level: opts.blindLevels ?? [],
+				tournament_chip_purchase: opts.chipPurchases ?? [],
+			},
+		});
+	}
+
+	it("creates the session and snapshots the structure when the caller owns the tournament", async () => {
+		const { db, inserted, selectedTables } = mockDb({
+			tournament: [
+				{
+					id: TOURNAMENT_ID,
+					roomId: ROOM_ID,
+					name: "Main Event",
+					variant: "nlh",
+					buyIn: 10_000,
+					entryFee: 1000,
+					startingStack: 20_000,
+					bountyAmount: null,
+					tableSize: 9,
+					currencyId: null,
+				},
+			],
+			room: [{ id: ROOM_ID, userId: CALLER }],
+			blindLevels: [
+				{ level: 1, isBreak: false, blind1: 100, blind2: 200, minutes: 15 },
+			],
+		});
+
+		const result = await callerFor(db, CALLER).liveTournamentSession.create({
+			tournamentId: TOURNAMENT_ID,
+		});
+
+		expect(typeof result.id).toBe("string");
+		// The room must be read to confirm tournament ownership.
+		expect(selectedTables).toContain("room");
+		// The session and its structure snapshot were persisted.
+		expect(inserted.game_session).toHaveLength(1);
+		expect(inserted.session_tournament_detail).toHaveLength(1);
+		expect(inserted.session_blind_level).toHaveLength(1);
+	});
+
+	it("throws FORBIDDEN and writes nothing when the tournament belongs to another user", async () => {
+		const { db, inserted } = mockDb({
+			tournament: [{ id: TOURNAMENT_ID, roomId: ROOM_ID }],
+			room: [{ id: ROOM_ID, userId: OTHER }],
+		});
+
+		await expect(
+			callerFor(db, CALLER).liveTournamentSession.create({
+				tournamentId: TOURNAMENT_ID,
+			})
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this tournament",
+		});
+		// The guard runs before any write, so nothing is persisted.
+		expect(inserted.game_session).toBeUndefined();
+		expect(inserted.session_blind_level).toBeUndefined();
+	});
+
+	it("throws NOT_FOUND and writes nothing when the tournament does not exist", async () => {
+		const { db, inserted } = mockDb({ tournament: [] });
+
+		await expect(
+			callerFor(db, CALLER).liveTournamentSession.create({
+				tournamentId: "missing",
+			})
+		).rejects.toMatchObject({
+			code: "NOT_FOUND",
+			message: "Tournament not found",
+		});
+		expect(inserted.game_session).toBeUndefined();
+	});
+
+	it("skips tournament ownership validation when tournamentId is omitted", async () => {
+		const { db, inserted, selectedTables } = mockDb({});
+
+		const result = await callerFor(db, CALLER).liveTournamentSession.create({});
+
+		expect(typeof result.id).toBe("string");
+		// No tournament / room lookups happen without a tournamentId.
+		expect(selectedTables).not.toContain("tournament");
+		expect(selectedTables).not.toContain("room");
+		expect(inserted.game_session).toHaveLength(1);
+		expect(inserted.session_blind_level).toBeUndefined();
 	});
 });

--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -384,7 +384,6 @@ describe("liveTournamentSession.updateSnapshot input validation", () => {
 	});
 });
 
-<<<<<<< HEAD
 // Regression guard for SA2-115: updateSnapshot re-seeds blind levels via the
 // shared persistSessionBlindLevels helper, which DELETEs then re-INSERTs. D1
 // rejects any statement binding >100 params, so a 9-column blind row must be

--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -10,7 +10,9 @@ import {
 	parseSessionCursor,
 	selectInChunks,
 	toProfitLossSeriesPoint,
+	validateEntityOwnership,
 } from "../routers/session";
+import { createChainableMockDb } from "./test-utils";
 
 const DERIVED_FIELDS_RE = /Cannot edit fields derived from live session events/;
 const RING_CONFIG_RE = /variant|blind1|blind2/;
@@ -880,5 +882,71 @@ describe("computeTournamentPL", () => {
 	it("adds bounty prizes to income", () => {
 		// income (0 + 400) - cost (100 + 0 + 0) = 300
 		expect(computeTournamentPL(100, 0, 0, 0, 400)).toBe(300);
+	});
+});
+
+describe("validateEntityOwnership (tournament branch)", () => {
+	const CALLER = "user-1";
+	const OTHER = "user-2";
+	const TOURNAMENT_ID = "tn-1";
+	const ROOM_ID = "room-1";
+
+	function mockDbFor(opts: {
+		tournament?: Record<string, unknown>[];
+		room?: Record<string, unknown>[];
+	}) {
+		return createChainableMockDb({
+			select: {
+				tournament: opts.tournament ?? [],
+				room: opts.room ?? [],
+			},
+		});
+	}
+
+	it("resolves when the tournament's room is owned by the caller", async () => {
+		const { db, selectedTables } = mockDbFor({
+			tournament: [{ id: TOURNAMENT_ID, roomId: ROOM_ID }],
+			room: [{ id: ROOM_ID, userId: CALLER }],
+		});
+		await expect(
+			validateEntityOwnership(db, "tournament", TOURNAMENT_ID, CALLER)
+		).resolves.toBeUndefined();
+		// The room must be read to confirm ownership.
+		expect(selectedTables).toEqual(["tournament", "room"]);
+	});
+
+	it("throws FORBIDDEN when the tournament's room belongs to another user", async () => {
+		const { db } = mockDbFor({
+			tournament: [{ id: TOURNAMENT_ID, roomId: ROOM_ID }],
+			room: [{ id: ROOM_ID, userId: OTHER }],
+		});
+		await expect(
+			validateEntityOwnership(db, "tournament", TOURNAMENT_ID, CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this tournament",
+		});
+	});
+
+	it("throws NOT_FOUND when the tournament does not exist", async () => {
+		const { db, selectedTables } = mockDbFor({ tournament: [] });
+		await expect(
+			validateEntityOwnership(db, "tournament", "missing", CALLER)
+		).rejects.toMatchObject({
+			code: "NOT_FOUND",
+			message: "Tournament not found",
+		});
+		// Must short-circuit before reading the room.
+		expect(selectedTables).toEqual(["tournament"]);
+	});
+
+	it("throws FORBIDDEN when the tournament's room row is missing", async () => {
+		const { db } = mockDbFor({
+			tournament: [{ id: TOURNAMENT_ID, roomId: ROOM_ID }],
+			room: [],
+		});
+		await expect(
+			validateEntityOwnership(db, "tournament", TOURNAMENT_ID, CALLER)
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
 	});
 });

--- a/packages/api/src/__tests__/test-utils.ts
+++ b/packages/api/src/__tests__/test-utils.ts
@@ -1,4 +1,5 @@
-import { expect } from "vitest";
+import { getTableName } from "drizzle-orm";
+import { expect, vi } from "vitest";
 
 interface ZodLikeSchema {
 	safeParse: (value: unknown) => { success: boolean };
@@ -73,4 +74,70 @@ export function expectType(
 	type: "mutation" | "query" | "subscription"
 ): void {
 	expect(getProcedureDef(procedure).type).toBe(type);
+}
+
+type MockRow = Record<string, unknown>;
+
+interface ChainableMockDbConfig {
+	/** Rows returned by `select().from(table)…` keyed by the SQL table name. */
+	select?: Record<string, MockRow[]>;
+}
+
+/**
+ * A minimal chainable Drizzle-style mock `db` for exercising router
+ * procedures / helpers end-to-end without a real database.
+ *
+ * `select()` chains (`.from().where().limit().orderBy()`) resolve to the rows
+ * configured for the table passed to `.from(table)` (matched via
+ * `getTableName`); `insert(table).values(rows)` records the inserted payload.
+ * It tracks which tables were read (`selectedTables`) so ownership guards can
+ * be asserted, and which tables were written (`inserted`).
+ */
+export function createChainableMockDb(config: ChainableMockDbConfig = {}) {
+	const selectRows = config.select ?? {};
+	const inserted: Record<string, unknown[]> = {};
+	const selectedTables: string[] = [];
+
+	// The chain is a real Promise (so `await`-ing any step resolves the rows
+	// natively) with Drizzle's builder methods attached. Non-terminal steps
+	// (`where` / `limit` / `orderBy` / joins) return the same promise; `from`
+	// starts a fresh chain scoped to the table's configured rows.
+	function makeSelectChain(rows: MockRow[]) {
+		const chain = Promise.resolve(rows) as Promise<MockRow[]> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = (table: unknown) => {
+			const name = getTableName(table as never);
+			selectedTables.push(name);
+			return makeSelectChain(selectRows[name] ?? []);
+		};
+		chain.where = () => chain;
+		chain.limit = () => chain;
+		chain.orderBy = () => chain;
+		chain.leftJoin = () => chain;
+		chain.innerJoin = () => chain;
+		return chain;
+	}
+
+	const select = vi.fn(() => makeSelectChain([]));
+	const insert = vi.fn((table: unknown) => ({
+		values: vi.fn((values: unknown) => {
+			const name = getTableName(table as never);
+			const bucket = inserted[name] ?? [];
+			bucket.push(values);
+			inserted[name] = bucket;
+			return Promise.resolve(undefined);
+		}),
+	}));
+	const del = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+	const update = vi.fn(() => ({
+		set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+	}));
+
+	return {
+		db: { select, insert, delete: del, update } as never,
+		select,
+		insert,
+		inserted,
+		selectedTables,
+	};
 }

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -27,6 +27,7 @@ import {
 	resnapshotTournamentStructure,
 	resolveTournamentRuleSnapshot,
 	snapshotTournamentStructure,
+	validateEntityOwnership,
 } from "./session";
 
 const DEFAULT_LIMIT = 20;
@@ -665,6 +666,18 @@ export const liveTournamentSessionRouter = router({
 			const userId = ctx.session.user.id;
 
 			await assertNoActiveSession(ctx.db, userId);
+
+			// Validate tournament ownership before reading its structure so a
+			// caller cannot snapshot another user's blind levels / chip purchases
+			// via snapshotTournamentStructure (IDOR).
+			if (input.tournamentId) {
+				await validateEntityOwnership(
+					ctx.db,
+					"tournament",
+					input.tournamentId,
+					userId
+				);
+			}
 
 			const id = crypto.randomUUID();
 			const now = new Date();

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -359,6 +359,19 @@ async function validateEntityOwnership(
 				message: "Tournament not found",
 			});
 		}
+		// A tournament has no userId of its own; ownership is derived from its
+		// room. Without this check a caller could pass another user's
+		// tournamentId to snapshot their blind structure / chip purchases (IDOR).
+		const [foundRoom] = await db
+			.select()
+			.from(room)
+			.where(eq(room.id, found.roomId));
+		if (!foundRoom || foundRoom.userId !== userId) {
+			throw new TRPCError({
+				code: "FORBIDDEN",
+				message: "You do not own this tournament",
+			});
+		}
 	} else if (entityType === "currency") {
 		const [found] = await db
 			.select()
@@ -478,6 +491,7 @@ export {
 	computeTournamentPL,
 	getSessionChipPurchaseMap,
 	sumChipPurchaseCost,
+	validateEntityOwnership,
 	validateSessionOwnership,
 };
 


### PR DESCRIPTION
## 概要 (SA2-172)

SA2-102（PR #489）で `roomId`/`currencyId` の所有権検証を追加したが `tournamentId` は対象外だった。ライブトーナメント create 直後の `snapshotTournamentStructure` が他ユーザーのトーナメント構成（ブラインド構造・チップ購入）を**所有権チェックなし**に読み取れる、別系統の**読み取りIDOR**を修正する。

## 修正内容

- `packages/api/src/routers/session.ts` の `validateEntityOwnership` の `tournament` 分岐を強化。`tournament` テーブルに `userId` 列は無く所有権は `tournament.roomId → room.userId` で表現されるため、既存の `resolveTournamentAssignment` と同じく room を辿って所有者を検証し、他ユーザー所有/room欠如なら `FORBIDDEN`、トーナメント不在なら `NOT_FOUND`（room/currency と同一セマンティクス）。関数を export。
- `packages/api/src/routers/live-tournament-session.ts` の create で、`tournamentId` 指定時に**DB書き込み前**に `validateEntityOwnership(ctx.db, "tournament", ...)` を呼ぶ。
- update 経路は既に `resolveTournamentAssignment` 経由で同等の room 所有権検証済み（変更不要）。
- 通常セッション create（`validateCreateLinks` 経由）も強化が自動的に波及。

## テスト

TDD（RED→GREEN）。`validateEntityOwnership("tournament")` の単体（所有/他ユーザー/不在/room欠如）と、create のE2E（所有→snapshot実行、他ユーザー→FORBIDDENかつ未INSERT、不在→NOT_FOUNDかつ未INSERT、tournamentId省略→検証スキップ）を網羅。

### 検証結果
- `bunx vitest run --project api` 対象2ファイル → **122 passed**、api全体 **757 passed**。
- `bun x ultracite check`（5ファイル）クリーン、`bun run check-types` server/web ともに exit 0。

Closes SA2-172

_Generated by [Claude Code](https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ)_