### PR TITLE
fix(api): IDOR網羅対応 — 参照FKの所有権検証を追加 (SA2-175)

### DIFF
--- a/packages/api/src/__tests__/blind-level.test.ts
+++ b/packages/api/src/__tests__/blind-level.test.ts
@@ -1,3 +1,7 @@
+import { room } from "@sapphire2/db/schema/room";
+import { blindLevel, tournament } from "@sapphire2/db/schema/tournament";
+import { TRPCError } from "@trpc/server";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -6,6 +10,67 @@ import {
 	expectRejects,
 	expectType,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+const dialect = new SQLiteSyncDialect();
+
+function makeSelectChain(rows: Rows) {
+	const chain = Promise.resolve(rows) as Promise<Rows> &
+		Record<string, () => unknown>;
+	chain.where = () => chain;
+	chain.orderBy = () => chain;
+	chain.limit = () => chain;
+	return chain;
+}
+
+/**
+ * Mock db that resolves `select().from(table)` from a table-keyed map and
+ * records the SQL params bound to each `update().set().where(cond)` so tests
+ * can assert the WHERE predicate is scoped to the owned tournament (SA2-176).
+ */
+function createReorderMockDb(rowsByTable: Map<unknown, Rows>) {
+	const updateWhereParams: unknown[][] = [];
+	const db = {
+		select: () => ({
+			from: (table: unknown) => makeSelectChain(rowsByTable.get(table) ?? []),
+		}),
+		update: () => ({
+			set: () => ({
+				where: (cond: unknown) => {
+					updateWhereParams.push(dialect.sqlToQuery(cond as never).params);
+					return Promise.resolve(undefined);
+				},
+			}),
+		}),
+	};
+	return { db, updateWhereParams };
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+function makeCaller(userId: string, rowsByTable: Map<unknown, Rows>) {
+	const { db, updateWhereParams } = createReorderMockDb(rowsByTable);
+	const caller = appRouter.createCaller({
+		session: { user: { id: userId } },
+		db,
+	} as unknown as Parameters<typeof appRouter.createCaller>[0]).blindLevel;
+	return { caller, updateWhereParams };
+}
+
+const CALLER = "user-1";
+const OTHER = "user-2";
 
 describe("blindLevel router", () => {
 	it("appRouter has blindLevel namespace", () => {
@@ -180,5 +245,47 @@ describe("blindLevel.reorder input validation", () => {
 			tournamentId: "tn1",
 			levelIds: ["bl1", 2],
 		});
+	});
+});
+
+describe("blindLevel.reorder tournament scoping (SA2-176)", () => {
+	function ownedRows() {
+		return new Map<unknown, Rows>([
+			[tournament, [{ id: "tn1", roomId: "room1" }]],
+			[room, [{ id: "room1", userId: CALLER }]],
+			[blindLevel, [{ id: "bl1", level: 1 }]],
+		]);
+	}
+
+	it("scopes each level UPDATE to both the level id and the owned tournament", async () => {
+		const { caller, updateWhereParams } = makeCaller(CALLER, ownedRows());
+		await caller.reorder({ tournamentId: "tn1", levelIds: ["bl1", "bl2"] });
+		expect(updateWhereParams).toHaveLength(2);
+		// Every UPDATE must constrain the row to the caller's tournament so a
+		// foreign levelId matches nothing.
+		expect(updateWhereParams[0]).toContain("bl1");
+		expect(updateWhereParams[0]).toContain("tn1");
+		expect(updateWhereParams[1]).toContain("bl2");
+		expect(updateWhereParams[1]).toContain("tn1");
+	});
+
+	it("runs no UPDATE when levelIds is empty", async () => {
+		const { caller, updateWhereParams } = makeCaller(CALLER, ownedRows());
+		await caller.reorder({ tournamentId: "tn1", levelIds: [] });
+		expect(updateWhereParams).toHaveLength(0);
+	});
+
+	it("throws FORBIDDEN and runs no UPDATE when the tournament is owned by another user", async () => {
+		const rows = new Map<unknown, Rows>([
+			[tournament, [{ id: "tn1", roomId: "room1" }]],
+			[room, [{ id: "room1", userId: OTHER }]],
+			[blindLevel, []],
+		]);
+		const { caller, updateWhereParams } = makeCaller(CALLER, rows);
+		await expectTrpcCode(
+			caller.reorder({ tournamentId: "tn1", levelIds: ["bl1"] }),
+			"FORBIDDEN"
+		);
+		expect(updateWhereParams).toHaveLength(0);
 	});
 });

--- a/packages/api/src/__tests__/currency-transaction.test.ts
+++ b/packages/api/src/__tests__/currency-transaction.test.ts
@@ -1,3 +1,10 @@
+import {
+	currency,
+	currencyTransaction,
+	transactionType,
+} from "@sapphire2/db/schema/currency";
+import { TRPCError } from "@trpc/server";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -6,6 +13,77 @@ import {
 	expectRejects,
 	expectType,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+const dialect = new SQLiteSyncDialect();
+
+/**
+ * Mock db keyed by schema-table reference: `select().from(t)...` resolves to
+ * the rows registered for `t`; every `.where(cond)` records its bound SQL
+ * params (so cursor scoping can be asserted) and `insert(t).values()` records
+ * the inserted payload (so a rejected ownership guard can be shown to skip the
+ * write).
+ */
+function createMockDb(rowsByTable: Map<unknown, Rows>) {
+	const selectWhereParams: unknown[][] = [];
+	const inserted: { table: unknown; values: unknown }[] = [];
+	const makeChain = (rows: Rows) => {
+		const chain = Promise.resolve(rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = (table: unknown) => makeChain(rowsByTable.get(table) ?? []);
+		chain.where = (cond: unknown) => {
+			selectWhereParams.push(dialect.sqlToQuery(cond as never).params);
+			return chain;
+		};
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.innerJoin = () => chain;
+		chain.leftJoin = () => chain;
+		return chain;
+	};
+	const db = {
+		select: () => makeChain([]),
+		insert: (table: unknown) => ({
+			values: (values: unknown) => {
+				inserted.push({ table, values });
+				return Promise.resolve(undefined);
+			},
+		}),
+		update: () => ({
+			set: () => ({ where: () => Promise.resolve(undefined) }),
+		}),
+		delete: () => ({ where: () => Promise.resolve(undefined) }),
+	};
+	return { db, selectWhereParams, inserted };
+}
+
+function makeCaller(userId: string, rowsByTable: Map<unknown, Rows>) {
+	const { db, selectWhereParams, inserted } = createMockDb(rowsByTable);
+	const caller = appRouter.createCaller({
+		session: { user: { id: userId } },
+		db,
+	} as unknown as Parameters<
+		typeof appRouter.createCaller
+	>[0]).currencyTransaction;
+	return { caller, selectWhereParams, inserted };
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+const OWNER = "user-1";
+const OTHER = "user-2";
 
 describe("currencyTransaction router structure", () => {
 	it("appRouter has currencyTransaction namespace", () => {
@@ -156,5 +234,151 @@ describe("currencyTransaction.delete input validation", () => {
 
 	it("rejects non-string id", () => {
 		expectRejects(appRouter.currencyTransaction.delete, { id: 123 });
+	});
+});
+
+describe("currencyTransaction.create transactionType ownership (SA2-179)", () => {
+	const validInput = {
+		currencyId: "c1",
+		transactionTypeId: "tt1",
+		amount: 1000,
+		transactedAt: "2024-01-01T00:00:00Z",
+	};
+
+	it("accepts a transaction type owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[currency, [{ id: "c1", userId: OWNER }]],
+			[transactionType, [{ id: "tt1", userId: OWNER }]],
+			[currencyTransaction, [{ id: "tx-new" }]],
+		]);
+		const { caller } = makeCaller(OWNER, rows);
+		await expect(caller.create(validInput)).resolves.toBeDefined();
+	});
+
+	it("rejects a transaction type owned by another user and skips the insert", async () => {
+		const rows = new Map<unknown, Rows>([
+			[currency, [{ id: "c1", userId: OWNER }]],
+			[transactionType, [{ id: "tt1", userId: OTHER }]],
+		]);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expectTrpcCode(caller.create(validInput), "FORBIDDEN");
+		expect(inserted.some((i) => i.table === currencyTransaction)).toBe(false);
+	});
+
+	it("throws NOT_FOUND when the transaction type does not exist", async () => {
+		const rows = new Map<unknown, Rows>([
+			[currency, [{ id: "c1", userId: OWNER }]],
+			[transactionType, []],
+		]);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expectTrpcCode(caller.create(validInput), "NOT_FOUND");
+		expect(inserted.some((i) => i.table === currencyTransaction)).toBe(false);
+	});
+
+	it("rejects before validating the transaction type when the currency is foreign", async () => {
+		const rows = new Map<unknown, Rows>([
+			[currency, [{ id: "c1", userId: OTHER }]],
+			[transactionType, [{ id: "tt1", userId: OWNER }]],
+		]);
+		const { caller } = makeCaller(OWNER, rows);
+		await expectTrpcCode(caller.create(validInput), "FORBIDDEN");
+	});
+});
+
+describe("currencyTransaction.update transactionType ownership (SA2-179)", () => {
+	function ownedTransactionRows(extra?: Map<unknown, Rows>) {
+		const map = new Map<unknown, Rows>([
+			[
+				currencyTransaction,
+				[
+					{
+						currencyTransaction: {
+							id: "tx1",
+							currencyId: "c1",
+							sessionId: null,
+						},
+						currency: { id: "c1", userId: OWNER },
+					},
+				],
+			],
+		]);
+		if (extra) {
+			for (const [k, v] of extra) {
+				map.set(k, v);
+			}
+		}
+		return map;
+	}
+
+	it("accepts a transaction type owned by the caller", async () => {
+		const rows = ownedTransactionRows(
+			new Map<unknown, Rows>([
+				[transactionType, [{ id: "tt2", userId: OWNER }]],
+			])
+		);
+		const { caller } = makeCaller(OWNER, rows);
+		await expect(
+			caller.update({ id: "tx1", transactionTypeId: "tt2" })
+		).resolves.toBeDefined();
+	});
+
+	it("rejects a transaction type owned by another user with FORBIDDEN", async () => {
+		const rows = ownedTransactionRows(
+			new Map<unknown, Rows>([
+				[transactionType, [{ id: "tt2", userId: OTHER }]],
+			])
+		);
+		const { caller } = makeCaller(OWNER, rows);
+		await expectTrpcCode(
+			caller.update({ id: "tx1", transactionTypeId: "tt2" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("throws NOT_FOUND when the transaction type does not exist", async () => {
+		const rows = ownedTransactionRows(
+			new Map<unknown, Rows>([[transactionType, []]])
+		);
+		const { caller } = makeCaller(OWNER, rows);
+		await expectTrpcCode(
+			caller.update({ id: "tx1", transactionTypeId: "missing" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("does not validate the transaction type when the field is omitted", async () => {
+		const rows = ownedTransactionRows();
+		const { caller, selectWhereParams } = makeCaller(OWNER, rows);
+		await expect(
+			caller.update({ id: "tx1", amount: 50 })
+		).resolves.toBeDefined();
+		// transaction_type is never seeded → no extra ownership read fired.
+		expect(rows.has(transactionType)).toBe(false);
+		expect(selectWhereParams.length).toBeGreaterThan(0);
+	});
+});
+
+describe("currencyTransaction.listByCurrency cursor scoping (SA2-182)", () => {
+	it("scopes the cursor boundary subquery to the target currency", async () => {
+		const rows = new Map<unknown, Rows>([
+			[currency, [{ id: "c1", userId: OWNER }]],
+			[currencyTransaction, []],
+		]);
+		const { caller, selectWhereParams } = makeCaller(OWNER, rows);
+		await caller.listByCurrency({ currencyId: "c1", cursor: "tx-cursor" });
+		const listWhere = selectWhereParams.find((p) => p.includes("tx-cursor"));
+		expect(listWhere).toBeDefined();
+		// currencyId appears twice: the base filter + the cursor subquery scope.
+		expect((listWhere as unknown[]).filter((p) => p === "c1")).toHaveLength(2);
+	});
+
+	it("does not add a cursor subquery when no cursor is supplied", async () => {
+		const rows = new Map<unknown, Rows>([
+			[currency, [{ id: "c1", userId: OWNER }]],
+			[currencyTransaction, []],
+		]);
+		const { caller, selectWhereParams } = makeCaller(OWNER, rows);
+		await caller.listByCurrency({ currencyId: "c1" });
+		expect(selectWhereParams.every((p) => !p.includes("tx-cursor"))).toBe(true);
 	});
 });

--- a/packages/api/src/__tests__/live-cash-game-session.test.ts
+++ b/packages/api/src/__tests__/live-cash-game-session.test.ts
@@ -4,6 +4,7 @@ import { room } from "@sapphire2/db/schema/room";
 import { gameSession } from "@sapphire2/db/schema/session";
 import { sessionCashDetail } from "@sapphire2/db/schema/session-cash-detail";
 import { TRPCError } from "@trpc/server";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -669,5 +670,59 @@ describe("liveCashGameSession.updateSnapshot input validation", () => {
 			id: "s1",
 			blind1: 1.5,
 		});
+	});
+});
+
+const dialect = new SQLiteSyncDialect();
+
+/**
+ * Mock db that records the SQL params bound to the list query's `.where(...)`
+ * so the cursor-boundary subquery can be shown to be scoped to the caller
+ * (SA2-182). `select().from()` resolves to no rows; the enrichment loop is
+ * skipped because there are no items.
+ */
+function createListWhereMockDb() {
+	const selectWhereParams: unknown[][] = [];
+	const makeChain = () => {
+		const chain = Promise.resolve([] as Rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = () => chain;
+		chain.where = (cond: unknown) => {
+			selectWhereParams.push(dialect.sqlToQuery(cond as never).params);
+			return chain;
+		};
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.leftJoin = () => chain;
+		chain.innerJoin = () => chain;
+		return chain;
+	};
+	const db = { select: () => makeChain() };
+	return { db, selectWhereParams };
+}
+
+describe("liveCashGameSession.list cursor scoping (SA2-182)", () => {
+	it("scopes the cursor boundary subquery to the caller's user id", async () => {
+		const { db, selectWhereParams } = createListWhereMockDb();
+		const caller = appRouter.createCaller({
+			session: { user: { id: OWNER } },
+			db,
+		} as unknown as Parameters<typeof appRouter.createCaller>[0]);
+		await caller.liveCashGameSession.list({ cursor: "s-cursor", limit: 10 });
+		const listWhere = selectWhereParams.find((p) => p.includes("s-cursor"));
+		expect(listWhere).toBeDefined();
+		// userId appears twice: the base filter + the cursor subquery scope.
+		expect((listWhere as unknown[]).filter((p) => p === OWNER)).toHaveLength(2);
+	});
+
+	it("does not add a cursor subquery when no cursor is supplied", async () => {
+		const { db, selectWhereParams } = createListWhereMockDb();
+		const caller = appRouter.createCaller({
+			session: { user: { id: OWNER } },
+			db,
+		} as unknown as Parameters<typeof appRouter.createCaller>[0]);
+		await caller.liveCashGameSession.list({ limit: 10 });
+		const base = selectWhereParams[0] as unknown[];
+		expect(base.filter((p) => p === OWNER)).toHaveLength(1);
 	});
 });

--- a/packages/api/src/__tests__/live-cash-game-session.test.ts
+++ b/packages/api/src/__tests__/live-cash-game-session.test.ts
@@ -1,6 +1,8 @@
 import { currency } from "@sapphire2/db/schema/currency";
+import { ringGame } from "@sapphire2/db/schema/ring-game";
 import { room } from "@sapphire2/db/schema/room";
 import { gameSession } from "@sapphire2/db/schema/session";
+import { sessionCashDetail } from "@sapphire2/db/schema/session-cash-detail";
 import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
@@ -240,6 +242,125 @@ describe("liveCashGameSession.update ownership validation (SA2-102)", () => {
 		]);
 		await expect(
 			makeCaller(OWNER, rows).update({ id: "s1", memo: "note" })
+		).resolves.toBeDefined();
+	});
+});
+
+describe("liveCashGameSession.create ring game ownership (SA2-174)", () => {
+	it("accepts a ring game whose room is owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: "room-1", minBuyIn: null, maxBuyIn: null }],
+			],
+			[room, [{ id: "room-1", userId: OWNER }]],
+			[sessionCashDetail, []],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 1000, ringGameId: "rg-1" })
+		).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
+	});
+
+	it("rejects a ring game whose room belongs to another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: "room-1", minBuyIn: null, maxBuyIn: null }],
+			],
+			[room, [{ id: "room-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, ringGameId: "rg-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a ring game with a null roomId (auto-generated row) with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: null, minBuyIn: null, maxBuyIn: null }],
+			],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, ringGameId: "rg-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a non-existent ring game with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[ringGame, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, ringGameId: "rg-x" }),
+			"NOT_FOUND"
+		);
+	});
+});
+
+describe("liveCashGameSession.update ring game ownership (SA2-174)", () => {
+	it("accepts a ring game whose room is owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[ringGame, [{ id: "rg-1", roomId: "room-1", currencyId: null }]],
+			[room, [{ id: "room-1", userId: OWNER }]],
+			[sessionCashDetail, []],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({ id: "s1", ringGameId: "rg-1" })
+		).resolves.toBeDefined();
+	});
+
+	it("rejects a ring game whose room belongs to another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[ringGame, [{ id: "rg-1", roomId: "room-1", currencyId: null }]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[sessionCashDetail, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", ringGameId: "rg-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a ring game with a null roomId (auto-generated row) with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[ringGame, [{ id: "rg-1", roomId: null, currencyId: null }]],
+			[sessionCashDetail, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", ringGameId: "rg-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a non-existent ring game with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[ringGame, []],
+			[sessionCashDetail, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", ringGameId: "rg-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("clears ringGameId with null without an ownership error", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[ringGame, [{ id: "rg-1", roomId: null, currencyId: null }]],
+			[sessionCashDetail, []],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({ id: "s1", ringGameId: null })
 		).resolves.toBeDefined();
 	});
 });

--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -2,6 +2,7 @@ import { currency } from "@sapphire2/db/schema/currency";
 import { room } from "@sapphire2/db/schema/room";
 import { gameSession } from "@sapphire2/db/schema/session";
 import { TRPCError } from "@trpc/server";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it, vi } from "vitest";
 import { t } from "../index";
 import { appRouter } from "../routers";
@@ -806,5 +807,55 @@ describe("liveTournamentSession.create tournament ownership (IDOR guard)", () =>
 		expect(selectedTables).not.toContain("room");
 		expect(inserted.game_session).toHaveLength(1);
 		expect(inserted.session_blind_level).toBeUndefined();
+	});
+});
+
+const listCursorDialect = new SQLiteSyncDialect();
+
+/**
+ * Mock db recording the SQL params bound to the list query's `.where(...)` so
+ * the cursor-boundary subquery can be shown to be scoped to the caller
+ * (SA2-182). `select().from()` resolves to no rows; enrichment is skipped.
+ */
+function createListWhereMockDb() {
+	const selectWhereParams: unknown[][] = [];
+	const makeChain = () => {
+		const chain = Promise.resolve([] as Rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = () => chain;
+		chain.where = (cond: unknown) => {
+			selectWhereParams.push(
+				listCursorDialect.sqlToQuery(cond as never).params
+			);
+			return chain;
+		};
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.leftJoin = () => chain;
+		chain.innerJoin = () => chain;
+		return chain;
+	};
+	const db = { select: () => makeChain() };
+	return { db, selectWhereParams };
+}
+
+describe("liveTournamentSession.list cursor scoping (SA2-182)", () => {
+	it("scopes the cursor boundary subquery to the caller's user id", async () => {
+		const { db, selectWhereParams } = createListWhereMockDb();
+		await callerFor(db, OWNER).liveTournamentSession.list({
+			cursor: "s-cursor",
+			limit: 10,
+		});
+		const listWhere = selectWhereParams.find((p) => p.includes("s-cursor"));
+		expect(listWhere).toBeDefined();
+		// userId appears twice: the base filter + the cursor subquery scope.
+		expect((listWhere as unknown[]).filter((p) => p === OWNER)).toHaveLength(2);
+	});
+
+	it("does not add a cursor subquery when no cursor is supplied", async () => {
+		const { db, selectWhereParams } = createListWhereMockDb();
+		await callerFor(db, OWNER).liveTournamentSession.list({ limit: 10 });
+		const base = selectWhereParams[0] as unknown[];
+		expect(base.filter((p) => p === OWNER)).toHaveLength(1);
 	});
 });

--- a/packages/api/src/__tests__/player.test.ts
+++ b/packages/api/src/__tests__/player.test.ts
@@ -1,3 +1,9 @@
+import {
+	player,
+	playerTag,
+	playerToPlayerTag,
+} from "@sapphire2/db/schema/player";
+import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -6,6 +12,69 @@ import {
 	expectRejects,
 	expectType,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+
+/**
+ * Mock db keyed by schema-table reference: `select().from(t)...` resolves to
+ * the rows registered for `t`; `insert(t).values()` records the payload so a
+ * rejected tag-ownership guard can be shown to skip the `player_to_player_tag`
+ * write (SA2-178).
+ */
+function createMockDb(rowsByTable: Map<unknown, Rows>) {
+	const inserted: { table: unknown; values: unknown }[] = [];
+	const makeChain = (rows: Rows) => {
+		const chain = Promise.resolve(rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = (table: unknown) => makeChain(rowsByTable.get(table) ?? []);
+		chain.where = () => chain;
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.innerJoin = () => chain;
+		chain.leftJoin = () => chain;
+		return chain;
+	};
+	const db = {
+		select: () => makeChain([]),
+		insert: (table: unknown) => ({
+			values: (values: unknown) => {
+				inserted.push({ table, values });
+				return Promise.resolve(undefined);
+			},
+		}),
+		update: () => ({
+			set: () => ({ where: () => Promise.resolve(undefined) }),
+		}),
+		delete: () => ({ where: () => Promise.resolve(undefined) }),
+	};
+	return { db, inserted };
+}
+
+function makeCaller(userId: string, rowsByTable: Map<unknown, Rows>) {
+	const { db, inserted } = createMockDb(rowsByTable);
+	const caller = appRouter.createCaller({
+		session: { user: { id: userId } },
+		db,
+	} as unknown as Parameters<typeof appRouter.createCaller>[0]).player;
+	return { caller, inserted };
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+const OWNER = "user-1";
+const OTHER = "user-2";
 
 describe("player router structure", () => {
 	it("appRouter has player namespace", () => {
@@ -172,5 +241,102 @@ describe("player.delete input validation", () => {
 
 	it("rejects missing id", () => {
 		expectRejects(appRouter.player.delete, {});
+	});
+});
+
+describe("player.create tag ownership (SA2-178)", () => {
+	it("accepts tags owned by the caller and links them", async () => {
+		const rows = new Map<unknown, Rows>([
+			[playerTag, [{ id: "t1" }, { id: "t2" }]],
+			[player, [{ id: "p-new", userId: OWNER }]],
+			[playerToPlayerTag, []],
+		]);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expect(
+			caller.create({ name: "Alice", tagIds: ["t1", "t2"] })
+		).resolves.toBeDefined();
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(true);
+	});
+
+	it("rejects a tag owned by another user and skips the join insert", async () => {
+		const rows = new Map<unknown, Rows>([
+			// Only one of the two requested tags is owned by the caller.
+			[playerTag, [{ id: "t1" }]],
+			[player, [{ id: "p-new", userId: OWNER }]],
+		]);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expectTrpcCode(
+			caller.create({ name: "Alice", tagIds: ["t1", "t2"] }),
+			"FORBIDDEN"
+		);
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
+	});
+
+	it("does not validate tags when tagIds is omitted", async () => {
+		const rows = new Map<unknown, Rows>([
+			[player, [{ id: "p-new", userId: OWNER }]],
+			[playerToPlayerTag, []],
+		]);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expect(caller.create({ name: "Alice" })).resolves.toBeDefined();
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
+	});
+});
+
+describe("player.update tag ownership (SA2-178)", () => {
+	function ownedPlayerRows(extra: Map<unknown, Rows>) {
+		const map = new Map<unknown, Rows>([
+			[player, [{ id: "p1", userId: OWNER }]],
+			[playerToPlayerTag, []],
+		]);
+		for (const [k, v] of extra) {
+			map.set(k, v);
+		}
+		return map;
+	}
+
+	it("accepts tags owned by the caller and links them", async () => {
+		const rows = ownedPlayerRows(
+			new Map<unknown, Rows>([[playerTag, [{ id: "t1" }, { id: "t2" }]]])
+		);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expect(
+			caller.update({ id: "p1", tagIds: ["t1", "t2"] })
+		).resolves.toBeDefined();
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(true);
+	});
+
+	it("rejects a tag owned by another user and skips the join insert", async () => {
+		const rows = ownedPlayerRows(
+			new Map<unknown, Rows>([[playerTag, [{ id: "t1" }]]])
+		);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expectTrpcCode(
+			caller.update({ id: "p1", tagIds: ["t1", "t2"] }),
+			"FORBIDDEN"
+		);
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
+	});
+
+	it("does not validate tags when tagIds is omitted", async () => {
+		const rows = ownedPlayerRows(new Map());
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expect(
+			caller.update({ id: "p1", name: "Bob" })
+		).resolves.toBeDefined();
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
+	});
+
+	it("rejects updating a player owned by another user before touching tags", async () => {
+		const rows = new Map<unknown, Rows>([
+			[player, [{ id: "p1", userId: OTHER }]],
+			[playerTag, [{ id: "t1" }]],
+		]);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expectTrpcCode(
+			caller.update({ id: "p1", tagIds: ["t1"] }),
+			"FORBIDDEN"
+		);
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
 	});
 });

--- a/packages/api/src/__tests__/ring-game.test.ts
+++ b/packages/api/src/__tests__/ring-game.test.ts
@@ -1,3 +1,7 @@
+import { currency } from "@sapphire2/db/schema/currency";
+import { ringGame } from "@sapphire2/db/schema/ring-game";
+import { room } from "@sapphire2/db/schema/room";
+import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -7,6 +11,54 @@ import {
 	expectType,
 	getInputSchema,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+
+function createMockDb(rowsByTable: Map<unknown, Rows>) {
+	const makeChain = (rows: Rows) => {
+		const chain = Promise.resolve(rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = (table: unknown) => makeChain(rowsByTable.get(table) ?? []);
+		chain.where = () => chain;
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.innerJoin = () => chain;
+		chain.leftJoin = () => chain;
+		return chain;
+	};
+	return {
+		select: () => makeChain([]),
+		insert: () => ({ values: () => Promise.resolve(undefined) }),
+		update: () => ({
+			set: () => ({ where: () => Promise.resolve(undefined) }),
+		}),
+		delete: () => ({ where: () => Promise.resolve(undefined) }),
+	};
+}
+
+function ringGameCaller(userId: string, rowsByTable: Map<unknown, Rows>) {
+	return appRouter.createCaller({
+		session: { user: { id: userId } },
+		db: createMockDb(rowsByTable),
+	} as unknown as Parameters<typeof appRouter.createCaller>[0]).ringGame;
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+const CUR_OWNER = "user-1";
+const CUR_OTHER = "user-2";
 
 describe("ringGame router", () => {
 	it("appRouter has ringGame namespace", () => {
@@ -187,5 +239,80 @@ describe("ringGame.{archive,restore,delete} input validation", () => {
 		expectRejects(appRouter.ringGame.archive, {});
 		expectRejects(appRouter.ringGame.restore, {});
 		expectRejects(appRouter.ringGame.delete, {});
+	});
+});
+
+describe("ringGame currency ownership (SA2-180)", () => {
+	const ownedRoom = { id: "room-1", userId: CUR_OWNER };
+	const ownedRingGame = { id: "rg-1", roomId: "room-1" };
+
+	function createRows(currencyRows: Rows) {
+		return new Map<unknown, Rows>([
+			[room, [ownedRoom]],
+			[ringGame, [ownedRingGame]],
+			[currency, currencyRows],
+		]);
+	}
+
+	it("create accepts a currency owned by the caller", async () => {
+		const caller = ringGameCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OWNER }])
+		);
+		await expect(
+			caller.create({ roomId: "room-1", name: "RG", currencyId: "cur-1" })
+		).resolves.toBeDefined();
+	});
+
+	it("create rejects a currency owned by another user with FORBIDDEN", async () => {
+		const caller = ringGameCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expectTrpcCode(
+			caller.create({ roomId: "room-1", name: "RG", currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("create skips currency validation when currencyId is omitted", async () => {
+		const caller = ringGameCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expect(
+			caller.create({ roomId: "room-1", name: "RG" })
+		).resolves.toBeDefined();
+	});
+
+	it("update rejects a foreign currency with FORBIDDEN", async () => {
+		const caller = ringGameCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expectTrpcCode(
+			caller.update({ id: "rg-1", currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("update accepts a currency owned by the caller", async () => {
+		const caller = ringGameCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OWNER }])
+		);
+		await expect(
+			caller.update({ id: "rg-1", currencyId: "cur-1" })
+		).resolves.toBeDefined();
+	});
+
+	it("update allows clearing the currency with null", async () => {
+		const caller = ringGameCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expect(
+			caller.update({ id: "rg-1", currencyId: null })
+		).resolves.toBeDefined();
 	});
 });

--- a/packages/api/src/__tests__/session-table-player.test.ts
+++ b/packages/api/src/__tests__/session-table-player.test.ts
@@ -1,3 +1,10 @@
+import {
+	player,
+	playerTag,
+	playerToPlayerTag,
+} from "@sapphire2/db/schema/player";
+import { gameSession } from "@sapphire2/db/schema/session";
+import { TRPCError } from "@trpc/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -461,5 +468,114 @@ describe("insertPlayerLeaveEvent (write-side ordering contract)", () => {
 		expect(JSON.parse(inserted.payload as string)).toEqual({
 			playerId: "player-abc",
 		});
+	});
+});
+
+describe("sessionTablePlayer.addNew tag ownership (SA2-178)", () => {
+	type Rows = Record<string, unknown>[];
+	const OWNER = "owner-1";
+
+	function createMockDb(rowsByTable: Map<unknown, Rows>) {
+		const inserted: { table: unknown; values: unknown }[] = [];
+		const makeChain = (rows: Rows) => {
+			const chain = Promise.resolve(rows) as Promise<Rows> &
+				Record<string, (...args: unknown[]) => unknown>;
+			chain.from = (table: unknown) => makeChain(rowsByTable.get(table) ?? []);
+			chain.where = () => chain;
+			chain.orderBy = () => chain;
+			chain.limit = () => chain;
+			chain.innerJoin = () => chain;
+			chain.leftJoin = () => chain;
+			return chain;
+		};
+		return {
+			db: {
+				select: () => makeChain([]),
+				insert: (table: unknown) => ({
+					values: (values: unknown) => {
+						inserted.push({ table, values });
+						return Promise.resolve(undefined);
+					},
+				}),
+				update: () => ({
+					set: () => ({ where: () => Promise.resolve(undefined) }),
+				}),
+				delete: () => ({ where: () => Promise.resolve(undefined) }),
+			},
+			inserted,
+		};
+	}
+
+	function makeCaller(rowsByTable: Map<unknown, Rows>) {
+		const { db, inserted } = createMockDb(rowsByTable);
+		const caller = appRouter.createCaller({
+			session: { user: { id: OWNER } },
+			db,
+		} as unknown as Parameters<
+			typeof appRouter.createCaller
+		>[0]).sessionTablePlayer;
+		return { caller, inserted };
+	}
+
+	function ownedSessionRows(extra: Map<unknown, Rows>) {
+		const map = new Map<unknown, Rows>([
+			[gameSession, [{ id: "s1", userId: OWNER, kind: "cash_game" }]],
+		]);
+		for (const [k, v] of extra) {
+			map.set(k, v);
+		}
+		return map;
+	}
+
+	async function expectForbidden(promise: Promise<unknown>): Promise<void> {
+		try {
+			await promise;
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+			expect((error as { code: string }).code).toBe("FORBIDDEN");
+			return;
+		}
+		throw new Error("expected the call to throw FORBIDDEN but it resolved");
+	}
+
+	it("accepts player tags owned by the caller and links them", async () => {
+		const rows = ownedSessionRows(
+			new Map<unknown, Rows>([[playerTag, [{ id: "t1" }, { id: "t2" }]]])
+		);
+		const { caller, inserted } = makeCaller(rows);
+		await expect(
+			caller.addNew({
+				sessionId: "s1",
+				playerName: "Alice",
+				playerTagIds: ["t1", "t2"],
+			})
+		).resolves.toBeDefined();
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(true);
+	});
+
+	it("rejects a player tag owned by another user and skips the join insert", async () => {
+		const rows = ownedSessionRows(
+			new Map<unknown, Rows>([[playerTag, [{ id: "t1" }]]])
+		);
+		const { caller, inserted } = makeCaller(rows);
+		await expectForbidden(
+			caller.addNew({
+				sessionId: "s1",
+				playerName: "Alice",
+				playerTagIds: ["t1", "t2"],
+			})
+		);
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
+	});
+
+	it("does not validate tags when playerTagIds is omitted", async () => {
+		const rows = ownedSessionRows(new Map());
+		const { caller, inserted } = makeCaller(rows);
+		await expect(
+			caller.addNew({ sessionId: "s1", playerName: "Alice" })
+		).resolves.toBeDefined();
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
+		// The player itself is still created.
+		expect(inserted.some((i) => i.table === player)).toBe(true);
 	});
 });

--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -1,3 +1,4 @@
+import { sessionTag } from "@sapphire2/db/schema/session-tag";
 import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
@@ -11,6 +12,7 @@ import {
 	selectInChunks,
 	toProfitLossSeriesPoint,
 	validateEntityOwnership,
+	validateTagsOwnership,
 } from "../routers/session";
 import { createChainableMockDb } from "./test-utils";
 
@@ -947,6 +949,147 @@ describe("validateEntityOwnership (tournament branch)", () => {
 		});
 		await expect(
 			validateEntityOwnership(db, "tournament", TOURNAMENT_ID, CALLER)
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+	});
+});
+
+describe("validateEntityOwnership (ringGame branch) (SA2-174)", () => {
+	const CALLER = "user-1";
+	const OTHER = "user-2";
+	const RING_GAME_ID = "rg-1";
+	const ROOM_ID = "room-1";
+
+	function mockDbFor(opts: {
+		ringGame?: Record<string, unknown>[];
+		room?: Record<string, unknown>[];
+	}) {
+		return createChainableMockDb({
+			select: {
+				ring_game: opts.ringGame ?? [],
+				room: opts.room ?? [],
+			},
+		});
+	}
+
+	it("resolves when the ring game's room is owned by the caller", async () => {
+		const { db, selectedTables } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID }],
+			room: [{ id: ROOM_ID, userId: CALLER }],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).resolves.toBeUndefined();
+		// The room must be read to confirm ownership.
+		expect(selectedTables).toEqual(["ring_game", "room"]);
+	});
+
+	it("throws FORBIDDEN when the ring game's room belongs to another user", async () => {
+		const { db } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID }],
+			room: [{ id: ROOM_ID, userId: OTHER }],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
+	});
+
+	it("throws FORBIDDEN when the ring game has a null roomId (auto-generated row)", async () => {
+		const { db, selectedTables } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: null }],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
+		// Ownership cannot be proven; must not fall through to reading a room.
+		expect(selectedTables).toEqual(["ring_game"]);
+	});
+
+	it("throws NOT_FOUND when the ring game does not exist", async () => {
+		const { db, selectedTables } = mockDbFor({ ringGame: [] });
+		await expect(
+			validateEntityOwnership(db, "ringGame", "missing", CALLER)
+		).rejects.toMatchObject({
+			code: "NOT_FOUND",
+			message: "Ring game not found",
+		});
+		// Must short-circuit before reading the room.
+		expect(selectedTables).toEqual(["ring_game"]);
+	});
+
+	it("throws FORBIDDEN when the ring game's room row is missing", async () => {
+		const { db } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID }],
+			room: [],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
+	});
+});
+
+describe("validateTagsOwnership (SA2-177)", () => {
+	const CALLER = "user-1";
+
+	it("resolves without reading when ids is undefined", async () => {
+		const { db, selectedTables } = createChainableMockDb();
+		await expect(
+			validateTagsOwnership(db, sessionTag, undefined, CALLER)
+		).resolves.toBeUndefined();
+		expect(selectedTables).toEqual([]);
+	});
+
+	it("resolves without reading when ids is empty", async () => {
+		const { db, selectedTables } = createChainableMockDb();
+		await expect(
+			validateTagsOwnership(db, sessionTag, [], CALLER)
+		).resolves.toBeUndefined();
+		expect(selectedTables).toEqual([]);
+	});
+
+	it("resolves when every tag is owned by the caller", async () => {
+		const { db, selectedTables } = createChainableMockDb({
+			select: { session_tag: [{ id: "t1" }, { id: "t2" }] },
+		});
+		await expect(
+			validateTagsOwnership(db, sessionTag, ["t1", "t2"], CALLER)
+		).resolves.toBeUndefined();
+		expect(selectedTables).toEqual(["session_tag"]);
+	});
+
+	it("deduplicates ids before comparing the owned count", async () => {
+		const { db } = createChainableMockDb({
+			select: { session_tag: [{ id: "t1" }] },
+		});
+		await expect(
+			validateTagsOwnership(db, sessionTag, ["t1", "t1"], CALLER)
+		).resolves.toBeUndefined();
+	});
+
+	it("throws FORBIDDEN when a tag is owned by another user (fewer rows returned)", async () => {
+		const { db } = createChainableMockDb({
+			select: { session_tag: [{ id: "t1" }] },
+		});
+		await expect(
+			validateTagsOwnership(db, sessionTag, ["t1", "t2"], CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own one or more of these tags",
+		});
+	});
+
+	it("throws FORBIDDEN when none of the tags are owned", async () => {
+		const { db } = createChainableMockDb({ select: { session_tag: [] } });
+		await expect(
+			validateTagsOwnership(db, sessionTag, ["t1"], CALLER)
 		).rejects.toMatchObject({ code: "FORBIDDEN" });
 	});
 });

--- a/packages/api/src/__tests__/tournament-chip-purchase.test.ts
+++ b/packages/api/src/__tests__/tournament-chip-purchase.test.ts
@@ -1,3 +1,10 @@
+import { room } from "@sapphire2/db/schema/room";
+import {
+	tournament,
+	tournamentChipPurchase,
+} from "@sapphire2/db/schema/tournament";
+import { TRPCError } from "@trpc/server";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -6,6 +13,69 @@ import {
 	expectRejects,
 	expectType,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+const dialect = new SQLiteSyncDialect();
+
+function makeSelectChain(rows: Rows) {
+	const chain = Promise.resolve(rows) as Promise<Rows> &
+		Record<string, () => unknown>;
+	chain.where = () => chain;
+	chain.orderBy = () => chain;
+	chain.limit = () => chain;
+	return chain;
+}
+
+/**
+ * Mock db that resolves `select().from(table)` from a table-keyed map and
+ * records the SQL params bound to each `update().set().where(cond)` so tests
+ * can assert the WHERE predicate is scoped to the owned tournament (SA2-123).
+ */
+function createReorderMockDb(rowsByTable: Map<unknown, Rows>) {
+	const updateWhereParams: unknown[][] = [];
+	const db = {
+		select: () => ({
+			from: (table: unknown) => makeSelectChain(rowsByTable.get(table) ?? []),
+		}),
+		update: () => ({
+			set: () => ({
+				where: (cond: unknown) => {
+					updateWhereParams.push(dialect.sqlToQuery(cond as never).params);
+					return Promise.resolve(undefined);
+				},
+			}),
+		}),
+	};
+	return { db, updateWhereParams };
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+function makeCaller(userId: string, rowsByTable: Map<unknown, Rows>) {
+	const { db, updateWhereParams } = createReorderMockDb(rowsByTable);
+	const caller = appRouter.createCaller({
+		session: { user: { id: userId } },
+		db,
+	} as unknown as Parameters<
+		typeof appRouter.createCaller
+	>[0]).tournamentChipPurchase;
+	return { caller, updateWhereParams };
+}
+
+const CALLER = "user-1";
+const OTHER = "user-2";
 
 describe("tournamentChipPurchase router structure", () => {
 	it("appRouter has tournamentChipPurchase namespace", () => {
@@ -177,5 +247,45 @@ describe("tournamentChipPurchase.reorder input validation", () => {
 			tournamentId: "tn1",
 			ids: ["cp1", 42],
 		});
+	});
+});
+
+describe("tournamentChipPurchase.reorder tournament scoping (SA2-123)", () => {
+	function ownedRows() {
+		return new Map<unknown, Rows>([
+			[tournament, [{ id: "tn1", roomId: "room1" }]],
+			[room, [{ id: "room1", userId: CALLER }]],
+			[tournamentChipPurchase, [{ id: "cp1", sortOrder: 0 }]],
+		]);
+	}
+
+	it("scopes each UPDATE to both the row id and the owned tournament", async () => {
+		const { caller, updateWhereParams } = makeCaller(CALLER, ownedRows());
+		await caller.reorder({ tournamentId: "tn1", ids: ["cp1", "cp2"] });
+		expect(updateWhereParams).toHaveLength(2);
+		expect(updateWhereParams[0]).toContain("cp1");
+		expect(updateWhereParams[0]).toContain("tn1");
+		expect(updateWhereParams[1]).toContain("cp2");
+		expect(updateWhereParams[1]).toContain("tn1");
+	});
+
+	it("runs no UPDATE when ids is empty", async () => {
+		const { caller, updateWhereParams } = makeCaller(CALLER, ownedRows());
+		await caller.reorder({ tournamentId: "tn1", ids: [] });
+		expect(updateWhereParams).toHaveLength(0);
+	});
+
+	it("throws FORBIDDEN and runs no UPDATE when the tournament is owned by another user", async () => {
+		const rows = new Map<unknown, Rows>([
+			[tournament, [{ id: "tn1", roomId: "room1" }]],
+			[room, [{ id: "room1", userId: OTHER }]],
+			[tournamentChipPurchase, []],
+		]);
+		const { caller, updateWhereParams } = makeCaller(CALLER, rows);
+		await expectTrpcCode(
+			caller.reorder({ tournamentId: "tn1", ids: ["cp1"] }),
+			"FORBIDDEN"
+		);
+		expect(updateWhereParams).toHaveLength(0);
 	});
 });

--- a/packages/api/src/__tests__/tournament.test.ts
+++ b/packages/api/src/__tests__/tournament.test.ts
@@ -1,3 +1,7 @@
+import { currency } from "@sapphire2/db/schema/currency";
+import { room } from "@sapphire2/db/schema/room";
+import { tournament } from "@sapphire2/db/schema/tournament";
+import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -7,6 +11,54 @@ import {
 	expectType,
 	getInputSchema,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+
+function createMockDb(rowsByTable: Map<unknown, Rows>) {
+	const makeChain = (rows: Rows) => {
+		const chain = Promise.resolve(rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = (table: unknown) => makeChain(rowsByTable.get(table) ?? []);
+		chain.where = () => chain;
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.innerJoin = () => chain;
+		chain.leftJoin = () => chain;
+		return chain;
+	};
+	return {
+		select: () => makeChain([]),
+		insert: () => ({ values: () => Promise.resolve(undefined) }),
+		update: () => ({
+			set: () => ({ where: () => Promise.resolve(undefined) }),
+		}),
+		delete: () => ({ where: () => Promise.resolve(undefined) }),
+	};
+}
+
+function tournamentCaller(userId: string, rowsByTable: Map<unknown, Rows>) {
+	return appRouter.createCaller({
+		session: { user: { id: userId } },
+		db: createMockDb(rowsByTable),
+	} as unknown as Parameters<typeof appRouter.createCaller>[0]).tournament;
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+const CUR_OWNER = "user-1";
+const CUR_OTHER = "user-2";
 
 describe("tournament router", () => {
 	it("appRouter has tournament namespace", () => {
@@ -283,5 +335,116 @@ describe("tournament.{archive,restore,delete,getById} input validation", () => {
 		expectRejects(appRouter.tournament.restore, {});
 		expectRejects(appRouter.tournament.delete, {});
 		expectRejects(appRouter.tournament.getById, {});
+	});
+});
+
+describe("tournament currency ownership (SA2-180)", () => {
+	const ownedRoom = { id: "room-1", userId: CUR_OWNER };
+	const ownedTournament = { id: "tn-1", roomId: "room-1" };
+
+	function createRows(currencyRows: Rows) {
+		return new Map<unknown, Rows>([
+			[room, [ownedRoom]],
+			[tournament, [ownedTournament]],
+			[currency, currencyRows],
+		]);
+	}
+
+	it("create accepts a currency owned by the caller", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OWNER }])
+		);
+		await expect(
+			caller.create({ roomId: "room-1", name: "T", currencyId: "cur-1" })
+		).resolves.toBeDefined();
+	});
+
+	it("create rejects a currency owned by another user with FORBIDDEN", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expectTrpcCode(
+			caller.create({ roomId: "room-1", name: "T", currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("create skips currency validation when currencyId is omitted", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expect(
+			caller.create({ roomId: "room-1", name: "T" })
+		).resolves.toBeDefined();
+	});
+
+	it("update rejects a foreign currency with FORBIDDEN", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expectTrpcCode(
+			caller.update({ id: "tn-1", currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("update allows clearing the currency with null", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expect(
+			caller.update({ id: "tn-1", currencyId: null })
+		).resolves.toBeDefined();
+	});
+
+	it("createWithLevels rejects a foreign currency with FORBIDDEN", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expectTrpcCode(
+			caller.createWithLevels({
+				roomId: "room-1",
+				name: "T",
+				currencyId: "cur-1",
+				blindLevels: [],
+			}),
+			"FORBIDDEN"
+		);
+	});
+
+	it("updateWithLevels rejects a foreign currency with FORBIDDEN", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expectTrpcCode(
+			caller.updateWithLevels({
+				id: "tn-1",
+				currencyId: "cur-1",
+				blindLevels: [],
+			}),
+			"FORBIDDEN"
+		);
+	});
+
+	it("createWithLevels accepts a currency owned by the caller", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OWNER }])
+		);
+		await expect(
+			caller.createWithLevels({
+				roomId: "room-1",
+				name: "T",
+				currencyId: "cur-1",
+				blindLevels: [],
+			})
+		).resolves.toBeDefined();
 	});
 });

--- a/packages/api/src/routers/blind-level.ts
+++ b/packages/api/src/routers/blind-level.ts
@@ -1,7 +1,7 @@
 import { room } from "@sapphire2/db/schema/room";
 import { blindLevel, tournament } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
 
@@ -196,7 +196,14 @@ export const blindLevelRouter = router({
 					ctx.db
 						.update(blindLevel)
 						.set({ level: index + 1 })
-						.where(eq(blindLevel.id, id))
+						// Scope to the owned tournament so a foreign levelId matches
+						// nothing (write-IDOR, SA2-176).
+						.where(
+							and(
+								eq(blindLevel.id, id),
+								eq(blindLevel.tournamentId, input.tournamentId)
+							)
+						)
 				)
 			);
 

--- a/packages/api/src/routers/currency-transaction.ts
+++ b/packages/api/src/routers/currency-transaction.ts
@@ -14,6 +14,41 @@ import { paginate } from "./_pagination";
 
 const PAGE_SIZE = 10;
 
+type DbInstance = Parameters<
+	Parameters<typeof protectedProcedure.query>[0]
+>[0]["ctx"]["db"];
+
+/**
+ * Verifies the referenced transaction type belongs to the caller before it is
+ * linked to a transaction. Without this a caller could attach another user's
+ * transaction type id to their own transaction (read-IDOR, SA2-179). Mirrors
+ * the currency-ownership check already used in create / update below.
+ */
+async function validateTransactionTypeOwnership(
+	db: DbInstance,
+	transactionTypeId: string,
+	userId: string
+) {
+	const [found] = await db
+		.select()
+		.from(transactionType)
+		.where(eq(transactionType.id, transactionTypeId));
+
+	if (!found) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Transaction type not found",
+		});
+	}
+
+	if (found.userId !== userId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own this transaction type",
+		});
+	}
+}
+
 export const currencyTransactionRouter = router({
 	listByCurrency: protectedProcedure
 		.input(z.object({ currencyId: z.string(), cursor: z.string().optional() }))
@@ -45,7 +80,7 @@ export const currencyTransactionRouter = router({
 				// tuple against the cursor row keeps paging aligned with the visible
 				// order — comparing the random-UUID id alone skips/duplicates rows.
 				conditions.push(
-					sql`(${currencyTransaction.transactedAt}, ${currencyTransaction.id}) < (SELECT transacted_at, id FROM currency_transaction WHERE id = ${input.cursor})`
+					sql`(${currencyTransaction.transactedAt}, ${currencyTransaction.id}) < (SELECT transacted_at, id FROM currency_transaction WHERE id = ${input.cursor} AND currency_id = ${input.currencyId})`
 				);
 			}
 
@@ -122,6 +157,12 @@ export const currencyTransactionRouter = router({
 				});
 			}
 
+			await validateTransactionTypeOwnership(
+				ctx.db,
+				input.transactionTypeId,
+				userId
+			);
+
 			const id = crypto.randomUUID();
 			await ctx.db.insert(currencyTransaction).values({
 				id,
@@ -181,6 +222,11 @@ export const currencyTransactionRouter = router({
 
 			const updateData: Partial<typeof found.currencyTransaction> = {};
 			if (input.transactionTypeId !== undefined) {
+				await validateTransactionTypeOwnership(
+					ctx.db,
+					input.transactionTypeId,
+					userId
+				);
 				updateData.transactionTypeId = input.transactionTypeId;
 			}
 			if (input.amount !== undefined) {

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -21,7 +21,11 @@ import {
 	recalculateCashGameSession,
 } from "../services/live-session-pl";
 import { floorToMinute } from "../utils/session-event-time";
-import { resolveCashRuleSnapshot, validateLiveLinkOwnership } from "./session";
+import {
+	resolveCashRuleSnapshot,
+	validateEntityOwnership,
+	validateLiveLinkOwnership,
+} from "./session";
 
 const DEFAULT_LIMIT = 20;
 
@@ -365,6 +369,14 @@ export const liveCashGameSessionRouter = router({
 			}
 
 			if (input.ringGameId) {
+				// Verify ring-game ownership BEFORE any ring_game read so a caller
+				// cannot probe another user's config via the buy-in bounds (SA2-174).
+				await validateEntityOwnership(
+					ctx.db,
+					"ringGame",
+					input.ringGameId,
+					userId
+				);
 				const [foundRingGame] = await ctx.db
 					.select({
 						minBuyIn: ringGame.minBuyIn,
@@ -485,6 +497,13 @@ export const liveCashGameSessionRouter = router({
 			if (input.ringGameId === null) {
 				cashDetailUpdate.ringGameId = null;
 			} else if (input.ringGameId !== undefined) {
+				// Verify ring-game ownership BEFORE the snapshot read (SA2-174).
+				await validateEntityOwnership(
+					ctx.db,
+					"ringGame",
+					input.ringGameId,
+					userId
+				);
 				const resolvedRoomId =
 					updateData.roomId === undefined ? existing.roomId : updateData.roomId;
 				const resolvedCurrencyId =

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -203,7 +203,7 @@ export const liveCashGameSessionRouter = router({
 			}
 			if (input.cursor) {
 				conditions.push(
-					sql`${gameSession.startedAt} < (SELECT started_at FROM game_session WHERE id = ${input.cursor})`
+					sql`${gameSession.startedAt} < (SELECT started_at FROM game_session WHERE id = ${input.cursor} AND user_id = ${userId})`
 				);
 			}
 

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -490,7 +490,7 @@ export const liveTournamentSessionRouter = router({
 			}
 			if (input.cursor) {
 				conditions.push(
-					sql`${gameSession.startedAt} < (SELECT started_at FROM game_session WHERE id = ${input.cursor})`
+					sql`${gameSession.startedAt} < (SELECT started_at FROM game_session WHERE id = ${input.cursor} AND user_id = ${userId})`
 				);
 			}
 

--- a/packages/api/src/routers/player.ts
+++ b/packages/api/src/routers/player.ts
@@ -7,6 +7,7 @@ import { TRPCError } from "@trpc/server";
 import { and, asc, eq, inArray, like } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
+import { validateTagsOwnership } from "./session";
 
 export const playerRouter = router({
 	list: protectedProcedure
@@ -141,6 +142,9 @@ export const playerRouter = router({
 		)
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
+			// Reject before any write so a foreign tag id cannot be linked (IDOR).
+			await validateTagsOwnership(ctx.db, playerTag, input.tagIds, userId);
+
 			const id = crypto.randomUUID();
 
 			await ctx.db.insert(player).values({
@@ -226,6 +230,8 @@ export const playerRouter = router({
 				.where(eq(player.id, input.id));
 
 			if (input.tagIds !== undefined) {
+				// Verify tag ownership before mutating the join rows (IDOR).
+				await validateTagsOwnership(ctx.db, playerTag, input.tagIds, userId);
 				await ctx.db
 					.delete(playerToPlayerTag)
 					.where(eq(playerToPlayerTag.playerId, input.id));

--- a/packages/api/src/routers/ring-game.ts
+++ b/packages/api/src/routers/ring-game.ts
@@ -1,34 +1,10 @@
-import { currency } from "@sapphire2/db/schema/currency";
 import { ringGame } from "@sapphire2/db/schema/ring-game";
 import { room } from "@sapphire2/db/schema/room";
 import { TRPCError } from "@trpc/server";
 import { and, eq, isNotNull, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
-
-async function validateCurrencyOwnership(
-	db: Parameters<
-		Parameters<typeof protectedProcedure.query>[0]
-	>[0]["ctx"]["db"],
-	currencyId: string,
-	userId: string
-) {
-	const [found] = await db
-		.select()
-		.from(currency)
-		.where(eq(currency.id, currencyId));
-
-	if (!found) {
-		throw new TRPCError({ code: "NOT_FOUND", message: "Currency not found" });
-	}
-
-	if (found.userId !== userId) {
-		throw new TRPCError({
-			code: "FORBIDDEN",
-			message: "You do not own this currency",
-		});
-	}
-}
+import { validateEntityOwnership } from "./session";
 
 async function validateRoomOwnership(
 	db: Parameters<
@@ -123,7 +99,12 @@ export const ringGameRouter = router({
 			const userId = ctx.session.user.id;
 			await validateRoomOwnership(ctx.db, input.roomId, userId);
 			if (input.currencyId) {
-				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+				await validateEntityOwnership(
+					ctx.db,
+					"currency",
+					input.currencyId,
+					userId
+				);
 			}
 
 			const id = crypto.randomUUID();
@@ -174,7 +155,12 @@ export const ringGameRouter = router({
 			const userId = ctx.session.user.id;
 			const found = await validateRingGameOwnership(ctx.db, input.id, userId);
 			if (input.currencyId) {
-				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+				await validateEntityOwnership(
+					ctx.db,
+					"currency",
+					input.currencyId,
+					userId
+				);
 			}
 
 			const updateData: Partial<typeof found> = { updatedAt: new Date() };

--- a/packages/api/src/routers/ring-game.ts
+++ b/packages/api/src/routers/ring-game.ts
@@ -1,9 +1,34 @@
+import { currency } from "@sapphire2/db/schema/currency";
 import { ringGame } from "@sapphire2/db/schema/ring-game";
 import { room } from "@sapphire2/db/schema/room";
 import { TRPCError } from "@trpc/server";
 import { and, eq, isNotNull, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
+
+async function validateCurrencyOwnership(
+	db: Parameters<
+		Parameters<typeof protectedProcedure.query>[0]
+	>[0]["ctx"]["db"],
+	currencyId: string,
+	userId: string
+) {
+	const [found] = await db
+		.select()
+		.from(currency)
+		.where(eq(currency.id, currencyId));
+
+	if (!found) {
+		throw new TRPCError({ code: "NOT_FOUND", message: "Currency not found" });
+	}
+
+	if (found.userId !== userId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own this currency",
+		});
+	}
+}
 
 async function validateRoomOwnership(
 	db: Parameters<
@@ -97,6 +122,9 @@ export const ringGameRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
 			await validateRoomOwnership(ctx.db, input.roomId, userId);
+			if (input.currencyId) {
+				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+			}
 
 			const id = crypto.randomUUID();
 			await ctx.db.insert(ringGame).values({
@@ -145,6 +173,9 @@ export const ringGameRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
 			const found = await validateRingGameOwnership(ctx.db, input.id, userId);
+			if (input.currencyId) {
+				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+			}
 
 			const updateData: Partial<typeof found> = { updatedAt: new Date() };
 			if (input.name !== undefined) {

--- a/packages/api/src/routers/session-table-player.ts
+++ b/packages/api/src/routers/session-table-player.ts
@@ -2,7 +2,11 @@ import {
 	MAX_SEAT_POSITION,
 	playerJoinPayload,
 } from "@sapphire2/db/constants/session-event-types";
-import { player, playerToPlayerTag } from "@sapphire2/db/schema/player";
+import {
+	player,
+	playerTag,
+	playerToPlayerTag,
+} from "@sapphire2/db/schema/player";
 import { ringGame } from "@sapphire2/db/schema/ring-game";
 import { room } from "@sapphire2/db/schema/room";
 import { gameSession } from "@sapphire2/db/schema/session";
@@ -19,6 +23,7 @@ import {
 	floorToMinute,
 	nextAppendSortOrder,
 } from "../utils/session-event-time";
+import { validateTagsOwnership } from "./session";
 
 type DbInstance = Parameters<
 	Parameters<typeof protectedProcedure.query>[0]
@@ -334,6 +339,13 @@ export const sessionTablePlayerRouter = router({
 			const { seatPosition } = input;
 			const userId = ctx.session.user.id;
 			await resolveSessionOwnership(ctx.db, sessionId, userId);
+			// Reject foreign player tags before creating the player (IDOR).
+			await validateTagsOwnership(
+				ctx.db,
+				playerTag,
+				input.playerTagIds,
+				userId
+			);
 
 			const now = new Date();
 			const playerId = crypto.randomUUID();

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -22,6 +22,7 @@ import {
 } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
 import { and, asc, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
+import type { SQLiteColumn, SQLiteTable } from "drizzle-orm/sqlite-core";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
 
@@ -320,6 +321,54 @@ export async function persistSessionBlindLevels(
 	}
 }
 
+/**
+ * Assert the room `roomId` exists and belongs to `userId`, else throw FORBIDDEN
+ * with `forbiddenMessage`. Shared by the room-derived ownership branches
+ * (ringGame / tournament) so their ownership rule stays in one place.
+ */
+async function assertRoomOwnedBy(
+	db: DbInstance,
+	roomId: string,
+	userId: string,
+	forbiddenMessage: string
+): Promise<void> {
+	const [foundRoom] = await db.select().from(room).where(eq(room.id, roomId));
+	if (!foundRoom || foundRoom.userId !== userId) {
+		throw new TRPCError({ code: "FORBIDDEN", message: forbiddenMessage });
+	}
+}
+
+async function validateRingGameOwnershipBranch(
+	db: DbInstance,
+	entityId: string,
+	userId: string
+): Promise<void> {
+	const [found] = await db
+		.select()
+		.from(ringGame)
+		.where(eq(ringGame.id, entityId));
+	if (!found) {
+		throw new TRPCError({ code: "NOT_FOUND", message: "Ring game not found" });
+	}
+	// A ring game has no userId of its own; ownership is derived from its room.
+	// Auto-generated snapshot rows have a null roomId and are never
+	// user-selectable, so a caller-supplied id pointing at one cannot be proven
+	// owned → FORBIDDEN. Without this a caller could pass another user's
+	// ringGameId to snapshot their cash-game rule config (IDOR, SA2-174).
+	if (!found.roomId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
+	}
+	await assertRoomOwnedBy(
+		db,
+		found.roomId,
+		userId,
+		"You do not own this ring game"
+	);
+}
+
 async function validateEntityOwnership(
 	db: DbInstance,
 	entityType: "currency" | "ringGame" | "room" | "tournament",
@@ -338,16 +387,7 @@ async function validateEntityOwnership(
 			});
 		}
 	} else if (entityType === "ringGame") {
-		const [found] = await db
-			.select()
-			.from(ringGame)
-			.where(eq(ringGame.id, entityId));
-		if (!found) {
-			throw new TRPCError({
-				code: "NOT_FOUND",
-				message: "Ring game not found",
-			});
-		}
+		await validateRingGameOwnershipBranch(db, entityId, userId);
 	} else if (entityType === "tournament") {
 		const [found] = await db
 			.select()
@@ -362,16 +402,12 @@ async function validateEntityOwnership(
 		// A tournament has no userId of its own; ownership is derived from its
 		// room. Without this check a caller could pass another user's
 		// tournamentId to snapshot their blind structure / chip purchases (IDOR).
-		const [foundRoom] = await db
-			.select()
-			.from(room)
-			.where(eq(room.id, found.roomId));
-		if (!foundRoom || foundRoom.userId !== userId) {
-			throw new TRPCError({
-				code: "FORBIDDEN",
-				message: "You do not own this tournament",
-			});
-		}
+		await assertRoomOwnedBy(
+			db,
+			found.roomId,
+			userId,
+			"You do not own this tournament"
+		);
 	} else if (entityType === "currency") {
 		const [found] = await db
 			.select()
@@ -935,6 +971,38 @@ export async function validateLiveLinkOwnership(
 	}
 	if (input.currencyId) {
 		await validateEntityOwnership(db, "currency", input.currencyId, userId);
+	}
+}
+
+/**
+ * Ownership guard for a set of tag ids linked to a session / player / etc.
+ * Generic over any tag table exposing `id` + `userId` columns (session_tag,
+ * player_tag, tournament_tag, …). Selects the caller-owned subset in a single
+ * `WHERE id IN (…) AND userId = caller` query; if the distinct owned count
+ * differs from the requested distinct count, at least one id is missing or
+ * belongs to another user → FORBIDDEN. No-ops on empty / omitted ids so the
+ * caller can pass `input.tagIds` directly. Prevents IDOR on tag links
+ * (SA2-177).
+ */
+export async function validateTagsOwnership(
+	db: DbInstance,
+	table: SQLiteTable & { id: SQLiteColumn; userId: SQLiteColumn },
+	ids: string[] | undefined,
+	userId: string
+): Promise<void> {
+	if (!ids || ids.length === 0) {
+		return;
+	}
+	const uniqueIds = [...new Set(ids)];
+	const owned = await db
+		.select({ id: table.id })
+		.from(table)
+		.where(and(inArray(table.id, uniqueIds), eq(table.userId, userId)));
+	if (owned.length !== uniqueIds.length) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own one or more of these tags",
+		});
 	}
 }
 
@@ -2150,6 +2218,7 @@ export const sessionRouter = router({
 				await insertTournamentSessionDetail(ctx.db, id, input);
 			}
 
+			await validateTagsOwnership(ctx.db, sessionTag, input.tagIds, userId);
 			await insertSessionTags(ctx.db, id, input.tagIds);
 
 			await maybeCreateCurrencyTransactionForCreate(
@@ -2323,6 +2392,7 @@ export const sessionRouter = router({
 			}
 
 			if (input.tagIds !== undefined) {
+				await validateTagsOwnership(ctx.db, sessionTag, input.tagIds, userId);
 				await ctx.db
 					.delete(sessionToSessionTag)
 					.where(eq(sessionToSessionTag.sessionId, input.id));

--- a/packages/api/src/routers/tournament-chip-purchase.ts
+++ b/packages/api/src/routers/tournament-chip-purchase.ts
@@ -4,7 +4,7 @@ import {
 	tournamentChipPurchase,
 } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
 
@@ -190,7 +190,14 @@ export const tournamentChipPurchaseRouter = router({
 					ctx.db
 						.update(tournamentChipPurchase)
 						.set({ sortOrder: index })
-						.where(eq(tournamentChipPurchase.id, id))
+						// Scope to the owned tournament so a foreign id matches nothing
+						// (write-IDOR, SA2-123).
+						.where(
+							and(
+								eq(tournamentChipPurchase.id, id),
+								eq(tournamentChipPurchase.tournamentId, input.tournamentId)
+							)
+						)
 				)
 			);
 

--- a/packages/api/src/routers/tournament.ts
+++ b/packages/api/src/routers/tournament.ts
@@ -1,3 +1,4 @@
+import { currency } from "@sapphire2/db/schema/currency";
 import { room } from "@sapphire2/db/schema/room";
 import {
 	blindLevel,
@@ -9,6 +10,30 @@ import { TRPCError } from "@trpc/server";
 import { and, asc, eq, isNotNull, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
+
+async function validateCurrencyOwnership(
+	db: Parameters<
+		Parameters<typeof protectedProcedure.query>[0]
+	>[0]["ctx"]["db"],
+	currencyId: string,
+	userId: string
+) {
+	const [found] = await db
+		.select()
+		.from(currency)
+		.where(eq(currency.id, currencyId));
+
+	if (!found) {
+		throw new TRPCError({ code: "NOT_FOUND", message: "Currency not found" });
+	}
+
+	if (found.userId !== userId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own this currency",
+		});
+	}
+}
 
 async function validateRoomOwnership(
 	db: Parameters<
@@ -156,6 +181,9 @@ export const tournamentRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
 			await validateRoomOwnership(ctx.db, input.roomId, userId);
+			if (input.currencyId) {
+				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+			}
 
 			const id = crypto.randomUUID();
 			await ctx.db.insert(tournament).values({
@@ -198,6 +226,9 @@ export const tournamentRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
 			const found = await validateTournamentOwnership(ctx.db, input.id, userId);
+			if (input.currencyId) {
+				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+			}
 
 			const updateData: Partial<typeof found> = { updatedAt: new Date() };
 			if (input.name !== undefined) {
@@ -326,6 +357,9 @@ export const tournamentRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
 			await validateRoomOwnership(ctx.db, input.roomId, userId);
+			if (input.currencyId) {
+				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+			}
 
 			const id = crypto.randomUUID();
 			await ctx.db.insert(tournament).values({
@@ -419,6 +453,9 @@ export const tournamentRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
 			const found = await validateTournamentOwnership(ctx.db, input.id, userId);
+			if (input.currencyId) {
+				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+			}
 
 			const updateData: Partial<typeof found> = { updatedAt: new Date() };
 			if (input.name !== undefined) {

--- a/packages/api/src/routers/tournament.ts
+++ b/packages/api/src/routers/tournament.ts
@@ -1,4 +1,3 @@
-import { currency } from "@sapphire2/db/schema/currency";
 import { room } from "@sapphire2/db/schema/room";
 import {
 	blindLevel,
@@ -10,30 +9,7 @@ import { TRPCError } from "@trpc/server";
 import { and, asc, eq, isNotNull, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
-
-async function validateCurrencyOwnership(
-	db: Parameters<
-		Parameters<typeof protectedProcedure.query>[0]
-	>[0]["ctx"]["db"],
-	currencyId: string,
-	userId: string
-) {
-	const [found] = await db
-		.select()
-		.from(currency)
-		.where(eq(currency.id, currencyId));
-
-	if (!found) {
-		throw new TRPCError({ code: "NOT_FOUND", message: "Currency not found" });
-	}
-
-	if (found.userId !== userId) {
-		throw new TRPCError({
-			code: "FORBIDDEN",
-			message: "You do not own this currency",
-		});
-	}
-}
+import { validateEntityOwnership } from "./session";
 
 async function validateRoomOwnership(
 	db: Parameters<
@@ -182,7 +158,12 @@ export const tournamentRouter = router({
 			const userId = ctx.session.user.id;
 			await validateRoomOwnership(ctx.db, input.roomId, userId);
 			if (input.currencyId) {
-				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+				await validateEntityOwnership(
+					ctx.db,
+					"currency",
+					input.currencyId,
+					userId
+				);
 			}
 
 			const id = crypto.randomUUID();
@@ -227,7 +208,12 @@ export const tournamentRouter = router({
 			const userId = ctx.session.user.id;
 			const found = await validateTournamentOwnership(ctx.db, input.id, userId);
 			if (input.currencyId) {
-				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+				await validateEntityOwnership(
+					ctx.db,
+					"currency",
+					input.currencyId,
+					userId
+				);
 			}
 
 			const updateData: Partial<typeof found> = { updatedAt: new Date() };
@@ -358,7 +344,12 @@ export const tournamentRouter = router({
 			const userId = ctx.session.user.id;
 			await validateRoomOwnership(ctx.db, input.roomId, userId);
 			if (input.currencyId) {
-				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+				await validateEntityOwnership(
+					ctx.db,
+					"currency",
+					input.currencyId,
+					userId
+				);
 			}
 
 			const id = crypto.randomUUID();
@@ -454,7 +445,12 @@ export const tournamentRouter = router({
 			const userId = ctx.session.user.id;
 			const found = await validateTournamentOwnership(ctx.db, input.id, userId);
 			if (input.currencyId) {
-				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+				await validateEntityOwnership(
+					ctx.db,
+					"currency",
+					input.currencyId,
+					userId
+				);
 			}
 
 			const updateData: Partial<typeof found> = { updatedAt: new Date() };


### PR DESCRIPTION
## 概要

親課題 **SA2-175**（IDOR / broken object-level authorization の網羅対応）。tRPC プロシージャで、入力として渡される参照 FK（他エンティティの id）に対する所有権検証が欠落していた箇所を横断的に塞ぐ。各修正は TDD（RED→GREEN）で対応し、Part 1 で追加した共有ヘルパー（`validateEntityOwnership` / `validateTagsOwnership`）とローカル `validateXxxOwnership` パターンを再利用している。

---

## Part 1（既コミット済み）

- **SA2-174**: `validateEntityOwnership` の `ringGame` 分岐が存在確認のみだった問題を修正。room 経由で所有権を検証し、`roomId` が null の自動生成行は所有権を証明できないため FORBIDDEN とする。あわせて `liveCashGameSession` の create / update でスナップショット読取前に明示的な所有権チェックを追加。
  - ガード: `packages/api/src/routers/session.ts` `validateEntityOwnership` ringGame 分岐、`live-cash-game-session.ts` create/update
- **SA2-177**: 共有ヘルパー `validateTagsOwnership(db, table, ids, userId)` を追加し、`session.create` / `session.update` の `tagIds` に適用。他ユーザーの `session_tag` を紐付ける read-IDOR を防止。
- **SA2-176**: `blindLevel.reorder` の各 UPDATE の WHERE に `tournamentId` を追加し、所有するトーナメント配下のレベルのみ更新されるようスコープを限定（write-IDOR）。
- **SA2-123**: `tournamentChipPurchase.reorder` も同様に `tournamentId` でスコープを限定。

---

## Part 2（本コミット）

### SA2-178 — player_tag のリンク時の所有権検証（read-IDOR）
`playerTag`（`id`, `userId`）に対し `validateTagsOwnership` を join 挿入前に適用。
- `player.create`（`player.ts`）: player 挿入前に `input.tagIds` を検証
- `player.update`（`player.ts`）: join の delete/insert 前に `input.tagIds` を検証
- `sessionTablePlayer.addNew`（`session-table-player.ts`）: player 作成前に `input.playerTagIds` を検証
- テスト: 所有タグは受理・link 挿入あり／他ユーザー所有タグは FORBIDDEN かつ `player_to_player_tag` 挿入なし／未指定は検証スキップ

### SA2-179 — transaction_type の所有権検証（read-IDOR）
`currency-transaction.ts` にローカル `validateTransactionTypeOwnership` を追加。`create`（必須）と `update`（`transactionTypeId` 指定時）で、参照先 `transaction_type` を id で SELECT → 不在なら NOT_FOUND、`userId` 不一致なら FORBIDDEN。既存の currency 所有権チェックに準拠。
- テスト: 所有 type 受理／他ユーザー type は FORBIDDEN（挿入なし）／不在は NOT_FOUND／未指定はスキップ

### SA2-180 — tournament / ring-game の currency リンク所有権検証
各ファイルにローカル `validateCurrencyOwnership(db, currencyId, userId)` を追加（既存 `validateRoomOwnership` パターンに準拠）。`currencyId` が非 null 文字列のときに書き込み前検証。
- `tournament.ts`: `create` / `update` / `createWithLevels` / `updateWithLevels`
- `ring-game.ts`: `create` / `update`
- 注: `ring_game.currencyId` は後段で実際に参照されるため実害のある read-IDOR を塞ぐ。`tournament.currencyId` は多層防御。
- テスト: 所有 currency 受理／他ユーザー currency は FORBIDDEN／null・未指定はスキップ

### SA2-182 — カーソル境界サブクエリのスコープ強化（hardening）
他ユーザーのカーソル id によるプローブを防ぐため、境界サブクエリにスコープ述語を追加。
- `live-cash-game-session.ts` list: サブクエリに `AND user_id = ${userId}`
- `live-tournament-session.ts` list: 同上
- `currency-transaction.ts` `listByCurrency`: サブクエリに `AND currency_id = ${input.currencyId}`
- テスト: SQLiteSyncDialect でバインドパラメータを検査し、カーソル指定時に `userId` / `currencyId` がサブクエリ側にも含まれる（=2回出現）ことを確認。カーソル未指定時は挙動不変。

---

## 除外

- **SA2-181**（`ring_game` に `userId` カラム追加 / null-`roomId` の構造的対応）はマイグレーションを要するため本 PR から意図的に除外し、別課題で追跡する。

---

## 検証結果

- テスト: `bunx vitest run --project api` → **24 files / 862 tests passed**
- Lint: `bun x ultracite check`（変更14ファイル）→ **No fixes applied（クリーン）**
- 型チェック: `bun run check-types` → **exit 0**（api パッケージ単体でも新規エラーなし。既存の `db/src/index.ts` の D1Database、`live-tournament-session.test.ts` の型エラーは Part 1 既知の pre-existing で本 PR とは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ)_