### PR TITLE
feat(ring-game): 所有者 user_id を追加して構造的 IDOR を修正 (SA2-181)

### DIFF
--- a/apps/web/src/features/rooms/hooks/__tests__/use-ring-games.test.ts
+++ b/apps/web/src/features/rooms/hooks/__tests__/use-ring-games.test.ts
@@ -83,6 +83,7 @@ function makeGame(overrides: Partial<RingGame> = {}): RingGame {
 		archivedAt: null,
 		createdAt: "2026-01-01",
 		updatedAt: "2026-01-01",
+		userId: "user-1",
 		...overrides,
 	};
 }

--- a/apps/web/src/features/rooms/hooks/use-ring-games.ts
+++ b/apps/web/src/features/rooms/hooks/use-ring-games.ts
@@ -24,6 +24,7 @@ export interface RingGame {
 	roomId: string | null;
 	tableSize: number | null;
 	updatedAt: string;
+	userId: string | null;
 	variant: string;
 }
 
@@ -64,6 +65,9 @@ function buildOptimisticRingGame(
 		tableSize: values.tableSize ?? null,
 		createdAt: new Date().toISOString(),
 		updatedAt: new Date().toISOString(),
+		// Optimistic placeholder; replaced by the server row (which carries the
+		// real userId) on settle.
+		userId: null,
 		variant: values.variant,
 	};
 }

--- a/packages/api/src/__tests__/live-cash-game-session.test.ts
+++ b/packages/api/src/__tests__/live-cash-game-session.test.ts
@@ -247,13 +247,21 @@ describe("liveCashGameSession.update ownership validation (SA2-102)", () => {
 	});
 });
 
-describe("liveCashGameSession.create ring game ownership (SA2-174)", () => {
-	it("accepts a ring game whose room is owned by the caller", async () => {
+describe("liveCashGameSession.create ring game ownership (SA2-181)", () => {
+	it("accepts a ring game owned by the caller via userId", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, []],
 			[
 				ringGame,
-				[{ id: "rg-1", roomId: "room-1", minBuyIn: null, maxBuyIn: null }],
+				[
+					{
+						id: "rg-1",
+						roomId: "room-1",
+						userId: OWNER,
+						minBuyIn: null,
+						maxBuyIn: null,
+					},
+				],
 			],
 			[room, [{ id: "room-1", userId: OWNER }]],
 			[sessionCashDetail, []],
@@ -263,14 +271,43 @@ describe("liveCashGameSession.create ring game ownership (SA2-174)", () => {
 		).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
 	});
 
-	it("rejects a ring game whose room belongs to another user with FORBIDDEN", async () => {
+	it("accepts a null-roomId auto-generated ring game owned via userId", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, []],
 			[
 				ringGame,
-				[{ id: "rg-1", roomId: "room-1", minBuyIn: null, maxBuyIn: null }],
+				[
+					{
+						id: "rg-1",
+						roomId: null,
+						userId: OWNER,
+						minBuyIn: null,
+						maxBuyIn: null,
+					},
+				],
 			],
-			[room, [{ id: "room-1", userId: OTHER }]],
+			[sessionCashDetail, []],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 1000, ringGameId: "rg-1" })
+		).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
+	});
+
+	it("rejects a ring game owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[
+				ringGame,
+				[
+					{
+						id: "rg-1",
+						roomId: "room-1",
+						userId: OTHER,
+						minBuyIn: null,
+						maxBuyIn: null,
+					},
+				],
+			],
 		]);
 		await expectTrpcCode(
 			makeCaller(OWNER, rows).create({ initialBuyIn: 0, ringGameId: "rg-1" }),
@@ -278,12 +315,20 @@ describe("liveCashGameSession.create ring game ownership (SA2-174)", () => {
 		);
 	});
 
-	it("rejects a ring game with a null roomId (auto-generated row) with FORBIDDEN", async () => {
+	it("rejects a legacy ring game with null userId with FORBIDDEN", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, []],
 			[
 				ringGame,
-				[{ id: "rg-1", roomId: null, minBuyIn: null, maxBuyIn: null }],
+				[
+					{
+						id: "rg-1",
+						roomId: null,
+						userId: null,
+						minBuyIn: null,
+						maxBuyIn: null,
+					},
+				],
 			],
 		]);
 		await expectTrpcCode(
@@ -304,11 +349,14 @@ describe("liveCashGameSession.create ring game ownership (SA2-174)", () => {
 	});
 });
 
-describe("liveCashGameSession.update ring game ownership (SA2-174)", () => {
-	it("accepts a ring game whose room is owned by the caller", async () => {
+describe("liveCashGameSession.update ring game ownership (SA2-181)", () => {
+	it("accepts a ring game owned by the caller via userId", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, [ownedSession]],
-			[ringGame, [{ id: "rg-1", roomId: "room-1", currencyId: null }]],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: "room-1", userId: OWNER, currencyId: null }],
+			],
 			[room, [{ id: "room-1", userId: OWNER }]],
 			[sessionCashDetail, []],
 		]);
@@ -317,11 +365,27 @@ describe("liveCashGameSession.update ring game ownership (SA2-174)", () => {
 		).resolves.toBeDefined();
 	});
 
-	it("rejects a ring game whose room belongs to another user with FORBIDDEN", async () => {
+	it("accepts a null-roomId auto-generated ring game owned via userId", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, [ownedSession]],
-			[ringGame, [{ id: "rg-1", roomId: "room-1", currencyId: null }]],
-			[room, [{ id: "room-1", userId: OTHER }]],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: null, userId: OWNER, currencyId: null }],
+			],
+			[sessionCashDetail, []],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({ id: "s1", ringGameId: "rg-1" })
+		).resolves.toBeDefined();
+	});
+
+	it("rejects a ring game owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: "room-1", userId: OTHER, currencyId: null }],
+			],
 			[sessionCashDetail, []],
 		]);
 		await expectTrpcCode(
@@ -330,10 +394,13 @@ describe("liveCashGameSession.update ring game ownership (SA2-174)", () => {
 		);
 	});
 
-	it("rejects a ring game with a null roomId (auto-generated row) with FORBIDDEN", async () => {
+	it("rejects a legacy ring game with null userId with FORBIDDEN", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, [ownedSession]],
-			[ringGame, [{ id: "rg-1", roomId: null, currencyId: null }]],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: null, userId: null, currencyId: null }],
+			],
 			[sessionCashDetail, []],
 		]);
 		await expectTrpcCode(
@@ -357,7 +424,10 @@ describe("liveCashGameSession.update ring game ownership (SA2-174)", () => {
 	it("clears ringGameId with null without an ownership error", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, [ownedSession]],
-			[ringGame, [{ id: "rg-1", roomId: null, currencyId: null }]],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: null, userId: OWNER, currencyId: null }],
+			],
 			[sessionCashDetail, []],
 		]);
 		await expect(

--- a/packages/api/src/__tests__/ring-game.test.ts
+++ b/packages/api/src/__tests__/ring-game.test.ts
@@ -244,7 +244,7 @@ describe("ringGame.{archive,restore,delete} input validation", () => {
 
 describe("ringGame currency ownership (SA2-180)", () => {
 	const ownedRoom = { id: "room-1", userId: CUR_OWNER };
-	const ownedRingGame = { id: "rg-1", roomId: "room-1" };
+	const ownedRingGame = { id: "rg-1", roomId: "room-1", userId: CUR_OWNER };
 
 	function createRows(currencyRows: Rows) {
 		return new Map<unknown, Rows>([
@@ -315,4 +315,75 @@ describe("ringGame currency ownership (SA2-180)", () => {
 			caller.update({ id: "rg-1", currencyId: null })
 		).resolves.toBeDefined();
 	});
+});
+
+describe("ringGame.create sets userId to the caller (SA2-181)", () => {
+	it("stamps the created ring game with the caller's userId", async () => {
+		const rowsByTable = new Map<unknown, Rows>([
+			[room, [{ id: "room-1", userId: CUR_OWNER }]],
+			[ringGame, []],
+			[currency, []],
+		]);
+		const inserted: Record<string, unknown>[] = [];
+		const baseDb = createMockDb(rowsByTable);
+		const db = {
+			...baseDb,
+			insert: () => ({
+				values: (v: Record<string, unknown>) => {
+					inserted.push(v);
+					return Promise.resolve(undefined);
+				},
+			}),
+		};
+		const caller = appRouter.createCaller({
+			session: { user: { id: CUR_OWNER } },
+			db,
+		} as unknown as Parameters<typeof appRouter.createCaller>[0]).ringGame;
+
+		await caller.create({ roomId: "room-1", name: "RG" });
+
+		expect(inserted).toHaveLength(1);
+		expect(inserted[0]).toMatchObject({ userId: CUR_OWNER, roomId: "room-1" });
+	});
+});
+
+describe("validateRingGameOwnership via mutations (SA2-181)", () => {
+	function ringGameRows(rg: Rows) {
+		return new Map<unknown, Rows>([
+			[room, []],
+			[ringGame, rg],
+			[currency, []],
+		]);
+	}
+
+	for (const op of ["update", "archive", "restore", "delete"] as const) {
+		it(`${op} resolves for a ring game owned by the caller (userId match)`, async () => {
+			const caller = ringGameCaller(
+				CUR_OWNER,
+				ringGameRows([{ id: "rg-1", roomId: null, userId: CUR_OWNER }])
+			);
+			await expect(caller[op]({ id: "rg-1" })).resolves.toBeDefined();
+		});
+
+		it(`${op} throws FORBIDDEN for a ring game owned by another user`, async () => {
+			const caller = ringGameCaller(
+				CUR_OWNER,
+				ringGameRows([{ id: "rg-1", roomId: "room-1", userId: CUR_OTHER }])
+			);
+			await expectTrpcCode(caller[op]({ id: "rg-1" }), "FORBIDDEN");
+		});
+
+		it(`${op} throws FORBIDDEN for a legacy row with null userId`, async () => {
+			const caller = ringGameCaller(
+				CUR_OWNER,
+				ringGameRows([{ id: "rg-1", roomId: null, userId: null }])
+			);
+			await expectTrpcCode(caller[op]({ id: "rg-1" }), "FORBIDDEN");
+		});
+
+		it(`${op} throws NOT_FOUND when the ring game does not exist`, async () => {
+			const caller = ringGameCaller(CUR_OWNER, ringGameRows([]));
+			await expectTrpcCode(caller[op]({ id: "missing" }), "NOT_FOUND");
+		});
+	}
 });

--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -953,7 +953,7 @@ describe("validateEntityOwnership (tournament branch)", () => {
 	});
 });
 
-describe("validateEntityOwnership (ringGame branch) (SA2-174)", () => {
+describe("validateEntityOwnership (ringGame branch) (SA2-181)", () => {
 	const CALLER = "user-1";
 	const OTHER = "user-2";
 	const RING_GAME_ID = "rg-1";
@@ -971,43 +971,51 @@ describe("validateEntityOwnership (ringGame branch) (SA2-174)", () => {
 		});
 	}
 
-	it("resolves when the ring game's room is owned by the caller", async () => {
+	it("resolves when the ring game's userId matches the caller", async () => {
 		const { db, selectedTables } = mockDbFor({
-			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID }],
-			room: [{ id: ROOM_ID, userId: CALLER }],
+			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID, userId: CALLER }],
 		});
 		await expect(
 			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
 		).resolves.toBeUndefined();
-		// The room must be read to confirm ownership.
-		expect(selectedTables).toEqual(["ring_game", "room"]);
-	});
-
-	it("throws FORBIDDEN when the ring game's room belongs to another user", async () => {
-		const { db } = mockDbFor({
-			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID }],
-			room: [{ id: ROOM_ID, userId: OTHER }],
-		});
-		await expect(
-			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
-		).rejects.toMatchObject({
-			code: "FORBIDDEN",
-			message: "You do not own this ring game",
-		});
-	});
-
-	it("throws FORBIDDEN when the ring game has a null roomId (auto-generated row)", async () => {
-		const { db, selectedTables } = mockDbFor({
-			ringGame: [{ id: RING_GAME_ID, roomId: null }],
-		});
-		await expect(
-			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
-		).rejects.toMatchObject({
-			code: "FORBIDDEN",
-			message: "You do not own this ring game",
-		});
-		// Ownership cannot be proven; must not fall through to reading a room.
+		// Ownership is a direct userId check; the room is never read (SA2-181).
 		expect(selectedTables).toEqual(["ring_game"]);
+	});
+
+	it("resolves for a null-roomId auto-generated row owned via userId", async () => {
+		const { db, selectedTables } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: null, userId: CALLER }],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).resolves.toBeUndefined();
+		expect(selectedTables).toEqual(["ring_game"]);
+	});
+
+	it("throws FORBIDDEN when the ring game belongs to another user", async () => {
+		const { db, selectedTables } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID, userId: OTHER }],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
+		// Must not fall through to reading a room.
+		expect(selectedTables).toEqual(["ring_game"]);
+	});
+
+	it("throws FORBIDDEN for a legacy row with a null userId", async () => {
+		const { db } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: null, userId: null }],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
 	});
 
 	it("throws NOT_FOUND when the ring game does not exist", async () => {
@@ -1018,20 +1026,32 @@ describe("validateEntityOwnership (ringGame branch) (SA2-174)", () => {
 			code: "NOT_FOUND",
 			message: "Ring game not found",
 		});
-		// Must short-circuit before reading the room.
 		expect(selectedTables).toEqual(["ring_game"]);
 	});
+});
 
-	it("throws FORBIDDEN when the ring game's room row is missing", async () => {
-		const { db } = mockDbFor({
-			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID }],
-			room: [],
+describe("session.create auto-generated ring game ownership (SA2-181)", () => {
+	const CALLER = "user-1";
+
+	it("stamps the creating user's id on the auto-generated ring_game", async () => {
+		const { db, inserted } = createChainableMockDb({ select: {} });
+		const caller = appRouter.createCaller({
+			session: { user: { id: CALLER } },
+			db,
+		} as unknown as Parameters<typeof appRouter.createCaller>[0]);
+
+		await caller.session.create({
+			type: "cash_game",
+			sessionDate: 1_700_000_000,
+			buyIn: 1000,
+			cashOut: 2000,
 		});
-		await expect(
-			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
-		).rejects.toMatchObject({
-			code: "FORBIDDEN",
-			message: "You do not own this ring game",
+
+		const ringGameInserts = inserted.ring_game ?? [];
+		expect(ringGameInserts).toHaveLength(1);
+		expect(ringGameInserts[0]).toMatchObject({
+			userId: CALLER,
+			roomId: null,
 		});
 	});
 });

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -145,17 +145,15 @@ async function resolveRingGameAssignment(
 		});
 	}
 
-	if (foundRingGame.roomId) {
-		const [foundRoom] = await db
-			.select()
-			.from(room)
-			.where(eq(room.id, foundRingGame.roomId));
-		if (!foundRoom || foundRoom.userId !== userId) {
-			throw new TRPCError({
-				code: "FORBIDDEN",
-				message: "You do not own this ring game",
-			});
-		}
+	// Ownership is anchored on ring_game.userId (SA2-181), not derived from the
+	// room, so null-roomId auto-generated snapshot rows are covered too. This
+	// mirrors the caller's pre-check (validateEntityOwnership("ringGame", …)) as
+	// defense-in-depth and keeps the ownership model unified.
+	if (foundRingGame.userId !== userId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
 	}
 
 	if (

--- a/packages/api/src/routers/ring-game.ts
+++ b/packages/api/src/routers/ring-game.ts
@@ -48,8 +48,15 @@ async function validateRingGameOwnership(
 		});
 	}
 
-	if (found.roomId) {
-		await validateRoomOwnership(db, found.roomId, userId);
+	// Ownership is now anchored on ring_game.userId (SA2-181). A null userId is a
+	// legacy/orphan row that predates the backfill and cannot be proven owned →
+	// FORBIDDEN. This closes the null-roomId IDOR gap the room-derived check left
+	// open for auto-generated snapshot rows.
+	if (found.userId !== userId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
 	}
 
 	return found;
@@ -111,6 +118,7 @@ export const ringGameRouter = router({
 			await ctx.db.insert(ringGame).values({
 				id,
 				roomId: input.roomId,
+				userId,
 				name: input.name,
 				variant: input.variant,
 				blind1: input.blind1 ?? null,

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -350,23 +350,17 @@ async function validateRingGameOwnershipBranch(
 	if (!found) {
 		throw new TRPCError({ code: "NOT_FOUND", message: "Ring game not found" });
 	}
-	// A ring game has no userId of its own; ownership is derived from its room.
-	// Auto-generated snapshot rows have a null roomId and are never
-	// user-selectable, so a caller-supplied id pointing at one cannot be proven
-	// owned → FORBIDDEN. Without this a caller could pass another user's
-	// ringGameId to snapshot their cash-game rule config (IDOR, SA2-174).
-	if (!found.roomId) {
+	// A ring game now carries its own userId (SA2-181), so ownership is a direct
+	// comparison — no longer derived from the room. A null userId is a
+	// legacy/orphan row that cannot be proven owned → FORBIDDEN. This supersedes
+	// the previous room-join and keeps null-roomId auto-generated snapshot rows
+	// correctly owned after the backfill, closing the IDOR gap (SA2-174/SA2-181).
+	if (found.userId !== userId) {
 		throw new TRPCError({
 			code: "FORBIDDEN",
 			message: "You do not own this ring game",
 		});
 	}
-	await assertRoomOwnedBy(
-		db,
-		found.roomId,
-		userId,
-		"You do not own this ring game"
-	);
 }
 
 async function validateEntityOwnership(
@@ -1865,7 +1859,8 @@ async function insertCashGameSessionDetail(
 	db: DbInstance,
 	sessionId: string,
 	input: z.infer<typeof cashGameCreateSchema>,
-	now: Date
+	now: Date,
+	userId: string
 ): Promise<void> {
 	let ringGameId = input.ringGameId ?? null;
 	const snapshot = await resolveCashRuleSnapshot(db, input);
@@ -1876,6 +1871,9 @@ async function insertCashGameSessionDetail(
 		await db.insert(ringGame).values({
 			id: ringGameId,
 			roomId: null,
+			// Auto-generated snapshot row: anchor ownership on the creating user
+			// (SA2-181) since it has no room to derive ownership from.
+			userId,
 			name: derivedName,
 			variant: snapshot.variant,
 			blind1: snapshot.blind1,
@@ -2213,7 +2211,7 @@ export const sessionRouter = router({
 			});
 
 			if (input.type === "cash_game") {
-				await insertCashGameSessionDetail(ctx.db, id, input, now);
+				await insertCashGameSessionDetail(ctx.db, id, input, now, userId);
 			} else {
 				await insertTournamentSessionDetail(ctx.db, id, input);
 			}

--- a/packages/db/src/__tests__/ring-game.test.ts
+++ b/packages/db/src/__tests__/ring-game.test.ts
@@ -19,6 +19,7 @@ describe("RingGame schema", () => {
 		expect(columns.maxBuyIn).toBeDefined();
 		expect(columns.tableSize).toBeDefined();
 		expect(columns.currencyId).toBeDefined();
+		expect(columns.userId).toBeDefined();
 		expect(columns.memo).toBeDefined();
 		expect(columns.archivedAt).toBeDefined();
 		expect(columns.createdAt).toBeDefined();
@@ -38,6 +39,11 @@ describe("RingGame schema", () => {
 	it("roomId is nullable", () => {
 		const columns = getTableColumns(ringGame);
 		expect(columns.roomId.notNull).toBe(false);
+	});
+
+	it("userId is nullable (DB-level; app sets it on every insert, SA2-181)", () => {
+		const columns = getTableColumns(ringGame);
+		expect(columns.userId.notNull).toBe(false);
 	});
 
 	it("name is not null", () => {
@@ -128,8 +134,18 @@ describe("RingGame — FK cascade policies", () => {
 		expect(fkByColumn("currency_id")?.onDelete).toBe("set null");
 	});
 
-	it("has exactly 2 foreign keys", () => {
-		expect(config.foreignKeys).toHaveLength(2);
+	it("userId FK cascades on user deletion (SA2-181)", () => {
+		expect(fkByColumn("user_id")?.onDelete).toBe("cascade");
+	});
+
+	it("userId FK references the user id column (SA2-181)", () => {
+		const fk = fkByColumn("user_id")?.reference();
+		expect(fk?.foreignColumns.map((c) => c.name)).toEqual(["id"]);
+		expect(getTableConfig(fk?.foreignTable as never).name).toBe("user");
+	});
+
+	it("has exactly 3 foreign keys", () => {
+		expect(config.foreignKeys).toHaveLength(3);
 	});
 });
 
@@ -139,6 +155,10 @@ describe("RingGame — indexes", () => {
 
 	it("has roomId index for per-room ring-game listing", () => {
 		expect(idxNames).toContain("ringGame_roomId_idx");
+	});
+
+	it("has userId index for owner-scoped queries (SA2-181)", () => {
+		expect(idxNames).toContain("ringGame_userId_idx");
 	});
 
 	it("has no unique indexes (ring games can share names within a room)", () => {

--- a/packages/db/src/migrations/0033_ring_game_add_user_id.sql
+++ b/packages/db/src/migrations/0033_ring_game_add_user_id.sql
@@ -1,0 +1,10 @@
+-- SA2-181: ring_game に本来の所有者 user_id を追加する（構造的 IDOR 修正）。
+-- これまで所有権は room_id -> room.user_id で導出していたが、自動生成された
+-- キャッシュルール行は room_id が NULL のため所有権の起点が無く、null-roomId 行が
+-- 誰のものでもない状態になっていた。NULL 許容で追加し、既存行はバックフィルする。
+ALTER TABLE `ring_game` ADD `user_id` text REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade;--> statement-breakpoint
+-- room に紐づく行: room.user_id から所有者を復元する。
+UPDATE `ring_game` SET `user_id` = (SELECT `user_id` FROM `room` WHERE `room`.`id` = `ring_game`.`room_id`) WHERE `room_id` IS NOT NULL;--> statement-breakpoint
+-- 自動生成（room_id が NULL）の行: 所有セッション経由で所有者を復元する。
+UPDATE `ring_game` SET `user_id` = (SELECT `gs`.`user_id` FROM `session_cash_detail` `scd` JOIN `game_session` `gs` ON `gs`.`id` = `scd`.`session_id` WHERE `scd`.`ring_game_id` = `ring_game`.`id` LIMIT 1) WHERE `room_id` IS NULL AND `user_id` IS NULL;--> statement-breakpoint
+CREATE INDEX `ringGame_userId_idx` ON `ring_game` (`user_id`);

--- a/packages/db/src/schema/ring-game.ts
+++ b/packages/db/src/schema/ring-game.ts
@@ -1,5 +1,6 @@
 import { relations, sql } from "drizzle-orm";
 import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { user } from "./auth";
 import { currency } from "./currency";
 import { room } from "./room";
 
@@ -8,6 +9,14 @@ export const ringGame = sqliteTable(
 	{
 		id: text("id").primaryKey(),
 		roomId: text("room_id").references(() => room.id, {
+			onDelete: "cascade",
+		}),
+		// Real ownership anchor (SA2-181). Nullable at the DB level so the ADD
+		// COLUMN migration is safe on populated tables; the app sets it on every
+		// insert and ownership treats null as not-owned. This closes the IDOR gap
+		// for auto-generated snapshot rows whose roomId is null and therefore had
+		// no ownership anchor under the room-derived model.
+		userId: text("user_id").references(() => user.id, {
 			onDelete: "cascade",
 		}),
 		name: text("name").notNull(),
@@ -32,13 +41,20 @@ export const ringGame = sqliteTable(
 			.$onUpdate(() => /* @__PURE__ */ new Date())
 			.notNull(),
 	},
-	(table) => [index("ringGame_roomId_idx").on(table.roomId)]
+	(table) => [
+		index("ringGame_roomId_idx").on(table.roomId),
+		index("ringGame_userId_idx").on(table.userId),
+	]
 );
 
 export const ringGameRelations = relations(ringGame, ({ one }) => ({
 	room: one(room, {
 		fields: [ringGame.roomId],
 		references: [room.id],
+	}),
+	user: one(user, {
+		fields: [ringGame.userId],
+		references: [user.id],
 	}),
 	currency: one(currency, {
 		fields: [ringGame.currencyId],


### PR DESCRIPTION
## 概要 (SA2-181)

`ring_game` の所有権はこれまで `room_id -> room.user_id` で導出していたが、`room_id` は自動生成されるキャッシュルール行では **NULL** のため、それらの行が所有権の起点を持たず「誰のものでもない」状態になっていた（構造的 IDOR）。本 PR は `ring_game` に本来の所有者 `user_id` を持たせ、所有権判定を `userId` の直接比較へ切り替える。

> **スタック PR**: 本 PR は #509 (SA2-175 IDOR ownership sweep) のブランチ `claude/sa2-175-idor-ownership-sweep` に **スタック** している。#509 が dev にマージされたら本 PR の base を **dev に付け替える**こと。#509 が導入した room 経由の ringGame 所有権チェックを、本 PR で userId ベースへ簡素化している。

## 変更内容

### 1. スキーマ (`packages/db/src/schema/ring-game.ts`)
- NULL 許容の `user_id`（`user.id` 参照、`onDelete: cascade`）を追加。DB 列は NULL 許容のまま（populated テーブルに対する ADD COLUMN を安全にするため）。アプリは全 insert で必ずセットし、所有権判定は null を「非所有」として扱う。
- `ringGame_userId_idx` インデックスを追加（`room.ts` の index スタイルに合わせる）。

### 2. マイグレーション（手書き `0033_ring_game_add_user_id.sql`）
- **SA2-158 のため `bun run db:generate` / drizzle-kit generate は使わない**（`_journal.json` が idx 12 で凍結され、0013–0032 は journal エントリなしで手追加されている）。0013–0032 の慣習に従い `.sql` を手書きし、`_journal.json` は変更していない。
- ADD COLUMN → room 経由バックフィル → 所有セッション経由バックフィル（null-room 行）→ index の 4 文を `--> statement-breakpoint` 区切りで記述。
- `bun run db:migrate:local` で 0033 まで適用成功を確認済み（✅）。

### 3. 所有権モデルを userId ベースへ
- `ring-game.ts` `create`: insert に `userId: ctx.session.user.id` を追加。
- `session.ts` `insertCashGameSessionDetail`: `userId` 引数を追加し、自動生成 `ring_game` 行に設定。呼び出し元 `session.create` からセッションの `userId` を渡す。
- `ring-game.ts` `validateRingGameOwnership`: `found.userId === userId` を検証（欠損→NOT_FOUND、null/不一致→FORBIDDEN）。`update`/`archive`/`restore`/`delete` の null-roomId ギャップを閉じる（SA2-181 本体）。
- `session.ts` `validateRingGameOwnershipBranch`（#509 の room 導出ヘルパー）: userId 直接比較へ簡素化。バックフィル後は null-roomId 行も正しく所有判定される。

### 4. web の型追従
- `use-ring-games.ts` のローカル `RingGame` 型に `userId: string | null` を追加（API 由来の型が userId を含むようになったため）。

## 検証

- `bunx vitest run --project api`: **882 passed (24 files)**
- `bunx vitest run --project db`: **380 passed (13 files)**
- `bun x ultracite check`（変更ファイル）: クリーン、修正なし
- `bun run check-types`: **exit 0**
- `bun run db:migrate:local`: 0033 まで全マイグレーション適用成功

### TDD
- `packages/db/.../ring-game.test.ts`: `user_id` 列 / FK(user.id, cascade) / `ringGame_userId_idx` / null 許容を `getTableConfig` で検証。
- `packages/api/.../ring-game.test.ts`: create が userId をスタンプ / update・archive・restore・delete で owned→ok, foreign→FORBIDDEN, null userId→FORBIDDEN, missing→NOT_FOUND。
- `packages/api/.../session.test.ts`, `live-cash-game-session.test.ts`: ringGame 所有権を userId モデルへ更新。session.create の自動生成 ring_game が userId を持つことを検証。

## 補足
- `db:generate` は SA2-158 のため意図的に不使用。


---
_Generated by [Claude Code](https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ)_