### PR TITLE
fix(db): 日跨ぎ既存セッション行のバックフィル補正 (SA2-184)

### DIFF
--- a/packages/db/src/migrations/0034_backfill_day_crossing_session_end.sql
+++ b/packages/db/src/migrations/0034_backfill_day_crossing_session_end.sql
@@ -1,0 +1,7 @@
+-- SA2-184 (SA2-157 バックフィル): 日跨ぎで終了 < 開始 のまま保存された既存
+-- セッション行を +1日 補正する。書き込み時補正(computeSessionTimes)導入前に
+-- 22:00開始→翌02:00終了 のような入力が ended_at < started_at として保存され、
+-- プレー時間が負値表示＋サーバー統計から消失していた行が対象。
+-- started_at / ended_at は integer(mode:"timestamp") = Unix 秒なので 86400 秒 = 1日。
+-- WHERE で補正済み(ended_at >= started_at)の行は除外されるため再適用しても冪等。
+UPDATE `game_session` SET `ended_at` = `ended_at` + 86400 WHERE `ended_at` IS NOT NULL AND `started_at` IS NOT NULL AND `ended_at` < `started_at`;


### PR DESCRIPTION
## 概要

親Issue SA2-157（#512）は**書き込み時の日跨ぎ補正**を入れたが、これは新規・編集時のみ有効。導入前に `ended_at < started_at` として保存された**既存の破損行**は不正なまま残り、サーバー側 `computeRowPlayMinutes` の0クランプによりプレー時間が統計（Play time / 時給 / BB/hr / playTime チャート）から消失し続ける。本PRはその既存行を救うデータ移行。

## 変更内容

マイグレーション `0034_backfill_day_crossing_session_end.sql` を追加:

```sql
UPDATE `game_session` SET `ended_at` = `ended_at` + 86400
WHERE `ended_at` IS NOT NULL AND `started_at` IS NOT NULL AND `ended_at` < `started_at`;
```

- `started_at` / `ended_at` は `integer(mode:"timestamp")` = **Unix 秒**なので `+86400` = +1日
- **冪等**: 補正後は `ended_at >= started_at` になり WHERE から除外されるため、再適用しても二重加算しない
- 対象は「終了 < 開始」の1回跨ぎのみ（フォーム構造上、複数日跨ぎは発生しない）

### マイグレーション運用（SA2-158）

マイグレーション台帳（`_journal.json`）が壊れているため、`bun run db:generate` は使わず**手書きで 0034 を追加**。`_journal.json` は触らず、wrangler のファイル名ベース追跡に従う（0013〜0033 と同じ運用）。`bun run db:migrate:local` で適用確認済み（✅ 2 commands executed successfully）。

## 影響範囲

`game_session` テーブルのデータ補正のみ。スキーマ変更なし・アプリコード変更なし。DST は考慮不要（対象ロケール=日本に DST 無し、固定 86400 で正しい）。

## スタック

このPRは #512（SA2-157）の上にスタックしています。**#512 マージ後にベースを `dev` へ付け替え**ます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2PCs2aNZZoS7ABp1zRQNJ)_