### PR TITLE
release/v3.2.1

### DIFF
--- a/.claude/rules/db-migrations.md
+++ b/.claude/rules/db-migrations.md
@@ -37,6 +37,11 @@ current schema, chained onto `0012`. There are intentionally no per-migration sn
 snapshots do not exist and were not fabricated. `db:generate` only ever reads the newest snapshot,
 so this is sufficient and correct.
 
+> Caveat: `drizzle-kit check` (not currently in CI) validates that a snapshot exists for every
+> journal entry and would flag the intentionally-absent 0013–0033 snapshots. Do not add it to CI
+> without first regenerating a full snapshot chain (or dropping the unbacked journal entries) — the
+> re-baseline above deliberately trades a complete snapshot history for a lean, honest ledger.
+
 ## Keeping the ledger from drifting again
 
 `bun run db:generate` must report **"No schema changes, nothing to migrate"** whenever

--- a/.claude/rules/db-migrations.md
+++ b/.claude/rules/db-migrations.md
@@ -1,0 +1,58 @@
+---
+paths:
+  - "packages/db/**"
+---
+
+# Database Migrations (Drizzle + Cloudflare D1)
+
+Migrations live in [`packages/db/src/migrations`](../../packages/db/src/migrations) as numbered
+`NNNN_name.sql` files. **They are hand-written and applied by `wrangler d1 migrations apply`**
+(`bun run db:migrate:local` / `db:migrate:remote`), which reads the `.sql` files directly and
+tracks applied migrations in D1's own `d1_migrations` table. Wrangler never looks at Drizzle's
+`meta/` folder.
+
+## Why migrations are hand-authored
+
+Many migrations do things `drizzle-kit generate` cannot express: data backfills
+(`0018_backfill_session_start_timer`, `0034_backfill_day_crossing_session_end`), event-model
+rewrites (`0013`, `0019`–`0022`), and table renames with data moves
+(`0029_rename_store_to_room`). Those must be written by hand. Never assume a migration was
+machine-generated.
+
+## The Drizzle `meta/` ledger and `db:generate`
+
+`bun run db:generate` (`drizzle-kit generate`) does **not** apply anything — it diffs the current
+`src/schema/*.ts` against the newest snapshot in `meta/` and writes a candidate migration + a new
+snapshot. It exists so schema-only changes can be scaffolded and, more importantly, so the ledger's
+newest snapshot stays a faithful mirror of the live schema (Drizzle Studio and any future diff read
+it).
+
+The ledger drifted once (SA2-158): `meta/_journal.json` and the snapshots froze at
+`0012_boring_vivisector` while 0013–0034 were added by hand. Diffing the real schema against a
+20-migration-old snapshot made `db:generate` emit a giant, destructive migration under a filename
+that collided with an existing one. It was re-baselined by registering 0013–0034 in
+`_journal.json` and adding a single tip snapshot (`0034_snapshot.json`) that captures the true
+current schema, chained onto `0012`. There are intentionally no per-migration snapshots for
+0013–0033 — those migrations were authored in bulk, outside Drizzle, so faithful intermediate
+snapshots do not exist and were not fabricated. `db:generate` only ever reads the newest snapshot,
+so this is sufficient and correct.
+
+## Keeping the ledger from drifting again
+
+`bun run db:generate` must report **"No schema changes, nothing to migrate"** whenever
+`src/schema/*.ts` and the migrations are in sync. Treat a non-empty diff as a signal, not a
+finished migration:
+
+1. Write (or edit) the migration `.sql` by hand — pick the next `NNNN` prefix.
+2. Run `bun run db:generate`. If it reports changes, the newest snapshot is now stale relative to
+   your schema edits. Let it write the fresh snapshot + journal entry, then **replace its
+   auto-generated `.sql` with your hand-written migration** (or delete the auto `.sql` if your
+   hand-written one already covers it) so `wrangler` still applies the intended SQL. The goal is a
+   `meta/` tip snapshot that matches the schema and a `.sql` that expresses the real (possibly
+   data-carrying) change.
+3. Re-run `bun run db:generate` and confirm it prints "No schema changes".
+
+If you ever need to re-baseline again, generate a clean current-schema snapshot from an empty
+`meta/` baseline (`drizzle-kit generate` with an empty `_journal.json` produces one snapshot of the
+whole schema), then transplant its body into a new tip snapshot whose `prevId` chains onto the
+previous tip's `id`.

--- a/.claude/rules/db-migrations.md
+++ b/.claude/rules/db-migrations.md
@@ -6,26 +6,41 @@ paths:
 # Database Migrations (Drizzle + Cloudflare D1)
 
 Migrations live in [`packages/db/src/migrations`](../../packages/db/src/migrations) as numbered
-`NNNN_name.sql` files. **They are hand-written and applied by `wrangler d1 migrations apply`**
-(`bun run db:migrate:local` / `db:migrate:remote`), which reads the `.sql` files directly and
-tracks applied migrations in D1's own `d1_migrations` table. Wrangler never looks at Drizzle's
-`meta/` folder.
+`NNNN_name.sql` files, applied by `wrangler d1 migrations apply` (`bun run db:migrate:local` /
+`db:migrate:remote`), which reads the `.sql` files directly and tracks applied migrations in D1's
+own `d1_migrations` table. Wrangler never looks at Drizzle's `meta/` folder.
 
-## Why migrations are hand-authored
+## How to author a migration
 
-Many migrations do things `drizzle-kit generate` cannot express: data backfills
-(`0018_backfill_session_start_timer`, `0034_backfill_day_crossing_session_end`), event-model
-rewrites (`0013`, `0019`–`0022`), and table renames with data moves
-(`0029_rename_store_to_room`). Those must be written by hand. Never assume a migration was
-machine-generated.
+**`bun run db:generate` is the default path for schema-shape changes.** After the SA2-158
+re-baseline the `meta/` ledger mirrors the live schema, so `drizzle-kit generate` produces a correct
+diff and — critically — writes the updated snapshot for you, which is what keeps the ledger from
+drifting again. Reach for it first for additive/structural changes: new column
+(`ALTER TABLE … ADD COLUMN`), new table, new index. Drizzle's `--> statement-breakpoint` markers are
+comments, so `wrangler` applies the generated SQL as-is.
 
-## The Drizzle `meta/` ledger and `db:generate`
+**Hand-write (or heavily edit the generated SQL) only when `drizzle-kit generate` can't express the
+change or would do it unsafely:**
+
+- **Data backfills / transforms** — `UPDATE` / `INSERT` / event-model rewrites
+  (`0018_backfill_session_start_timer`, `0034_backfill_day_crossing_session_end`, `0019`–`0022`).
+  Drizzle emits schema diffs only.
+- **Renames that must preserve data** — `0029_rename_store_to_room`. Drizzle tends to read a rename
+  as drop-then-create (data loss) unless you answer its interactive prompts.
+- **Column removal / type changes on SQLite/D1** — Drizzle emulates these by recreating the table
+  (`__new_*` → copy → drop → rename); it works but review it carefully against foreign keys and data
+  volume.
+
+When you hand-write a migration, still run `db:generate` afterward (see below) so the snapshot stays
+in sync — let it write the fresh snapshot, then replace/delete its auto `.sql` so `wrangler` applies
+your intended SQL.
+
+## The Drizzle `meta/` ledger
 
 `bun run db:generate` (`drizzle-kit generate`) does **not** apply anything — it diffs the current
-`src/schema/*.ts` against the newest snapshot in `meta/` and writes a candidate migration + a new
-snapshot. It exists so schema-only changes can be scaffolded and, more importantly, so the ledger's
-newest snapshot stays a faithful mirror of the live schema (Drizzle Studio and any future diff read
-it).
+`src/schema/*.ts` against the newest snapshot in `meta/` and writes a migration + a new snapshot.
+Besides scaffolding schema changes, it keeps the ledger's newest snapshot a faithful mirror of the
+live schema (Drizzle Studio and any future diff read it).
 
 The ledger drifted once (SA2-158): `meta/_journal.json` and the snapshots froze at
 `0012_boring_vivisector` while 0013–0034 were added by hand. Diffing the real schema against a
@@ -45,17 +60,18 @@ so this is sufficient and correct.
 ## Keeping the ledger from drifting again
 
 `bun run db:generate` must report **"No schema changes, nothing to migrate"** whenever
-`src/schema/*.ts` and the migrations are in sync. Treat a non-empty diff as a signal, not a
-finished migration:
+`src/schema/*.ts` and the migrations are in sync. The workflows:
 
-1. Write (or edit) the migration `.sql` by hand — pick the next `NNNN` prefix.
-2. Run `bun run db:generate`. If it reports changes, the newest snapshot is now stale relative to
-   your schema edits. Let it write the fresh snapshot + journal entry, then **replace its
-   auto-generated `.sql` with your hand-written migration** (or delete the auto `.sql` if your
-   hand-written one already covers it) so `wrangler` still applies the intended SQL. The goal is a
-   `meta/` tip snapshot that matches the schema and a `.sql` that expresses the real (possibly
-   data-carrying) change.
-3. Re-run `bun run db:generate` and confirm it prints "No schema changes".
+- **Schema-shape change** — edit `src/schema/*.ts`, run `bun run db:generate`, keep the generated
+  `.sql` + snapshot. Done.
+- **Data / rename / destructive change** — hand-write the `.sql` (next `NNNN` prefix), then run
+  `bun run db:generate`; let it write the fresh snapshot + journal entry, and **replace its
+  auto-generated `.sql` with your hand-written migration** (or delete the auto `.sql` if yours
+  already covers it) so `wrangler` applies the intended SQL. The goal is a `meta/` tip snapshot that
+  matches the schema and a `.sql` that expresses the real (possibly data-carrying) change.
+
+Either way, re-run `bun run db:generate` last and confirm it prints "No schema changes" — a
+non-empty diff means the snapshot is out of sync and the ledger is drifting.
 
 If you ever need to re-baseline again, generate a clean current-schema snapshot from an empty
 `meta/` baseline (`drizzle-kit generate` with an empty `_journal.json` produces one snapshot of the

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -89,9 +89,20 @@ jobs:
               IS_NEW=true
               echo "Created D1 database: $DB_ID"
             else
-              # Create returned no id — most likely the DB already exists but the
-              # list lookup raced/paginated past it. Re-resolve after a delay.
-              echo "Create returned no id; re-resolving. Response: $CREATE_RESP"
+              # Create returned no id. Distinguish the cause so the downstream
+              # seed step (gated on is_new_db) still runs when appropriate:
+              #   - duplicate-name (7502): the DB already existed -> not new,
+              #     the seed was already applied on its first deploy, skip it.
+              #   - any other transient failure: the DB may have just been
+              #     created but the response was unparseable -> treat as new so
+              #     the seed runs and the preview DB is not left empty.
+              if echo "$CREATE_RESP" | jq -e '.errors[]? | select(.code == 7502)' >/dev/null 2>&1; then
+                echo "DB already exists (7502); re-resolving id. Response: $CREATE_RESP"
+                IS_NEW=false
+              else
+                echo "Create returned no id (transient?); re-resolving id, treating as new. Response: $CREATE_RESP"
+                IS_NEW=true
+              fi
               sleep 3
               DB_ID=$(resolve_id || true)
             fi

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: preview-deploy-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -56,29 +60,52 @@ jobs:
         id: resolve
         run: |
           DB_NAME="${{ needs.setup.outputs.d1_db_name }}"
+          API="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/d1/database"
 
-          # Check if database already exists
-          EXISTING_ID=$(curl -sf \
-            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/d1/database" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            | jq -r ".result[] | select(.name == \"${DB_NAME}\") | .uuid")
+          # Resolve an existing DB id by exact name. The list endpoint is
+          # paginated and also accepts a `name` filter, so pass a large per_page
+          # plus the name filter, then still select by exact name to guard
+          # against prefix matches.
+          resolve_id() {
+            curl -sf "${API}?per_page=1000&name=${DB_NAME}" \
+              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              | jq -r ".result[] | select(.name == \"${DB_NAME}\") | .uuid" \
+              | head -n1
+          }
 
-          if [ -n "$EXISTING_ID" ]; then
-            echo "Reusing existing D1 database: $EXISTING_ID"
-            echo "d1_database_id=${EXISTING_ID}" >> "$GITHUB_OUTPUT"
-            echo "is_new_db=false" >> "$GITHUB_OUTPUT"
-          else
-            # Create new database
-            NEW_ID=$(curl -sf -X POST \
-              "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/d1/database" \
+          DB_ID=$(resolve_id || true)
+          IS_NEW=false
+
+          if [ -z "$DB_ID" ]; then
+            # No existing DB found — create it. Capture the full response so a
+            # duplicate-name error (7502) or an empty uuid does not silently
+            # leave DB_ID blank and break the migrate job downstream.
+            CREATE_RESP=$(curl -s -X POST "${API}" \
               -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
               -H "Content-Type: application/json" \
-              -d "{\"name\": \"${DB_NAME}\"}" \
-              | jq -r '.result.uuid')
-            echo "Created D1 database: $NEW_ID"
-            echo "d1_database_id=${NEW_ID}" >> "$GITHUB_OUTPUT"
-            echo "is_new_db=true" >> "$GITHUB_OUTPUT"
+              -d "{\"name\": \"${DB_NAME}\"}")
+            DB_ID=$(echo "$CREATE_RESP" | jq -r '.result.uuid // empty')
+            if [ -n "$DB_ID" ]; then
+              IS_NEW=true
+              echo "Created D1 database: $DB_ID"
+            else
+              # Create returned no id — most likely the DB already exists but the
+              # list lookup raced/paginated past it. Re-resolve after a delay.
+              echo "Create returned no id; re-resolving. Response: $CREATE_RESP"
+              sleep 3
+              DB_ID=$(resolve_id || true)
+            fi
+          else
+            echo "Reusing existing D1 database: $DB_ID"
           fi
+
+          if [ -z "$DB_ID" ]; then
+            echo "::error::Could not resolve or create D1 database ${DB_NAME}"
+            exit 1
+          fi
+
+          echo "d1_database_id=${DB_ID}" >> "$GITHUB_OUTPUT"
+          echo "is_new_db=${IS_NEW}" >> "$GITHUB_OUTPUT"
 
   db-migrate:
     needs: [setup, d1-setup]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ bun run lint             # ultracite check
 bun run fix              # ultracite fix (auto-format & auto-fix)
 bun run check-types      # tsc --noEmit (all workspaces)
 bun run build            # build all workspaces
-bun run db:generate      # drizzle-kit generate
+bun run db:generate      # drizzle-kit generate — migrations are hand-written; see .claude/rules/db-migrations.md
 bun run db:migrate:local # apply migrations to local D1
 bun run db:studio        # drizzle-kit studio
 ```
@@ -169,6 +169,7 @@ The following rule files live in `.claude/rules/` and are loaded automatically w
 | `web-ui.md` | `apps/web/**` | PageHeader, shadcn primitives (Table / Badge / Avatar / RadioGroup), mobile = Drawer, tabler-icons. |
 | `web-data-fetching.md` | `apps/web/**` | Optimistic updates must go through `utils/optimistic-update.ts` helpers. |
 | `web-theme.md` | `apps/web/**` | Sapphire 2 Design System (single theme): token format, semantic colors, typography roles, sheet patterns. |
+| `db-migrations.md` | `packages/db/**` | Migrations are hand-written & applied by `wrangler`; how the Drizzle `meta/` ledger works and how to keep `db:generate` from drifting. |
 
 ## Maintaining This File (Self-Evolution)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ bun run lint             # ultracite check
 bun run fix              # ultracite fix (auto-format & auto-fix)
 bun run check-types      # tsc --noEmit (all workspaces)
 bun run build            # build all workspaces
-bun run db:generate      # drizzle-kit generate — migrations are hand-written; see .claude/rules/db-migrations.md
+bun run db:generate      # drizzle-kit generate — default for schema-shape changes; hand-write only data/rename/destructive migrations. see .claude/rules/db-migrations.md
 bun run db:migrate:local # apply migrations to local D1
 bun run db:studio        # drizzle-kit studio
 ```
@@ -169,7 +169,7 @@ The following rule files live in `.claude/rules/` and are loaded automatically w
 | `web-ui.md` | `apps/web/**` | PageHeader, shadcn primitives (Table / Badge / Avatar / RadioGroup), mobile = Drawer, tabler-icons. |
 | `web-data-fetching.md` | `apps/web/**` | Optimistic updates must go through `utils/optimistic-update.ts` helpers. |
 | `web-theme.md` | `apps/web/**` | Sapphire 2 Design System (single theme): token format, semantic colors, typography roles, sheet patterns. |
-| `db-migrations.md` | `packages/db/**` | Migrations are hand-written & applied by `wrangler`; how the Drizzle `meta/` ledger works and how to keep `db:generate` from drifting. |
+| `db-migrations.md` | `packages/db/**` | Applied by `wrangler`; `db:generate` is the default for schema-shape changes, hand-write data/rename/destructive ones; how the Drizzle `meta/` ledger works and how to keep it from drifting. |
 
 ## Maintaining This File (Self-Evolution)
 

--- a/apps/web/src/__tests__/settings-route.test.tsx
+++ b/apps/web/src/__tests__/settings-route.test.tsx
@@ -41,6 +41,7 @@ describe("SettingsComponent", () => {
 		mocks.navigate.mockReset();
 		mocks.signOut.mockReset();
 		mocks.clearPersistedQueryCache.mockReset();
+		mocks.clearPersistedQueryCache.mockResolvedValue(undefined);
 		mocks.signOut.mockImplementation(
 			(options?: { fetchOptions?: { onSuccess?: () => void } }) => {
 				options?.fetchOptions?.onSuccess?.();

--- a/apps/web/src/__tests__/settings-route.test.tsx
+++ b/apps/web/src/__tests__/settings-route.test.tsx
@@ -6,6 +6,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
 	navigate: vi.fn(),
 	signOut: vi.fn(),
+	clearPersistedQueryCache: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -25,6 +26,10 @@ vi.mock("@/lib/auth-client", () => ({
 	},
 }));
 
+vi.mock("@/utils/trpc", () => ({
+	clearPersistedQueryCache: mocks.clearPersistedQueryCache,
+}));
+
 let routeModule: typeof import("@/routes/settings");
 
 describe("SettingsComponent", () => {
@@ -35,6 +40,7 @@ describe("SettingsComponent", () => {
 	beforeEach(() => {
 		mocks.navigate.mockReset();
 		mocks.signOut.mockReset();
+		mocks.clearPersistedQueryCache.mockReset();
 		mocks.signOut.mockImplementation(
 			(options?: { fetchOptions?: { onSuccess?: () => void } }) => {
 				options?.fetchOptions?.onSuccess?.();
@@ -62,7 +68,11 @@ describe("SettingsComponent", () => {
 		await user.click(screen.getByRole("button", { name: "Sign out" }));
 
 		expect(mocks.signOut).toHaveBeenCalledOnce();
+		expect(mocks.clearPersistedQueryCache).toHaveBeenCalledTimes(1);
 		expect(mocks.navigate).toHaveBeenCalledWith({ to: "/" });
+		expect(
+			mocks.clearPersistedQueryCache.mock.invocationCallOrder[0]
+		).toBeLessThan(mocks.navigate.mock.invocationCallOrder[0]);
 	});
 
 	it("does not navigate when signOut does not call onSuccess", async () => {

--- a/apps/web/src/__tests__/tz.ts
+++ b/apps/web/src/__tests__/tz.ts
@@ -1,0 +1,32 @@
+// Deterministic time-zone control for date-formatting tests. Node/Bun re-reads
+// `process.env.TZ` on every Date operation, so wrapping an assertion in `withTz`
+// exercises a specific zone regardless of the host machine's local time.
+//
+// The pristine host zone is captured once at module load and restored in a
+// `finally`, so a test can never leak a zone into sibling files that share the
+// same project under vitest's `isolate: false` (both `web-node` and `web-dom`
+// run this way). When the host had no `TZ` set, the restore must `delete` the
+// var — assigning `undefined` coerces to the string `"undefined"`, which Node
+// treats as an invalid zone and silently falls back to UTC (SA2-145).
+const ORIGINAL_TZ = process.env.TZ;
+
+/** Common zones used by the date tests: west of / east of / at UTC. */
+export const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the off-by-one bug
+export const TZ_EAST = "Asia/Tokyo"; // UTC+9
+
+export function withTz<T>(tz: string, fn: () => T): T {
+	process.env.TZ = tz;
+	try {
+		return fn();
+	} finally {
+		if (ORIGINAL_TZ === undefined) {
+			// Truly unset it: `process.env.TZ = undefined` coerces to the string
+			// "undefined" (an invalid zone Node silently reads as UTC), which would
+			// leak instead of restoring the pristine "no TZ" state. Reflect avoids
+			// the `delete` operator that lint/performance/noDelete forbids.
+			Reflect.deleteProperty(process.env, "TZ");
+		} else {
+			process.env.TZ = ORIGINAL_TZ;
+		}
+	}
+}

--- a/apps/web/src/features/live-sessions/components/active-session-scene/__tests__/use-active-session-scene-state.test.ts
+++ b/apps/web/src/features/live-sessions/components/active-session-scene/__tests__/use-active-session-scene-state.test.ts
@@ -1,3 +1,4 @@
+import { MAX_SEAT_POSITION } from "@sapphire2/db/constants/session-event-types";
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -181,6 +182,17 @@ describe("useActiveSessionSceneState", () => {
 
 		it("falls back to 9 seats when table size is out of range", () => {
 			const { result } = renderState({ tableSize: 25 });
+			expect(result.current.tableSize).toBe(9);
+		});
+
+		it("accepts a table size at the shared MAX_SEAT_POSITION-derived maximum", () => {
+			const { result } = renderState({ tableSize: MAX_SEAT_POSITION + 1 });
+			expect(result.current.tableSize).toBe(MAX_SEAT_POSITION + 1);
+			expect(result.current.seats).toHaveLength(MAX_SEAT_POSITION + 1);
+		});
+
+		it("falls back to 9 seats when table size exceeds the shared maximum by one", () => {
+			const { result } = renderState({ tableSize: MAX_SEAT_POSITION + 2 });
 			expect(result.current.tableSize).toBe(9);
 		});
 

--- a/apps/web/src/features/live-sessions/components/active-session-scene/use-active-session-scene-state.ts
+++ b/apps/web/src/features/live-sessions/components/active-session-scene/use-active-session-scene-state.ts
@@ -1,3 +1,4 @@
+import { MAX_SEAT_POSITION } from "@sapphire2/db/constants/session-event-types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { updateHeroSeatViaClient } from "@/features/live-sessions/utils/seat-screenshot";
@@ -14,7 +15,7 @@ import { trpc } from "@/utils/trpc";
 
 const DEFAULT_SEAT_COUNT = 9;
 const MIN_SEAT_COUNT = 2;
-const MAX_SEAT_COUNT = 10;
+const MAX_SEAT_COUNT = MAX_SEAT_POSITION + 1;
 
 export type SessionParam =
 	| { liveCashGameSessionId: string; liveTournamentSessionId?: never }

--- a/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-compact-summary/__tests__/use-cash-game-compact-summary.test.ts
+++ b/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-compact-summary/__tests__/use-cash-game-compact-summary.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/shared/hooks/use-elapsed-time", () => ({
 import { useCashGameCompactSummary } from "@/features/live-sessions/pages/active-session-page/cash-game-compact-summary/use-cash-game-compact-summary";
 
 const BASE_INPUT = {
+	chipRemoveTotal: 0,
 	currentStack: 0,
 	evDiff: 0,
 	startedAt: new Date("2026-01-01T00:00:00Z"),
@@ -73,6 +74,7 @@ describe("useCashGameCompactSummary", () => {
 	it("computes evPL separately from displayPL when evDiff != 0 and shows when different", () => {
 		const { result } = renderHook(() =>
 			useCashGameCompactSummary({
+				chipRemoveTotal: 0,
 				currentStack: 12_000,
 				evDiff: 500,
 				startedAt: new Date(),
@@ -89,6 +91,7 @@ describe("useCashGameCompactSummary", () => {
 	it("hides evPL when evDiff is 0 (computation branch gates)", () => {
 		const { result } = renderHook(() =>
 			useCashGameCompactSummary({
+				chipRemoveTotal: 0,
 				currentStack: 12_000,
 				evDiff: 0,
 				startedAt: new Date(),
@@ -108,6 +111,7 @@ describe("useCashGameCompactSummary", () => {
 		// So when evDiff != 0 and evPL is not null, showEvPL must be true.
 		const { result } = renderHook(() =>
 			useCashGameCompactSummary({
+				chipRemoveTotal: 0,
 				currentStack: 1,
 				evDiff: 1,
 				startedAt: new Date(),
@@ -115,6 +119,64 @@ describe("useCashGameCompactSummary", () => {
 			})
 		);
 		expect(result.current.showEvPL).toBe(true);
+	});
+
+	it("adds chipRemoveTotal to displayPL (issue scenario: 400 + 300 - 500 = 200)", () => {
+		// SA2-124: header P/L must match the server / chart formula
+		// stack + chipRemoveTotal - totalBuyIn. Without chipRemoveTotal the
+		// header would show 400 - 500 = -100, contradicting the chart's +200.
+		const { result } = renderHook(() =>
+			useCashGameCompactSummary({
+				...BASE_INPUT,
+				chipRemoveTotal: 300,
+				currentStack: 400,
+				evDiff: 0,
+				totalBuyIn: 500,
+			})
+		);
+		expect(result.current.displayPL).toBe(200);
+	});
+
+	it("adds chipRemoveTotal to evPL as well (400 + 300 + 100 - 500 = 300)", () => {
+		const { result } = renderHook(() =>
+			useCashGameCompactSummary({
+				...BASE_INPUT,
+				chipRemoveTotal: 300,
+				currentStack: 400,
+				evDiff: 100,
+				totalBuyIn: 500,
+			})
+		);
+		expect(result.current.displayPL).toBe(200);
+		expect(result.current.evPL).toBe(300);
+		expect(result.current.showEvPL).toBe(true);
+	});
+
+	it("keeps displayPL as currentStack - totalBuyIn when chipRemoveTotal is 0", () => {
+		const { result } = renderHook(() =>
+			useCashGameCompactSummary({
+				...BASE_INPUT,
+				chipRemoveTotal: 0,
+				currentStack: 400,
+				evDiff: 0,
+				totalBuyIn: 500,
+			})
+		);
+		expect(result.current.displayPL).toBe(-100);
+	});
+
+	it("returns null displayPL even when chipRemoveTotal is positive but currentStack is null", () => {
+		const { result } = renderHook(() =>
+			useCashGameCompactSummary({
+				...BASE_INPUT,
+				chipRemoveTotal: 300,
+				currentStack: null,
+				evDiff: 200,
+				totalBuyIn: 500,
+			})
+		);
+		expect(result.current.displayPL).toBeNull();
+		expect(result.current.evPL).toBeNull();
 	});
 
 	it("formats totalBuyIn via formatCompactNumber (0 → '0')", () => {

--- a/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-compact-summary/use-cash-game-compact-summary.ts
+++ b/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-compact-summary/use-cash-game-compact-summary.ts
@@ -6,6 +6,7 @@ import {
 } from "@/utils/format-profit-loss";
 
 interface CashGameCompactSummaryInput {
+	chipRemoveTotal: number;
 	currentStack: number | null;
 	evDiff: number;
 	startedAt: Date | string | number;
@@ -29,14 +30,20 @@ export function useCashGameCompactSummary(
 ): CashGameCompactSummaryViewModel {
 	const duration = useElapsedTime(summary.startedAt);
 
+	// SA2-124: P/L must match the server (`live-session-pl.ts`) and the session
+	// chart (`session-timeline.ts`): stack + chipRemoveTotal - totalBuyIn.
+	// Chips racked off the table are already-pocketed value, not a loss.
 	const displayPL =
 		summary.currentStack === null
 			? null
-			: summary.currentStack - summary.totalBuyIn;
+			: summary.currentStack + summary.chipRemoveTotal - summary.totalBuyIn;
 
 	const evPL =
 		summary.currentStack !== null && summary.evDiff !== 0
-			? summary.currentStack + summary.evDiff - summary.totalBuyIn
+			? summary.currentStack +
+				summary.chipRemoveTotal +
+				summary.evDiff -
+				summary.totalBuyIn
 			: null;
 	const showEvPL = evPL !== null && evPL !== displayPL;
 

--- a/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-session/__tests__/use-cash-game-session-view.test.ts
+++ b/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-session/__tests__/use-cash-game-session-view.test.ts
@@ -61,7 +61,12 @@ function makeSession(
 		memo: null,
 		ringGameId: null,
 		startedAt: new Date("2026-06-01T10:00:00Z"),
-		summary: { currentStack: 1500, evDiff: 50, totalBuyIn: 1000 },
+		summary: {
+			chipRemoveTotal: 0,
+			currentStack: 1500,
+			evDiff: 50,
+			totalBuyIn: 1000,
+		},
 		...overrides,
 	};
 }
@@ -140,6 +145,7 @@ describe("useCashGameSessionView", () => {
 			mocks.session = makeSession({ startedAt });
 			const { result } = renderHook(() => useCashGameSessionView("cg-1"));
 			expect(result.current.summary).toEqual({
+				chipRemoveTotal: 0,
 				currentStack: 1500,
 				evDiff: 50,
 				startedAt,
@@ -153,6 +159,32 @@ describe("useCashGameSessionView", () => {
 			});
 			const { result } = renderHook(() => useCashGameSessionView("cg-1"));
 			expect(result.current.summary?.evDiff).toBe(0);
+		});
+
+		it("threads chipRemoveTotal from the session summary (SA2-124)", () => {
+			mocks.session = makeSession({
+				summary: {
+					chipRemoveTotal: 300,
+					currentStack: 400,
+					evDiff: 0,
+					totalBuyIn: 500,
+				},
+			});
+			const { result } = renderHook(() => useCashGameSessionView("cg-1"));
+			expect(result.current.summary?.chipRemoveTotal).toBe(300);
+		});
+
+		it("coerces a non-numeric chipRemoveTotal to 0", () => {
+			mocks.session = makeSession({
+				summary: {
+					chipRemoveTotal: undefined,
+					currentStack: 1500,
+					evDiff: 0,
+					totalBuyIn: 1000,
+				},
+			});
+			const { result } = renderHook(() => useCashGameSessionView("cg-1"));
+			expect(result.current.summary?.chipRemoveTotal).toBe(0);
 		});
 
 		it("falls back to now when startedAt is missing", () => {

--- a/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-session/use-cash-game-session-view.ts
+++ b/apps/web/src/features/live-sessions/pages/active-session-page/cash-game-session/use-cash-game-session-view.ts
@@ -11,6 +11,7 @@ import { useCashGameSession } from "@/features/live-sessions/hooks/use-cash-game
 import { useCashGameStack } from "@/features/live-sessions/hooks/use-cash-game-stack";
 
 export interface CashGameCompactSummaryData {
+	chipRemoveTotal: number;
 	currentStack: number | null;
 	evDiff: number;
 	startedAt: Date | string | number;
@@ -45,6 +46,10 @@ export function useCashGameSessionView(sessionId: string) {
 
 	const summary: CashGameCompactSummaryData | null = session
 		? {
+				chipRemoveTotal:
+					typeof session.summary.chipRemoveTotal === "number"
+						? session.summary.chipRemoveTotal
+						: 0,
 				currentStack: session.summary.currentStack,
 				evDiff:
 					typeof session.summary.evDiff === "number"

--- a/apps/web/src/features/live-sessions/utils/__tests__/optimistic-session-event.test.ts
+++ b/apps/web/src/features/live-sessions/utils/__tests__/optimistic-session-event.test.ts
@@ -191,6 +191,34 @@ describe("buildOptimisticSessionSummary", () => {
 			expect(result.cashOut).toBeUndefined();
 			expect(result.profitLoss).toBeUndefined();
 		});
+
+		it("includes chipRemoveTotal in profitLoss (SA2-124: 400 + 300 - 500 = 200)", () => {
+			const result = buildOptimisticSessionSummary(
+				{ chipRemoveTotal: 300, totalBuyIn: 500 },
+				"session_end",
+				{ cashOutAmount: 400 }
+			);
+			expect(result.cashOut).toBe(400);
+			expect(result.profitLoss).toBe(200);
+		});
+
+		it("treats missing chipRemoveTotal as 0 when computing profitLoss", () => {
+			const result = buildOptimisticSessionSummary(
+				{ totalBuyIn: 500 },
+				"session_end",
+				{ cashOutAmount: 400 }
+			);
+			expect(result.profitLoss).toBe(-100);
+		});
+
+		it("treats non-numeric chipRemoveTotal as 0 when computing profitLoss", () => {
+			const result = buildOptimisticSessionSummary(
+				{ chipRemoveTotal: "nope", totalBuyIn: 500 },
+				"session_end",
+				{ cashOutAmount: 400 }
+			);
+			expect(result.profitLoss).toBe(-100);
+		});
 	});
 
 	describe("session_end — tournament branch (beforeDeadline=false)", () => {

--- a/apps/web/src/features/live-sessions/utils/optimistic-session-event.ts
+++ b/apps/web/src/features/live-sessions/utils/optimistic-session-event.ts
@@ -80,17 +80,29 @@ function applySessionStartSummary(
 	}
 }
 
+function applyCashSessionEndSummary(
+	summary: Record<string, unknown>,
+	payload: Record<string, unknown>
+) {
+	// Cash game end: cashOutAmount drives profitLoss. SA2-124: mirror the
+	// server / chart formula cashOut + chipRemoveTotal - totalBuyIn so racked-off
+	// chips are counted, not treated as a loss.
+	if (typeof payload.cashOutAmount !== "number") {
+		return;
+	}
+	summary.cashOut = payload.cashOutAmount;
+	const totalBuyIn =
+		typeof summary.totalBuyIn === "number" ? summary.totalBuyIn : 0;
+	const chipRemoveTotal =
+		typeof summary.chipRemoveTotal === "number" ? summary.chipRemoveTotal : 0;
+	summary.profitLoss = payload.cashOutAmount + chipRemoveTotal - totalBuyIn;
+}
+
 function applySessionEndSummary(
 	summary: Record<string, unknown>,
 	payload: Record<string, unknown>
 ) {
-	// Cash game end: cashOutAmount drives profitLoss
-	if (typeof payload.cashOutAmount === "number") {
-		summary.cashOut = payload.cashOutAmount;
-		const totalBuyIn =
-			typeof summary.totalBuyIn === "number" ? summary.totalBuyIn : 0;
-		summary.profitLoss = payload.cashOutAmount - totalBuyIn;
-	}
+	applyCashSessionEndSummary(summary, payload);
 
 	// Tournament end (not before deadline): placement + prizes
 	if (payload.beforeDeadline === false) {

--- a/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.test.tsx
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.test.tsx
@@ -71,6 +71,16 @@ describe("LocationPicker", () => {
 		expect(screen.getByRole("tab", { name: "Current" })).toBeInTheDocument();
 	});
 
+	it("renders the Location label with the shared field-label style", () => {
+		renderPicker();
+		const label = screen.getByText("Location");
+		// Aligns with the other room-form inputs, whose labels render through the
+		// shared Field/Label component as a <label> with `font-medium text-sm`.
+		expect(label.tagName).toBe("LABEL");
+		expect(label).toHaveClass("font-medium", "text-sm");
+		expect(label).not.toHaveClass("text-muted-foreground");
+	});
+
 	it("triggers handleSearch from the search button", () => {
 		const handleSearch = vi.fn();
 		renderPicker({ query: "casino", handleSearch });

--- a/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.tsx
+++ b/apps/web/src/features/rooms/components/room-form/location-picker/location-picker.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tabler/icons-react";
 import { Button } from "@/shared/components/ui/button";
 import { Input } from "@/shared/components/ui/input";
+import { Label } from "@/shared/components/ui/label";
 import {
 	Tabs,
 	TabsContent,
@@ -58,7 +59,7 @@ export function LocationPicker({
 
 	return (
 		<div className="flex flex-col gap-3">
-			<span className="t-label text-muted-foreground">Location</span>
+			<Label>Location</Label>
 			<Tabs defaultValue="search">
 				<TabsList className="w-full">
 					<TabsTrigger value="search">Search</TabsTrigger>

--- a/apps/web/src/features/rooms/components/tournament-modal-content/__tests__/tournament-modal-content.test.tsx
+++ b/apps/web/src/features/rooms/components/tournament-modal-content/__tests__/tournament-modal-content.test.tsx
@@ -1,21 +1,25 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { TournamentModalContent } from "../tournament-modal-content";
 
-const hoisted = vi.hoisted(() => ({
-	useTournamentModalContent: vi.fn(),
-}));
-
-vi.mock("../use-tournament-modal-content", () => ({
-	useTournamentModalContent: hoisted.useTournamentModalContent,
-}));
-
+// The real (trivial, useState-only) useTournamentModalContent hook is used so
+// the controlled-tab behavior (activeTab / setActiveTab) is exercised end to end.
 vi.mock(
 	"@/features/rooms/components/tournament-modal-content/tournament-form",
 	() => ({
-		TournamentForm: ({ formId }: { formId: string }) => (
-			<div data-form-id={formId} data-testid="tournament-form" />
+		TournamentForm: ({
+			formId,
+			onInvalidSubmit,
+		}: {
+			formId: string;
+			onInvalidSubmit?: () => void;
+		}) => (
+			<div data-form-id={formId} data-testid="tournament-form">
+				<button onClick={() => onInvalidSubmit?.()} type="button">
+					trigger-invalid
+				</button>
+			</div>
 		),
 	})
 );
@@ -25,13 +29,6 @@ vi.mock("@/features/rooms/components/blind-level-editor", () => ({
 }));
 
 const AI_BUTTON_RE = /Auto-fill with AI/;
-
-beforeEach(() => {
-	hoisted.useTournamentModalContent.mockReturnValue({
-		localBlindLevels: [],
-		setLocalBlindLevels: vi.fn(),
-	});
-});
 
 describe("TournamentModalContent", () => {
 	it("does not render the AI auto-fill button when onOpenAi is undefined", () => {
@@ -91,6 +88,38 @@ describe("TournamentModalContent", () => {
 		// ...but the Details form must remain in the DOM: the FormSheet Save
 		// button submits it via `form={formId}`, which resolves nothing if the
 		// form has been unmounted (SA2-97).
-		expect(screen.getByTestId("tournament-form")).toBeInTheDocument();
+		const form = screen.getByTestId("tournament-form");
+		expect(form).toBeInTheDocument();
+		// forceMount renders inactive content without the `hidden` attr, so it is
+		// hidden via `data-[state=inactive]:hidden` — assert the panel carries the
+		// inactive state that drives that class (regression guard for the fix).
+		expect(form.closest("[data-slot='tabs-content']")).toHaveAttribute(
+			"data-state",
+			"inactive"
+		);
+	});
+
+	it("switches back to the Details tab when a submit fails validation so the user sees the error", async () => {
+		const user = userEvent.setup();
+		render(
+			<TournamentModalContent
+				formId="tournament-test-form"
+				initialBlindLevels={[]}
+				onSave={vi.fn()}
+			/>
+		);
+		await user.click(screen.getByRole("tab", { name: "Structure" }));
+		expect(screen.getByRole("tab", { name: "Structure" })).toHaveAttribute(
+			"data-state",
+			"active"
+		);
+		// The form reports an invalid submit (e.g. empty required name) while the
+		// Structure tab is open; the sheet must reveal the erroring Details tab
+		// instead of silently swallowing the click (SA2-97 follow-up).
+		await user.click(screen.getByRole("button", { name: "trigger-invalid" }));
+		expect(screen.getByRole("tab", { name: "Details" })).toHaveAttribute(
+			"data-state",
+			"active"
+		);
 	});
 });

--- a/apps/web/src/features/rooms/components/tournament-modal-content/__tests__/tournament-modal-content.test.tsx
+++ b/apps/web/src/features/rooms/components/tournament-modal-content/__tests__/tournament-modal-content.test.tsx
@@ -75,4 +75,22 @@ describe("TournamentModalContent", () => {
 			"tournament-edit-form"
 		);
 	});
+
+	it("keeps the tournament form mounted when the Structure tab is active so the external Save button still submits", async () => {
+		const user = userEvent.setup();
+		render(
+			<TournamentModalContent
+				formId="tournament-test-form"
+				initialBlindLevels={[]}
+				onSave={vi.fn()}
+			/>
+		);
+		await user.click(screen.getByRole("tab", { name: "Structure" }));
+		// The Structure tab content is now shown...
+		expect(screen.getByTestId("blind-structure")).toBeInTheDocument();
+		// ...but the Details form must remain in the DOM: the FormSheet Save
+		// button submits it via `form={formId}`, which resolves nothing if the
+		// form has been unmounted (SA2-97).
+		expect(screen.getByTestId("tournament-form")).toBeInTheDocument();
+	});
 });

--- a/apps/web/src/features/rooms/components/tournament-modal-content/__tests__/use-tournament-modal-content.test.ts
+++ b/apps/web/src/features/rooms/components/tournament-modal-content/__tests__/use-tournament-modal-content.test.ts
@@ -39,4 +39,21 @@ describe("useTournamentModalContent", () => {
 		});
 		expect(result.current.localBlindLevels).toEqual([ROW]);
 	});
+
+	it("defaults activeTab to details", () => {
+		const { result } = renderHook(() =>
+			useTournamentModalContent({ initialBlindLevels: [] })
+		);
+		expect(result.current.activeTab).toBe("details");
+	});
+
+	it("setActiveTab switches the active tab", () => {
+		const { result } = renderHook(() =>
+			useTournamentModalContent({ initialBlindLevels: [] })
+		);
+		act(() => {
+			result.current.setActiveTab("structure");
+		});
+		expect(result.current.activeTab).toBe("structure");
+	});
 });

--- a/apps/web/src/features/rooms/components/tournament-modal-content/tournament-form/__tests__/use-tournament-form.test.ts
+++ b/apps/web/src/features/rooms/components/tournament-modal-content/tournament-form/__tests__/use-tournament-form.test.ts
@@ -99,6 +99,39 @@ describe("useTournamentForm", () => {
 		expect(onSubmit).not.toHaveBeenCalled();
 	});
 
+	it("calls onInvalidSubmit (and not onSubmit) when submit fails validation", async () => {
+		const qc = createClient();
+		const onSubmit = vi.fn();
+		const onInvalidSubmit = vi.fn();
+		const { result } = renderHook(
+			() => useTournamentForm({ onSubmit, onInvalidSubmit }),
+			{ wrapper: wrapper(qc) }
+		);
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(onInvalidSubmit).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not call onInvalidSubmit when submit succeeds", async () => {
+		const qc = createClient();
+		const onSubmit = vi.fn();
+		const onInvalidSubmit = vi.fn();
+		const { result } = renderHook(
+			() => useTournamentForm({ onSubmit, onInvalidSubmit }),
+			{ wrapper: wrapper(qc) }
+		);
+		act(() => {
+			result.current.form.setFieldValue("name", "Main");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onInvalidSubmit).not.toHaveBeenCalled();
+	});
+
 	it("submits with parsed numbers and optional fields collapsed", async () => {
 		const qc = createClient();
 		const onSubmit = vi.fn();

--- a/apps/web/src/features/rooms/components/tournament-modal-content/tournament-form/tournament-form.tsx
+++ b/apps/web/src/features/rooms/components/tournament-modal-content/tournament-form/tournament-form.tsx
@@ -31,6 +31,12 @@ interface TournamentFormProps {
 	 */
 	formId: string;
 	/**
+	 * Called when a submit attempt fails validation. Lets the surrounding modal
+	 * reveal this (Details) tab so the user sees the errors instead of a
+	 * seemingly dead Save button on another tab (SA2-97 follow-up).
+	 */
+	onInvalidSubmit?: () => void;
+	/**
 	 * Registers a getter for the form's current values so AI auto-fill can
 	 * merge over what the user has already entered.
 	 */
@@ -47,10 +53,12 @@ export function TournamentForm({
 	onSubmit,
 	defaultValues,
 	formId,
+	onInvalidSubmit,
 	onRegisterLiveValues,
 }: TournamentFormProps) {
 	const { form, currencies } = useTournamentForm({
 		defaultValues,
+		onInvalidSubmit,
 		onRegisterLiveValues,
 		onSubmit,
 	});

--- a/apps/web/src/features/rooms/components/tournament-modal-content/tournament-form/use-tournament-form.ts
+++ b/apps/web/src/features/rooms/components/tournament-modal-content/tournament-form/use-tournament-form.ts
@@ -94,12 +94,14 @@ interface UseTournamentFormOptions {
 		chipPurchases?: Array<{ name: string; cost: number; chips: number }>;
 		tags?: string[];
 	};
+	onInvalidSubmit?: () => void;
 	onRegisterLiveValues?: (getter: () => TournamentPartialFormValues) => void;
 	onSubmit: (values: TournamentFormValues) => void;
 }
 
 export function useTournamentForm({
 	defaultValues,
+	onInvalidSubmit,
 	onRegisterLiveValues,
 	onSubmit,
 }: UseTournamentFormOptions) {
@@ -146,6 +148,9 @@ export function useTournamentForm({
 		},
 		validators: {
 			onSubmit: tournamentFormSchema,
+		},
+		onSubmitInvalid: () => {
+			onInvalidSubmit?.();
 		},
 	});
 

--- a/apps/web/src/features/rooms/components/tournament-modal-content/tournament-modal-content.tsx
+++ b/apps/web/src/features/rooms/components/tournament-modal-content/tournament-modal-content.tsx
@@ -47,9 +47,10 @@ export function TournamentModalContent({
 	onRegisterLiveValues,
 	onSave,
 }: TournamentModalContentProps) {
-	const { localBlindLevels, setLocalBlindLevels } = useTournamentModalContent({
-		initialBlindLevels,
-	});
+	const { localBlindLevels, setLocalBlindLevels, activeTab, setActiveTab } =
+		useTournamentModalContent({
+			initialBlindLevels,
+		});
 
 	return (
 		<div className="flex flex-col gap-3">
@@ -68,7 +69,12 @@ export function TournamentModalContent({
 					</Badge>
 				</Button>
 			) : null}
-			<Tabs defaultValue="details">
+			<Tabs
+				onValueChange={(value) =>
+					setActiveTab(value as "details" | "structure")
+				}
+				value={activeTab}
+			>
 				<TabsList className="w-full">
 					<TabsTrigger value="details">Details</TabsTrigger>
 					<TabsTrigger value="structure">Structure</TabsTrigger>
@@ -89,6 +95,7 @@ export function TournamentModalContent({
 					<TournamentForm
 						defaultValues={initialFormValues}
 						formId={formId}
+						onInvalidSubmit={() => setActiveTab("details")}
 						onRegisterLiveValues={onRegisterLiveValues}
 						onSubmit={(values) => onSave(values, localBlindLevels)}
 					/>

--- a/apps/web/src/features/rooms/components/tournament-modal-content/tournament-modal-content.tsx
+++ b/apps/web/src/features/rooms/components/tournament-modal-content/tournament-modal-content.tsx
@@ -73,7 +73,19 @@ export function TournamentModalContent({
 					<TabsTrigger value="details">Details</TabsTrigger>
 					<TabsTrigger value="structure">Structure</TabsTrigger>
 				</TabsList>
-				<TabsContent value="details">
+				{/*
+				 * forceMount keeps the `<form id={formId}>` in the DOM while the
+				 * Structure tab is active. Otherwise Radix unmounts this panel and
+				 * the FormSheet Save button (which submits via `form={formId}`)
+				 * resolves nothing, so saving silently fails from the Structure tab
+				 * (SA2-97). `data-[state=inactive]:hidden` hides it while inactive
+				 * since forceMount renders inactive content without the `hidden` attr.
+				 */}
+				<TabsContent
+					className="data-[state=inactive]:hidden"
+					forceMount
+					value="details"
+				>
 					<TournamentForm
 						defaultValues={initialFormValues}
 						formId={formId}

--- a/apps/web/src/features/rooms/components/tournament-modal-content/tournament-modal-content.tsx
+++ b/apps/web/src/features/rooms/components/tournament-modal-content/tournament-modal-content.tsx
@@ -11,7 +11,10 @@ import {
 	TabsList,
 	TabsTrigger,
 } from "@/shared/components/ui/tabs";
-import { useTournamentModalContent } from "./use-tournament-modal-content";
+import {
+	type TournamentModalTab,
+	useTournamentModalContent,
+} from "./use-tournament-modal-content";
 
 export type TournamentPartialFormValues = Omit<
 	TournamentFormValues,
@@ -70,9 +73,7 @@ export function TournamentModalContent({
 				</Button>
 			) : null}
 			<Tabs
-				onValueChange={(value) =>
-					setActiveTab(value as "details" | "structure")
-				}
+				onValueChange={(value) => setActiveTab(value as TournamentModalTab)}
 				value={activeTab}
 			>
 				<TabsList className="w-full">

--- a/apps/web/src/features/rooms/components/tournament-modal-content/use-tournament-modal-content.ts
+++ b/apps/web/src/features/rooms/components/tournament-modal-content/use-tournament-modal-content.ts
@@ -5,14 +5,21 @@ interface UseTournamentModalContentOptions {
 	initialBlindLevels: BlindLevelRow[];
 }
 
+export type TournamentModalTab = "details" | "structure";
+
 export function useTournamentModalContent({
 	initialBlindLevels,
 }: UseTournamentModalContentOptions) {
 	const [localBlindLevels, setLocalBlindLevels] =
 		useState<BlindLevelRow[]>(initialBlindLevels);
+	// Controlled so an invalid submit from the Structure tab can pull the user
+	// back to Details, where the validation errors are shown (SA2-97 follow-up).
+	const [activeTab, setActiveTab] = useState<TournamentModalTab>("details");
 
 	return {
 		localBlindLevels,
 		setLocalBlindLevels,
+		activeTab,
+		setActiveTab,
 	};
 }

--- a/apps/web/src/features/rooms/hooks/__tests__/use-ring-games.test.ts
+++ b/apps/web/src/features/rooms/hooks/__tests__/use-ring-games.test.ts
@@ -83,6 +83,7 @@ function makeGame(overrides: Partial<RingGame> = {}): RingGame {
 		archivedAt: null,
 		createdAt: "2026-01-01",
 		updatedAt: "2026-01-01",
+		userId: "user-1",
 		...overrides,
 	};
 }

--- a/apps/web/src/features/rooms/hooks/use-ring-games.ts
+++ b/apps/web/src/features/rooms/hooks/use-ring-games.ts
@@ -24,6 +24,7 @@ export interface RingGame {
 	roomId: string | null;
 	tableSize: number | null;
 	updatedAt: string;
+	userId: string | null;
 	variant: string;
 }
 
@@ -64,6 +65,9 @@ function buildOptimisticRingGame(
 		tableSize: values.tableSize ?? null,
 		createdAt: new Date().toISOString(),
 		updatedAt: new Date().toISOString(),
+		// Optimistic placeholder; replaced by the server row (which carries the
+		// real userId) on settle.
+		userId: null,
 		variant: values.variant,
 	};
 }

--- a/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
+++ b/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
@@ -102,6 +102,27 @@ const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const TIME_HH_MM_PATTERN = /^\d{2}:\d{2}$/;
 const TEMP_ID_PATTERN = /^temp-/;
 
+// SA2-145: sessionDate must round-trip as a UTC calendar date regardless of
+// the machine's local time zone. Node/Bun re-reads `process.env.TZ` on every
+// Date operation, so we can drive a west-of-UTC and an east-of-UTC zone
+// deterministically. Always restore the original TZ so this file cannot leak
+// into sibling test files that share the worker.
+const ORIGINAL_TZ = process.env.TZ;
+const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the bug
+const TZ_EAST = "Asia/Tokyo"; // UTC+9 — the primary user base
+function withTz<T>(tz: string, fn: () => T): T {
+	process.env.TZ = tz;
+	try {
+		return fn();
+	} finally {
+		if (ORIGINAL_TZ === undefined) {
+			process.env.TZ = undefined;
+		} else {
+			process.env.TZ = ORIGINAL_TZ;
+		}
+	}
+}
+
 function createClient(): QueryClient {
 	return new QueryClient({
 		defaultOptions: {
@@ -219,7 +240,7 @@ function baseSessionItem(overrides: Partial<SessionItem> = {}): SessionItem {
 
 describe("pure helpers", () => {
 	describe("formatDateForInput", () => {
-		it("formats ISO strings to YYYY-MM-DD (local time zone safe for midday)", () => {
+		it("formats ISO strings to YYYY-MM-DD", () => {
 			expect(formatDateForInput("2026-04-23T12:00:00Z")).toMatch(
 				ISO_DATE_PATTERN
 			);
@@ -230,6 +251,87 @@ describe("pure helpers", () => {
 			const [, month, day] = result.split("-");
 			expect(month).toHaveLength(2);
 			expect(day).toHaveLength(2);
+		});
+
+		// SA2-145: the API returns sessionDate as a UTC-midnight ISO string.
+		// The edit form must echo back the SAME calendar day the user saved,
+		// otherwise opening + saving an edit shifts the stored date one day
+		// earlier for every user west of UTC.
+		it("keeps the UTC calendar day at the exact UTC-midnight boundary west of UTC", () => {
+			expect(
+				withTz(TZ_WEST, () => formatDateForInput("2026-07-04T00:00:00Z"))
+			).toBe("2026-07-04");
+		});
+
+		it("keeps the UTC calendar day at the exact UTC-midnight boundary east of UTC", () => {
+			expect(
+				withTz(TZ_EAST, () => formatDateForInput("2026-07-04T00:00:00Z"))
+			).toBe("2026-07-04");
+		});
+
+		it("produces the same calendar day in west-of-UTC, east-of-UTC, and UTC zones", () => {
+			const iso = "2026-01-01T00:00:00Z";
+			const west = withTz(TZ_WEST, () => formatDateForInput(iso));
+			const east = withTz(TZ_EAST, () => formatDateForInput(iso));
+			const utc = withTz("UTC", () => formatDateForInput(iso));
+			expect(west).toBe("2026-01-01");
+			expect(east).toBe("2026-01-01");
+			expect(utc).toBe("2026-01-01");
+		});
+
+		it("does not roll back across a year boundary west of UTC", () => {
+			expect(
+				withTz(TZ_WEST, () => formatDateForInput("2026-01-01T00:00:00Z"))
+			).toBe("2026-01-01");
+		});
+	});
+
+	// SA2-145: round-trip stability. Rendering a saved session into the edit
+	// form and saving it unchanged must reproduce the original UTC-midnight
+	// epoch. Before the fix, a west-of-UTC formatter shifted the day back one,
+	// so each edit-save drifted the stored date earlier (cumulative).
+	describe("sessionDate round-trip stability (UTC calendar date)", () => {
+		it("buildCreatePayload stores UTC-midnight epoch seconds regardless of local zone", () => {
+			const expected = Math.floor(Date.UTC(2026, 3, 1) / 1000);
+			const west = withTz(
+				TZ_WEST,
+				() =>
+					buildCreatePayload(cashValues({ sessionDate: "2026-04-01" }))
+						.sessionDate
+			);
+			const east = withTz(
+				TZ_EAST,
+				() =>
+					buildCreatePayload(cashValues({ sessionDate: "2026-04-01" }))
+						.sessionDate
+			);
+			expect(west).toBe(expected);
+			expect(east).toBe(expected);
+		});
+
+		it("format → save reproduces the original epoch and is stable on re-save (west of UTC)", () => {
+			withTz(TZ_WEST, () => {
+				const apiIso = "2026-07-04T00:00:00Z";
+				const originalEpoch = Math.floor(Date.UTC(2026, 6, 4) / 1000);
+
+				// First edit cycle: hydrate the form from the API row, save unchanged.
+				const formValue = formatDateForInput(apiIso);
+				expect(formValue).toBe("2026-07-04");
+				const firstSave = buildUpdatePayload({
+					...cashValues({ sessionDate: formValue }),
+					id: "s1",
+				}).sessionDate;
+				expect(firstSave).toBe(originalEpoch);
+
+				// Second edit cycle: re-render the just-saved epoch and save again.
+				const roundTripIso = new Date(firstSave * 1000).toISOString();
+				const secondForm = formatDateForInput(roundTripIso);
+				const secondSave = buildUpdatePayload({
+					...cashValues({ sessionDate: secondForm }),
+					id: "s1",
+				}).sessionDate;
+				expect(secondSave).toBe(originalEpoch);
+			});
 		});
 	});
 

--- a/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
+++ b/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TZ_EAST, TZ_WEST, withTz } from "@/__tests__/tz";
 import type {
 	SessionFormValues,
 	SessionItem,
@@ -102,26 +103,9 @@ const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const TIME_HH_MM_PATTERN = /^\d{2}:\d{2}$/;
 const TEMP_ID_PATTERN = /^temp-/;
 
-// SA2-145: sessionDate must round-trip as a UTC calendar date regardless of
-// the machine's local time zone. Node/Bun re-reads `process.env.TZ` on every
-// Date operation, so we can drive a west-of-UTC and an east-of-UTC zone
-// deterministically. Always restore the original TZ so this file cannot leak
-// into sibling test files that share the worker.
-const ORIGINAL_TZ = process.env.TZ;
-const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the bug
-const TZ_EAST = "Asia/Tokyo"; // UTC+9 — the primary user base
-function withTz<T>(tz: string, fn: () => T): T {
-	process.env.TZ = tz;
-	try {
-		return fn();
-	} finally {
-		if (ORIGINAL_TZ === undefined) {
-			process.env.TZ = undefined;
-		} else {
-			process.env.TZ = ORIGINAL_TZ;
-		}
-	}
-}
+// SA2-145: sessionDate must round-trip as a UTC calendar date regardless of the
+// machine's local time zone. `withTz` (shared helper) drives a west-of-UTC and
+// an east-of-UTC zone deterministically and restores the host zone afterwards.
 
 function createClient(): QueryClient {
 	return new QueryClient({

--- a/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
+++ b/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
@@ -415,6 +415,33 @@ describe("pure helpers", () => {
 			expect(out.startedAt).toBeUndefined();
 			expect(out.endedAt).toBeUndefined();
 		});
+
+		it("rolls the end time forward a day when it lands before the start (day-crossing, SA2-157)", () => {
+			// 22:00 → 02:00 crossed midnight; endedAt must land 4h after startedAt,
+			// not ~20h before it (which zeroed the session out of every stat).
+			const out = buildCreatePayload(
+				cashValues({ startTime: "22:00", endTime: "02:00" })
+			);
+			expect((out.endedAt as number) - (out.startedAt as number)).toBe(
+				4 * 3600
+			);
+		});
+
+		it("does not roll forward a normal same-day span (SA2-157)", () => {
+			const out = buildCreatePayload(
+				cashValues({ startTime: "09:00", endTime: "12:30" })
+			);
+			expect((out.endedAt as number) - (out.startedAt as number)).toBe(
+				3.5 * 3600
+			);
+		});
+
+		it("does not roll forward when start and end are equal (SA2-157)", () => {
+			const out = buildCreatePayload(
+				cashValues({ startTime: "20:00", endTime: "20:00" })
+			);
+			expect(out.endedAt).toBe(out.startedAt);
+		});
 	});
 
 	describe("buildUpdatePayload", () => {
@@ -460,6 +487,16 @@ describe("pure helpers", () => {
 				id: "s1",
 			}) as Record<string, unknown>;
 			expect(tourney.ruleName).toBe("Weekly Deepstack");
+		});
+
+		it("rolls the end time forward a day for a day-crossing update (SA2-157)", () => {
+			const out = buildUpdatePayload({
+				...cashValues({ startTime: "23:30", endTime: "01:00" }),
+				id: "s1",
+			}) as Record<string, unknown>;
+			expect((out.endedAt as number) - (out.startedAt as number)).toBe(
+				1.5 * 3600
+			);
 		});
 
 		it("forwards cash min/max buy-in edits", () => {

--- a/apps/web/src/features/sessions/hooks/use-sessions.ts
+++ b/apps/web/src/features/sessions/hooks/use-sessions.ts
@@ -393,11 +393,16 @@ export function filtersToListInput(filters: SessionFilterValues) {
 	};
 }
 
+// sessionDate is stored/returned as UTC midnight and the create/update payloads
+// re-encode a date-only string as UTC midnight, so the edit form must read back
+// the UTC calendar day. Local getters shift the day back one for users west of
+// UTC, and saving that value drifts the stored date one day earlier on every
+// edit (SA2-145).
 export function formatDateForInput(date: string): string {
 	const d = new Date(date);
-	const year = d.getFullYear();
-	const month = String(d.getMonth() + 1).padStart(2, "0");
-	const day = String(d.getDate()).padStart(2, "0");
+	const year = d.getUTCFullYear();
+	const month = String(d.getUTCMonth() + 1).padStart(2, "0");
+	const day = String(d.getUTCDate()).padStart(2, "0");
 	return `${year}-${month}-${day}`;
 }
 

--- a/apps/web/src/features/sessions/hooks/use-sessions.ts
+++ b/apps/web/src/features/sessions/hooks/use-sessions.ts
@@ -108,12 +108,41 @@ function timeToUnix(
 	return Math.floor(new Date(`${sessionDate}T${time}`).getTime() / 1000);
 }
 
+const DAY_SECONDS = 24 * 60 * 60;
+
+/**
+ * Converts the form's start/end clock times — both entered against a single
+ * `sessionDate` with no separate end-date field — into Unix seconds, rolling the
+ * end forward 24h when it lands strictly before the start (the session crossed
+ * midnight, e.g. 22:00 → 02:00). Without this the end was stored ~20h before the
+ * start, so the UI showed a negative duration and the server clamped play time to
+ * 0, dropping the session out of every play-time statistic (SA2-157). Equal
+ * start/end is treated as a 0-length span, never a 24h one.
+ */
+function computeSessionTimes(
+	sessionDate: string,
+	startTime: string | undefined,
+	endTime: string | undefined
+): { startedAt: number | undefined; endedAt: number | undefined } {
+	const startedAt = timeToUnix(sessionDate, startTime);
+	let endedAt = timeToUnix(sessionDate, endTime);
+	if (startedAt !== undefined && endedAt !== undefined && endedAt < startedAt) {
+		endedAt += DAY_SECONDS;
+	}
+	return { startedAt, endedAt };
+}
+
 export function buildCreatePayload(values: SessionFormValues) {
 	const sessionDate = Math.floor(new Date(values.sessionDate).getTime() / 1000);
+	const { startedAt, endedAt } = computeSessionTimes(
+		values.sessionDate,
+		values.startTime,
+		values.endTime
+	);
 	const common = {
 		sessionDate,
-		startedAt: timeToUnix(values.sessionDate, values.startTime),
-		endedAt: timeToUnix(values.sessionDate, values.endTime),
+		startedAt,
+		endedAt,
 		breakMinutes: values.breakMinutes,
 		memo: values.memo,
 		tagIds: values.tagIds,
@@ -174,11 +203,16 @@ export function buildLiveLinkedUpdatePayload(
 }
 
 export function buildUpdatePayload(values: SessionFormValues & { id: string }) {
+	const { startedAt, endedAt } = computeSessionTimes(
+		values.sessionDate,
+		values.startTime,
+		values.endTime
+	);
 	const common = {
 		id: values.id,
 		sessionDate: Math.floor(new Date(values.sessionDate).getTime() / 1000),
-		startedAt: timeToUnix(values.sessionDate, values.startTime) ?? null,
-		endedAt: timeToUnix(values.sessionDate, values.endTime) ?? null,
+		startedAt: startedAt ?? null,
+		endedAt: endedAt ?? null,
 		breakMinutes: values.breakMinutes ?? null,
 		memo: values.memo,
 		ruleName: values.ruleName,

--- a/apps/web/src/features/sessions/utils/__tests__/session-display.test.ts
+++ b/apps/web/src/features/sessions/utils/__tests__/session-display.test.ts
@@ -125,6 +125,20 @@ describe("formatSessionDuration", () => {
 			formatSessionDuration("2026-01-01T10:00:00", "2026-01-01T10:40:00")
 		).toBe("0.7h");
 	});
+
+	it("clamps a negative raw span to '0.0h' (legacy day-crossing row, SA2-157)", () => {
+		// endedAt before startedAt (a row saved before the day-crossing fix) must
+		// never surface a negative "-20.0h" duration.
+		expect(
+			formatSessionDuration("2026-01-01T22:00:00", "2026-01-01T02:00:00")
+		).toBe("0.0h");
+	});
+
+	it("clamps to '0.0h' when break minutes exceed the played span (SA2-157)", () => {
+		expect(
+			formatSessionDuration("2026-01-01T10:00:00", "2026-01-01T11:00:00", 120)
+		).toBe("0.0h");
+	});
 });
 
 describe("buildCashRuleRows", () => {

--- a/apps/web/src/features/sessions/utils/__tests__/share-session.test.ts
+++ b/apps/web/src/features/sessions/utils/__tests__/share-session.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TZ_EAST, TZ_WEST, withTz } from "@/__tests__/tz";
 import {
 	createSessionShareText,
 	type ShareableSession,
@@ -10,23 +11,8 @@ const ANY_DURATION = /\d+\.\dh/;
 const COMPACT_500 = /📈 \+500 \n/;
 
 // SA2-145: the shared text's 📅 line must show the UTC calendar day the user
-// saved (sessionDate is a UTC-midnight ISO string). Node/Bun re-reads
-// process.env.TZ on each Date op; restore the original zone after each case.
-const ORIGINAL_TZ = process.env.TZ;
-const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the bug
-const TZ_EAST = "Asia/Tokyo"; // UTC+9
-function withTz<T>(tz: string, fn: () => T): T {
-	process.env.TZ = tz;
-	try {
-		return fn();
-	} finally {
-		if (ORIGINAL_TZ === undefined) {
-			process.env.TZ = undefined;
-		} else {
-			process.env.TZ = ORIGINAL_TZ;
-		}
-	}
-}
+// saved (sessionDate is a UTC-midnight ISO string). `withTz` (shared helper)
+// drives a deterministic zone per case and restores the host zone afterwards.
 
 function cashSession(
 	overrides: Partial<ShareableSession> = {}

--- a/apps/web/src/features/sessions/utils/__tests__/share-session.test.ts
+++ b/apps/web/src/features/sessions/utils/__tests__/share-session.test.ts
@@ -8,6 +8,7 @@ import {
 
 const DURATION_3_5H = /\/ 3\.5h/;
 const ANY_DURATION = /\d+\.\dh/;
+const NEGATIVE_DURATION = /-\d+\.\dh/;
 const COMPACT_500 = /📈 \+500 \n/;
 
 // SA2-145: the shared text's 📅 line must show the UTC calendar day the user
@@ -119,6 +120,18 @@ describe("createSessionShareText", () => {
 				})
 			);
 			expect(text).not.toMatch(ANY_DURATION);
+		});
+
+		it("clamps a negative duration to '0.0h' (legacy day-crossing row, SA2-157)", () => {
+			// endedAt before startedAt must not leak a "-20.0h" into the share text.
+			const text = createSessionShareText(
+				cashSession({
+					startedAt: "2026-04-22T22:00:00Z",
+					endedAt: "2026-04-22T02:00:00Z",
+				})
+			);
+			expect(text).toContain("0.0h");
+			expect(text).not.toMatch(NEGATIVE_DURATION);
 		});
 
 		it("falls back to 'Cash Game' when ringGameName is null", () => {

--- a/apps/web/src/features/sessions/utils/__tests__/share-session.test.ts
+++ b/apps/web/src/features/sessions/utils/__tests__/share-session.test.ts
@@ -9,6 +9,25 @@ const DURATION_3_5H = /\/ 3\.5h/;
 const ANY_DURATION = /\d+\.\dh/;
 const COMPACT_500 = /📈 \+500 \n/;
 
+// SA2-145: the shared text's 📅 line must show the UTC calendar day the user
+// saved (sessionDate is a UTC-midnight ISO string). Node/Bun re-reads
+// process.env.TZ on each Date op; restore the original zone after each case.
+const ORIGINAL_TZ = process.env.TZ;
+const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the bug
+const TZ_EAST = "Asia/Tokyo"; // UTC+9
+function withTz<T>(tz: string, fn: () => T): T {
+	process.env.TZ = tz;
+	try {
+		return fn();
+	} finally {
+		if (ORIGINAL_TZ === undefined) {
+			process.env.TZ = undefined;
+		} else {
+			process.env.TZ = ORIGINAL_TZ;
+		}
+	}
+}
+
 function cashSession(
 	overrides: Partial<ShareableSession> = {}
 ): ShareableSession {
@@ -60,6 +79,25 @@ describe("createSessionShareText", () => {
 			expect(text).toContain("📍 Downtown");
 			expect(text).toContain("💲 NL2k/5k");
 			expect(text).toContain("📈 +5.0K JPY");
+		});
+
+		// SA2-145: the 📅 date must not roll back a day west of UTC.
+		it("renders the UTC calendar day west of UTC (no off-by-one)", () => {
+			const text = withTz(TZ_WEST, () =>
+				createSessionShareText(
+					cashSession({ sessionDate: "2026-04-22T00:00:00Z" })
+				)
+			);
+			expect(text).toContain("📅 2026/4/22");
+		});
+
+		it("renders the same UTC calendar day east of UTC", () => {
+			const text = withTz(TZ_EAST, () =>
+				createSessionShareText(
+					cashSession({ sessionDate: "2026-04-22T00:00:00Z" })
+				)
+			);
+			expect(text).toContain("📅 2026/4/22");
 		});
 
 		it("omits room line when roomName is null", () => {

--- a/apps/web/src/features/sessions/utils/session-display.ts
+++ b/apps/web/src/features/sessions/utils/session-display.ts
@@ -57,7 +57,10 @@ export function formatSessionDuration(
 	}
 	const diffMs = new Date(endedAt).getTime() - new Date(startedAt).getTime();
 	const breakMs = (breakMinutes ?? 0) * 60 * 1000;
-	const hours = (diffMs - breakMs) / (1000 * 60 * 60);
+	// Clamp to zero so a legacy row saved before the day-crossing fix (endedAt
+	// before startedAt) — or an over-long break — never renders a negative
+	// duration (SA2-157). New rows are corrected at write time in use-sessions.ts.
+	const hours = Math.max(0, (diffMs - breakMs) / (1000 * 60 * 60));
 	return `${hours.toFixed(1)}h`;
 }
 

--- a/apps/web/src/features/sessions/utils/share-session.ts
+++ b/apps/web/src/features/sessions/utils/share-session.ts
@@ -44,8 +44,11 @@ function formatDuration(
 	if (!(startedAt && endedAt)) {
 		return null;
 	}
+	// Clamp to zero so a legacy row saved before the day-crossing fix (endedAt
+	// before startedAt) never leaks a negative duration into the share text
+	// (SA2-157).
 	const diffMs = new Date(endedAt).getTime() - new Date(startedAt).getTime();
-	const hours = diffMs / (1000 * 60 * 60);
+	const hours = Math.max(0, diffMs / (1000 * 60 * 60));
 	return `${hours.toFixed(1)}h`;
 }
 

--- a/apps/web/src/features/sessions/utils/share-session.ts
+++ b/apps/web/src/features/sessions/utils/share-session.ts
@@ -88,7 +88,11 @@ export function createSessionShareText(session: ShareableSession): string {
 	const plIcon = profitLoss >= 0 ? "📈" : "📉";
 	const plSign = profitLoss >= 0 ? "+" : "";
 	const currencyUnit = session.currencyUnit ?? "";
-	const date = new Date(session.sessionDate).toLocaleDateString("ja-JP");
+	// sessionDate is UTC midnight; force UTC so the shared date is the calendar
+	// day the user saved rather than its local rendering (SA2-145).
+	const date = new Date(session.sessionDate).toLocaleDateString("ja-JP", {
+		timeZone: "UTC",
+	});
 	const gameIcon = isTournament ? "🏆" : "💲";
 
 	let text = "📊 Poker Session Result\n";

--- a/apps/web/src/features/settings/pages/settings-page/__tests__/use-settings-page.test.ts
+++ b/apps/web/src/features/settings/pages/settings-page/__tests__/use-settings-page.test.ts
@@ -2,48 +2,32 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-	navigate: vi.fn(),
-	signOut: vi.fn(),
+	onSignOut: vi.fn(),
+	useSignOut: vi.fn(),
 }));
 
-vi.mock("@tanstack/react-router", () => ({
-	useNavigate: () => mocks.navigate,
-}));
-
-vi.mock("@/lib/auth-client", () => ({
-	authClient: {
-		signOut: mocks.signOut,
-	},
+vi.mock("@/shared/hooks/use-sign-out", () => ({
+	useSignOut: mocks.useSignOut,
 }));
 
 import { useSettingsPage } from "@/features/settings/pages/settings-page/use-settings-page";
 
 describe("useSettingsPage", () => {
 	beforeEach(() => {
-		mocks.navigate.mockReset();
-		mocks.signOut.mockReset();
+		mocks.onSignOut.mockReset();
+		mocks.useSignOut.mockReset();
+		mocks.useSignOut.mockReturnValue({ onSignOut: mocks.onSignOut });
 	});
 
-	it("onSignOut calls authClient.signOut exactly once", () => {
+	it("delegates sign-out to the shared useSignOut hook", () => {
 		const { result } = renderHook(() => useSettingsPage());
-		result.current.onSignOut();
-		expect(mocks.signOut).toHaveBeenCalledTimes(1);
+		expect(mocks.useSignOut).toHaveBeenCalledTimes(1);
+		expect(result.current.onSignOut).toBe(mocks.onSignOut);
 	});
 
-	it("does not navigate before sign-out succeeds", () => {
+	it("invokes the shared handler when onSignOut is called", () => {
 		const { result } = renderHook(() => useSettingsPage());
 		result.current.onSignOut();
-		expect(mocks.navigate).not.toHaveBeenCalled();
-	});
-
-	it("navigates to the public home page when sign-out succeeds", () => {
-		const { result } = renderHook(() => useSettingsPage());
-		result.current.onSignOut();
-		const fetchOptions = mocks.signOut.mock.calls[0][0]?.fetchOptions as {
-			onSuccess: () => void;
-		};
-		fetchOptions.onSuccess();
-		expect(mocks.navigate).toHaveBeenCalledTimes(1);
-		expect(mocks.navigate).toHaveBeenNthCalledWith(1, { to: "/" });
+		expect(mocks.onSignOut).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/web/src/features/settings/pages/settings-page/use-settings-page.ts
+++ b/apps/web/src/features/settings/pages/settings-page/use-settings-page.ts
@@ -1,18 +1,7 @@
-import { useNavigate } from "@tanstack/react-router";
-import { authClient } from "@/lib/auth-client";
+import { useSignOut } from "@/shared/hooks/use-sign-out";
 
 export function useSettingsPage() {
-	const navigate = useNavigate();
-
-	const onSignOut = () => {
-		authClient.signOut({
-			fetchOptions: {
-				onSuccess: () => {
-					navigate({ to: "/" });
-				},
-			},
-		});
-	};
+	const { onSignOut } = useSignOut();
 
 	return { onSignOut };
 }

--- a/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/__tests__/use-user-menu.test.ts
+++ b/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/__tests__/use-user-menu.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	useSession: vi.fn(),
+	updateNotesSheet: {
+		isOpen: false,
+		open: vi.fn(),
+		close: vi.fn(),
+		setIsOpen: vi.fn(),
+	},
+	onSignOut: vi.fn(),
+	useSignOut: vi.fn(),
+	useUpdateNotesSheet: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+	authClient: {
+		useSession: mocks.useSession,
+	},
+}));
+
+vi.mock("@/features/update-notes/components/update-notes-sheet", () => ({
+	useUpdateNotesSheet: mocks.useUpdateNotesSheet,
+}));
+
+vi.mock("@/shared/hooks/use-sign-out", () => ({
+	useSignOut: mocks.useSignOut,
+}));
+
+import { useUserMenu } from "@/shared/components/authenticated-shell/sidebar-nav/user-menu/use-user-menu";
+
+describe("useUserMenu", () => {
+	beforeEach(() => {
+		mocks.useSession.mockReset();
+		mocks.onSignOut.mockReset();
+		mocks.useSignOut.mockReset();
+		mocks.useUpdateNotesSheet.mockReset();
+		mocks.useSignOut.mockReturnValue({ onSignOut: mocks.onSignOut });
+		mocks.useUpdateNotesSheet.mockReturnValue(mocks.updateNotesSheet);
+	});
+
+	it("exposes the authenticated session and update-notes controls", () => {
+		const session = {
+			data: { user: { email: "hero@example.com", name: "Hero User" } },
+			isPending: false,
+		};
+		mocks.useSession.mockReturnValue(session);
+
+		const { result } = renderHook(() => useUserMenu());
+
+		expect(result.current.session).toBe(session.data);
+		expect(result.current.isPending).toBe(false);
+		expect(result.current.updateNotesSheet).toBe(mocks.updateNotesSheet);
+	});
+
+	it("surfaces isPending while the session is loading", () => {
+		mocks.useSession.mockReturnValue({ data: null, isPending: true });
+
+		const { result } = renderHook(() => useUserMenu());
+
+		expect(result.current.isPending).toBe(true);
+		expect(result.current.session).toBeNull();
+	});
+
+	it("delegates sign-out to the shared useSignOut hook", () => {
+		mocks.useSession.mockReturnValue({ data: null, isPending: false });
+
+		const { result } = renderHook(() => useUserMenu());
+		result.current.onSignOut();
+
+		expect(mocks.useSignOut).toHaveBeenCalledTimes(1);
+		expect(result.current.onSignOut).toBe(mocks.onSignOut);
+		expect(mocks.onSignOut).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/use-user-menu.ts
+++ b/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/use-user-menu.ts
@@ -1,0 +1,11 @@
+import { useUpdateNotesSheet } from "@/features/update-notes/components/update-notes-sheet";
+import { authClient } from "@/lib/auth-client";
+import { useSignOut } from "@/shared/hooks/use-sign-out";
+
+export function useUserMenu() {
+	const { data: session, isPending } = authClient.useSession();
+	const updateNotesSheet = useUpdateNotesSheet();
+	const { onSignOut } = useSignOut();
+
+	return { session, isPending, updateNotesSheet, onSignOut };
+}

--- a/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/user-menu.test.tsx
+++ b/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/user-menu.test.tsx
@@ -1,50 +1,44 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UserMenu } from "./user-menu";
 
 const mocks = vi.hoisted(() => ({
-	navigate: vi.fn(),
-	sessionState: {
-		data: null as null | {
-			user: {
-				email: string;
-				name: string;
-			};
-		},
+	menuState: {
+		session: null as null | { user: { email: string; name: string } },
 		isPending: false,
+		updateNotesSheet: {
+			isOpen: false,
+			open: vi.fn(),
+			close: vi.fn(),
+			setIsOpen: vi.fn(),
+		},
+		onSignOut: vi.fn(),
 	},
-	signOut: vi.fn(),
-	updateNotesSheet: {
-		isOpen: false,
-		open: vi.fn(),
-		close: vi.fn(),
-		setIsOpen: vi.fn(),
-	},
+	useUserMenu: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-router", () => ({
 	Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
 		<a href={to}>{children}</a>
 	),
-	useNavigate: () => mocks.navigate,
 }));
 
-vi.mock("@/lib/auth-client", () => ({
-	authClient: {
-		signOut: mocks.signOut,
-		useSession: () => mocks.sessionState,
-	},
-}));
-
-vi.mock("@/features/update-notes/components/update-notes-sheet", () => ({
-	useUpdateNotesSheet: () => mocks.updateNotesSheet,
+vi.mock("./use-user-menu", () => ({
+	useUserMenu: mocks.useUserMenu,
 }));
 
 describe("UserMenu", () => {
+	beforeEach(() => {
+		mocks.menuState.updateNotesSheet.open.mockReset();
+		mocks.menuState.onSignOut.mockReset();
+		mocks.useUserMenu.mockReset();
+		mocks.useUserMenu.mockImplementation(() => mocks.menuState);
+	});
+
 	it("shows the loading skeleton", () => {
-		mocks.sessionState.isPending = true;
-		mocks.sessionState.data = null;
+		mocks.menuState.isPending = true;
+		mocks.menuState.session = null;
 
 		const { container } = render(<UserMenu />);
 
@@ -52,8 +46,8 @@ describe("UserMenu", () => {
 	});
 
 	it("renders sign in when there is no session", () => {
-		mocks.sessionState.isPending = false;
-		mocks.sessionState.data = null;
+		mocks.menuState.isPending = false;
+		mocks.menuState.session = null;
 
 		render(<UserMenu />);
 
@@ -63,20 +57,12 @@ describe("UserMenu", () => {
 		);
 	});
 
-	it("renders the user trigger and signs out to home", async () => {
+	it("renders the user trigger and calls onSignOut", async () => {
 		const user = userEvent.setup();
-		mocks.sessionState.isPending = false;
-		mocks.sessionState.data = {
-			user: {
-				email: "hero@example.com",
-				name: "Hero User",
-			},
+		mocks.menuState.isPending = false;
+		mocks.menuState.session = {
+			user: { email: "hero@example.com", name: "Hero User" },
 		};
-		mocks.signOut.mockImplementation(
-			({ fetchOptions }: { fetchOptions: { onSuccess: () => void } }) => {
-				fetchOptions.onSuccess();
-			}
-		);
 
 		render(<UserMenu />);
 
@@ -84,7 +70,6 @@ describe("UserMenu", () => {
 		expect(screen.getByText("hero@example.com")).toBeInTheDocument();
 		await user.click(screen.getByText("Sign Out"));
 
-		expect(mocks.signOut).toHaveBeenCalled();
-		expect(mocks.navigate).toHaveBeenCalledWith({ to: "/" });
+		expect(mocks.menuState.onSignOut).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/user-menu.tsx
+++ b/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/user-menu.tsx
@@ -1,6 +1,4 @@
-import { Link, useNavigate } from "@tanstack/react-router";
-import { useUpdateNotesSheet } from "@/features/update-notes/components/update-notes-sheet";
-import { authClient } from "@/lib/auth-client";
+import { Link } from "@tanstack/react-router";
 import { Button } from "@/shared/components/ui/button";
 import {
 	DropdownMenu,
@@ -12,11 +10,10 @@ import {
 	DropdownMenuTrigger,
 } from "@/shared/components/ui/dropdown-menu";
 import { Skeleton } from "@/shared/components/ui/skeleton";
+import { useUserMenu } from "./use-user-menu";
 
 export function UserMenu() {
-	const navigate = useNavigate();
-	const { data: session, isPending } = authClient.useSession();
-	const updateNotesSheet = useUpdateNotesSheet();
+	const { session, isPending, updateNotesSheet, onSignOut } = useUserMenu();
 
 	if (isPending) {
 		return <Skeleton className="h-8 w-24" />;
@@ -47,20 +44,7 @@ export function UserMenu() {
 					<DropdownMenuItem onClick={updateNotesSheet.open}>
 						Update Notes
 					</DropdownMenuItem>
-					<DropdownMenuItem
-						onClick={() => {
-							authClient.signOut({
-								fetchOptions: {
-									onSuccess: () => {
-										navigate({
-											to: "/",
-										});
-									},
-								},
-							});
-						}}
-						variant="destructive"
-					>
+					<DropdownMenuItem onClick={onSignOut} variant="destructive">
 						Sign Out
 					</DropdownMenuItem>
 				</DropdownMenuGroup>

--- a/apps/web/src/shared/hooks/__tests__/use-sign-out.test.ts
+++ b/apps/web/src/shared/hooks/__tests__/use-sign-out.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	navigate: vi.fn(),
+	signOut: vi.fn(),
+	clearPersistedQueryCache: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+	useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+	authClient: {
+		signOut: mocks.signOut,
+	},
+}));
+
+vi.mock("@/utils/trpc", () => ({
+	clearPersistedQueryCache: mocks.clearPersistedQueryCache,
+}));
+
+import { useSignOut } from "@/shared/hooks/use-sign-out";
+
+interface FetchOptions {
+	onError: () => void;
+	onSuccess: () => void;
+}
+
+function getFetchOptions(): FetchOptions {
+	return mocks.signOut.mock.calls[0][0].fetchOptions as FetchOptions;
+}
+
+describe("useSignOut", () => {
+	beforeEach(() => {
+		mocks.navigate.mockReset();
+		mocks.signOut.mockReset();
+		mocks.clearPersistedQueryCache.mockReset();
+	});
+
+	it("onSignOut calls authClient.signOut exactly once", () => {
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+		expect(mocks.signOut).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not clear the cache or navigate before sign-out resolves", () => {
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+		expect(mocks.clearPersistedQueryCache).not.toHaveBeenCalled();
+		expect(mocks.navigate).not.toHaveBeenCalled();
+	});
+
+	it("on success clears the persisted cache before navigating home", () => {
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+
+		getFetchOptions().onSuccess();
+
+		expect(mocks.clearPersistedQueryCache).toHaveBeenCalledTimes(1);
+		expect(mocks.navigate).toHaveBeenCalledTimes(1);
+		expect(mocks.navigate).toHaveBeenNthCalledWith(1, { to: "/" });
+		expect(
+			mocks.clearPersistedQueryCache.mock.invocationCallOrder[0]
+		).toBeLessThan(mocks.navigate.mock.invocationCallOrder[0]);
+	});
+
+	it("on error still clears the persisted cache and does not navigate", () => {
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+
+		getFetchOptions().onError();
+
+		expect(mocks.clearPersistedQueryCache).toHaveBeenCalledTimes(1);
+		expect(mocks.navigate).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/shared/hooks/__tests__/use-sign-out.test.ts
+++ b/apps/web/src/shared/hooks/__tests__/use-sign-out.test.ts
@@ -52,11 +52,12 @@ describe("useSignOut", () => {
 		expect(mocks.navigate).not.toHaveBeenCalled();
 	});
 
-	it("on success clears the persisted cache before navigating home", () => {
+	it("on success clears the persisted cache before navigating home", async () => {
+		mocks.clearPersistedQueryCache.mockResolvedValue(undefined);
 		const { result } = renderHook(() => useSignOut());
 		result.current.onSignOut();
 
-		getFetchOptions().onSuccess();
+		await getFetchOptions().onSuccess();
 
 		expect(mocks.clearPersistedQueryCache).toHaveBeenCalledTimes(1);
 		expect(mocks.navigate).toHaveBeenCalledTimes(1);
@@ -66,13 +67,58 @@ describe("useSignOut", () => {
 		).toBeLessThan(mocks.navigate.mock.invocationCallOrder[0]);
 	});
 
+	it("does not navigate until the persisted cache clear resolves", async () => {
+		let resolveClear: () => void = () => {
+			// overwritten synchronously below
+		};
+		mocks.clearPersistedQueryCache.mockReturnValue(
+			new Promise<void>((resolve) => {
+				resolveClear = resolve;
+			})
+		);
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+
+		const pendingSuccess = getFetchOptions().onSuccess();
+		await Promise.resolve();
+		expect(mocks.navigate).not.toHaveBeenCalled();
+
+		resolveClear();
+		await pendingSuccess;
+
+		expect(mocks.navigate).toHaveBeenCalledTimes(1);
+	});
+
+	it("still navigates home when the persisted cache clear rejects on success", async () => {
+		mocks.clearPersistedQueryCache.mockRejectedValue(new Error("idb error"));
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+
+		await expect(getFetchOptions().onSuccess()).resolves.toBeUndefined();
+
+		expect(mocks.navigate).toHaveBeenCalledTimes(1);
+	});
+
 	it("on error still clears the persisted cache and does not navigate", () => {
+		mocks.clearPersistedQueryCache.mockResolvedValue(undefined);
 		const { result } = renderHook(() => useSignOut());
 		result.current.onSignOut();
 
 		getFetchOptions().onError();
 
 		expect(mocks.clearPersistedQueryCache).toHaveBeenCalledTimes(1);
+		expect(mocks.navigate).not.toHaveBeenCalled();
+	});
+
+	it("does not throw when the persisted cache clear rejects on error", async () => {
+		mocks.clearPersistedQueryCache.mockRejectedValue(new Error("idb error"));
+		const { result } = renderHook(() => useSignOut());
+		result.current.onSignOut();
+
+		expect(() => getFetchOptions().onError()).not.toThrow();
+		await Promise.resolve();
+		await Promise.resolve();
+
 		expect(mocks.navigate).not.toHaveBeenCalled();
 	});
 });

--- a/apps/web/src/shared/hooks/use-sign-out.ts
+++ b/apps/web/src/shared/hooks/use-sign-out.ts
@@ -17,12 +17,17 @@ export function useSignOut() {
 	const onSignOut = () => {
 		authClient.signOut({
 			fetchOptions: {
-				onSuccess: () => {
-					clearPersistedQueryCache();
+				onSuccess: async () => {
+					await clearPersistedQueryCache().catch(() => {
+						// Clearing the cache is best-effort: a failed IndexedDB delete
+						// must not block the user from being navigated away.
+					});
 					navigate({ to: "/" });
 				},
 				onError: () => {
-					clearPersistedQueryCache();
+					clearPersistedQueryCache().catch(() => {
+						// Same best-effort rationale as the success path above.
+					});
 				},
 			},
 		});

--- a/apps/web/src/shared/hooks/use-sign-out.ts
+++ b/apps/web/src/shared/hooks/use-sign-out.ts
@@ -1,0 +1,32 @@
+import { useNavigate } from "@tanstack/react-router";
+import { authClient } from "@/lib/auth-client";
+import { clearPersistedQueryCache } from "@/utils/trpc";
+
+/**
+ * Shared sign-out handler for every sign-out entry point (user menu, settings).
+ *
+ * After Better Auth's `signOut`, the React Query cache and its persisted
+ * IndexedDB store are cleared before navigating home so the previous user's
+ * financial data can never leak to the next account on a shared device
+ * (SA2-159). The cache is cleared on `onError` too so a failed request never
+ * leaves stale data behind.
+ */
+export function useSignOut() {
+	const navigate = useNavigate();
+
+	const onSignOut = () => {
+		authClient.signOut({
+			fetchOptions: {
+				onSuccess: () => {
+					clearPersistedQueryCache();
+					navigate({ to: "/" });
+				},
+				onError: () => {
+					clearPersistedQueryCache();
+				},
+			},
+		});
+	};
+
+	return { onSignOut };
+}

--- a/apps/web/src/shared/lib/__tests__/pwa-manifest.test.ts
+++ b/apps/web/src/shared/lib/__tests__/pwa-manifest.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { pwaManifest } from "../pwa-manifest";
+
+/**
+ * Regression guard for SA2-163: the PWA manifest `start_url` must resolve to a
+ * route that actually exists in the generated route tree. The bug was
+ * `start_url: "/dashboard"`, a route removed in PR #341/#363 — launching the
+ * installed PWA landed on TanStack Router's not-found shell.
+ *
+ * Instead of hard-coding the expected path we derive the set of real routes
+ * from `src/routeTree.gen.ts` (the generated source of truth) so this test
+ * keeps working as routes come and go, and fails the moment `start_url` points
+ * anywhere the router can't serve.
+ */
+function readGeneratedRoutePaths(): Set<string> {
+	const routeTreePath = path.resolve(
+		import.meta.dirname,
+		"../../../routeTree.gen.ts"
+	);
+	const source = readFileSync(routeTreePath, "utf8");
+	const paths = new Set<string>();
+	const pathLiteral = /(?:full)?[Pp]ath:\s*'([^']+)'/g;
+	let match = pathLiteral.exec(source);
+	while (match !== null) {
+		paths.add(match[1]);
+		match = pathLiteral.exec(source);
+	}
+	return paths;
+}
+
+describe("pwaManifest", () => {
+	const routePaths = readGeneratedRoutePaths();
+
+	it("derives a non-empty route-path set from the generated route tree", () => {
+		// Sanity: the regex must actually find routes, otherwise the guard below
+		// would pass vacuously.
+		expect(routePaths.size).toBeGreaterThan(0);
+		expect(routePaths.has("/")).toBe(true);
+	});
+
+	it("points start_url at a route that exists in the generated route tree", () => {
+		expect(routePaths.has(pwaManifest.start_url as string)).toBe(true);
+	});
+
+	it("uses '/' — the only always-reachable entry point after the dashboard removal", () => {
+		expect(pwaManifest.start_url).toBe("/");
+	});
+
+	it("does not point start_url at the removed /dashboard route", () => {
+		// Documents the SA2-163 root cause: /dashboard is no longer in the tree,
+		// so it must never be the launch target again.
+		expect(routePaths.has("/dashboard")).toBe(false);
+		expect(pwaManifest.start_url).not.toBe("/dashboard");
+	});
+});

--- a/apps/web/src/shared/lib/pwa-manifest.ts
+++ b/apps/web/src/shared/lib/pwa-manifest.ts
@@ -1,0 +1,21 @@
+import type { ManifestOptions } from "vite-plugin-pwa";
+
+/**
+ * PWA manifest, extracted into its own module so it can be unit-tested
+ * independently of `vite.config.ts` (importing the config would pull in the
+ * whole Vite plugin graph).
+ *
+ * `start_url` MUST reference a route that actually exists in the generated
+ * route tree (`src/routeTree.gen.ts`). The previous value `"/dashboard"`
+ * pointed at a route removed in PR #341 (and cleanup #363), so a PWA launched
+ * from the home screen landed on TanStack Router's not-found shell (blank/404).
+ * `"/"` is the only always-reachable entry point: the index route dispatches
+ * signed-in users to `/statistics` and everyone else to `/login`.
+ */
+export const pwaManifest: Partial<ManifestOptions> = {
+	name: "sapphire2",
+	short_name: "sapphire2",
+	description: "sapphire2 - PWA Application",
+	theme_color: "#0c0c0c",
+	start_url: "/",
+};

--- a/apps/web/src/utils/__tests__/format-number.test.ts
+++ b/apps/web/src/utils/__tests__/format-number.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { TZ_EAST, TZ_WEST, withTz } from "@/__tests__/tz";
 import {
 	createGroupFormatter,
 	formatCompactNumber,
@@ -8,24 +9,8 @@ import {
 const B_SUFFIX = /B$/;
 
 // SA2-145: sessionDate is a UTC-midnight ISO string, so formatYmdSlash must
-// read UTC calendar fields. Node/Bun re-reads process.env.TZ on every Date
-// operation; restore the original TZ so this file (web-node, isolate:false)
-// cannot leak a zone into sibling pure-util test files.
-const ORIGINAL_TZ = process.env.TZ;
-const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the bug
-const TZ_EAST = "Asia/Tokyo"; // UTC+9
-function withTz<T>(tz: string, fn: () => T): T {
-	process.env.TZ = tz;
-	try {
-		return fn();
-	} finally {
-		if (ORIGINAL_TZ === undefined) {
-			process.env.TZ = undefined;
-		} else {
-			process.env.TZ = ORIGINAL_TZ;
-		}
-	}
-}
+// read UTC calendar fields. `withTz` (shared helper) drives a deterministic
+// zone per assertion and restores the host zone afterwards.
 
 describe("formatCompactNumber", () => {
 	describe("below the 10k threshold", () => {

--- a/apps/web/src/utils/__tests__/format-number.test.ts
+++ b/apps/web/src/utils/__tests__/format-number.test.ts
@@ -6,7 +6,26 @@ import {
 } from "@/utils/format-number";
 
 const B_SUFFIX = /B$/;
-const YMD_SHAPE = /^2026\/06\/1[45]$/;
+
+// SA2-145: sessionDate is a UTC-midnight ISO string, so formatYmdSlash must
+// read UTC calendar fields. Node/Bun re-reads process.env.TZ on every Date
+// operation; restore the original TZ so this file (web-node, isolate:false)
+// cannot leak a zone into sibling pure-util test files.
+const ORIGINAL_TZ = process.env.TZ;
+const TZ_WEST = "America/Los_Angeles"; // UTC-8/-7 — reproduces the bug
+const TZ_EAST = "Asia/Tokyo"; // UTC+9
+function withTz<T>(tz: string, fn: () => T): T {
+	process.env.TZ = tz;
+	try {
+		return fn();
+	} finally {
+		if (ORIGINAL_TZ === undefined) {
+			process.env.TZ = undefined;
+		} else {
+			process.env.TZ = ORIGINAL_TZ;
+		}
+	}
+}
 
 describe("formatCompactNumber", () => {
 	describe("below the 10k threshold", () => {
@@ -188,28 +207,45 @@ describe("createGroupFormatter", () => {
 });
 
 describe("formatYmdSlash", () => {
-	it("formats a Date as Y/MM/DD", () => {
-		expect(formatYmdSlash(new Date(2026, 3, 5))).toBe("2026/04/05");
+	it("formats a UTC Date as Y/MM/DD", () => {
+		expect(formatYmdSlash(new Date(Date.UTC(2026, 3, 5)))).toBe("2026/04/05");
 	});
 
 	it("zero-pads single-digit months and days", () => {
-		expect(formatYmdSlash(new Date(2026, 0, 1))).toBe("2026/01/01");
-		expect(formatYmdSlash(new Date(2026, 8, 9))).toBe("2026/09/09");
+		expect(formatYmdSlash(new Date(Date.UTC(2026, 0, 1)))).toBe("2026/01/01");
+		expect(formatYmdSlash(new Date(Date.UTC(2026, 8, 9)))).toBe("2026/09/09");
 	});
 
-	it("parses a YYYY-MM-DD string (local interpretation)", () => {
-		// JS Date parses 'YYYY-MM-DD' as UTC, but we output local date fields.
-		// Pin to a value that resolves the same in any timezone we run in:
-		const iso = "2026-06-15T09:00:00";
-		const result = formatYmdSlash(iso);
-		expect(result).toMatch(YMD_SHAPE);
+	it("parses a UTC-midnight ISO string to its UTC calendar day", () => {
+		expect(formatYmdSlash("2026-06-15T00:00:00Z")).toBe("2026/06/15");
 	});
 
 	it("formats December 31 without off-by-one", () => {
-		expect(formatYmdSlash(new Date(2026, 11, 31))).toBe("2026/12/31");
+		expect(formatYmdSlash(new Date(Date.UTC(2026, 11, 31)))).toBe("2026/12/31");
 	});
 
 	it("handles a pre-epoch date", () => {
-		expect(formatYmdSlash(new Date(1969, 6, 20))).toBe("1969/07/20");
+		expect(formatYmdSlash(new Date(Date.UTC(1969, 6, 20)))).toBe("1969/07/20");
+	});
+
+	// SA2-145: the session-list card and detail meta row must show the UTC
+	// calendar day the user saved, not the local rendering of UTC midnight.
+	it("keeps the UTC calendar day at the UTC-midnight boundary west of UTC", () => {
+		expect(withTz(TZ_WEST, () => formatYmdSlash("2026-04-22T00:00:00Z"))).toBe(
+			"2026/04/22"
+		);
+	});
+
+	it("keeps the UTC calendar day at the UTC-midnight boundary east of UTC", () => {
+		expect(withTz(TZ_EAST, () => formatYmdSlash("2026-04-22T00:00:00Z"))).toBe(
+			"2026/04/22"
+		);
+	});
+
+	it("renders the same day west-of-UTC, east-of-UTC, and in UTC", () => {
+		const iso = "2026-01-01T00:00:00Z";
+		expect(withTz(TZ_WEST, () => formatYmdSlash(iso))).toBe("2026/01/01");
+		expect(withTz(TZ_EAST, () => formatYmdSlash(iso))).toBe("2026/01/01");
+		expect(withTz("UTC", () => formatYmdSlash(iso))).toBe("2026/01/01");
 	});
 });

--- a/apps/web/src/utils/format-number.ts
+++ b/apps/web/src/utils/format-number.ts
@@ -57,10 +57,13 @@ export function createGroupFormatter(
 	return (value: number) => formatWithTier(value, tier);
 }
 
+// sessionDate is stored/returned as UTC midnight, so read UTC calendar fields
+// to render the day the user actually saved. Using local getters shifts the
+// day back one for users west of UTC (SA2-145).
 export function formatYmdSlash(input: string | Date): string {
 	const d = typeof input === "string" ? new Date(input) : input;
-	const y = d.getFullYear();
-	const m = String(d.getMonth() + 1).padStart(2, "0");
-	const day = String(d.getDate()).padStart(2, "0");
+	const y = d.getUTCFullYear();
+	const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+	const day = String(d.getUTCDate()).padStart(2, "0");
 	return `${y}/${m}/${day}`;
 }

--- a/apps/web/src/utils/trpc.ts
+++ b/apps/web/src/utils/trpc.ts
@@ -45,6 +45,21 @@ export const persister = createAsyncStoragePersister({
 	key: "sapphire2-query-cache",
 });
 
+/**
+ * Wipe every trace of the signed-in user's data on sign-out.
+ *
+ * The whole tRPC query cache is persisted to IndexedDB keyed only by procedure
+ * name (not per-user), so on a shared device the next account would briefly see
+ * the previous user's financial data (SA2-159). Clearing the in-memory cache
+ * (`queryClient.clear()`) removes what is currently rendered, and
+ * `persister.removeClient()` deletes the persisted `sapphire2-query-cache` store
+ * so nothing can be rehydrated on the next load.
+ */
+export function clearPersistedQueryCache() {
+	queryClient.clear();
+	return persister.removeClient();
+}
+
 export const trpcClient = createTRPCClient<AppRouter>({
 	links: [
 		httpBatchLink({

--- a/apps/web/src/utils/trpc.ts
+++ b/apps/web/src/utils/trpc.ts
@@ -55,9 +55,9 @@ export const persister = createAsyncStoragePersister({
  * `persister.removeClient()` deletes the persisted `sapphire2-query-cache` store
  * so nothing can be rehydrated on the next load.
  */
-export function clearPersistedQueryCache() {
+export function clearPersistedQueryCache(): Promise<void> {
 	queryClient.clear();
-	return persister.removeClient();
+	return Promise.resolve(persister.removeClient());
 }
 
 export const trpcClient = createTRPCClient<AppRouter>({

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -5,6 +5,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { githubReleasesPlugin } from "./src/plugins/vite-plugin-github-releases";
+import { pwaManifest } from "./src/shared/lib/pwa-manifest";
 
 export default defineConfig({
 	plugins: [
@@ -14,13 +15,7 @@ export default defineConfig({
 		react(),
 		VitePWA({
 			registerType: "autoUpdate",
-			manifest: {
-				name: "sapphire2",
-				short_name: "sapphire2",
-				description: "sapphire2 - PWA Application",
-				theme_color: "#0c0c0c",
-				start_url: "/dashboard",
-			},
+			manifest: pwaManifest,
 			pwaAssets: { disabled: false, config: true },
 			devOptions: { enabled: true },
 		}),

--- a/apps/web/vitest.dom.config.ts
+++ b/apps/web/vitest.dom.config.ts
@@ -28,7 +28,6 @@ export default defineConfig({
 			"src/features/**/components/**/__tests__/*.test.ts",
 			"src/features/**/pages/**/__tests__/*.test.ts",
 			"src/features/**/hooks/__tests__/*.test.ts",
-			"src/features/dashboard/widgets/**/__tests__/*.test.ts",
 			"src/features/sessions/utils/__tests__/share-session.test.ts",
 			"src/routes/**/__tests__/*.test.ts",
 		],

--- a/packages/api/src/__tests__/blind-level.test.ts
+++ b/packages/api/src/__tests__/blind-level.test.ts
@@ -1,3 +1,7 @@
+import { room } from "@sapphire2/db/schema/room";
+import { blindLevel, tournament } from "@sapphire2/db/schema/tournament";
+import { TRPCError } from "@trpc/server";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -6,6 +10,67 @@ import {
 	expectRejects,
 	expectType,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+const dialect = new SQLiteSyncDialect();
+
+function makeSelectChain(rows: Rows) {
+	const chain = Promise.resolve(rows) as Promise<Rows> &
+		Record<string, () => unknown>;
+	chain.where = () => chain;
+	chain.orderBy = () => chain;
+	chain.limit = () => chain;
+	return chain;
+}
+
+/**
+ * Mock db that resolves `select().from(table)` from a table-keyed map and
+ * records the SQL params bound to each `update().set().where(cond)` so tests
+ * can assert the WHERE predicate is scoped to the owned tournament (SA2-176).
+ */
+function createReorderMockDb(rowsByTable: Map<unknown, Rows>) {
+	const updateWhereParams: unknown[][] = [];
+	const db = {
+		select: () => ({
+			from: (table: unknown) => makeSelectChain(rowsByTable.get(table) ?? []),
+		}),
+		update: () => ({
+			set: () => ({
+				where: (cond: unknown) => {
+					updateWhereParams.push(dialect.sqlToQuery(cond as never).params);
+					return Promise.resolve(undefined);
+				},
+			}),
+		}),
+	};
+	return { db, updateWhereParams };
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+function makeCaller(userId: string, rowsByTable: Map<unknown, Rows>) {
+	const { db, updateWhereParams } = createReorderMockDb(rowsByTable);
+	const caller = appRouter.createCaller({
+		session: { user: { id: userId } },
+		db,
+	} as unknown as Parameters<typeof appRouter.createCaller>[0]).blindLevel;
+	return { caller, updateWhereParams };
+}
+
+const CALLER = "user-1";
+const OTHER = "user-2";
 
 describe("blindLevel router", () => {
 	it("appRouter has blindLevel namespace", () => {
@@ -180,5 +245,47 @@ describe("blindLevel.reorder input validation", () => {
 			tournamentId: "tn1",
 			levelIds: ["bl1", 2],
 		});
+	});
+});
+
+describe("blindLevel.reorder tournament scoping (SA2-176)", () => {
+	function ownedRows() {
+		return new Map<unknown, Rows>([
+			[tournament, [{ id: "tn1", roomId: "room1" }]],
+			[room, [{ id: "room1", userId: CALLER }]],
+			[blindLevel, [{ id: "bl1", level: 1 }]],
+		]);
+	}
+
+	it("scopes each level UPDATE to both the level id and the owned tournament", async () => {
+		const { caller, updateWhereParams } = makeCaller(CALLER, ownedRows());
+		await caller.reorder({ tournamentId: "tn1", levelIds: ["bl1", "bl2"] });
+		expect(updateWhereParams).toHaveLength(2);
+		// Every UPDATE must constrain the row to the caller's tournament so a
+		// foreign levelId matches nothing.
+		expect(updateWhereParams[0]).toContain("bl1");
+		expect(updateWhereParams[0]).toContain("tn1");
+		expect(updateWhereParams[1]).toContain("bl2");
+		expect(updateWhereParams[1]).toContain("tn1");
+	});
+
+	it("runs no UPDATE when levelIds is empty", async () => {
+		const { caller, updateWhereParams } = makeCaller(CALLER, ownedRows());
+		await caller.reorder({ tournamentId: "tn1", levelIds: [] });
+		expect(updateWhereParams).toHaveLength(0);
+	});
+
+	it("throws FORBIDDEN and runs no UPDATE when the tournament is owned by another user", async () => {
+		const rows = new Map<unknown, Rows>([
+			[tournament, [{ id: "tn1", roomId: "room1" }]],
+			[room, [{ id: "room1", userId: OTHER }]],
+			[blindLevel, []],
+		]);
+		const { caller, updateWhereParams } = makeCaller(CALLER, rows);
+		await expectTrpcCode(
+			caller.reorder({ tournamentId: "tn1", levelIds: ["bl1"] }),
+			"FORBIDDEN"
+		);
+		expect(updateWhereParams).toHaveLength(0);
 	});
 });

--- a/packages/api/src/__tests__/currency-transaction.test.ts
+++ b/packages/api/src/__tests__/currency-transaction.test.ts
@@ -1,3 +1,10 @@
+import {
+	currency,
+	currencyTransaction,
+	transactionType,
+} from "@sapphire2/db/schema/currency";
+import { TRPCError } from "@trpc/server";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -6,6 +13,77 @@ import {
 	expectRejects,
 	expectType,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+const dialect = new SQLiteSyncDialect();
+
+/**
+ * Mock db keyed by schema-table reference: `select().from(t)...` resolves to
+ * the rows registered for `t`; every `.where(cond)` records its bound SQL
+ * params (so cursor scoping can be asserted) and `insert(t).values()` records
+ * the inserted payload (so a rejected ownership guard can be shown to skip the
+ * write).
+ */
+function createMockDb(rowsByTable: Map<unknown, Rows>) {
+	const selectWhereParams: unknown[][] = [];
+	const inserted: { table: unknown; values: unknown }[] = [];
+	const makeChain = (rows: Rows) => {
+		const chain = Promise.resolve(rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = (table: unknown) => makeChain(rowsByTable.get(table) ?? []);
+		chain.where = (cond: unknown) => {
+			selectWhereParams.push(dialect.sqlToQuery(cond as never).params);
+			return chain;
+		};
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.innerJoin = () => chain;
+		chain.leftJoin = () => chain;
+		return chain;
+	};
+	const db = {
+		select: () => makeChain([]),
+		insert: (table: unknown) => ({
+			values: (values: unknown) => {
+				inserted.push({ table, values });
+				return Promise.resolve(undefined);
+			},
+		}),
+		update: () => ({
+			set: () => ({ where: () => Promise.resolve(undefined) }),
+		}),
+		delete: () => ({ where: () => Promise.resolve(undefined) }),
+	};
+	return { db, selectWhereParams, inserted };
+}
+
+function makeCaller(userId: string, rowsByTable: Map<unknown, Rows>) {
+	const { db, selectWhereParams, inserted } = createMockDb(rowsByTable);
+	const caller = appRouter.createCaller({
+		session: { user: { id: userId } },
+		db,
+	} as unknown as Parameters<
+		typeof appRouter.createCaller
+	>[0]).currencyTransaction;
+	return { caller, selectWhereParams, inserted };
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+const OWNER = "user-1";
+const OTHER = "user-2";
 
 describe("currencyTransaction router structure", () => {
 	it("appRouter has currencyTransaction namespace", () => {
@@ -156,5 +234,151 @@ describe("currencyTransaction.delete input validation", () => {
 
 	it("rejects non-string id", () => {
 		expectRejects(appRouter.currencyTransaction.delete, { id: 123 });
+	});
+});
+
+describe("currencyTransaction.create transactionType ownership (SA2-179)", () => {
+	const validInput = {
+		currencyId: "c1",
+		transactionTypeId: "tt1",
+		amount: 1000,
+		transactedAt: "2024-01-01T00:00:00Z",
+	};
+
+	it("accepts a transaction type owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[currency, [{ id: "c1", userId: OWNER }]],
+			[transactionType, [{ id: "tt1", userId: OWNER }]],
+			[currencyTransaction, [{ id: "tx-new" }]],
+		]);
+		const { caller } = makeCaller(OWNER, rows);
+		await expect(caller.create(validInput)).resolves.toBeDefined();
+	});
+
+	it("rejects a transaction type owned by another user and skips the insert", async () => {
+		const rows = new Map<unknown, Rows>([
+			[currency, [{ id: "c1", userId: OWNER }]],
+			[transactionType, [{ id: "tt1", userId: OTHER }]],
+		]);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expectTrpcCode(caller.create(validInput), "FORBIDDEN");
+		expect(inserted.some((i) => i.table === currencyTransaction)).toBe(false);
+	});
+
+	it("throws NOT_FOUND when the transaction type does not exist", async () => {
+		const rows = new Map<unknown, Rows>([
+			[currency, [{ id: "c1", userId: OWNER }]],
+			[transactionType, []],
+		]);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expectTrpcCode(caller.create(validInput), "NOT_FOUND");
+		expect(inserted.some((i) => i.table === currencyTransaction)).toBe(false);
+	});
+
+	it("rejects before validating the transaction type when the currency is foreign", async () => {
+		const rows = new Map<unknown, Rows>([
+			[currency, [{ id: "c1", userId: OTHER }]],
+			[transactionType, [{ id: "tt1", userId: OWNER }]],
+		]);
+		const { caller } = makeCaller(OWNER, rows);
+		await expectTrpcCode(caller.create(validInput), "FORBIDDEN");
+	});
+});
+
+describe("currencyTransaction.update transactionType ownership (SA2-179)", () => {
+	function ownedTransactionRows(extra?: Map<unknown, Rows>) {
+		const map = new Map<unknown, Rows>([
+			[
+				currencyTransaction,
+				[
+					{
+						currencyTransaction: {
+							id: "tx1",
+							currencyId: "c1",
+							sessionId: null,
+						},
+						currency: { id: "c1", userId: OWNER },
+					},
+				],
+			],
+		]);
+		if (extra) {
+			for (const [k, v] of extra) {
+				map.set(k, v);
+			}
+		}
+		return map;
+	}
+
+	it("accepts a transaction type owned by the caller", async () => {
+		const rows = ownedTransactionRows(
+			new Map<unknown, Rows>([
+				[transactionType, [{ id: "tt2", userId: OWNER }]],
+			])
+		);
+		const { caller } = makeCaller(OWNER, rows);
+		await expect(
+			caller.update({ id: "tx1", transactionTypeId: "tt2" })
+		).resolves.toBeDefined();
+	});
+
+	it("rejects a transaction type owned by another user with FORBIDDEN", async () => {
+		const rows = ownedTransactionRows(
+			new Map<unknown, Rows>([
+				[transactionType, [{ id: "tt2", userId: OTHER }]],
+			])
+		);
+		const { caller } = makeCaller(OWNER, rows);
+		await expectTrpcCode(
+			caller.update({ id: "tx1", transactionTypeId: "tt2" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("throws NOT_FOUND when the transaction type does not exist", async () => {
+		const rows = ownedTransactionRows(
+			new Map<unknown, Rows>([[transactionType, []]])
+		);
+		const { caller } = makeCaller(OWNER, rows);
+		await expectTrpcCode(
+			caller.update({ id: "tx1", transactionTypeId: "missing" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("does not validate the transaction type when the field is omitted", async () => {
+		const rows = ownedTransactionRows();
+		const { caller, selectWhereParams } = makeCaller(OWNER, rows);
+		await expect(
+			caller.update({ id: "tx1", amount: 50 })
+		).resolves.toBeDefined();
+		// transaction_type is never seeded → no extra ownership read fired.
+		expect(rows.has(transactionType)).toBe(false);
+		expect(selectWhereParams.length).toBeGreaterThan(0);
+	});
+});
+
+describe("currencyTransaction.listByCurrency cursor scoping (SA2-182)", () => {
+	it("scopes the cursor boundary subquery to the target currency", async () => {
+		const rows = new Map<unknown, Rows>([
+			[currency, [{ id: "c1", userId: OWNER }]],
+			[currencyTransaction, []],
+		]);
+		const { caller, selectWhereParams } = makeCaller(OWNER, rows);
+		await caller.listByCurrency({ currencyId: "c1", cursor: "tx-cursor" });
+		const listWhere = selectWhereParams.find((p) => p.includes("tx-cursor"));
+		expect(listWhere).toBeDefined();
+		// currencyId appears twice: the base filter + the cursor subquery scope.
+		expect((listWhere as unknown[]).filter((p) => p === "c1")).toHaveLength(2);
+	});
+
+	it("does not add a cursor subquery when no cursor is supplied", async () => {
+		const rows = new Map<unknown, Rows>([
+			[currency, [{ id: "c1", userId: OWNER }]],
+			[currencyTransaction, []],
+		]);
+		const { caller, selectWhereParams } = makeCaller(OWNER, rows);
+		await caller.listByCurrency({ currencyId: "c1" });
+		expect(selectWhereParams.every((p) => !p.includes("tx-cursor"))).toBe(true);
 	});
 });

--- a/packages/api/src/__tests__/live-cash-game-session.test.ts
+++ b/packages/api/src/__tests__/live-cash-game-session.test.ts
@@ -214,6 +214,13 @@ describe("liveCashGameSession.updateHeroSeat input validation", () => {
 		});
 	});
 
+	it("accepts heroSeatPosition 9 (last seat of a 10-max table)", () => {
+		expectAccepts(appRouter.liveCashGameSession.updateHeroSeat, {
+			id: "s1",
+			heroSeatPosition: 9,
+		});
+	});
+
 	it("accepts heroSeatPosition: null (hero stands up)", () => {
 		expectAccepts(appRouter.liveCashGameSession.updateHeroSeat, {
 			id: "s1",
@@ -221,10 +228,10 @@ describe("liveCashGameSession.updateHeroSeat input validation", () => {
 		});
 	});
 
-	it("rejects seat position outside [0, 8]", () => {
+	it("rejects seat position outside [0, 9]", () => {
 		expectRejects(appRouter.liveCashGameSession.updateHeroSeat, {
 			id: "s1",
-			heroSeatPosition: 9,
+			heroSeatPosition: 10,
 		});
 		expectRejects(appRouter.liveCashGameSession.updateHeroSeat, {
 			id: "s1",

--- a/packages/api/src/__tests__/live-cash-game-session.test.ts
+++ b/packages/api/src/__tests__/live-cash-game-session.test.ts
@@ -4,6 +4,7 @@ import { room } from "@sapphire2/db/schema/room";
 import { gameSession } from "@sapphire2/db/schema/session";
 import { sessionCashDetail } from "@sapphire2/db/schema/session-cash-detail";
 import { TRPCError } from "@trpc/server";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -669,5 +670,59 @@ describe("liveCashGameSession.updateSnapshot input validation", () => {
 			id: "s1",
 			blind1: 1.5,
 		});
+	});
+});
+
+const dialect = new SQLiteSyncDialect();
+
+/**
+ * Mock db that records the SQL params bound to the list query's `.where(...)`
+ * so the cursor-boundary subquery can be shown to be scoped to the caller
+ * (SA2-182). `select().from()` resolves to no rows; the enrichment loop is
+ * skipped because there are no items.
+ */
+function createListWhereMockDb() {
+	const selectWhereParams: unknown[][] = [];
+	const makeChain = () => {
+		const chain = Promise.resolve([] as Rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = () => chain;
+		chain.where = (cond: unknown) => {
+			selectWhereParams.push(dialect.sqlToQuery(cond as never).params);
+			return chain;
+		};
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.leftJoin = () => chain;
+		chain.innerJoin = () => chain;
+		return chain;
+	};
+	const db = { select: () => makeChain() };
+	return { db, selectWhereParams };
+}
+
+describe("liveCashGameSession.list cursor scoping (SA2-182)", () => {
+	it("scopes the cursor boundary subquery to the caller's user id", async () => {
+		const { db, selectWhereParams } = createListWhereMockDb();
+		const caller = appRouter.createCaller({
+			session: { user: { id: OWNER } },
+			db,
+		} as unknown as Parameters<typeof appRouter.createCaller>[0]);
+		await caller.liveCashGameSession.list({ cursor: "s-cursor", limit: 10 });
+		const listWhere = selectWhereParams.find((p) => p.includes("s-cursor"));
+		expect(listWhere).toBeDefined();
+		// userId appears twice: the base filter + the cursor subquery scope.
+		expect((listWhere as unknown[]).filter((p) => p === OWNER)).toHaveLength(2);
+	});
+
+	it("does not add a cursor subquery when no cursor is supplied", async () => {
+		const { db, selectWhereParams } = createListWhereMockDb();
+		const caller = appRouter.createCaller({
+			session: { user: { id: OWNER } },
+			db,
+		} as unknown as Parameters<typeof appRouter.createCaller>[0]);
+		await caller.liveCashGameSession.list({ limit: 10 });
+		const base = selectWhereParams[0] as unknown[];
+		expect(base.filter((p) => p === OWNER)).toHaveLength(1);
 	});
 });

--- a/packages/api/src/__tests__/live-cash-game-session.test.ts
+++ b/packages/api/src/__tests__/live-cash-game-session.test.ts
@@ -247,13 +247,21 @@ describe("liveCashGameSession.update ownership validation (SA2-102)", () => {
 	});
 });
 
-describe("liveCashGameSession.create ring game ownership (SA2-174)", () => {
-	it("accepts a ring game whose room is owned by the caller", async () => {
+describe("liveCashGameSession.create ring game ownership (SA2-181)", () => {
+	it("accepts a ring game owned by the caller via userId", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, []],
 			[
 				ringGame,
-				[{ id: "rg-1", roomId: "room-1", minBuyIn: null, maxBuyIn: null }],
+				[
+					{
+						id: "rg-1",
+						roomId: "room-1",
+						userId: OWNER,
+						minBuyIn: null,
+						maxBuyIn: null,
+					},
+				],
 			],
 			[room, [{ id: "room-1", userId: OWNER }]],
 			[sessionCashDetail, []],
@@ -263,14 +271,43 @@ describe("liveCashGameSession.create ring game ownership (SA2-174)", () => {
 		).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
 	});
 
-	it("rejects a ring game whose room belongs to another user with FORBIDDEN", async () => {
+	it("accepts a null-roomId auto-generated ring game owned via userId", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, []],
 			[
 				ringGame,
-				[{ id: "rg-1", roomId: "room-1", minBuyIn: null, maxBuyIn: null }],
+				[
+					{
+						id: "rg-1",
+						roomId: null,
+						userId: OWNER,
+						minBuyIn: null,
+						maxBuyIn: null,
+					},
+				],
 			],
-			[room, [{ id: "room-1", userId: OTHER }]],
+			[sessionCashDetail, []],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 1000, ringGameId: "rg-1" })
+		).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
+	});
+
+	it("rejects a ring game owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[
+				ringGame,
+				[
+					{
+						id: "rg-1",
+						roomId: "room-1",
+						userId: OTHER,
+						minBuyIn: null,
+						maxBuyIn: null,
+					},
+				],
+			],
 		]);
 		await expectTrpcCode(
 			makeCaller(OWNER, rows).create({ initialBuyIn: 0, ringGameId: "rg-1" }),
@@ -278,12 +315,20 @@ describe("liveCashGameSession.create ring game ownership (SA2-174)", () => {
 		);
 	});
 
-	it("rejects a ring game with a null roomId (auto-generated row) with FORBIDDEN", async () => {
+	it("rejects a legacy ring game with null userId with FORBIDDEN", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, []],
 			[
 				ringGame,
-				[{ id: "rg-1", roomId: null, minBuyIn: null, maxBuyIn: null }],
+				[
+					{
+						id: "rg-1",
+						roomId: null,
+						userId: null,
+						minBuyIn: null,
+						maxBuyIn: null,
+					},
+				],
 			],
 		]);
 		await expectTrpcCode(
@@ -304,11 +349,14 @@ describe("liveCashGameSession.create ring game ownership (SA2-174)", () => {
 	});
 });
 
-describe("liveCashGameSession.update ring game ownership (SA2-174)", () => {
-	it("accepts a ring game whose room is owned by the caller", async () => {
+describe("liveCashGameSession.update ring game ownership (SA2-181)", () => {
+	it("accepts a ring game owned by the caller via userId", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, [ownedSession]],
-			[ringGame, [{ id: "rg-1", roomId: "room-1", currencyId: null }]],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: "room-1", userId: OWNER, currencyId: null }],
+			],
 			[room, [{ id: "room-1", userId: OWNER }]],
 			[sessionCashDetail, []],
 		]);
@@ -317,11 +365,27 @@ describe("liveCashGameSession.update ring game ownership (SA2-174)", () => {
 		).resolves.toBeDefined();
 	});
 
-	it("rejects a ring game whose room belongs to another user with FORBIDDEN", async () => {
+	it("accepts a null-roomId auto-generated ring game owned via userId", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, [ownedSession]],
-			[ringGame, [{ id: "rg-1", roomId: "room-1", currencyId: null }]],
-			[room, [{ id: "room-1", userId: OTHER }]],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: null, userId: OWNER, currencyId: null }],
+			],
+			[sessionCashDetail, []],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({ id: "s1", ringGameId: "rg-1" })
+		).resolves.toBeDefined();
+	});
+
+	it("rejects a ring game owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: "room-1", userId: OTHER, currencyId: null }],
+			],
 			[sessionCashDetail, []],
 		]);
 		await expectTrpcCode(
@@ -330,10 +394,13 @@ describe("liveCashGameSession.update ring game ownership (SA2-174)", () => {
 		);
 	});
 
-	it("rejects a ring game with a null roomId (auto-generated row) with FORBIDDEN", async () => {
+	it("rejects a legacy ring game with null userId with FORBIDDEN", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, [ownedSession]],
-			[ringGame, [{ id: "rg-1", roomId: null, currencyId: null }]],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: null, userId: null, currencyId: null }],
+			],
 			[sessionCashDetail, []],
 		]);
 		await expectTrpcCode(
@@ -357,7 +424,10 @@ describe("liveCashGameSession.update ring game ownership (SA2-174)", () => {
 	it("clears ringGameId with null without an ownership error", async () => {
 		const rows = new Map<unknown, Rows>([
 			[gameSession, [ownedSession]],
-			[ringGame, [{ id: "rg-1", roomId: null, currencyId: null }]],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: null, userId: OWNER, currencyId: null }],
+			],
 			[sessionCashDetail, []],
 		]);
 		await expect(

--- a/packages/api/src/__tests__/live-cash-game-session.test.ts
+++ b/packages/api/src/__tests__/live-cash-game-session.test.ts
@@ -1,3 +1,7 @@
+import { currency } from "@sapphire2/db/schema/currency";
+import { room } from "@sapphire2/db/schema/room";
+import { gameSession } from "@sapphire2/db/schema/session";
+import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -7,6 +11,238 @@ import {
 	expectType,
 	getInputSchema,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+
+/**
+ * Minimal drizzle-shaped mock db: `select().from(t).where().limit()` chains
+ * resolve to the rows registered for table `t`; `insert`/`update`/`delete`
+ * resolve to no-ops. Keyed by the imported schema object reference so the
+ * ownership `select().from(room|currency)` reads the seeded owner rows.
+ */
+type ChainablePromise = Promise<Rows> & Record<string, () => ChainablePromise>;
+
+function createMockDb(tableRows: Map<unknown, Rows>) {
+	const makeResult = (table: unknown): ChainablePromise => {
+		const promise = Promise.resolve(
+			tableRows.get(table) ?? []
+		) as ChainablePromise;
+		const same = () => promise;
+		for (const method of [
+			"where",
+			"limit",
+			"orderBy",
+			"groupBy",
+			"innerJoin",
+			"leftJoin",
+		]) {
+			promise[method] = same;
+		}
+		return promise;
+	};
+	return {
+		select: () => ({ from: (table: unknown) => makeResult(table) }),
+		insert: () => ({ values: () => Promise.resolve(undefined) }),
+		update: () => ({
+			set: () => ({ where: () => Promise.resolve(undefined) }),
+		}),
+		delete: () => ({ where: () => Promise.resolve(undefined) }),
+	};
+}
+
+function makeCaller(userId: string, tableRows: Map<unknown, Rows>) {
+	return appRouter.createCaller({
+		session: { user: { id: userId } },
+		db: createMockDb(tableRows),
+	} as unknown as Parameters<typeof appRouter.createCaller>[0])
+		.liveCashGameSession;
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+const OWNER = "user-1";
+const OTHER = "user-2";
+
+const ownedSession = {
+	id: "s1",
+	userId: OWNER,
+	kind: "cash_game",
+	status: "active",
+	source: "live",
+	roomId: null,
+	currencyId: null,
+};
+
+describe("liveCashGameSession.create ownership validation (SA2-102)", () => {
+	it("accepts a room and currency owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, [{ id: "room-1", userId: OWNER }]],
+			[currency, [{ id: "cur-1", userId: OWNER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).create({
+				initialBuyIn: 1000,
+				roomId: "room-1",
+				currencyId: "cur-1",
+			})
+		).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
+	});
+
+	it("rejects a room owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, [{ id: "room-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, roomId: "room-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a currency owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a non-existent room with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, roomId: "room-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("rejects a non-existent currency with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[currency, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, currencyId: "cur-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("does not validate ownership when room/currency are omitted", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0 })
+		).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
+	});
+});
+
+describe("liveCashGameSession.update ownership validation (SA2-102)", () => {
+	it("accepts a room and currency owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OWNER }]],
+			[currency, [{ id: "cur-1", userId: OWNER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({
+				id: "s1",
+				roomId: "room-1",
+				currencyId: "cur-1",
+			})
+		).resolves.toBeDefined();
+	});
+
+	it("rejects a room owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", roomId: "room-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a currency owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a non-existent room with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", roomId: "room-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("rejects a non-existent currency with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[currency, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", currencyId: "cur-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("clears roomId/currencyId with null without an ownership error", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({
+				id: "s1",
+				roomId: null,
+				currencyId: null,
+			})
+		).resolves.toBeDefined();
+	});
+
+	it("does not validate ownership when room/currency are omitted", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({ id: "s1", memo: "note" })
+		).resolves.toBeDefined();
+	});
+});
 
 describe("liveCashGameSession router", () => {
 	it("appRouter has liveCashGameSession namespace", () => {

--- a/packages/api/src/__tests__/live-cash-game-session.test.ts
+++ b/packages/api/src/__tests__/live-cash-game-session.test.ts
@@ -1,6 +1,8 @@
 import { currency } from "@sapphire2/db/schema/currency";
+import { ringGame } from "@sapphire2/db/schema/ring-game";
 import { room } from "@sapphire2/db/schema/room";
 import { gameSession } from "@sapphire2/db/schema/session";
+import { sessionCashDetail } from "@sapphire2/db/schema/session-cash-detail";
 import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
@@ -240,6 +242,125 @@ describe("liveCashGameSession.update ownership validation (SA2-102)", () => {
 		]);
 		await expect(
 			makeCaller(OWNER, rows).update({ id: "s1", memo: "note" })
+		).resolves.toBeDefined();
+	});
+});
+
+describe("liveCashGameSession.create ring game ownership (SA2-174)", () => {
+	it("accepts a ring game whose room is owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: "room-1", minBuyIn: null, maxBuyIn: null }],
+			],
+			[room, [{ id: "room-1", userId: OWNER }]],
+			[sessionCashDetail, []],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 1000, ringGameId: "rg-1" })
+		).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
+	});
+
+	it("rejects a ring game whose room belongs to another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: "room-1", minBuyIn: null, maxBuyIn: null }],
+			],
+			[room, [{ id: "room-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, ringGameId: "rg-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a ring game with a null roomId (auto-generated row) with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[
+				ringGame,
+				[{ id: "rg-1", roomId: null, minBuyIn: null, maxBuyIn: null }],
+			],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, ringGameId: "rg-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a non-existent ring game with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[ringGame, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ initialBuyIn: 0, ringGameId: "rg-x" }),
+			"NOT_FOUND"
+		);
+	});
+});
+
+describe("liveCashGameSession.update ring game ownership (SA2-174)", () => {
+	it("accepts a ring game whose room is owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[ringGame, [{ id: "rg-1", roomId: "room-1", currencyId: null }]],
+			[room, [{ id: "room-1", userId: OWNER }]],
+			[sessionCashDetail, []],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({ id: "s1", ringGameId: "rg-1" })
+		).resolves.toBeDefined();
+	});
+
+	it("rejects a ring game whose room belongs to another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[ringGame, [{ id: "rg-1", roomId: "room-1", currencyId: null }]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[sessionCashDetail, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", ringGameId: "rg-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a ring game with a null roomId (auto-generated row) with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[ringGame, [{ id: "rg-1", roomId: null, currencyId: null }]],
+			[sessionCashDetail, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", ringGameId: "rg-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a non-existent ring game with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[ringGame, []],
+			[sessionCashDetail, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", ringGameId: "rg-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("clears ringGameId with null without an ownership error", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[ringGame, [{ id: "rg-1", roomId: null, currencyId: null }]],
+			[sessionCashDetail, []],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({ id: "s1", ringGameId: null })
 		).resolves.toBeDefined();
 	});
 });

--- a/packages/api/src/__tests__/live-session-pl.test.ts
+++ b/packages/api/src/__tests__/live-session-pl.test.ts
@@ -403,6 +403,77 @@ describe("computeCashGamePLFromEvents", () => {
 		expect(result.profitLoss).toBe(150);
 	});
 
+	it("exposes chipRemoveTotal from negative chips_add_remove events (SA2-124)", () => {
+		// buyIn 500, chip removal 300, cashOut 400 =>
+		// profitLoss = 400 + 300 - 500 = 200, and chipRemoveTotal is surfaced
+		// so the live header can mirror the chart's stack + chipRemoveTotal - buyIn.
+		const events = [
+			{
+				eventType: "session_start",
+				payload: JSON.stringify({ buyInAmount: 500 }),
+			},
+			{
+				eventType: "chips_add_remove",
+				payload: JSON.stringify({ amount: -300, type: "remove" }),
+			},
+			{
+				eventType: "session_end",
+				payload: JSON.stringify({ cashOutAmount: 400 }),
+			},
+		];
+		const result = computeCashGamePLFromEvents(events);
+		expect(result.chipRemoveTotal).toBe(300);
+		expect(result.totalBuyIn).toBe(500);
+		expect(result.profitLoss).toBe(200);
+	});
+
+	it("reports chipRemoveTotal as 0 when there are no chip removals", () => {
+		const events = [
+			{
+				eventType: "session_start",
+				payload: JSON.stringify({ buyInAmount: 500 }),
+			},
+			{
+				eventType: "session_end",
+				payload: JSON.stringify({ cashOutAmount: 400 }),
+			},
+		];
+		const result = computeCashGamePLFromEvents(events);
+		expect(result.chipRemoveTotal).toBe(0);
+		expect(result.profitLoss).toBe(-100);
+	});
+
+	it("accumulates chipRemoveTotal across multiple removals without touching addonTotal", () => {
+		const events = [
+			{
+				eventType: "session_start",
+				payload: JSON.stringify({ buyInAmount: 1000 }),
+			},
+			{
+				eventType: "chips_add_remove",
+				payload: JSON.stringify({ amount: -200, type: "remove" }),
+			},
+			{
+				eventType: "chips_add_remove",
+				payload: JSON.stringify({ amount: 300, type: "add" }),
+			},
+			{
+				eventType: "chips_add_remove",
+				payload: JSON.stringify({ amount: -100, type: "remove" }),
+			},
+			{
+				eventType: "session_end",
+				payload: JSON.stringify({ cashOutAmount: 900 }),
+			},
+		];
+		const result = computeCashGamePLFromEvents(events);
+		expect(result.chipRemoveTotal).toBe(300);
+		expect(result.addonTotal).toBe(300);
+		expect(result.totalBuyIn).toBe(1300);
+		// profitLoss = 900 + 300 - 1300 = -100
+		expect(result.profitLoss).toBe(-100);
+	});
+
 	it("computes evCashOut correctly using all_in events", () => {
 		// EV diff = potSize * (equity / 100) - (potSize / trials) * wins
 		// potSize=400, equity=75, trials=1, wins=0 => 400 * 0.75 - (400 / 1) * 0 = 300

--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import { t } from "../index";
 import { appRouter } from "../routers";
 import { persistSessionBlindLevels } from "../routers/session";
 import {
+	createChainableMockDb,
 	expectAccepts,
 	expectProtected,
 	expectRejects,
@@ -53,6 +55,15 @@ function createBlindLevelMockDb() {
 /** The row array passed to each `.values()` call, in call order. */
 function insertedChunks(values: ReturnType<typeof vi.fn>): InsertedRow[][] {
 	return values.mock.calls.map((call) => call[0] as InsertedRow[]);
+}
+
+const createCaller = t.createCallerFactory(appRouter);
+
+function callerFor(db: unknown, userId: string) {
+	return createCaller({
+		session: { user: { id: userId } },
+		db,
+	} as never);
 }
 
 describe("liveTournamentSession router", () => {
@@ -373,6 +384,7 @@ describe("liveTournamentSession.updateSnapshot input validation", () => {
 	});
 });
 
+<<<<<<< HEAD
 // Regression guard for SA2-115: updateSnapshot re-seeds blind levels via the
 // shared persistSessionBlindLevels helper, which DELETEs then re-INSERTs. D1
 // rejects any statement binding >100 params, so a 9-column blind row must be
@@ -457,5 +469,111 @@ describe("persistSessionBlindLevels chunking (SA2-115)", () => {
 		expect(deleteWhere).toHaveBeenCalledTimes(1);
 		expect(insert).not.toHaveBeenCalled();
 		expect(values).not.toHaveBeenCalled();
+	});
+});
+
+describe("liveTournamentSession.create tournament ownership (IDOR guard)", () => {
+	const CALLER = "user-1";
+	const OTHER = "user-2";
+	const TOURNAMENT_ID = "tn-1";
+	const ROOM_ID = "room-1";
+
+	function mockDb(opts: {
+		tournament?: Record<string, unknown>[];
+		room?: Record<string, unknown>[];
+		blindLevels?: Record<string, unknown>[];
+		chipPurchases?: Record<string, unknown>[];
+	}) {
+		return createChainableMockDb({
+			select: {
+				// no session is currently active
+				game_session: [],
+				tournament: opts.tournament ?? [],
+				room: opts.room ?? [],
+				blind_level: opts.blindLevels ?? [],
+				tournament_chip_purchase: opts.chipPurchases ?? [],
+			},
+		});
+	}
+
+	it("creates the session and snapshots the structure when the caller owns the tournament", async () => {
+		const { db, inserted, selectedTables } = mockDb({
+			tournament: [
+				{
+					id: TOURNAMENT_ID,
+					roomId: ROOM_ID,
+					name: "Main Event",
+					variant: "nlh",
+					buyIn: 10_000,
+					entryFee: 1000,
+					startingStack: 20_000,
+					bountyAmount: null,
+					tableSize: 9,
+					currencyId: null,
+				},
+			],
+			room: [{ id: ROOM_ID, userId: CALLER }],
+			blindLevels: [
+				{ level: 1, isBreak: false, blind1: 100, blind2: 200, minutes: 15 },
+			],
+		});
+
+		const result = await callerFor(db, CALLER).liveTournamentSession.create({
+			tournamentId: TOURNAMENT_ID,
+		});
+
+		expect(typeof result.id).toBe("string");
+		// The room must be read to confirm tournament ownership.
+		expect(selectedTables).toContain("room");
+		// The session and its structure snapshot were persisted.
+		expect(inserted.game_session).toHaveLength(1);
+		expect(inserted.session_tournament_detail).toHaveLength(1);
+		expect(inserted.session_blind_level).toHaveLength(1);
+	});
+
+	it("throws FORBIDDEN and writes nothing when the tournament belongs to another user", async () => {
+		const { db, inserted } = mockDb({
+			tournament: [{ id: TOURNAMENT_ID, roomId: ROOM_ID }],
+			room: [{ id: ROOM_ID, userId: OTHER }],
+		});
+
+		await expect(
+			callerFor(db, CALLER).liveTournamentSession.create({
+				tournamentId: TOURNAMENT_ID,
+			})
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this tournament",
+		});
+		// The guard runs before any write, so nothing is persisted.
+		expect(inserted.game_session).toBeUndefined();
+		expect(inserted.session_blind_level).toBeUndefined();
+	});
+
+	it("throws NOT_FOUND and writes nothing when the tournament does not exist", async () => {
+		const { db, inserted } = mockDb({ tournament: [] });
+
+		await expect(
+			callerFor(db, CALLER).liveTournamentSession.create({
+				tournamentId: "missing",
+			})
+		).rejects.toMatchObject({
+			code: "NOT_FOUND",
+			message: "Tournament not found",
+		});
+		expect(inserted.game_session).toBeUndefined();
+	});
+
+	it("skips tournament ownership validation when tournamentId is omitted", async () => {
+		const { db, inserted, selectedTables } = mockDb({});
+
+		const result = await callerFor(db, CALLER).liveTournamentSession.create({});
+
+		expect(typeof result.id).toBe("string");
+		// No tournament / room lookups happen without a tournamentId.
+		expect(selectedTables).not.toContain("tournament");
+		expect(selectedTables).not.toContain("room");
+		expect(inserted.game_session).toHaveLength(1);
+		expect(inserted.session_blind_level).toBeUndefined();
 	});
 });

--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -1,3 +1,7 @@
+import { currency } from "@sapphire2/db/schema/currency";
+import { room } from "@sapphire2/db/schema/room";
+import { gameSession } from "@sapphire2/db/schema/session";
+import { TRPCError } from "@trpc/server";
 import { describe, expect, it, vi } from "vitest";
 import { t } from "../index";
 import { appRouter } from "../routers";
@@ -65,6 +69,234 @@ function callerFor(db: unknown, userId: string) {
 		db,
 	} as never);
 }
+
+type Rows = Record<string, unknown>[];
+
+/**
+ * Minimal drizzle-shaped mock db: `select().from(t).where().limit()` chains
+ * resolve to the rows registered for table `t`; `insert`/`update`/`delete`
+ * resolve to no-ops. Keyed by the imported schema object reference so the
+ * ownership `select().from(room|currency)` reads the seeded owner rows.
+ */
+type ChainablePromise = Promise<Rows> & Record<string, () => ChainablePromise>;
+
+function createMockDb(tableRows: Map<unknown, Rows>) {
+	const makeResult = (table: unknown): ChainablePromise => {
+		const promise = Promise.resolve(
+			tableRows.get(table) ?? []
+		) as ChainablePromise;
+		const same = () => promise;
+		for (const method of [
+			"where",
+			"limit",
+			"orderBy",
+			"groupBy",
+			"innerJoin",
+			"leftJoin",
+		]) {
+			promise[method] = same;
+		}
+		return promise;
+	};
+	return {
+		select: () => ({ from: (table: unknown) => makeResult(table) }),
+		insert: () => ({ values: () => Promise.resolve(undefined) }),
+		update: () => ({
+			set: () => ({ where: () => Promise.resolve(undefined) }),
+		}),
+		delete: () => ({ where: () => Promise.resolve(undefined) }),
+	};
+}
+
+function makeCaller(userId: string, tableRows: Map<unknown, Rows>) {
+	return appRouter.createCaller({
+		session: { user: { id: userId } },
+		db: createMockDb(tableRows),
+	} as unknown as Parameters<typeof appRouter.createCaller>[0])
+		.liveTournamentSession;
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+const OWNER = "user-1";
+const OTHER = "user-2";
+
+const ownedSession = {
+	id: "s1",
+	userId: OWNER,
+	kind: "tournament",
+	status: "active",
+	source: "live",
+	roomId: null,
+	currencyId: null,
+};
+
+describe("liveTournamentSession.create ownership validation (SA2-102)", () => {
+	it("accepts a room and currency owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, [{ id: "room-1", userId: OWNER }]],
+			[currency, [{ id: "cur-1", userId: OWNER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).create({ roomId: "room-1", currencyId: "cur-1" })
+		).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
+	});
+
+	it("rejects a room owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, [{ id: "room-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ roomId: "room-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a currency owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a non-existent room with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ roomId: "room-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("rejects a non-existent currency with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[currency, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).create({ currencyId: "cur-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("does not validate ownership when room/currency are omitted", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, []],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expect(makeCaller(OWNER, rows).create({})).resolves.toEqual(
+			expect.objectContaining({ id: expect.any(String) })
+		);
+	});
+});
+
+describe("liveTournamentSession.update ownership validation (SA2-102)", () => {
+	it("accepts a room and currency owned by the caller", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OWNER }]],
+			[currency, [{ id: "cur-1", userId: OWNER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({
+				id: "s1",
+				roomId: "room-1",
+				currencyId: "cur-1",
+			})
+		).resolves.toBeDefined();
+	});
+
+	it("rejects a room owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", roomId: "room-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a currency owned by another user with FORBIDDEN", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("rejects a non-existent room with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", roomId: "room-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("rejects a non-existent currency with NOT_FOUND", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[currency, []],
+		]);
+		await expectTrpcCode(
+			makeCaller(OWNER, rows).update({ id: "s1", currencyId: "cur-x" }),
+			"NOT_FOUND"
+		);
+	});
+
+	it("clears roomId/currencyId with null without an ownership error", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({
+				id: "s1",
+				roomId: null,
+				currencyId: null,
+			})
+		).resolves.toBeDefined();
+	});
+
+	it("does not validate ownership when room/currency are omitted", async () => {
+		const rows = new Map<unknown, Rows>([
+			[gameSession, [ownedSession]],
+			[room, [{ id: "room-1", userId: OTHER }]],
+			[currency, [{ id: "cur-1", userId: OTHER }]],
+		]);
+		await expect(
+			makeCaller(OWNER, rows).update({ id: "s1", memo: "note" })
+		).resolves.toBeDefined();
+	});
+});
 
 describe("liveTournamentSession router", () => {
 	it("appRouter has liveTournamentSession namespace", () => {

--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -224,6 +224,13 @@ describe("liveTournamentSession.updateHeroSeat input validation", () => {
 		});
 	});
 
+	it("accepts heroSeatPosition 9 (last seat of a 10-max table)", () => {
+		expectAccepts(appRouter.liveTournamentSession.updateHeroSeat, {
+			id: "s1",
+			heroSeatPosition: 9,
+		});
+	});
+
 	it("accepts heroSeatPosition: null", () => {
 		expectAccepts(appRouter.liveTournamentSession.updateHeroSeat, {
 			id: "s1",
@@ -231,10 +238,10 @@ describe("liveTournamentSession.updateHeroSeat input validation", () => {
 		});
 	});
 
-	it("rejects seat > 8", () => {
+	it("rejects seat > 9", () => {
 		expectRejects(appRouter.liveTournamentSession.updateHeroSeat, {
 			id: "s1",
-			heroSeatPosition: 9,
+			heroSeatPosition: 10,
 		});
 	});
 });

--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -2,6 +2,7 @@ import { currency } from "@sapphire2/db/schema/currency";
 import { room } from "@sapphire2/db/schema/room";
 import { gameSession } from "@sapphire2/db/schema/session";
 import { TRPCError } from "@trpc/server";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it, vi } from "vitest";
 import { t } from "../index";
 import { appRouter } from "../routers";
@@ -806,5 +807,55 @@ describe("liveTournamentSession.create tournament ownership (IDOR guard)", () =>
 		expect(selectedTables).not.toContain("room");
 		expect(inserted.game_session).toHaveLength(1);
 		expect(inserted.session_blind_level).toBeUndefined();
+	});
+});
+
+const listCursorDialect = new SQLiteSyncDialect();
+
+/**
+ * Mock db recording the SQL params bound to the list query's `.where(...)` so
+ * the cursor-boundary subquery can be shown to be scoped to the caller
+ * (SA2-182). `select().from()` resolves to no rows; enrichment is skipped.
+ */
+function createListWhereMockDb() {
+	const selectWhereParams: unknown[][] = [];
+	const makeChain = () => {
+		const chain = Promise.resolve([] as Rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = () => chain;
+		chain.where = (cond: unknown) => {
+			selectWhereParams.push(
+				listCursorDialect.sqlToQuery(cond as never).params
+			);
+			return chain;
+		};
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.leftJoin = () => chain;
+		chain.innerJoin = () => chain;
+		return chain;
+	};
+	const db = { select: () => makeChain() };
+	return { db, selectWhereParams };
+}
+
+describe("liveTournamentSession.list cursor scoping (SA2-182)", () => {
+	it("scopes the cursor boundary subquery to the caller's user id", async () => {
+		const { db, selectWhereParams } = createListWhereMockDb();
+		await callerFor(db, OWNER).liveTournamentSession.list({
+			cursor: "s-cursor",
+			limit: 10,
+		});
+		const listWhere = selectWhereParams.find((p) => p.includes("s-cursor"));
+		expect(listWhere).toBeDefined();
+		// userId appears twice: the base filter + the cursor subquery scope.
+		expect((listWhere as unknown[]).filter((p) => p === OWNER)).toHaveLength(2);
+	});
+
+	it("does not add a cursor subquery when no cursor is supplied", async () => {
+		const { db, selectWhereParams } = createListWhereMockDb();
+		await callerFor(db, OWNER).liveTournamentSession.list({ limit: 10 });
+		const base = selectWhereParams[0] as unknown[];
+		expect(base.filter((p) => p === OWNER)).toHaveLength(1);
 	});
 });

--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -1,11 +1,59 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { appRouter } from "../routers";
+import { persistSessionBlindLevels } from "../routers/session";
 import {
 	expectAccepts,
 	expectProtected,
 	expectRejects,
 	expectType,
 } from "./test-utils";
+
+const BLIND_LEVEL_COLUMNS = 9;
+const MAX_ROWS_PER_INSERT = Math.floor(100 / BLIND_LEVEL_COLUMNS); // 11
+
+interface BlindLevelInput {
+	ante?: number | null;
+	blind1?: number | null;
+	blind2?: number | null;
+	blind3?: number | null;
+	isBreak: boolean;
+	minutes?: number | null;
+}
+
+interface InsertedRow {
+	level: number;
+	sessionId: string;
+}
+
+function makeBlindLevels(count: number): BlindLevelInput[] {
+	return Array.from({ length: count }, (_, i) => ({
+		isBreak: false,
+		blind1: (i + 1) * 100,
+		blind2: (i + 1) * 200,
+		blind3: null,
+		ante: null,
+		minutes: 15,
+	}));
+}
+
+function createBlindLevelMockDb() {
+	const deleteWhere = vi.fn().mockResolvedValue(undefined);
+	const del = vi.fn(() => ({ where: deleteWhere }));
+	const values = vi.fn().mockResolvedValue(undefined);
+	const insert = vi.fn(() => ({ values }));
+	return {
+		db: { delete: del, insert } as never,
+		del,
+		deleteWhere,
+		insert,
+		values,
+	};
+}
+
+/** The row array passed to each `.values()` call, in call order. */
+function insertedChunks(values: ReturnType<typeof vi.fn>): InsertedRow[][] {
+	return values.mock.calls.map((call) => call[0] as InsertedRow[]);
+}
 
 describe("liveTournamentSession router", () => {
 	it("appRouter has liveTournamentSession namespace", () => {
@@ -315,5 +363,89 @@ describe("liveTournamentSession.updateSnapshot input validation", () => {
 			id: "s1",
 			blindLevels: [{ blind1: 100 }],
 		});
+	});
+});
+
+// Regression guard for SA2-115: updateSnapshot re-seeds blind levels via the
+// shared persistSessionBlindLevels helper, which DELETEs then re-INSERTs. D1
+// rejects any statement binding >100 params, so a 9-column blind row must be
+// chunked at 11 rows/INSERT. A single unchunked INSERT of >=12 levels (>=108
+// params) would throw at runtime AFTER the DELETE already committed, wiping the
+// session's blind structure permanently.
+describe("persistSessionBlindLevels chunking (SA2-115)", () => {
+	it("splits >11 blind levels into multiple INSERTs each within D1's 100-param cap", async () => {
+		const { db, del, deleteWhere, insert, values } = createBlindLevelMockDb();
+
+		await persistSessionBlindLevels(db, "sess-1", makeBlindLevels(12));
+
+		// DELETE runs exactly once before any INSERT.
+		expect(del).toHaveBeenCalledTimes(1);
+		expect(deleteWhere).toHaveBeenCalledTimes(1);
+		// 12 rows -> 11 + 1 => two INSERT statements.
+		expect(insert).toHaveBeenCalledTimes(2);
+		expect(values).toHaveBeenCalledTimes(2);
+		const [firstChunk, secondChunk] = insertedChunks(values);
+		expect(firstChunk).toHaveLength(MAX_ROWS_PER_INSERT);
+		expect(secondChunk).toHaveLength(12 - MAX_ROWS_PER_INSERT);
+		// Every INSERT stays under the 100 bound-parameter cap.
+		for (const chunk of insertedChunks(values)) {
+			expect(chunk.length * BLIND_LEVEL_COLUMNS).toBeLessThanOrEqual(100);
+		}
+	});
+
+	it("inserts every level exactly once, in ascending level order across chunks", async () => {
+		const { db, values } = createBlindLevelMockDb();
+
+		await persistSessionBlindLevels(db, "sess-1", makeBlindLevels(23));
+
+		const allRows = insertedChunks(values).flat();
+		expect(allRows).toHaveLength(23);
+		expect(allRows.map((r) => r.level)).toEqual(
+			Array.from({ length: 23 }, (_, i) => i + 1)
+		);
+		for (const row of allRows) {
+			expect(row.sessionId).toBe("sess-1");
+		}
+	});
+
+	it("keeps a single INSERT for exactly 11 levels (chunk boundary)", async () => {
+		const { db, insert, values } = createBlindLevelMockDb();
+
+		await persistSessionBlindLevels(db, "sess-1", makeBlindLevels(11));
+
+		expect(insert).toHaveBeenCalledTimes(1);
+		expect(values).toHaveBeenCalledTimes(1);
+		expect(insertedChunks(values).flat()).toHaveLength(11);
+	});
+
+	it("splits into two INSERTs for 12 levels (one over the boundary)", async () => {
+		const { db, insert, values } = createBlindLevelMockDb();
+
+		await persistSessionBlindLevels(db, "sess-1", makeBlindLevels(12));
+
+		expect(insert).toHaveBeenCalledTimes(2);
+		expect(values).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps a single INSERT for the small-N case (behavior unchanged)", async () => {
+		const { db, del, insert, values } = createBlindLevelMockDb();
+
+		await persistSessionBlindLevels(db, "sess-1", makeBlindLevels(5));
+
+		expect(del).toHaveBeenCalledTimes(1);
+		expect(insert).toHaveBeenCalledTimes(1);
+		expect(values).toHaveBeenCalledTimes(1);
+		expect(insertedChunks(values).flat()).toHaveLength(5);
+	});
+
+	it("DELETEs only and issues no INSERT for an empty blind-level list", async () => {
+		const { db, del, deleteWhere, insert, values } = createBlindLevelMockDb();
+
+		await persistSessionBlindLevels(db, "sess-1", []);
+
+		expect(del).toHaveBeenCalledTimes(1);
+		expect(deleteWhere).toHaveBeenCalledTimes(1);
+		expect(insert).not.toHaveBeenCalled();
+		expect(values).not.toHaveBeenCalled();
 	});
 });

--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -383,6 +383,9 @@ describe("persistSessionBlindLevels chunking (SA2-115)", () => {
 		expect(deleteWhere).toHaveBeenCalledTimes(1);
 		// 12 rows -> 11 + 1 => two INSERT statements.
 		expect(insert).toHaveBeenCalledTimes(2);
+		expect(del.mock.invocationCallOrder[0]).toBeLessThan(
+			insert.mock.invocationCallOrder[0]
+		);
 		expect(values).toHaveBeenCalledTimes(2);
 		const [firstChunk, secondChunk] = insertedChunks(values);
 		expect(firstChunk).toHaveLength(MAX_ROWS_PER_INSERT);

--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -384,7 +384,6 @@ describe("liveTournamentSession.updateSnapshot input validation", () => {
 	});
 });
 
-<<<<<<< HEAD
 // Regression guard for SA2-115: updateSnapshot re-seeds blind levels via the
 // shared persistSessionBlindLevels helper, which DELETEs then re-INSERTs. D1
 // rejects any statement binding >100 params, so a 9-column blind row must be

--- a/packages/api/src/__tests__/player.test.ts
+++ b/packages/api/src/__tests__/player.test.ts
@@ -1,3 +1,9 @@
+import {
+	player,
+	playerTag,
+	playerToPlayerTag,
+} from "@sapphire2/db/schema/player";
+import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -6,6 +12,69 @@ import {
 	expectRejects,
 	expectType,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+
+/**
+ * Mock db keyed by schema-table reference: `select().from(t)...` resolves to
+ * the rows registered for `t`; `insert(t).values()` records the payload so a
+ * rejected tag-ownership guard can be shown to skip the `player_to_player_tag`
+ * write (SA2-178).
+ */
+function createMockDb(rowsByTable: Map<unknown, Rows>) {
+	const inserted: { table: unknown; values: unknown }[] = [];
+	const makeChain = (rows: Rows) => {
+		const chain = Promise.resolve(rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = (table: unknown) => makeChain(rowsByTable.get(table) ?? []);
+		chain.where = () => chain;
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.innerJoin = () => chain;
+		chain.leftJoin = () => chain;
+		return chain;
+	};
+	const db = {
+		select: () => makeChain([]),
+		insert: (table: unknown) => ({
+			values: (values: unknown) => {
+				inserted.push({ table, values });
+				return Promise.resolve(undefined);
+			},
+		}),
+		update: () => ({
+			set: () => ({ where: () => Promise.resolve(undefined) }),
+		}),
+		delete: () => ({ where: () => Promise.resolve(undefined) }),
+	};
+	return { db, inserted };
+}
+
+function makeCaller(userId: string, rowsByTable: Map<unknown, Rows>) {
+	const { db, inserted } = createMockDb(rowsByTable);
+	const caller = appRouter.createCaller({
+		session: { user: { id: userId } },
+		db,
+	} as unknown as Parameters<typeof appRouter.createCaller>[0]).player;
+	return { caller, inserted };
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+const OWNER = "user-1";
+const OTHER = "user-2";
 
 describe("player router structure", () => {
 	it("appRouter has player namespace", () => {
@@ -172,5 +241,102 @@ describe("player.delete input validation", () => {
 
 	it("rejects missing id", () => {
 		expectRejects(appRouter.player.delete, {});
+	});
+});
+
+describe("player.create tag ownership (SA2-178)", () => {
+	it("accepts tags owned by the caller and links them", async () => {
+		const rows = new Map<unknown, Rows>([
+			[playerTag, [{ id: "t1" }, { id: "t2" }]],
+			[player, [{ id: "p-new", userId: OWNER }]],
+			[playerToPlayerTag, []],
+		]);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expect(
+			caller.create({ name: "Alice", tagIds: ["t1", "t2"] })
+		).resolves.toBeDefined();
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(true);
+	});
+
+	it("rejects a tag owned by another user and skips the join insert", async () => {
+		const rows = new Map<unknown, Rows>([
+			// Only one of the two requested tags is owned by the caller.
+			[playerTag, [{ id: "t1" }]],
+			[player, [{ id: "p-new", userId: OWNER }]],
+		]);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expectTrpcCode(
+			caller.create({ name: "Alice", tagIds: ["t1", "t2"] }),
+			"FORBIDDEN"
+		);
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
+	});
+
+	it("does not validate tags when tagIds is omitted", async () => {
+		const rows = new Map<unknown, Rows>([
+			[player, [{ id: "p-new", userId: OWNER }]],
+			[playerToPlayerTag, []],
+		]);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expect(caller.create({ name: "Alice" })).resolves.toBeDefined();
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
+	});
+});
+
+describe("player.update tag ownership (SA2-178)", () => {
+	function ownedPlayerRows(extra: Map<unknown, Rows>) {
+		const map = new Map<unknown, Rows>([
+			[player, [{ id: "p1", userId: OWNER }]],
+			[playerToPlayerTag, []],
+		]);
+		for (const [k, v] of extra) {
+			map.set(k, v);
+		}
+		return map;
+	}
+
+	it("accepts tags owned by the caller and links them", async () => {
+		const rows = ownedPlayerRows(
+			new Map<unknown, Rows>([[playerTag, [{ id: "t1" }, { id: "t2" }]]])
+		);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expect(
+			caller.update({ id: "p1", tagIds: ["t1", "t2"] })
+		).resolves.toBeDefined();
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(true);
+	});
+
+	it("rejects a tag owned by another user and skips the join insert", async () => {
+		const rows = ownedPlayerRows(
+			new Map<unknown, Rows>([[playerTag, [{ id: "t1" }]]])
+		);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expectTrpcCode(
+			caller.update({ id: "p1", tagIds: ["t1", "t2"] }),
+			"FORBIDDEN"
+		);
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
+	});
+
+	it("does not validate tags when tagIds is omitted", async () => {
+		const rows = ownedPlayerRows(new Map());
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expect(
+			caller.update({ id: "p1", name: "Bob" })
+		).resolves.toBeDefined();
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
+	});
+
+	it("rejects updating a player owned by another user before touching tags", async () => {
+		const rows = new Map<unknown, Rows>([
+			[player, [{ id: "p1", userId: OTHER }]],
+			[playerTag, [{ id: "t1" }]],
+		]);
+		const { caller, inserted } = makeCaller(OWNER, rows);
+		await expectTrpcCode(
+			caller.update({ id: "p1", tagIds: ["t1"] }),
+			"FORBIDDEN"
+		);
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
 	});
 });

--- a/packages/api/src/__tests__/ring-game.test.ts
+++ b/packages/api/src/__tests__/ring-game.test.ts
@@ -244,7 +244,7 @@ describe("ringGame.{archive,restore,delete} input validation", () => {
 
 describe("ringGame currency ownership (SA2-180)", () => {
 	const ownedRoom = { id: "room-1", userId: CUR_OWNER };
-	const ownedRingGame = { id: "rg-1", roomId: "room-1" };
+	const ownedRingGame = { id: "rg-1", roomId: "room-1", userId: CUR_OWNER };
 
 	function createRows(currencyRows: Rows) {
 		return new Map<unknown, Rows>([
@@ -315,4 +315,75 @@ describe("ringGame currency ownership (SA2-180)", () => {
 			caller.update({ id: "rg-1", currencyId: null })
 		).resolves.toBeDefined();
 	});
+});
+
+describe("ringGame.create sets userId to the caller (SA2-181)", () => {
+	it("stamps the created ring game with the caller's userId", async () => {
+		const rowsByTable = new Map<unknown, Rows>([
+			[room, [{ id: "room-1", userId: CUR_OWNER }]],
+			[ringGame, []],
+			[currency, []],
+		]);
+		const inserted: Record<string, unknown>[] = [];
+		const baseDb = createMockDb(rowsByTable);
+		const db = {
+			...baseDb,
+			insert: () => ({
+				values: (v: Record<string, unknown>) => {
+					inserted.push(v);
+					return Promise.resolve(undefined);
+				},
+			}),
+		};
+		const caller = appRouter.createCaller({
+			session: { user: { id: CUR_OWNER } },
+			db,
+		} as unknown as Parameters<typeof appRouter.createCaller>[0]).ringGame;
+
+		await caller.create({ roomId: "room-1", name: "RG" });
+
+		expect(inserted).toHaveLength(1);
+		expect(inserted[0]).toMatchObject({ userId: CUR_OWNER, roomId: "room-1" });
+	});
+});
+
+describe("validateRingGameOwnership via mutations (SA2-181)", () => {
+	function ringGameRows(rg: Rows) {
+		return new Map<unknown, Rows>([
+			[room, []],
+			[ringGame, rg],
+			[currency, []],
+		]);
+	}
+
+	for (const op of ["update", "archive", "restore", "delete"] as const) {
+		it(`${op} resolves for a ring game owned by the caller (userId match)`, async () => {
+			const caller = ringGameCaller(
+				CUR_OWNER,
+				ringGameRows([{ id: "rg-1", roomId: null, userId: CUR_OWNER }])
+			);
+			await expect(caller[op]({ id: "rg-1" })).resolves.toBeDefined();
+		});
+
+		it(`${op} throws FORBIDDEN for a ring game owned by another user`, async () => {
+			const caller = ringGameCaller(
+				CUR_OWNER,
+				ringGameRows([{ id: "rg-1", roomId: "room-1", userId: CUR_OTHER }])
+			);
+			await expectTrpcCode(caller[op]({ id: "rg-1" }), "FORBIDDEN");
+		});
+
+		it(`${op} throws FORBIDDEN for a legacy row with null userId`, async () => {
+			const caller = ringGameCaller(
+				CUR_OWNER,
+				ringGameRows([{ id: "rg-1", roomId: null, userId: null }])
+			);
+			await expectTrpcCode(caller[op]({ id: "rg-1" }), "FORBIDDEN");
+		});
+
+		it(`${op} throws NOT_FOUND when the ring game does not exist`, async () => {
+			const caller = ringGameCaller(CUR_OWNER, ringGameRows([]));
+			await expectTrpcCode(caller[op]({ id: "missing" }), "NOT_FOUND");
+		});
+	}
 });

--- a/packages/api/src/__tests__/ring-game.test.ts
+++ b/packages/api/src/__tests__/ring-game.test.ts
@@ -1,3 +1,7 @@
+import { currency } from "@sapphire2/db/schema/currency";
+import { ringGame } from "@sapphire2/db/schema/ring-game";
+import { room } from "@sapphire2/db/schema/room";
+import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -7,6 +11,54 @@ import {
 	expectType,
 	getInputSchema,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+
+function createMockDb(rowsByTable: Map<unknown, Rows>) {
+	const makeChain = (rows: Rows) => {
+		const chain = Promise.resolve(rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = (table: unknown) => makeChain(rowsByTable.get(table) ?? []);
+		chain.where = () => chain;
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.innerJoin = () => chain;
+		chain.leftJoin = () => chain;
+		return chain;
+	};
+	return {
+		select: () => makeChain([]),
+		insert: () => ({ values: () => Promise.resolve(undefined) }),
+		update: () => ({
+			set: () => ({ where: () => Promise.resolve(undefined) }),
+		}),
+		delete: () => ({ where: () => Promise.resolve(undefined) }),
+	};
+}
+
+function ringGameCaller(userId: string, rowsByTable: Map<unknown, Rows>) {
+	return appRouter.createCaller({
+		session: { user: { id: userId } },
+		db: createMockDb(rowsByTable),
+	} as unknown as Parameters<typeof appRouter.createCaller>[0]).ringGame;
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+const CUR_OWNER = "user-1";
+const CUR_OTHER = "user-2";
 
 describe("ringGame router", () => {
 	it("appRouter has ringGame namespace", () => {
@@ -187,5 +239,80 @@ describe("ringGame.{archive,restore,delete} input validation", () => {
 		expectRejects(appRouter.ringGame.archive, {});
 		expectRejects(appRouter.ringGame.restore, {});
 		expectRejects(appRouter.ringGame.delete, {});
+	});
+});
+
+describe("ringGame currency ownership (SA2-180)", () => {
+	const ownedRoom = { id: "room-1", userId: CUR_OWNER };
+	const ownedRingGame = { id: "rg-1", roomId: "room-1" };
+
+	function createRows(currencyRows: Rows) {
+		return new Map<unknown, Rows>([
+			[room, [ownedRoom]],
+			[ringGame, [ownedRingGame]],
+			[currency, currencyRows],
+		]);
+	}
+
+	it("create accepts a currency owned by the caller", async () => {
+		const caller = ringGameCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OWNER }])
+		);
+		await expect(
+			caller.create({ roomId: "room-1", name: "RG", currencyId: "cur-1" })
+		).resolves.toBeDefined();
+	});
+
+	it("create rejects a currency owned by another user with FORBIDDEN", async () => {
+		const caller = ringGameCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expectTrpcCode(
+			caller.create({ roomId: "room-1", name: "RG", currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("create skips currency validation when currencyId is omitted", async () => {
+		const caller = ringGameCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expect(
+			caller.create({ roomId: "room-1", name: "RG" })
+		).resolves.toBeDefined();
+	});
+
+	it("update rejects a foreign currency with FORBIDDEN", async () => {
+		const caller = ringGameCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expectTrpcCode(
+			caller.update({ id: "rg-1", currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("update accepts a currency owned by the caller", async () => {
+		const caller = ringGameCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OWNER }])
+		);
+		await expect(
+			caller.update({ id: "rg-1", currencyId: "cur-1" })
+		).resolves.toBeDefined();
+	});
+
+	it("update allows clearing the currency with null", async () => {
+		const caller = ringGameCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expect(
+			caller.update({ id: "rg-1", currencyId: null })
+		).resolves.toBeDefined();
 	});
 });

--- a/packages/api/src/__tests__/session-table-player.test.ts
+++ b/packages/api/src/__tests__/session-table-player.test.ts
@@ -1,3 +1,10 @@
+import {
+	player,
+	playerTag,
+	playerToPlayerTag,
+} from "@sapphire2/db/schema/player";
+import { gameSession } from "@sapphire2/db/schema/session";
+import { TRPCError } from "@trpc/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -461,5 +468,114 @@ describe("insertPlayerLeaveEvent (write-side ordering contract)", () => {
 		expect(JSON.parse(inserted.payload as string)).toEqual({
 			playerId: "player-abc",
 		});
+	});
+});
+
+describe("sessionTablePlayer.addNew tag ownership (SA2-178)", () => {
+	type Rows = Record<string, unknown>[];
+	const OWNER = "owner-1";
+
+	function createMockDb(rowsByTable: Map<unknown, Rows>) {
+		const inserted: { table: unknown; values: unknown }[] = [];
+		const makeChain = (rows: Rows) => {
+			const chain = Promise.resolve(rows) as Promise<Rows> &
+				Record<string, (...args: unknown[]) => unknown>;
+			chain.from = (table: unknown) => makeChain(rowsByTable.get(table) ?? []);
+			chain.where = () => chain;
+			chain.orderBy = () => chain;
+			chain.limit = () => chain;
+			chain.innerJoin = () => chain;
+			chain.leftJoin = () => chain;
+			return chain;
+		};
+		return {
+			db: {
+				select: () => makeChain([]),
+				insert: (table: unknown) => ({
+					values: (values: unknown) => {
+						inserted.push({ table, values });
+						return Promise.resolve(undefined);
+					},
+				}),
+				update: () => ({
+					set: () => ({ where: () => Promise.resolve(undefined) }),
+				}),
+				delete: () => ({ where: () => Promise.resolve(undefined) }),
+			},
+			inserted,
+		};
+	}
+
+	function makeCaller(rowsByTable: Map<unknown, Rows>) {
+		const { db, inserted } = createMockDb(rowsByTable);
+		const caller = appRouter.createCaller({
+			session: { user: { id: OWNER } },
+			db,
+		} as unknown as Parameters<
+			typeof appRouter.createCaller
+		>[0]).sessionTablePlayer;
+		return { caller, inserted };
+	}
+
+	function ownedSessionRows(extra: Map<unknown, Rows>) {
+		const map = new Map<unknown, Rows>([
+			[gameSession, [{ id: "s1", userId: OWNER, kind: "cash_game" }]],
+		]);
+		for (const [k, v] of extra) {
+			map.set(k, v);
+		}
+		return map;
+	}
+
+	async function expectForbidden(promise: Promise<unknown>): Promise<void> {
+		try {
+			await promise;
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+			expect((error as { code: string }).code).toBe("FORBIDDEN");
+			return;
+		}
+		throw new Error("expected the call to throw FORBIDDEN but it resolved");
+	}
+
+	it("accepts player tags owned by the caller and links them", async () => {
+		const rows = ownedSessionRows(
+			new Map<unknown, Rows>([[playerTag, [{ id: "t1" }, { id: "t2" }]]])
+		);
+		const { caller, inserted } = makeCaller(rows);
+		await expect(
+			caller.addNew({
+				sessionId: "s1",
+				playerName: "Alice",
+				playerTagIds: ["t1", "t2"],
+			})
+		).resolves.toBeDefined();
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(true);
+	});
+
+	it("rejects a player tag owned by another user and skips the join insert", async () => {
+		const rows = ownedSessionRows(
+			new Map<unknown, Rows>([[playerTag, [{ id: "t1" }]]])
+		);
+		const { caller, inserted } = makeCaller(rows);
+		await expectForbidden(
+			caller.addNew({
+				sessionId: "s1",
+				playerName: "Alice",
+				playerTagIds: ["t1", "t2"],
+			})
+		);
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
+	});
+
+	it("does not validate tags when playerTagIds is omitted", async () => {
+		const rows = ownedSessionRows(new Map());
+		const { caller, inserted } = makeCaller(rows);
+		await expect(
+			caller.addNew({ sessionId: "s1", playerName: "Alice" })
+		).resolves.toBeDefined();
+		expect(inserted.some((i) => i.table === playerToPlayerTag)).toBe(false);
+		// The player itself is still created.
+		expect(inserted.some((i) => i.table === player)).toBe(true);
 	});
 });

--- a/packages/api/src/__tests__/session-table-player.test.ts
+++ b/packages/api/src/__tests__/session-table-player.test.ts
@@ -88,7 +88,7 @@ describe("sessionTablePlayer.add input validation", () => {
 		});
 	});
 
-	it("accepts seat position in range [0, 8]", () => {
+	it("accepts seat position in range [0, 9]", () => {
 		expectAccepts(appRouter.sessionTablePlayer.add, {
 			liveCashGameSessionId: "lcg1",
 			playerId: "p1",
@@ -101,11 +101,19 @@ describe("sessionTablePlayer.add input validation", () => {
 		});
 	});
 
+	it("accepts seat position 9 (last seat of a 10-max table)", () => {
+		expectAccepts(appRouter.sessionTablePlayer.add, {
+			liveCashGameSessionId: "lcg1",
+			playerId: "p1",
+			seatPosition: 9,
+		});
+	});
+
 	it("rejects seat position out of range", () => {
 		expectRejects(appRouter.sessionTablePlayer.add, {
 			liveCashGameSessionId: "lcg1",
 			playerId: "p1",
-			seatPosition: 9,
+			seatPosition: 10,
 		});
 		expectRejects(appRouter.sessionTablePlayer.add, {
 			liveCashGameSessionId: "lcg1",
@@ -160,11 +168,19 @@ describe("sessionTablePlayer.addNew input validation", () => {
 		});
 	});
 
-	it("rejects seat position > 8", () => {
-		expectRejects(appRouter.sessionTablePlayer.addNew, {
+	it("accepts seat position 9 (last seat of a 10-max table)", () => {
+		expectAccepts(appRouter.sessionTablePlayer.addNew, {
 			liveCashGameSessionId: "lcg1",
 			playerName: "Guest",
 			seatPosition: 9,
+		});
+	});
+
+	it("rejects seat position > 9", () => {
+		expectRejects(appRouter.sessionTablePlayer.addNew, {
+			liveCashGameSessionId: "lcg1",
+			playerName: "Guest",
+			seatPosition: 10,
 		});
 	});
 });
@@ -191,11 +207,19 @@ describe("sessionTablePlayer.updateSeat input validation", () => {
 		});
 	});
 
-	it("rejects seat position out of [0, 8]", () => {
-		expectRejects(appRouter.sessionTablePlayer.updateSeat, {
+	it("accepts seat position 9 (last seat of a 10-max table)", () => {
+		expectAccepts(appRouter.sessionTablePlayer.updateSeat, {
 			liveCashGameSessionId: "lcg1",
 			playerId: "p1",
 			seatPosition: 9,
+		});
+	});
+
+	it("rejects seat position out of [0, 9]", () => {
+		expectRejects(appRouter.sessionTablePlayer.updateSeat, {
+			liveCashGameSessionId: "lcg1",
+			playerId: "p1",
+			seatPosition: 10,
 		});
 	});
 
@@ -237,10 +261,17 @@ describe("sessionTablePlayer.addTemporary input validation", () => {
 		});
 	});
 
-	it("rejects seat position > 8", () => {
-		expectRejects(appRouter.sessionTablePlayer.addTemporary, {
+	it("accepts seat position 9 (last seat of a 10-max table)", () => {
+		expectAccepts(appRouter.sessionTablePlayer.addTemporary, {
 			liveCashGameSessionId: "lcg1",
 			seatPosition: 9,
+		});
+	});
+
+	it("rejects seat position > 9", () => {
+		expectRejects(appRouter.sessionTablePlayer.addTemporary, {
+			liveCashGameSessionId: "lcg1",
+			seatPosition: 10,
 		});
 	});
 });

--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -10,7 +10,9 @@ import {
 	parseSessionCursor,
 	selectInChunks,
 	toProfitLossSeriesPoint,
+	validateEntityOwnership,
 } from "../routers/session";
+import { createChainableMockDb } from "./test-utils";
 
 const DERIVED_FIELDS_RE = /Cannot edit fields derived from live session events/;
 const RING_CONFIG_RE = /variant|blind1|blind2/;
@@ -880,5 +882,71 @@ describe("computeTournamentPL", () => {
 	it("adds bounty prizes to income", () => {
 		// income (0 + 400) - cost (100 + 0 + 0) = 300
 		expect(computeTournamentPL(100, 0, 0, 0, 400)).toBe(300);
+	});
+});
+
+describe("validateEntityOwnership (tournament branch)", () => {
+	const CALLER = "user-1";
+	const OTHER = "user-2";
+	const TOURNAMENT_ID = "tn-1";
+	const ROOM_ID = "room-1";
+
+	function mockDbFor(opts: {
+		tournament?: Record<string, unknown>[];
+		room?: Record<string, unknown>[];
+	}) {
+		return createChainableMockDb({
+			select: {
+				tournament: opts.tournament ?? [],
+				room: opts.room ?? [],
+			},
+		});
+	}
+
+	it("resolves when the tournament's room is owned by the caller", async () => {
+		const { db, selectedTables } = mockDbFor({
+			tournament: [{ id: TOURNAMENT_ID, roomId: ROOM_ID }],
+			room: [{ id: ROOM_ID, userId: CALLER }],
+		});
+		await expect(
+			validateEntityOwnership(db, "tournament", TOURNAMENT_ID, CALLER)
+		).resolves.toBeUndefined();
+		// The room must be read to confirm ownership.
+		expect(selectedTables).toEqual(["tournament", "room"]);
+	});
+
+	it("throws FORBIDDEN when the tournament's room belongs to another user", async () => {
+		const { db } = mockDbFor({
+			tournament: [{ id: TOURNAMENT_ID, roomId: ROOM_ID }],
+			room: [{ id: ROOM_ID, userId: OTHER }],
+		});
+		await expect(
+			validateEntityOwnership(db, "tournament", TOURNAMENT_ID, CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this tournament",
+		});
+	});
+
+	it("throws NOT_FOUND when the tournament does not exist", async () => {
+		const { db, selectedTables } = mockDbFor({ tournament: [] });
+		await expect(
+			validateEntityOwnership(db, "tournament", "missing", CALLER)
+		).rejects.toMatchObject({
+			code: "NOT_FOUND",
+			message: "Tournament not found",
+		});
+		// Must short-circuit before reading the room.
+		expect(selectedTables).toEqual(["tournament"]);
+	});
+
+	it("throws FORBIDDEN when the tournament's room row is missing", async () => {
+		const { db } = mockDbFor({
+			tournament: [{ id: TOURNAMENT_ID, roomId: ROOM_ID }],
+			room: [],
+		});
+		await expect(
+			validateEntityOwnership(db, "tournament", TOURNAMENT_ID, CALLER)
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
 	});
 });

--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -953,7 +953,7 @@ describe("validateEntityOwnership (tournament branch)", () => {
 	});
 });
 
-describe("validateEntityOwnership (ringGame branch) (SA2-174)", () => {
+describe("validateEntityOwnership (ringGame branch) (SA2-181)", () => {
 	const CALLER = "user-1";
 	const OTHER = "user-2";
 	const RING_GAME_ID = "rg-1";
@@ -971,43 +971,51 @@ describe("validateEntityOwnership (ringGame branch) (SA2-174)", () => {
 		});
 	}
 
-	it("resolves when the ring game's room is owned by the caller", async () => {
+	it("resolves when the ring game's userId matches the caller", async () => {
 		const { db, selectedTables } = mockDbFor({
-			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID }],
-			room: [{ id: ROOM_ID, userId: CALLER }],
+			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID, userId: CALLER }],
 		});
 		await expect(
 			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
 		).resolves.toBeUndefined();
-		// The room must be read to confirm ownership.
-		expect(selectedTables).toEqual(["ring_game", "room"]);
-	});
-
-	it("throws FORBIDDEN when the ring game's room belongs to another user", async () => {
-		const { db } = mockDbFor({
-			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID }],
-			room: [{ id: ROOM_ID, userId: OTHER }],
-		});
-		await expect(
-			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
-		).rejects.toMatchObject({
-			code: "FORBIDDEN",
-			message: "You do not own this ring game",
-		});
-	});
-
-	it("throws FORBIDDEN when the ring game has a null roomId (auto-generated row)", async () => {
-		const { db, selectedTables } = mockDbFor({
-			ringGame: [{ id: RING_GAME_ID, roomId: null }],
-		});
-		await expect(
-			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
-		).rejects.toMatchObject({
-			code: "FORBIDDEN",
-			message: "You do not own this ring game",
-		});
-		// Ownership cannot be proven; must not fall through to reading a room.
+		// Ownership is a direct userId check; the room is never read (SA2-181).
 		expect(selectedTables).toEqual(["ring_game"]);
+	});
+
+	it("resolves for a null-roomId auto-generated row owned via userId", async () => {
+		const { db, selectedTables } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: null, userId: CALLER }],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).resolves.toBeUndefined();
+		expect(selectedTables).toEqual(["ring_game"]);
+	});
+
+	it("throws FORBIDDEN when the ring game belongs to another user", async () => {
+		const { db, selectedTables } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID, userId: OTHER }],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
+		// Must not fall through to reading a room.
+		expect(selectedTables).toEqual(["ring_game"]);
+	});
+
+	it("throws FORBIDDEN for a legacy row with a null userId", async () => {
+		const { db } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: null, userId: null }],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
 	});
 
 	it("throws NOT_FOUND when the ring game does not exist", async () => {
@@ -1018,20 +1026,32 @@ describe("validateEntityOwnership (ringGame branch) (SA2-174)", () => {
 			code: "NOT_FOUND",
 			message: "Ring game not found",
 		});
-		// Must short-circuit before reading the room.
 		expect(selectedTables).toEqual(["ring_game"]);
 	});
+});
 
-	it("throws FORBIDDEN when the ring game's room row is missing", async () => {
-		const { db } = mockDbFor({
-			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID }],
-			room: [],
+describe("session.create auto-generated ring game ownership (SA2-181)", () => {
+	const CALLER = "user-1";
+
+	it("stamps the creating user's id on the auto-generated ring_game", async () => {
+		const { db, inserted } = createChainableMockDb({ select: {} });
+		const caller = appRouter.createCaller({
+			session: { user: { id: CALLER } },
+			db,
+		} as unknown as Parameters<typeof appRouter.createCaller>[0]);
+
+		await caller.session.create({
+			type: "cash_game",
+			sessionDate: 1_700_000_000,
+			buyIn: 1000,
+			cashOut: 2000,
 		});
-		await expect(
-			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
-		).rejects.toMatchObject({
-			code: "FORBIDDEN",
-			message: "You do not own this ring game",
+
+		const ringGameInserts = inserted.ring_game ?? [];
+		expect(ringGameInserts).toHaveLength(1);
+		expect(ringGameInserts[0]).toMatchObject({
+			userId: CALLER,
+			roomId: null,
 		});
 	});
 });

--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -1,3 +1,4 @@
+import { sessionTag } from "@sapphire2/db/schema/session-tag";
 import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
@@ -11,6 +12,7 @@ import {
 	selectInChunks,
 	toProfitLossSeriesPoint,
 	validateEntityOwnership,
+	validateTagsOwnership,
 } from "../routers/session";
 import { createChainableMockDb } from "./test-utils";
 
@@ -947,6 +949,147 @@ describe("validateEntityOwnership (tournament branch)", () => {
 		});
 		await expect(
 			validateEntityOwnership(db, "tournament", TOURNAMENT_ID, CALLER)
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+	});
+});
+
+describe("validateEntityOwnership (ringGame branch) (SA2-174)", () => {
+	const CALLER = "user-1";
+	const OTHER = "user-2";
+	const RING_GAME_ID = "rg-1";
+	const ROOM_ID = "room-1";
+
+	function mockDbFor(opts: {
+		ringGame?: Record<string, unknown>[];
+		room?: Record<string, unknown>[];
+	}) {
+		return createChainableMockDb({
+			select: {
+				ring_game: opts.ringGame ?? [],
+				room: opts.room ?? [],
+			},
+		});
+	}
+
+	it("resolves when the ring game's room is owned by the caller", async () => {
+		const { db, selectedTables } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID }],
+			room: [{ id: ROOM_ID, userId: CALLER }],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).resolves.toBeUndefined();
+		// The room must be read to confirm ownership.
+		expect(selectedTables).toEqual(["ring_game", "room"]);
+	});
+
+	it("throws FORBIDDEN when the ring game's room belongs to another user", async () => {
+		const { db } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID }],
+			room: [{ id: ROOM_ID, userId: OTHER }],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
+	});
+
+	it("throws FORBIDDEN when the ring game has a null roomId (auto-generated row)", async () => {
+		const { db, selectedTables } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: null }],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
+		// Ownership cannot be proven; must not fall through to reading a room.
+		expect(selectedTables).toEqual(["ring_game"]);
+	});
+
+	it("throws NOT_FOUND when the ring game does not exist", async () => {
+		const { db, selectedTables } = mockDbFor({ ringGame: [] });
+		await expect(
+			validateEntityOwnership(db, "ringGame", "missing", CALLER)
+		).rejects.toMatchObject({
+			code: "NOT_FOUND",
+			message: "Ring game not found",
+		});
+		// Must short-circuit before reading the room.
+		expect(selectedTables).toEqual(["ring_game"]);
+	});
+
+	it("throws FORBIDDEN when the ring game's room row is missing", async () => {
+		const { db } = mockDbFor({
+			ringGame: [{ id: RING_GAME_ID, roomId: ROOM_ID }],
+			room: [],
+		});
+		await expect(
+			validateEntityOwnership(db, "ringGame", RING_GAME_ID, CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
+	});
+});
+
+describe("validateTagsOwnership (SA2-177)", () => {
+	const CALLER = "user-1";
+
+	it("resolves without reading when ids is undefined", async () => {
+		const { db, selectedTables } = createChainableMockDb();
+		await expect(
+			validateTagsOwnership(db, sessionTag, undefined, CALLER)
+		).resolves.toBeUndefined();
+		expect(selectedTables).toEqual([]);
+	});
+
+	it("resolves without reading when ids is empty", async () => {
+		const { db, selectedTables } = createChainableMockDb();
+		await expect(
+			validateTagsOwnership(db, sessionTag, [], CALLER)
+		).resolves.toBeUndefined();
+		expect(selectedTables).toEqual([]);
+	});
+
+	it("resolves when every tag is owned by the caller", async () => {
+		const { db, selectedTables } = createChainableMockDb({
+			select: { session_tag: [{ id: "t1" }, { id: "t2" }] },
+		});
+		await expect(
+			validateTagsOwnership(db, sessionTag, ["t1", "t2"], CALLER)
+		).resolves.toBeUndefined();
+		expect(selectedTables).toEqual(["session_tag"]);
+	});
+
+	it("deduplicates ids before comparing the owned count", async () => {
+		const { db } = createChainableMockDb({
+			select: { session_tag: [{ id: "t1" }] },
+		});
+		await expect(
+			validateTagsOwnership(db, sessionTag, ["t1", "t1"], CALLER)
+		).resolves.toBeUndefined();
+	});
+
+	it("throws FORBIDDEN when a tag is owned by another user (fewer rows returned)", async () => {
+		const { db } = createChainableMockDb({
+			select: { session_tag: [{ id: "t1" }] },
+		});
+		await expect(
+			validateTagsOwnership(db, sessionTag, ["t1", "t2"], CALLER)
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: "You do not own one or more of these tags",
+		});
+	});
+
+	it("throws FORBIDDEN when none of the tags are owned", async () => {
+		const { db } = createChainableMockDb({ select: { session_tag: [] } });
+		await expect(
+			validateTagsOwnership(db, sessionTag, ["t1"], CALLER)
 		).rejects.toMatchObject({ code: "FORBIDDEN" });
 	});
 });

--- a/packages/api/src/__tests__/test-utils.ts
+++ b/packages/api/src/__tests__/test-utils.ts
@@ -1,4 +1,5 @@
-import { expect } from "vitest";
+import { getTableName } from "drizzle-orm";
+import { expect, vi } from "vitest";
 
 interface ZodLikeSchema {
 	safeParse: (value: unknown) => { success: boolean };
@@ -73,4 +74,70 @@ export function expectType(
 	type: "mutation" | "query" | "subscription"
 ): void {
 	expect(getProcedureDef(procedure).type).toBe(type);
+}
+
+type MockRow = Record<string, unknown>;
+
+interface ChainableMockDbConfig {
+	/** Rows returned by `select().from(table)…` keyed by the SQL table name. */
+	select?: Record<string, MockRow[]>;
+}
+
+/**
+ * A minimal chainable Drizzle-style mock `db` for exercising router
+ * procedures / helpers end-to-end without a real database.
+ *
+ * `select()` chains (`.from().where().limit().orderBy()`) resolve to the rows
+ * configured for the table passed to `.from(table)` (matched via
+ * `getTableName`); `insert(table).values(rows)` records the inserted payload.
+ * It tracks which tables were read (`selectedTables`) so ownership guards can
+ * be asserted, and which tables were written (`inserted`).
+ */
+export function createChainableMockDb(config: ChainableMockDbConfig = {}) {
+	const selectRows = config.select ?? {};
+	const inserted: Record<string, unknown[]> = {};
+	const selectedTables: string[] = [];
+
+	// The chain is a real Promise (so `await`-ing any step resolves the rows
+	// natively) with Drizzle's builder methods attached. Non-terminal steps
+	// (`where` / `limit` / `orderBy` / joins) return the same promise; `from`
+	// starts a fresh chain scoped to the table's configured rows.
+	function makeSelectChain(rows: MockRow[]) {
+		const chain = Promise.resolve(rows) as Promise<MockRow[]> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = (table: unknown) => {
+			const name = getTableName(table as never);
+			selectedTables.push(name);
+			return makeSelectChain(selectRows[name] ?? []);
+		};
+		chain.where = () => chain;
+		chain.limit = () => chain;
+		chain.orderBy = () => chain;
+		chain.leftJoin = () => chain;
+		chain.innerJoin = () => chain;
+		return chain;
+	}
+
+	const select = vi.fn(() => makeSelectChain([]));
+	const insert = vi.fn((table: unknown) => ({
+		values: vi.fn((values: unknown) => {
+			const name = getTableName(table as never);
+			const bucket = inserted[name] ?? [];
+			bucket.push(values);
+			inserted[name] = bucket;
+			return Promise.resolve(undefined);
+		}),
+	}));
+	const del = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }));
+	const update = vi.fn(() => ({
+		set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+	}));
+
+	return {
+		db: { select, insert, delete: del, update } as never,
+		select,
+		insert,
+		inserted,
+		selectedTables,
+	};
 }

--- a/packages/api/src/__tests__/tournament-chip-purchase.test.ts
+++ b/packages/api/src/__tests__/tournament-chip-purchase.test.ts
@@ -1,3 +1,10 @@
+import { room } from "@sapphire2/db/schema/room";
+import {
+	tournament,
+	tournamentChipPurchase,
+} from "@sapphire2/db/schema/tournament";
+import { TRPCError } from "@trpc/server";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -6,6 +13,69 @@ import {
 	expectRejects,
 	expectType,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+const dialect = new SQLiteSyncDialect();
+
+function makeSelectChain(rows: Rows) {
+	const chain = Promise.resolve(rows) as Promise<Rows> &
+		Record<string, () => unknown>;
+	chain.where = () => chain;
+	chain.orderBy = () => chain;
+	chain.limit = () => chain;
+	return chain;
+}
+
+/**
+ * Mock db that resolves `select().from(table)` from a table-keyed map and
+ * records the SQL params bound to each `update().set().where(cond)` so tests
+ * can assert the WHERE predicate is scoped to the owned tournament (SA2-123).
+ */
+function createReorderMockDb(rowsByTable: Map<unknown, Rows>) {
+	const updateWhereParams: unknown[][] = [];
+	const db = {
+		select: () => ({
+			from: (table: unknown) => makeSelectChain(rowsByTable.get(table) ?? []),
+		}),
+		update: () => ({
+			set: () => ({
+				where: (cond: unknown) => {
+					updateWhereParams.push(dialect.sqlToQuery(cond as never).params);
+					return Promise.resolve(undefined);
+				},
+			}),
+		}),
+	};
+	return { db, updateWhereParams };
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+function makeCaller(userId: string, rowsByTable: Map<unknown, Rows>) {
+	const { db, updateWhereParams } = createReorderMockDb(rowsByTable);
+	const caller = appRouter.createCaller({
+		session: { user: { id: userId } },
+		db,
+	} as unknown as Parameters<
+		typeof appRouter.createCaller
+	>[0]).tournamentChipPurchase;
+	return { caller, updateWhereParams };
+}
+
+const CALLER = "user-1";
+const OTHER = "user-2";
 
 describe("tournamentChipPurchase router structure", () => {
 	it("appRouter has tournamentChipPurchase namespace", () => {
@@ -177,5 +247,45 @@ describe("tournamentChipPurchase.reorder input validation", () => {
 			tournamentId: "tn1",
 			ids: ["cp1", 42],
 		});
+	});
+});
+
+describe("tournamentChipPurchase.reorder tournament scoping (SA2-123)", () => {
+	function ownedRows() {
+		return new Map<unknown, Rows>([
+			[tournament, [{ id: "tn1", roomId: "room1" }]],
+			[room, [{ id: "room1", userId: CALLER }]],
+			[tournamentChipPurchase, [{ id: "cp1", sortOrder: 0 }]],
+		]);
+	}
+
+	it("scopes each UPDATE to both the row id and the owned tournament", async () => {
+		const { caller, updateWhereParams } = makeCaller(CALLER, ownedRows());
+		await caller.reorder({ tournamentId: "tn1", ids: ["cp1", "cp2"] });
+		expect(updateWhereParams).toHaveLength(2);
+		expect(updateWhereParams[0]).toContain("cp1");
+		expect(updateWhereParams[0]).toContain("tn1");
+		expect(updateWhereParams[1]).toContain("cp2");
+		expect(updateWhereParams[1]).toContain("tn1");
+	});
+
+	it("runs no UPDATE when ids is empty", async () => {
+		const { caller, updateWhereParams } = makeCaller(CALLER, ownedRows());
+		await caller.reorder({ tournamentId: "tn1", ids: [] });
+		expect(updateWhereParams).toHaveLength(0);
+	});
+
+	it("throws FORBIDDEN and runs no UPDATE when the tournament is owned by another user", async () => {
+		const rows = new Map<unknown, Rows>([
+			[tournament, [{ id: "tn1", roomId: "room1" }]],
+			[room, [{ id: "room1", userId: OTHER }]],
+			[tournamentChipPurchase, []],
+		]);
+		const { caller, updateWhereParams } = makeCaller(CALLER, rows);
+		await expectTrpcCode(
+			caller.reorder({ tournamentId: "tn1", ids: ["cp1"] }),
+			"FORBIDDEN"
+		);
+		expect(updateWhereParams).toHaveLength(0);
 	});
 });

--- a/packages/api/src/__tests__/tournament.test.ts
+++ b/packages/api/src/__tests__/tournament.test.ts
@@ -1,3 +1,7 @@
+import { currency } from "@sapphire2/db/schema/currency";
+import { room } from "@sapphire2/db/schema/room";
+import { tournament } from "@sapphire2/db/schema/tournament";
+import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -7,6 +11,54 @@ import {
 	expectType,
 	getInputSchema,
 } from "./test-utils";
+
+type Rows = Record<string, unknown>[];
+
+function createMockDb(rowsByTable: Map<unknown, Rows>) {
+	const makeChain = (rows: Rows) => {
+		const chain = Promise.resolve(rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.from = (table: unknown) => makeChain(rowsByTable.get(table) ?? []);
+		chain.where = () => chain;
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.innerJoin = () => chain;
+		chain.leftJoin = () => chain;
+		return chain;
+	};
+	return {
+		select: () => makeChain([]),
+		insert: () => ({ values: () => Promise.resolve(undefined) }),
+		update: () => ({
+			set: () => ({ where: () => Promise.resolve(undefined) }),
+		}),
+		delete: () => ({ where: () => Promise.resolve(undefined) }),
+	};
+}
+
+function tournamentCaller(userId: string, rowsByTable: Map<unknown, Rows>) {
+	return appRouter.createCaller({
+		session: { user: { id: userId } },
+		db: createMockDb(rowsByTable),
+	} as unknown as Parameters<typeof appRouter.createCaller>[0]).tournament;
+}
+
+async function expectTrpcCode(
+	promise: Promise<unknown>,
+	code: TRPCError["code"]
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+		return;
+	}
+	throw new Error(`expected the call to throw ${code} but it resolved`);
+}
+
+const CUR_OWNER = "user-1";
+const CUR_OTHER = "user-2";
 
 describe("tournament router", () => {
 	it("appRouter has tournament namespace", () => {
@@ -283,5 +335,116 @@ describe("tournament.{archive,restore,delete,getById} input validation", () => {
 		expectRejects(appRouter.tournament.restore, {});
 		expectRejects(appRouter.tournament.delete, {});
 		expectRejects(appRouter.tournament.getById, {});
+	});
+});
+
+describe("tournament currency ownership (SA2-180)", () => {
+	const ownedRoom = { id: "room-1", userId: CUR_OWNER };
+	const ownedTournament = { id: "tn-1", roomId: "room-1" };
+
+	function createRows(currencyRows: Rows) {
+		return new Map<unknown, Rows>([
+			[room, [ownedRoom]],
+			[tournament, [ownedTournament]],
+			[currency, currencyRows],
+		]);
+	}
+
+	it("create accepts a currency owned by the caller", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OWNER }])
+		);
+		await expect(
+			caller.create({ roomId: "room-1", name: "T", currencyId: "cur-1" })
+		).resolves.toBeDefined();
+	});
+
+	it("create rejects a currency owned by another user with FORBIDDEN", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expectTrpcCode(
+			caller.create({ roomId: "room-1", name: "T", currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("create skips currency validation when currencyId is omitted", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expect(
+			caller.create({ roomId: "room-1", name: "T" })
+		).resolves.toBeDefined();
+	});
+
+	it("update rejects a foreign currency with FORBIDDEN", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expectTrpcCode(
+			caller.update({ id: "tn-1", currencyId: "cur-1" }),
+			"FORBIDDEN"
+		);
+	});
+
+	it("update allows clearing the currency with null", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expect(
+			caller.update({ id: "tn-1", currencyId: null })
+		).resolves.toBeDefined();
+	});
+
+	it("createWithLevels rejects a foreign currency with FORBIDDEN", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expectTrpcCode(
+			caller.createWithLevels({
+				roomId: "room-1",
+				name: "T",
+				currencyId: "cur-1",
+				blindLevels: [],
+			}),
+			"FORBIDDEN"
+		);
+	});
+
+	it("updateWithLevels rejects a foreign currency with FORBIDDEN", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OTHER }])
+		);
+		await expectTrpcCode(
+			caller.updateWithLevels({
+				id: "tn-1",
+				currencyId: "cur-1",
+				blindLevels: [],
+			}),
+			"FORBIDDEN"
+		);
+	});
+
+	it("createWithLevels accepts a currency owned by the caller", async () => {
+		const caller = tournamentCaller(
+			CUR_OWNER,
+			createRows([{ id: "cur-1", userId: CUR_OWNER }])
+		);
+		await expect(
+			caller.createWithLevels({
+				roomId: "room-1",
+				name: "T",
+				currencyId: "cur-1",
+				blindLevels: [],
+			})
+		).resolves.toBeDefined();
 	});
 });

--- a/packages/api/src/routers/blind-level.ts
+++ b/packages/api/src/routers/blind-level.ts
@@ -1,7 +1,7 @@
 import { room } from "@sapphire2/db/schema/room";
 import { blindLevel, tournament } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
 
@@ -196,7 +196,14 @@ export const blindLevelRouter = router({
 					ctx.db
 						.update(blindLevel)
 						.set({ level: index + 1 })
-						.where(eq(blindLevel.id, id))
+						// Scope to the owned tournament so a foreign levelId matches
+						// nothing (write-IDOR, SA2-176).
+						.where(
+							and(
+								eq(blindLevel.id, id),
+								eq(blindLevel.tournamentId, input.tournamentId)
+							)
+						)
 				)
 			);
 

--- a/packages/api/src/routers/currency-transaction.ts
+++ b/packages/api/src/routers/currency-transaction.ts
@@ -14,6 +14,41 @@ import { paginate } from "./_pagination";
 
 const PAGE_SIZE = 10;
 
+type DbInstance = Parameters<
+	Parameters<typeof protectedProcedure.query>[0]
+>[0]["ctx"]["db"];
+
+/**
+ * Verifies the referenced transaction type belongs to the caller before it is
+ * linked to a transaction. Without this a caller could attach another user's
+ * transaction type id to their own transaction (read-IDOR, SA2-179). Mirrors
+ * the currency-ownership check already used in create / update below.
+ */
+async function validateTransactionTypeOwnership(
+	db: DbInstance,
+	transactionTypeId: string,
+	userId: string
+) {
+	const [found] = await db
+		.select()
+		.from(transactionType)
+		.where(eq(transactionType.id, transactionTypeId));
+
+	if (!found) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Transaction type not found",
+		});
+	}
+
+	if (found.userId !== userId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own this transaction type",
+		});
+	}
+}
+
 export const currencyTransactionRouter = router({
 	listByCurrency: protectedProcedure
 		.input(z.object({ currencyId: z.string(), cursor: z.string().optional() }))
@@ -45,7 +80,7 @@ export const currencyTransactionRouter = router({
 				// tuple against the cursor row keeps paging aligned with the visible
 				// order — comparing the random-UUID id alone skips/duplicates rows.
 				conditions.push(
-					sql`(${currencyTransaction.transactedAt}, ${currencyTransaction.id}) < (SELECT transacted_at, id FROM currency_transaction WHERE id = ${input.cursor})`
+					sql`(${currencyTransaction.transactedAt}, ${currencyTransaction.id}) < (SELECT transacted_at, id FROM currency_transaction WHERE id = ${input.cursor} AND currency_id = ${input.currencyId})`
 				);
 			}
 
@@ -122,6 +157,12 @@ export const currencyTransactionRouter = router({
 				});
 			}
 
+			await validateTransactionTypeOwnership(
+				ctx.db,
+				input.transactionTypeId,
+				userId
+			);
+
 			const id = crypto.randomUUID();
 			await ctx.db.insert(currencyTransaction).values({
 				id,
@@ -181,6 +222,11 @@ export const currencyTransactionRouter = router({
 
 			const updateData: Partial<typeof found.currencyTransaction> = {};
 			if (input.transactionTypeId !== undefined) {
+				await validateTransactionTypeOwnership(
+					ctx.db,
+					input.transactionTypeId,
+					userId
+				);
 				updateData.transactionTypeId = input.transactionTypeId;
 			}
 			if (input.amount !== undefined) {

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -21,7 +21,11 @@ import {
 	recalculateCashGameSession,
 } from "../services/live-session-pl";
 import { floorToMinute } from "../utils/session-event-time";
-import { resolveCashRuleSnapshot, validateLiveLinkOwnership } from "./session";
+import {
+	resolveCashRuleSnapshot,
+	validateEntityOwnership,
+	validateLiveLinkOwnership,
+} from "./session";
 
 const DEFAULT_LIMIT = 20;
 
@@ -365,6 +369,14 @@ export const liveCashGameSessionRouter = router({
 			}
 
 			if (input.ringGameId) {
+				// Verify ring-game ownership BEFORE any ring_game read so a caller
+				// cannot probe another user's config via the buy-in bounds (SA2-174).
+				await validateEntityOwnership(
+					ctx.db,
+					"ringGame",
+					input.ringGameId,
+					userId
+				);
 				const [foundRingGame] = await ctx.db
 					.select({
 						minBuyIn: ringGame.minBuyIn,
@@ -485,6 +497,13 @@ export const liveCashGameSessionRouter = router({
 			if (input.ringGameId === null) {
 				cashDetailUpdate.ringGameId = null;
 			} else if (input.ringGameId !== undefined) {
+				// Verify ring-game ownership BEFORE the snapshot read (SA2-174).
+				await validateEntityOwnership(
+					ctx.db,
+					"ringGame",
+					input.ringGameId,
+					userId
+				);
 				const resolvedRoomId =
 					updateData.roomId === undefined ? existing.roomId : updateData.roomId;
 				const resolvedCurrencyId =

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -21,7 +21,7 @@ import {
 	recalculateCashGameSession,
 } from "../services/live-session-pl";
 import { floorToMinute } from "../utils/session-event-time";
-import { resolveCashRuleSnapshot } from "./session";
+import { resolveCashRuleSnapshot, validateLiveLinkOwnership } from "./session";
 
 const DEFAULT_LIMIT = 20;
 
@@ -395,6 +395,8 @@ export const liveCashGameSessionRouter = router({
 				}
 			}
 
+			await validateLiveLinkOwnership(ctx.db, input, userId);
+
 			const id = crypto.randomUUID();
 
 			await ctx.db.insert(gameSession).values({
@@ -464,6 +466,8 @@ export const liveCashGameSessionRouter = router({
 			const updateData: Partial<typeof gameSession.$inferInsert> = {
 				updatedAt: new Date(),
 			};
+
+			await validateLiveLinkOwnership(ctx.db, input, userId);
 
 			if (input.memo !== undefined) {
 				updateData.memo = input.memo;

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -145,17 +145,15 @@ async function resolveRingGameAssignment(
 		});
 	}
 
-	if (foundRingGame.roomId) {
-		const [foundRoom] = await db
-			.select()
-			.from(room)
-			.where(eq(room.id, foundRingGame.roomId));
-		if (!foundRoom || foundRoom.userId !== userId) {
-			throw new TRPCError({
-				code: "FORBIDDEN",
-				message: "You do not own this ring game",
-			});
-		}
+	// Ownership is anchored on ring_game.userId (SA2-181), not derived from the
+	// room, so null-roomId auto-generated snapshot rows are covered too. This
+	// mirrors the caller's pre-check (validateEntityOwnership("ringGame", …)) as
+	// defense-in-depth and keeps the ownership model unified.
+	if (foundRingGame.userId !== userId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
 	}
 
 	if (

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -296,6 +296,7 @@ export const liveCashGameSessionRouter = router({
 			const summary = {
 				totalBuyIn: s.totalBuyIn,
 				cashOut: s.cashOut,
+				chipRemoveTotal: pl.chipRemoveTotal,
 				profitLoss: pl.profitLoss,
 				evCashOut: pl.evCashOut,
 				evDiff: pl.evDiff,

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -203,7 +203,7 @@ export const liveCashGameSessionRouter = router({
 			}
 			if (input.cursor) {
 				conditions.push(
-					sql`${gameSession.startedAt} < (SELECT started_at FROM game_session WHERE id = ${input.cursor})`
+					sql`${gameSession.startedAt} < (SELECT started_at FROM game_session WHERE id = ${input.cursor} AND user_id = ${userId})`
 				);
 			}
 

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -2,6 +2,7 @@ import {
 	cashSessionEndPayload,
 	cashSessionStartPayload,
 	chipsAddRemovePayload,
+	MAX_SEAT_POSITION,
 	updateStackPayload,
 } from "@sapphire2/db/constants/session-event-types";
 import { currency } from "@sapphire2/db/schema/currency";
@@ -788,7 +789,12 @@ export const liveCashGameSessionRouter = router({
 		.input(
 			z.object({
 				id: z.string(),
-				heroSeatPosition: z.number().int().min(0).max(8).nullable(),
+				heroSeatPosition: z
+					.number()
+					.int()
+					.min(0)
+					.max(MAX_SEAT_POSITION)
+					.nullable(),
 			})
 		)
 		.mutation(async ({ ctx, input }) => {

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -1,4 +1,5 @@
 import {
+	MAX_SEAT_POSITION,
 	tournamentSessionEndPayload,
 	updateStackPayload,
 } from "@sapphire2/db/constants/session-event-types";
@@ -986,7 +987,12 @@ export const liveTournamentSessionRouter = router({
 		.input(
 			z.object({
 				id: z.string(),
-				heroSeatPosition: z.number().int().min(0).max(8).nullable(),
+				heroSeatPosition: z
+					.number()
+					.int()
+					.min(0)
+					.max(MAX_SEAT_POSITION)
+					.nullable(),
 			})
 		)
 		.mutation(async ({ ctx, input }) => {

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -28,6 +28,7 @@ import {
 	resolveTournamentRuleSnapshot,
 	snapshotTournamentStructure,
 	validateEntityOwnership,
+	validateLiveLinkOwnership,
 } from "./session";
 
 const DEFAULT_LIMIT = 20;
@@ -667,6 +668,7 @@ export const liveTournamentSessionRouter = router({
 
 			await assertNoActiveSession(ctx.db, userId);
 
+			await validateLiveLinkOwnership(ctx.db, input, userId);
 			// Validate tournament ownership before reading its structure so a
 			// caller cannot snapshot another user's blind levels / chip purchases
 			// via snapshotTournamentStructure (IDOR).
@@ -759,6 +761,8 @@ export const liveTournamentSessionRouter = router({
 				.select()
 				.from(sessionTournamentDetail)
 				.where(eq(sessionTournamentDetail.sessionId, input.id));
+
+			await validateLiveLinkOwnership(ctx.db, input, userId);
 
 			const baseUpdateData = buildLiveSessionUpdateData(input);
 			const { detailUpdate, patchedUpdateData } = await resolveDetailUpdate(

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -21,6 +21,7 @@ import {
 } from "../services/live-session-pl";
 import { floorToMinute } from "../utils/session-event-time";
 import {
+	persistSessionBlindLevels,
 	persistSessionChipPurchases,
 	resnapshotTournamentStructure,
 	resolveTournamentRuleSnapshot,
@@ -871,24 +872,12 @@ export const liveTournamentSessionRouter = router({
 			}
 
 			if (input.blindLevels !== undefined) {
-				await ctx.db
-					.delete(sessionBlindLevel)
-					.where(eq(sessionBlindLevel.sessionId, input.id));
-				if (input.blindLevels.length > 0) {
-					await ctx.db.insert(sessionBlindLevel).values(
-						input.blindLevels.map((l, idx) => ({
-							id: crypto.randomUUID(),
-							sessionId: input.id,
-							level: idx + 1,
-							isBreak: l.isBreak,
-							blind1: l.blind1 ?? null,
-							blind2: l.blind2 ?? null,
-							blind3: l.blind3 ?? null,
-							ante: l.ante ?? null,
-							minutes: l.minutes ?? null,
-						}))
-					);
-				}
+				// Reuse the shared helper so the DELETE + re-INSERT is chunked
+				// under D1's 100 bound-parameter cap (9 columns/row => 11 rows
+				// max per INSERT). A single unchunked INSERT of >=12 levels
+				// overflows and throws AFTER the DELETE commits, permanently
+				// wiping the session's blind structure (SA2-115).
+				await persistSessionBlindLevels(ctx.db, input.id, input.blindLevels);
 			}
 
 			if (input.chipPurchases !== undefined) {

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -27,6 +27,7 @@ import {
 	resnapshotTournamentStructure,
 	resolveTournamentRuleSnapshot,
 	snapshotTournamentStructure,
+	validateEntityOwnership,
 } from "./session";
 
 const DEFAULT_LIMIT = 20;
@@ -665,6 +666,18 @@ export const liveTournamentSessionRouter = router({
 			const userId = ctx.session.user.id;
 
 			await assertNoActiveSession(ctx.db, userId);
+
+			// Validate tournament ownership before reading its structure so a
+			// caller cannot snapshot another user's blind levels / chip purchases
+			// via snapshotTournamentStructure (IDOR).
+			if (input.tournamentId) {
+				await validateEntityOwnership(
+					ctx.db,
+					"tournament",
+					input.tournamentId,
+					userId
+				);
+			}
 
 			const id = crypto.randomUUID();
 			const now = new Date();

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -490,7 +490,7 @@ export const liveTournamentSessionRouter = router({
 			}
 			if (input.cursor) {
 				conditions.push(
-					sql`${gameSession.startedAt} < (SELECT started_at FROM game_session WHERE id = ${input.cursor})`
+					sql`${gameSession.startedAt} < (SELECT started_at FROM game_session WHERE id = ${input.cursor} AND user_id = ${userId})`
 				);
 			}
 

--- a/packages/api/src/routers/player.ts
+++ b/packages/api/src/routers/player.ts
@@ -7,6 +7,7 @@ import { TRPCError } from "@trpc/server";
 import { and, asc, eq, inArray, like } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
+import { validateTagsOwnership } from "./session";
 
 export const playerRouter = router({
 	list: protectedProcedure
@@ -141,6 +142,9 @@ export const playerRouter = router({
 		)
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
+			// Reject before any write so a foreign tag id cannot be linked (IDOR).
+			await validateTagsOwnership(ctx.db, playerTag, input.tagIds, userId);
+
 			const id = crypto.randomUUID();
 
 			await ctx.db.insert(player).values({
@@ -226,6 +230,8 @@ export const playerRouter = router({
 				.where(eq(player.id, input.id));
 
 			if (input.tagIds !== undefined) {
+				// Verify tag ownership before mutating the join rows (IDOR).
+				await validateTagsOwnership(ctx.db, playerTag, input.tagIds, userId);
 				await ctx.db
 					.delete(playerToPlayerTag)
 					.where(eq(playerToPlayerTag.playerId, input.id));

--- a/packages/api/src/routers/ring-game.ts
+++ b/packages/api/src/routers/ring-game.ts
@@ -48,8 +48,15 @@ async function validateRingGameOwnership(
 		});
 	}
 
-	if (found.roomId) {
-		await validateRoomOwnership(db, found.roomId, userId);
+	// Ownership is now anchored on ring_game.userId (SA2-181). A null userId is a
+	// legacy/orphan row that predates the backfill and cannot be proven owned →
+	// FORBIDDEN. This closes the null-roomId IDOR gap the room-derived check left
+	// open for auto-generated snapshot rows.
+	if (found.userId !== userId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
 	}
 
 	return found;
@@ -111,6 +118,7 @@ export const ringGameRouter = router({
 			await ctx.db.insert(ringGame).values({
 				id,
 				roomId: input.roomId,
+				userId,
 				name: input.name,
 				variant: input.variant,
 				blind1: input.blind1 ?? null,

--- a/packages/api/src/routers/ring-game.ts
+++ b/packages/api/src/routers/ring-game.ts
@@ -1,34 +1,10 @@
-import { currency } from "@sapphire2/db/schema/currency";
 import { ringGame } from "@sapphire2/db/schema/ring-game";
 import { room } from "@sapphire2/db/schema/room";
 import { TRPCError } from "@trpc/server";
 import { and, eq, isNotNull, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
-
-async function validateCurrencyOwnership(
-	db: Parameters<
-		Parameters<typeof protectedProcedure.query>[0]
-	>[0]["ctx"]["db"],
-	currencyId: string,
-	userId: string
-) {
-	const [found] = await db
-		.select()
-		.from(currency)
-		.where(eq(currency.id, currencyId));
-
-	if (!found) {
-		throw new TRPCError({ code: "NOT_FOUND", message: "Currency not found" });
-	}
-
-	if (found.userId !== userId) {
-		throw new TRPCError({
-			code: "FORBIDDEN",
-			message: "You do not own this currency",
-		});
-	}
-}
+import { validateEntityOwnership } from "./session";
 
 async function validateRoomOwnership(
 	db: Parameters<
@@ -123,7 +99,12 @@ export const ringGameRouter = router({
 			const userId = ctx.session.user.id;
 			await validateRoomOwnership(ctx.db, input.roomId, userId);
 			if (input.currencyId) {
-				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+				await validateEntityOwnership(
+					ctx.db,
+					"currency",
+					input.currencyId,
+					userId
+				);
 			}
 
 			const id = crypto.randomUUID();
@@ -174,7 +155,12 @@ export const ringGameRouter = router({
 			const userId = ctx.session.user.id;
 			const found = await validateRingGameOwnership(ctx.db, input.id, userId);
 			if (input.currencyId) {
-				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+				await validateEntityOwnership(
+					ctx.db,
+					"currency",
+					input.currencyId,
+					userId
+				);
 			}
 
 			const updateData: Partial<typeof found> = { updatedAt: new Date() };

--- a/packages/api/src/routers/ring-game.ts
+++ b/packages/api/src/routers/ring-game.ts
@@ -1,9 +1,34 @@
+import { currency } from "@sapphire2/db/schema/currency";
 import { ringGame } from "@sapphire2/db/schema/ring-game";
 import { room } from "@sapphire2/db/schema/room";
 import { TRPCError } from "@trpc/server";
 import { and, eq, isNotNull, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
+
+async function validateCurrencyOwnership(
+	db: Parameters<
+		Parameters<typeof protectedProcedure.query>[0]
+	>[0]["ctx"]["db"],
+	currencyId: string,
+	userId: string
+) {
+	const [found] = await db
+		.select()
+		.from(currency)
+		.where(eq(currency.id, currencyId));
+
+	if (!found) {
+		throw new TRPCError({ code: "NOT_FOUND", message: "Currency not found" });
+	}
+
+	if (found.userId !== userId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own this currency",
+		});
+	}
+}
 
 async function validateRoomOwnership(
 	db: Parameters<
@@ -97,6 +122,9 @@ export const ringGameRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
 			await validateRoomOwnership(ctx.db, input.roomId, userId);
+			if (input.currencyId) {
+				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+			}
 
 			const id = crypto.randomUUID();
 			await ctx.db.insert(ringGame).values({
@@ -145,6 +173,9 @@ export const ringGameRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
 			const found = await validateRingGameOwnership(ctx.db, input.id, userId);
+			if (input.currencyId) {
+				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+			}
 
 			const updateData: Partial<typeof found> = { updatedAt: new Date() };
 			if (input.name !== undefined) {

--- a/packages/api/src/routers/session-table-player.ts
+++ b/packages/api/src/routers/session-table-player.ts
@@ -1,4 +1,7 @@
-import { playerJoinPayload } from "@sapphire2/db/constants/session-event-types";
+import {
+	MAX_SEAT_POSITION,
+	playerJoinPayload,
+} from "@sapphire2/db/constants/session-event-types";
 import { player, playerToPlayerTag } from "@sapphire2/db/schema/player";
 import { ringGame } from "@sapphire2/db/schema/ring-game";
 import { room } from "@sapphire2/db/schema/room";
@@ -283,7 +286,7 @@ export const sessionTablePlayerRouter = router({
 		.input(
 			sessionIdInput.extend({
 				playerId: z.string().min(1),
-				seatPosition: z.number().int().min(0).max(8).optional(),
+				seatPosition: z.number().int().min(0).max(MAX_SEAT_POSITION).optional(),
 			})
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -323,7 +326,7 @@ export const sessionTablePlayerRouter = router({
 				playerMemo: z.string().optional(),
 				playerName: z.string().min(1),
 				playerTagIds: z.array(z.string()).optional(),
-				seatPosition: z.number().int().min(0).max(8).optional(),
+				seatPosition: z.number().int().min(0).max(MAX_SEAT_POSITION).optional(),
 			})
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -361,7 +364,7 @@ export const sessionTablePlayerRouter = router({
 		.input(
 			sessionIdInput.extend({
 				playerId: z.string().min(1),
-				seatPosition: z.number().int().min(0).max(8).nullable(),
+				seatPosition: z.number().int().min(0).max(MAX_SEAT_POSITION).nullable(),
 			})
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -447,7 +450,7 @@ export const sessionTablePlayerRouter = router({
 	addTemporary: protectedProcedure
 		.input(
 			sessionIdInput.extend({
-				seatPosition: z.number().int().min(0).max(8).optional(),
+				seatPosition: z.number().int().min(0).max(MAX_SEAT_POSITION).optional(),
 			})
 		)
 		.mutation(async ({ ctx, input }) => {

--- a/packages/api/src/routers/session-table-player.ts
+++ b/packages/api/src/routers/session-table-player.ts
@@ -2,7 +2,11 @@ import {
 	MAX_SEAT_POSITION,
 	playerJoinPayload,
 } from "@sapphire2/db/constants/session-event-types";
-import { player, playerToPlayerTag } from "@sapphire2/db/schema/player";
+import {
+	player,
+	playerTag,
+	playerToPlayerTag,
+} from "@sapphire2/db/schema/player";
 import { ringGame } from "@sapphire2/db/schema/ring-game";
 import { room } from "@sapphire2/db/schema/room";
 import { gameSession } from "@sapphire2/db/schema/session";
@@ -19,6 +23,7 @@ import {
 	floorToMinute,
 	nextAppendSortOrder,
 } from "../utils/session-event-time";
+import { validateTagsOwnership } from "./session";
 
 type DbInstance = Parameters<
 	Parameters<typeof protectedProcedure.query>[0]
@@ -334,6 +339,13 @@ export const sessionTablePlayerRouter = router({
 			const { seatPosition } = input;
 			const userId = ctx.session.user.id;
 			await resolveSessionOwnership(ctx.db, sessionId, userId);
+			// Reject foreign player tags before creating the player (IDOR).
+			await validateTagsOwnership(
+				ctx.db,
+				playerTag,
+				input.playerTagIds,
+				userId
+			);
 
 			const now = new Date();
 			const playerId = crypto.randomUUID();

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -359,6 +359,19 @@ async function validateEntityOwnership(
 				message: "Tournament not found",
 			});
 		}
+		// A tournament has no userId of its own; ownership is derived from its
+		// room. Without this check a caller could pass another user's
+		// tournamentId to snapshot their blind structure / chip purchases (IDOR).
+		const [foundRoom] = await db
+			.select()
+			.from(room)
+			.where(eq(room.id, found.roomId));
+		if (!foundRoom || foundRoom.userId !== userId) {
+			throw new TRPCError({
+				code: "FORBIDDEN",
+				message: "You do not own this tournament",
+			});
+		}
 	} else if (entityType === "currency") {
 		const [found] = await db
 			.select()
@@ -478,6 +491,7 @@ export {
 	computeTournamentPL,
 	getSessionChipPurchaseMap,
 	sumChipPurchaseCost,
+	validateEntityOwnership,
 	validateSessionOwnership,
 };
 

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -22,6 +22,7 @@ import {
 } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
 import { and, asc, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
+import type { SQLiteColumn, SQLiteTable } from "drizzle-orm/sqlite-core";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
 
@@ -320,6 +321,54 @@ export async function persistSessionBlindLevels(
 	}
 }
 
+/**
+ * Assert the room `roomId` exists and belongs to `userId`, else throw FORBIDDEN
+ * with `forbiddenMessage`. Shared by the room-derived ownership branches
+ * (ringGame / tournament) so their ownership rule stays in one place.
+ */
+async function assertRoomOwnedBy(
+	db: DbInstance,
+	roomId: string,
+	userId: string,
+	forbiddenMessage: string
+): Promise<void> {
+	const [foundRoom] = await db.select().from(room).where(eq(room.id, roomId));
+	if (!foundRoom || foundRoom.userId !== userId) {
+		throw new TRPCError({ code: "FORBIDDEN", message: forbiddenMessage });
+	}
+}
+
+async function validateRingGameOwnershipBranch(
+	db: DbInstance,
+	entityId: string,
+	userId: string
+): Promise<void> {
+	const [found] = await db
+		.select()
+		.from(ringGame)
+		.where(eq(ringGame.id, entityId));
+	if (!found) {
+		throw new TRPCError({ code: "NOT_FOUND", message: "Ring game not found" });
+	}
+	// A ring game has no userId of its own; ownership is derived from its room.
+	// Auto-generated snapshot rows have a null roomId and are never
+	// user-selectable, so a caller-supplied id pointing at one cannot be proven
+	// owned → FORBIDDEN. Without this a caller could pass another user's
+	// ringGameId to snapshot their cash-game rule config (IDOR, SA2-174).
+	if (!found.roomId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own this ring game",
+		});
+	}
+	await assertRoomOwnedBy(
+		db,
+		found.roomId,
+		userId,
+		"You do not own this ring game"
+	);
+}
+
 async function validateEntityOwnership(
 	db: DbInstance,
 	entityType: "currency" | "ringGame" | "room" | "tournament",
@@ -338,16 +387,7 @@ async function validateEntityOwnership(
 			});
 		}
 	} else if (entityType === "ringGame") {
-		const [found] = await db
-			.select()
-			.from(ringGame)
-			.where(eq(ringGame.id, entityId));
-		if (!found) {
-			throw new TRPCError({
-				code: "NOT_FOUND",
-				message: "Ring game not found",
-			});
-		}
+		await validateRingGameOwnershipBranch(db, entityId, userId);
 	} else if (entityType === "tournament") {
 		const [found] = await db
 			.select()
@@ -362,16 +402,12 @@ async function validateEntityOwnership(
 		// A tournament has no userId of its own; ownership is derived from its
 		// room. Without this check a caller could pass another user's
 		// tournamentId to snapshot their blind structure / chip purchases (IDOR).
-		const [foundRoom] = await db
-			.select()
-			.from(room)
-			.where(eq(room.id, found.roomId));
-		if (!foundRoom || foundRoom.userId !== userId) {
-			throw new TRPCError({
-				code: "FORBIDDEN",
-				message: "You do not own this tournament",
-			});
-		}
+		await assertRoomOwnedBy(
+			db,
+			found.roomId,
+			userId,
+			"You do not own this tournament"
+		);
 	} else if (entityType === "currency") {
 		const [found] = await db
 			.select()
@@ -935,6 +971,38 @@ export async function validateLiveLinkOwnership(
 	}
 	if (input.currencyId) {
 		await validateEntityOwnership(db, "currency", input.currencyId, userId);
+	}
+}
+
+/**
+ * Ownership guard for a set of tag ids linked to a session / player / etc.
+ * Generic over any tag table exposing `id` + `userId` columns (session_tag,
+ * player_tag, tournament_tag, …). Selects the caller-owned subset in a single
+ * `WHERE id IN (…) AND userId = caller` query; if the distinct owned count
+ * differs from the requested distinct count, at least one id is missing or
+ * belongs to another user → FORBIDDEN. No-ops on empty / omitted ids so the
+ * caller can pass `input.tagIds` directly. Prevents IDOR on tag links
+ * (SA2-177).
+ */
+export async function validateTagsOwnership(
+	db: DbInstance,
+	table: SQLiteTable & { id: SQLiteColumn; userId: SQLiteColumn },
+	ids: string[] | undefined,
+	userId: string
+): Promise<void> {
+	if (!ids || ids.length === 0) {
+		return;
+	}
+	const uniqueIds = [...new Set(ids)];
+	const owned = await db
+		.select({ id: table.id })
+		.from(table)
+		.where(and(inArray(table.id, uniqueIds), eq(table.userId, userId)));
+	if (owned.length !== uniqueIds.length) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own one or more of these tags",
+		});
 	}
 }
 
@@ -2150,6 +2218,7 @@ export const sessionRouter = router({
 				await insertTournamentSessionDetail(ctx.db, id, input);
 			}
 
+			await validateTagsOwnership(ctx.db, sessionTag, input.tagIds, userId);
 			await insertSessionTags(ctx.db, id, input.tagIds);
 
 			await maybeCreateCurrencyTransactionForCreate(
@@ -2323,6 +2392,7 @@ export const sessionRouter = router({
 			}
 
 			if (input.tagIds !== undefined) {
+				await validateTagsOwnership(ctx.db, sessionTag, input.tagIds, userId);
 				await ctx.db
 					.delete(sessionToSessionTag)
 					.where(eq(sessionToSessionTag.sessionId, input.id));

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -350,23 +350,17 @@ async function validateRingGameOwnershipBranch(
 	if (!found) {
 		throw new TRPCError({ code: "NOT_FOUND", message: "Ring game not found" });
 	}
-	// A ring game has no userId of its own; ownership is derived from its room.
-	// Auto-generated snapshot rows have a null roomId and are never
-	// user-selectable, so a caller-supplied id pointing at one cannot be proven
-	// owned → FORBIDDEN. Without this a caller could pass another user's
-	// ringGameId to snapshot their cash-game rule config (IDOR, SA2-174).
-	if (!found.roomId) {
+	// A ring game now carries its own userId (SA2-181), so ownership is a direct
+	// comparison — no longer derived from the room. A null userId is a
+	// legacy/orphan row that cannot be proven owned → FORBIDDEN. This supersedes
+	// the previous room-join and keeps null-roomId auto-generated snapshot rows
+	// correctly owned after the backfill, closing the IDOR gap (SA2-174/SA2-181).
+	if (found.userId !== userId) {
 		throw new TRPCError({
 			code: "FORBIDDEN",
 			message: "You do not own this ring game",
 		});
 	}
-	await assertRoomOwnedBy(
-		db,
-		found.roomId,
-		userId,
-		"You do not own this ring game"
-	);
 }
 
 async function validateEntityOwnership(
@@ -1865,7 +1859,8 @@ async function insertCashGameSessionDetail(
 	db: DbInstance,
 	sessionId: string,
 	input: z.infer<typeof cashGameCreateSchema>,
-	now: Date
+	now: Date,
+	userId: string
 ): Promise<void> {
 	let ringGameId = input.ringGameId ?? null;
 	const snapshot = await resolveCashRuleSnapshot(db, input);
@@ -1876,6 +1871,9 @@ async function insertCashGameSessionDetail(
 		await db.insert(ringGame).values({
 			id: ringGameId,
 			roomId: null,
+			// Auto-generated snapshot row: anchor ownership on the creating user
+			// (SA2-181) since it has no room to derive ownership from.
+			userId,
 			name: derivedName,
 			variant: snapshot.variant,
 			blind1: snapshot.blind1,
@@ -2213,7 +2211,7 @@ export const sessionRouter = router({
 			});
 
 			if (input.type === "cash_game") {
-				await insertCashGameSessionDetail(ctx.db, id, input, now);
+				await insertCashGameSessionDetail(ctx.db, id, input, now, userId);
 			} else {
 				await insertTournamentSessionDetail(ctx.db, id, input);
 			}

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -286,7 +286,7 @@ async function persistSessionChipPurchases(
  * (explicit override of the master snapshot) and update (session-wizard edits
  * to a session's own blind structure) so the array is always written fresh.
  */
-async function persistSessionBlindLevels(
+export async function persistSessionBlindLevels(
 	db: DbInstance,
 	sessionId: string,
 	blindLevels: {

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -918,6 +918,26 @@ async function validateCreateLinks(
 	}
 }
 
+/**
+ * Ownership guard for the room / currency links shared by the live cash-game
+ * and live-tournament routers. A falsy value (undefined = omitted, null =
+ * clear, "" = empty) skips validation; a provided id must exist AND belong to
+ * the caller, else validateEntityOwnership throws NOT_FOUND / FORBIDDEN.
+ * Prevents IDOR on the money-ledger links (SA2-102).
+ */
+export async function validateLiveLinkOwnership(
+	db: DbInstance,
+	input: { currencyId?: string | null; roomId?: string | null },
+	userId: string
+) {
+	if (input.roomId) {
+		await validateEntityOwnership(db, "room", input.roomId, userId);
+	}
+	if (input.currencyId) {
+		await validateEntityOwnership(db, "currency", input.currencyId, userId);
+	}
+}
+
 // ---------------------------------------------------------------------------
 // create helpers
 // ---------------------------------------------------------------------------

--- a/packages/api/src/routers/tournament-chip-purchase.ts
+++ b/packages/api/src/routers/tournament-chip-purchase.ts
@@ -4,7 +4,7 @@ import {
 	tournamentChipPurchase,
 } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
 
@@ -190,7 +190,14 @@ export const tournamentChipPurchaseRouter = router({
 					ctx.db
 						.update(tournamentChipPurchase)
 						.set({ sortOrder: index })
-						.where(eq(tournamentChipPurchase.id, id))
+						// Scope to the owned tournament so a foreign id matches nothing
+						// (write-IDOR, SA2-123).
+						.where(
+							and(
+								eq(tournamentChipPurchase.id, id),
+								eq(tournamentChipPurchase.tournamentId, input.tournamentId)
+							)
+						)
 				)
 			);
 

--- a/packages/api/src/routers/tournament.ts
+++ b/packages/api/src/routers/tournament.ts
@@ -1,3 +1,4 @@
+import { currency } from "@sapphire2/db/schema/currency";
 import { room } from "@sapphire2/db/schema/room";
 import {
 	blindLevel,
@@ -9,6 +10,30 @@ import { TRPCError } from "@trpc/server";
 import { and, asc, eq, isNotNull, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
+
+async function validateCurrencyOwnership(
+	db: Parameters<
+		Parameters<typeof protectedProcedure.query>[0]
+	>[0]["ctx"]["db"],
+	currencyId: string,
+	userId: string
+) {
+	const [found] = await db
+		.select()
+		.from(currency)
+		.where(eq(currency.id, currencyId));
+
+	if (!found) {
+		throw new TRPCError({ code: "NOT_FOUND", message: "Currency not found" });
+	}
+
+	if (found.userId !== userId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You do not own this currency",
+		});
+	}
+}
 
 async function validateRoomOwnership(
 	db: Parameters<
@@ -156,6 +181,9 @@ export const tournamentRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
 			await validateRoomOwnership(ctx.db, input.roomId, userId);
+			if (input.currencyId) {
+				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+			}
 
 			const id = crypto.randomUUID();
 			await ctx.db.insert(tournament).values({
@@ -198,6 +226,9 @@ export const tournamentRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
 			const found = await validateTournamentOwnership(ctx.db, input.id, userId);
+			if (input.currencyId) {
+				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+			}
 
 			const updateData: Partial<typeof found> = { updatedAt: new Date() };
 			if (input.name !== undefined) {
@@ -326,6 +357,9 @@ export const tournamentRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
 			await validateRoomOwnership(ctx.db, input.roomId, userId);
+			if (input.currencyId) {
+				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+			}
 
 			const id = crypto.randomUUID();
 			await ctx.db.insert(tournament).values({
@@ -419,6 +453,9 @@ export const tournamentRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const userId = ctx.session.user.id;
 			const found = await validateTournamentOwnership(ctx.db, input.id, userId);
+			if (input.currencyId) {
+				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+			}
 
 			const updateData: Partial<typeof found> = { updatedAt: new Date() };
 			if (input.name !== undefined) {

--- a/packages/api/src/routers/tournament.ts
+++ b/packages/api/src/routers/tournament.ts
@@ -1,4 +1,3 @@
-import { currency } from "@sapphire2/db/schema/currency";
 import { room } from "@sapphire2/db/schema/room";
 import {
 	blindLevel,
@@ -10,30 +9,7 @@ import { TRPCError } from "@trpc/server";
 import { and, asc, eq, isNotNull, isNull } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
-
-async function validateCurrencyOwnership(
-	db: Parameters<
-		Parameters<typeof protectedProcedure.query>[0]
-	>[0]["ctx"]["db"],
-	currencyId: string,
-	userId: string
-) {
-	const [found] = await db
-		.select()
-		.from(currency)
-		.where(eq(currency.id, currencyId));
-
-	if (!found) {
-		throw new TRPCError({ code: "NOT_FOUND", message: "Currency not found" });
-	}
-
-	if (found.userId !== userId) {
-		throw new TRPCError({
-			code: "FORBIDDEN",
-			message: "You do not own this currency",
-		});
-	}
-}
+import { validateEntityOwnership } from "./session";
 
 async function validateRoomOwnership(
 	db: Parameters<
@@ -182,7 +158,12 @@ export const tournamentRouter = router({
 			const userId = ctx.session.user.id;
 			await validateRoomOwnership(ctx.db, input.roomId, userId);
 			if (input.currencyId) {
-				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+				await validateEntityOwnership(
+					ctx.db,
+					"currency",
+					input.currencyId,
+					userId
+				);
 			}
 
 			const id = crypto.randomUUID();
@@ -227,7 +208,12 @@ export const tournamentRouter = router({
 			const userId = ctx.session.user.id;
 			const found = await validateTournamentOwnership(ctx.db, input.id, userId);
 			if (input.currencyId) {
-				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+				await validateEntityOwnership(
+					ctx.db,
+					"currency",
+					input.currencyId,
+					userId
+				);
 			}
 
 			const updateData: Partial<typeof found> = { updatedAt: new Date() };
@@ -358,7 +344,12 @@ export const tournamentRouter = router({
 			const userId = ctx.session.user.id;
 			await validateRoomOwnership(ctx.db, input.roomId, userId);
 			if (input.currencyId) {
-				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+				await validateEntityOwnership(
+					ctx.db,
+					"currency",
+					input.currencyId,
+					userId
+				);
 			}
 
 			const id = crypto.randomUUID();
@@ -454,7 +445,12 @@ export const tournamentRouter = router({
 			const userId = ctx.session.user.id;
 			const found = await validateTournamentOwnership(ctx.db, input.id, userId);
 			if (input.currencyId) {
-				await validateCurrencyOwnership(ctx.db, input.currencyId, userId);
+				await validateEntityOwnership(
+					ctx.db,
+					"currency",
+					input.currencyId,
+					userId
+				);
 			}
 
 			const updateData: Partial<typeof found> = { updatedAt: new Date() };

--- a/packages/api/src/services/live-session-pl.ts
+++ b/packages/api/src/services/live-session-pl.ts
@@ -30,6 +30,9 @@ type DbInstance = Parameters<
 interface CashGamePLResult {
 	addonTotal: number;
 	cashOut: number | null;
+	/** Σ of chips racked off the table (positive amount of every negative
+	 * chips_add_remove). Added back into P/L as already-pocketed chips. */
+	chipRemoveTotal: number;
 	evCashOut: number | null;
 	evDiff: number;
 	profitLoss: number | null;
@@ -154,6 +157,7 @@ export function computeCashGamePLFromEvents(
 	return {
 		totalBuyIn,
 		cashOut,
+		chipRemoveTotal,
 		profitLoss,
 		evCashOut,
 		evDiff: totalEvDiff,

--- a/packages/db/src/__tests__/ring-game.test.ts
+++ b/packages/db/src/__tests__/ring-game.test.ts
@@ -19,6 +19,7 @@ describe("RingGame schema", () => {
 		expect(columns.maxBuyIn).toBeDefined();
 		expect(columns.tableSize).toBeDefined();
 		expect(columns.currencyId).toBeDefined();
+		expect(columns.userId).toBeDefined();
 		expect(columns.memo).toBeDefined();
 		expect(columns.archivedAt).toBeDefined();
 		expect(columns.createdAt).toBeDefined();
@@ -38,6 +39,11 @@ describe("RingGame schema", () => {
 	it("roomId is nullable", () => {
 		const columns = getTableColumns(ringGame);
 		expect(columns.roomId.notNull).toBe(false);
+	});
+
+	it("userId is nullable (DB-level; app sets it on every insert, SA2-181)", () => {
+		const columns = getTableColumns(ringGame);
+		expect(columns.userId.notNull).toBe(false);
 	});
 
 	it("name is not null", () => {
@@ -128,8 +134,18 @@ describe("RingGame — FK cascade policies", () => {
 		expect(fkByColumn("currency_id")?.onDelete).toBe("set null");
 	});
 
-	it("has exactly 2 foreign keys", () => {
-		expect(config.foreignKeys).toHaveLength(2);
+	it("userId FK cascades on user deletion (SA2-181)", () => {
+		expect(fkByColumn("user_id")?.onDelete).toBe("cascade");
+	});
+
+	it("userId FK references the user id column (SA2-181)", () => {
+		const fk = fkByColumn("user_id")?.reference();
+		expect(fk?.foreignColumns.map((c) => c.name)).toEqual(["id"]);
+		expect(getTableConfig(fk?.foreignTable as never).name).toBe("user");
+	});
+
+	it("has exactly 3 foreign keys", () => {
+		expect(config.foreignKeys).toHaveLength(3);
 	});
 });
 
@@ -139,6 +155,10 @@ describe("RingGame — indexes", () => {
 
 	it("has roomId index for per-room ring-game listing", () => {
 		expect(idxNames).toContain("ringGame_roomId_idx");
+	});
+
+	it("has userId index for owner-scoped queries (SA2-181)", () => {
+		expect(idxNames).toContain("ringGame_userId_idx");
 	});
 
 	it("has no unique indexes (ring games can share names within a room)", () => {

--- a/packages/db/src/__tests__/session-event-types.test.ts
+++ b/packages/db/src/__tests__/session-event-types.test.ts
@@ -12,6 +12,7 @@ import {
 	isValidEventTypeForSessionType,
 	LIFECYCLE_EVENT_TYPES,
 	MANUAL_CREATE_BLOCKED_EVENT_TYPES,
+	MAX_SEAT_POSITION,
 	memoPayload,
 	PAUSE_RESUME_EVENT_TYPES,
 	playerJoinPayload,
@@ -277,6 +278,68 @@ describe("payload schemas", () => {
 
 		it("rejects empty playerId", () => {
 			expect(() => playerJoinPayload.parse({ playerId: "" })).toThrow();
+		});
+
+		it("accepts seatPosition 0 (lower boundary)", () => {
+			const result = playerJoinPayload.parse({
+				playerId: "player-1",
+				seatPosition: 0,
+			});
+			expect(result.seatPosition).toBe(0);
+		});
+
+		it("accepts seatPosition 8 (mid boundary)", () => {
+			const result = playerJoinPayload.parse({
+				playerId: "player-1",
+				seatPosition: 8,
+			});
+			expect(result.seatPosition).toBe(8);
+		});
+
+		it("accepts seatPosition 9 (last seat of a 10-max table)", () => {
+			const result = playerJoinPayload.parse({
+				playerId: "player-1",
+				seatPosition: 9,
+			});
+			expect(result.seatPosition).toBe(9);
+		});
+
+		it("rejects seatPosition 10 (beyond a 10-max table)", () => {
+			expect(() =>
+				playerJoinPayload.parse({ playerId: "player-1", seatPosition: 10 })
+			).toThrow();
+		});
+
+		it("rejects negative seatPosition", () => {
+			expect(() =>
+				playerJoinPayload.parse({ playerId: "player-1", seatPosition: -1 })
+			).toThrow();
+		});
+
+		it("rejects non-integer seatPosition", () => {
+			expect(() =>
+				playerJoinPayload.parse({ playerId: "player-1", seatPosition: 1.5 })
+			).toThrow();
+		});
+	});
+
+	describe("MAX_SEAT_POSITION", () => {
+		it("is 9 (10-max table, 0-indexed last seat)", () => {
+			expect(MAX_SEAT_POSITION).toBe(9);
+		});
+
+		it("bounds playerJoinPayload's seatPosition upper limit", () => {
+			expect(() =>
+				playerJoinPayload.parse({
+					playerId: "player-1",
+					seatPosition: MAX_SEAT_POSITION + 1,
+				})
+			).toThrow();
+			const result = playerJoinPayload.parse({
+				playerId: "player-1",
+				seatPosition: MAX_SEAT_POSITION,
+			});
+			expect(result.seatPosition).toBe(MAX_SEAT_POSITION);
 		});
 	});
 

--- a/packages/db/src/constants/session-event-types.ts
+++ b/packages/db/src/constants/session-event-types.ts
@@ -39,6 +39,16 @@ export const MANUAL_CREATE_BLOCKED_EVENT_TYPES: readonly string[] = [
 	"session_end",
 ] as const;
 
+// --- Seat bounds ---
+//
+// Seats are 0-indexed. A 10-max table (the largest `tableSize` selectable in
+// the ring-game / tournament / cash-game forms) therefore uses seat positions
+// 0–9, so the last valid seat is 9. Every server-side `seatPosition` /
+// `heroSeatPosition` bound derives from this single constant so the client's
+// `MAX_SEAT_COUNT` (10) and the server's validation can never drift apart
+// again (SA2-131).
+export const MAX_SEAT_POSITION = 9;
+
 // --- Payload Zod schemas ---
 
 // Lifecycle payloads
@@ -133,7 +143,7 @@ export const updateStackPayload = z.object({
 export const playerJoinPayload = z.object({
 	playerId: z.string().min(1).optional(),
 	isHero: z.boolean().default(false),
-	seatPosition: z.number().int().min(0).max(8).optional(),
+	seatPosition: z.number().int().min(0).max(MAX_SEAT_POSITION).optional(),
 });
 
 export const playerLeavePayload = z.object({

--- a/packages/db/src/migrations/0033_ring_game_add_user_id.sql
+++ b/packages/db/src/migrations/0033_ring_game_add_user_id.sql
@@ -1,0 +1,10 @@
+-- SA2-181: ring_game に本来の所有者 user_id を追加する（構造的 IDOR 修正）。
+-- これまで所有権は room_id -> room.user_id で導出していたが、自動生成された
+-- キャッシュルール行は room_id が NULL のため所有権の起点が無く、null-roomId 行が
+-- 誰のものでもない状態になっていた。NULL 許容で追加し、既存行はバックフィルする。
+ALTER TABLE `ring_game` ADD `user_id` text REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade;--> statement-breakpoint
+-- room に紐づく行: room.user_id から所有者を復元する。
+UPDATE `ring_game` SET `user_id` = (SELECT `user_id` FROM `room` WHERE `room`.`id` = `ring_game`.`room_id`) WHERE `room_id` IS NOT NULL;--> statement-breakpoint
+-- 自動生成（room_id が NULL）の行: 所有セッション経由で所有者を復元する。
+UPDATE `ring_game` SET `user_id` = (SELECT `gs`.`user_id` FROM `session_cash_detail` `scd` JOIN `game_session` `gs` ON `gs`.`id` = `scd`.`session_id` WHERE `scd`.`ring_game_id` = `ring_game`.`id` LIMIT 1) WHERE `room_id` IS NULL AND `user_id` IS NULL;--> statement-breakpoint
+CREATE INDEX `ringGame_userId_idx` ON `ring_game` (`user_id`);

--- a/packages/db/src/migrations/0034_backfill_day_crossing_session_end.sql
+++ b/packages/db/src/migrations/0034_backfill_day_crossing_session_end.sql
@@ -1,0 +1,7 @@
+-- SA2-184 (SA2-157 バックフィル): 日跨ぎで終了 < 開始 のまま保存された既存
+-- セッション行を +1日 補正する。書き込み時補正(computeSessionTimes)導入前に
+-- 22:00開始→翌02:00終了 のような入力が ended_at < started_at として保存され、
+-- プレー時間が負値表示＋サーバー統計から消失していた行が対象。
+-- started_at / ended_at は integer(mode:"timestamp") = Unix 秒なので 86400 秒 = 1日。
+-- WHERE で補正済み(ended_at >= started_at)の行は除外されるため再適用しても冪等。
+UPDATE `game_session` SET `ended_at` = `ended_at` + 86400 WHERE `ended_at` IS NOT NULL AND `started_at` IS NOT NULL AND `ended_at` < `started_at`;

--- a/packages/db/src/migrations/meta/0034_snapshot.json
+++ b/packages/db/src/migrations/meta/0034_snapshot.json
@@ -1,0 +1,2316 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "eb5aa2f3-bf45-450f-8861-bd81f9b85ace",
+  "prevId": "26ffc11d-23a7-4ff6-9ecc-099fe2fa11b3",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": ["identifier"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "currency": {
+      "name": "currency",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "currency_userId_idx": {
+          "name": "currency_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "currency_user_id_user_id_fk": {
+          "name": "currency_user_id_user_id_fk",
+          "tableFrom": "currency",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "currency_transaction": {
+      "name": "currency_transaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency_id": {
+          "name": "currency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transaction_type_id": {
+          "name": "transaction_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transacted_at": {
+          "name": "transacted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "currencyTransaction_currencyId_idx": {
+          "name": "currencyTransaction_currencyId_idx",
+          "columns": ["currency_id"],
+          "isUnique": false
+        },
+        "currencyTransaction_sessionId_idx": {
+          "name": "currencyTransaction_sessionId_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "currency_transaction_currency_id_currency_id_fk": {
+          "name": "currency_transaction_currency_id_currency_id_fk",
+          "tableFrom": "currency_transaction",
+          "tableTo": "currency",
+          "columnsFrom": ["currency_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "currency_transaction_transaction_type_id_transaction_type_id_fk": {
+          "name": "currency_transaction_transaction_type_id_transaction_type_id_fk",
+          "tableFrom": "currency_transaction",
+          "tableTo": "transaction_type",
+          "columnsFrom": ["transaction_type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "currency_transaction_session_id_game_session_id_fk": {
+          "name": "currency_transaction_session_id_game_session_id_fk",
+          "tableFrom": "currency_transaction",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_type": {
+      "name": "transaction_type",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactionType_userId_idx": {
+          "name": "transactionType_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_type_user_id_user_id_fk": {
+          "name": "transaction_type_user_id_user_id_fk",
+          "tableFrom": "transaction_type",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player": {
+      "name": "player",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_temporary": {
+          "name": "is_temporary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "player_userId_idx": {
+          "name": "player_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_user_id_user_id_fk": {
+          "name": "player_user_id_user_id_fk",
+          "tableFrom": "player",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_tag": {
+      "name": "player_tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gray'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "playerTag_userId_idx": {
+          "name": "playerTag_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_tag_user_id_user_id_fk": {
+          "name": "player_tag_user_id_user_id_fk",
+          "tableFrom": "player_tag",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_to_player_tag": {
+      "name": "player_to_player_tag",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_tag_id": {
+          "name": "player_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_to_player_tag_player_id_player_id_fk": {
+          "name": "player_to_player_tag_player_id_player_id_fk",
+          "tableFrom": "player_to_player_tag",
+          "tableTo": "player",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_to_player_tag_player_tag_id_player_tag_id_fk": {
+          "name": "player_to_player_tag_player_tag_id_player_tag_id_fk",
+          "tableFrom": "player_to_player_tag",
+          "tableTo": "player_tag",
+          "columnsFrom": ["player_tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_to_player_tag_player_id_player_tag_id_pk": {
+          "columns": ["player_id", "player_tag_id"],
+          "name": "player_to_player_tag_player_id_player_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ring_game": {
+      "name": "ring_game",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'nlh'"
+        },
+        "blind1": {
+          "name": "blind1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind2": {
+          "name": "blind2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind3": {
+          "name": "blind3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante": {
+          "name": "ante",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante_type": {
+          "name": "ante_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_buy_in": {
+          "name": "min_buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_buy_in": {
+          "name": "max_buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "table_size": {
+          "name": "table_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency_id": {
+          "name": "currency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ringGame_roomId_idx": {
+          "name": "ringGame_roomId_idx",
+          "columns": ["room_id"],
+          "isUnique": false
+        },
+        "ringGame_userId_idx": {
+          "name": "ringGame_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ring_game_room_id_room_id_fk": {
+          "name": "ring_game_room_id_room_id_fk",
+          "tableFrom": "ring_game",
+          "tableTo": "room",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ring_game_user_id_user_id_fk": {
+          "name": "ring_game_user_id_user_id_fk",
+          "tableFrom": "ring_game",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ring_game_currency_id_currency_id_fk": {
+          "name": "ring_game_currency_id_currency_id_fk",
+          "tableFrom": "ring_game",
+          "tableTo": "currency",
+          "columnsFrom": ["currency_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "room": {
+      "name": "room",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "room_userId_idx": {
+          "name": "room_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "room_user_id_user_id_fk": {
+          "name": "room_user_id_user_id_fk",
+          "tableFrom": "room",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_blind_level": {
+      "name": "session_blind_level",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_break": {
+          "name": "is_break",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "blind1": {
+          "name": "blind1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind2": {
+          "name": "blind2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind3": {
+          "name": "blind3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante": {
+          "name": "ante",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "minutes": {
+          "name": "minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_blind_level_session_idx": {
+          "name": "session_blind_level_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_blind_level_session_id_game_session_id_fk": {
+          "name": "session_blind_level_session_id_game_session_id_fk",
+          "tableFrom": "session_blind_level",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_cash_detail": {
+      "name": "session_cash_detail",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ring_game_id": {
+          "name": "ring_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "buy_in": {
+          "name": "buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cash_out": {
+          "name": "cash_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ev_cash_out": {
+          "name": "ev_cash_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Untitled'"
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'nlh'"
+        },
+        "blind1": {
+          "name": "blind1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind2": {
+          "name": "blind2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind3": {
+          "name": "blind3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante": {
+          "name": "ante",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante_type": {
+          "name": "ante_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_buy_in": {
+          "name": "min_buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_buy_in": {
+          "name": "max_buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "table_size": {
+          "name": "table_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_cash_ring_idx": {
+          "name": "session_cash_ring_idx",
+          "columns": ["ring_game_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_cash_detail_session_id_game_session_id_fk": {
+          "name": "session_cash_detail_session_id_game_session_id_fk",
+          "tableFrom": "session_cash_detail",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_cash_detail_ring_game_id_ring_game_id_fk": {
+          "name": "session_cash_detail_ring_game_id_ring_game_id_fk",
+          "tableFrom": "session_cash_detail",
+          "tableTo": "ring_game",
+          "columnsFrom": ["ring_game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_chip_purchase_result": {
+      "name": "session_chip_purchase_result",
+      "columns": {
+        "session_chip_purchase_id": {
+          "name": "session_chip_purchase_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_chip_purchase_result_session_chip_purchase_id_session_chip_purchase_id_fk": {
+          "name": "session_chip_purchase_result_session_chip_purchase_id_session_chip_purchase_id_fk",
+          "tableFrom": "session_chip_purchase_result",
+          "tableTo": "session_chip_purchase",
+          "columnsFrom": ["session_chip_purchase_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_chip_purchase": {
+      "name": "session_chip_purchase",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chips": {
+          "name": "chips",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "session_chip_purchase_session_idx": {
+          "name": "session_chip_purchase_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_chip_purchase_session_id_game_session_id_fk": {
+          "name": "session_chip_purchase_session_id_game_session_id_fk",
+          "tableFrom": "session_chip_purchase",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_event": {
+      "name": "session_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessionEvent_sessionId_idx": {
+          "name": "sessionEvent_sessionId_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        },
+        "sessionEvent_eventType_idx": {
+          "name": "sessionEvent_eventType_idx",
+          "columns": ["event_type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_event_session_id_game_session_id_fk": {
+          "name": "session_event_session_id_game_session_id_fk",
+          "tableFrom": "session_event",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_tag": {
+      "name": "session_tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "sessionTag_userId_idx": {
+          "name": "sessionTag_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_tag_user_id_user_id_fk": {
+          "name": "session_tag_user_id_user_id_fk",
+          "tableFrom": "session_tag",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_to_session_tag": {
+      "name": "session_to_session_tag",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_tag_id": {
+          "name": "session_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_to_session_tag_session_id_game_session_id_fk": {
+          "name": "session_to_session_tag_session_id_game_session_id_fk",
+          "tableFrom": "session_to_session_tag",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_to_session_tag_session_tag_id_session_tag_id_fk": {
+          "name": "session_to_session_tag_session_tag_id_session_tag_id_fk",
+          "tableFrom": "session_to_session_tag",
+          "tableTo": "session_tag",
+          "columnsFrom": ["session_tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_to_session_tag_session_id_session_tag_id_pk": {
+          "columns": ["session_id", "session_tag_id"],
+          "name": "session_to_session_tag_session_id_session_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_tournament_detail": {
+      "name": "session_tournament_detail",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tournament_buy_in": {
+          "name": "tournament_buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_entries": {
+          "name": "total_entries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_deadline": {
+          "name": "before_deadline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prize_money": {
+          "name": "prize_money",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bounty_prizes": {
+          "name": "bounty_prizes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timer_started_at": {
+          "name": "timer_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Untitled'"
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'nlh'"
+        },
+        "starting_stack": {
+          "name": "starting_stack",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bounty_amount": {
+          "name": "bounty_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "table_size": {
+          "name": "table_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_tournament_tournament_idx": {
+          "name": "session_tournament_tournament_idx",
+          "columns": ["tournament_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_tournament_detail_session_id_game_session_id_fk": {
+          "name": "session_tournament_detail_session_id_game_session_id_fk",
+          "tableFrom": "session_tournament_detail",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_tournament_detail_tournament_id_tournament_id_fk": {
+          "name": "session_tournament_detail_tournament_id_tournament_id_fk",
+          "tableFrom": "session_tournament_detail",
+          "tableTo": "tournament",
+          "columnsFrom": ["tournament_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_session": {
+      "name": "game_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_date": {
+          "name": "session_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency_id": {
+          "name": "currency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_kind_status_idx": {
+          "name": "session_user_kind_status_idx",
+          "columns": ["user_id", "kind", "status"],
+          "isUnique": false
+        },
+        "session_user_date_idx": {
+          "name": "session_user_date_idx",
+          "columns": ["user_id", "session_date"],
+          "isUnique": false
+        },
+        "session_room_idx": {
+          "name": "session_room_idx",
+          "columns": ["room_id"],
+          "isUnique": false
+        },
+        "session_currency_idx": {
+          "name": "session_currency_idx",
+          "columns": ["currency_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_session_user_id_user_id_fk": {
+          "name": "game_session_user_id_user_id_fk",
+          "tableFrom": "game_session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_session_room_id_room_id_fk": {
+          "name": "game_session_room_id_room_id_fk",
+          "tableFrom": "game_session",
+          "tableTo": "room",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "game_session_currency_id_currency_id_fk": {
+          "name": "game_session_currency_id_currency_id_fk",
+          "tableFrom": "game_session",
+          "tableTo": "currency",
+          "columnsFrom": ["currency_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "session_manual_completed_check": {
+          "name": "session_manual_completed_check",
+          "value": "(source != 'manual') OR (status = 'completed')"
+        }
+      }
+    },
+    "tournament_tag": {
+      "name": "tournament_tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "tournamentTag_tournamentId_idx": {
+          "name": "tournamentTag_tournamentId_idx",
+          "columns": ["tournament_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tournament_tag_tournament_id_tournament_id_fk": {
+          "name": "tournament_tag_tournament_id_tournament_id_fk",
+          "tableFrom": "tournament_tag",
+          "tableTo": "tournament",
+          "columnsFrom": ["tournament_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blind_level": {
+      "name": "blind_level",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_break": {
+          "name": "is_break",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "blind1": {
+          "name": "blind1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind2": {
+          "name": "blind2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind3": {
+          "name": "blind3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante": {
+          "name": "ante",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "minutes": {
+          "name": "minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blindLevel_tournamentId_idx": {
+          "name": "blindLevel_tournamentId_idx",
+          "columns": ["tournament_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blind_level_tournament_id_tournament_id_fk": {
+          "name": "blind_level_tournament_id_tournament_id_fk",
+          "tableFrom": "blind_level",
+          "tableTo": "tournament",
+          "columnsFrom": ["tournament_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tournament": {
+      "name": "tournament",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'nlh'"
+        },
+        "buy_in": {
+          "name": "buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "starting_stack": {
+          "name": "starting_stack",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bounty_amount": {
+          "name": "bounty_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "table_size": {
+          "name": "table_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency_id": {
+          "name": "currency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tournament_roomId_idx": {
+          "name": "tournament_roomId_idx",
+          "columns": ["room_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tournament_room_id_room_id_fk": {
+          "name": "tournament_room_id_room_id_fk",
+          "tableFrom": "tournament",
+          "tableTo": "room",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tournament_currency_id_currency_id_fk": {
+          "name": "tournament_currency_id_currency_id_fk",
+          "tableFrom": "tournament",
+          "tableTo": "currency",
+          "columnsFrom": ["currency_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tournament_chip_purchase": {
+      "name": "tournament_chip_purchase",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chips": {
+          "name": "chips",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "tournamentChipPurchase_tournamentId_idx": {
+          "name": "tournamentChipPurchase_tournamentId_idx",
+          "columns": ["tournament_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tournament_chip_purchase_tournament_id_tournament_id_fk": {
+          "name": "tournament_chip_purchase_tournament_id_tournament_id_fk",
+          "tableFrom": "tournament_chip_purchase",
+          "tableTo": "tournament",
+          "columnsFrom": ["tournament_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "update_note_view": {
+      "name": "update_note_view",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "update_note_view_user_id_idx": {
+          "name": "update_note_view_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "update_note_view_user_version_idx": {
+          "name": "update_note_view_user_version_idx",
+          "columns": ["user_id", "version"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "update_note_view_user_id_user_id_fk": {
+          "name": "update_note_view_user_id_user_id_fk",
+          "tableFrom": "update_note_view",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -92,6 +92,160 @@
       "when": 1775883379516,
       "tag": "0012_boring_vivisector",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0013_redesign_session_events",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0014_add_temporary_player",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0015_add_dashboard_widget",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0016_add_before_deadline",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0017_add_tournament_timer",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0018_backfill_session_start_timer",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0019_cti_session_refactor",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0020_normalize_session_event_ordering",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0021_consolidate_tournament_stack_events",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0022_consolidate_hero_seat_into_events",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0023_chips_add_remove_signed_amount",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0024_freeze_session_rule_snapshot",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0025_chip_purchase_result",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0026_drop_session_table_player",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0027_add_currency_description",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1780619773000,
+      "tag": "0028_currency_add_favorite",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1780663855000,
+      "tag": "0029_rename_store_to_room",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "6",
+      "when": 1780674911000,
+      "tag": "0030_room_add_favorite",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "6",
+      "when": 1781236774000,
+      "tag": "0031_drop_dashboard_widget",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "6",
+      "when": 1783050064000,
+      "tag": "0032_room_add_location",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1783222517000,
+      "tag": "0033_ring_game_add_user_id",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1783348319000,
+      "tag": "0034_backfill_day_crossing_session_end",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/ring-game.ts
+++ b/packages/db/src/schema/ring-game.ts
@@ -1,5 +1,6 @@
 import { relations, sql } from "drizzle-orm";
 import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { user } from "./auth";
 import { currency } from "./currency";
 import { room } from "./room";
 
@@ -8,6 +9,14 @@ export const ringGame = sqliteTable(
 	{
 		id: text("id").primaryKey(),
 		roomId: text("room_id").references(() => room.id, {
+			onDelete: "cascade",
+		}),
+		// Real ownership anchor (SA2-181). Nullable at the DB level so the ADD
+		// COLUMN migration is safe on populated tables; the app sets it on every
+		// insert and ownership treats null as not-owned. This closes the IDOR gap
+		// for auto-generated snapshot rows whose roomId is null and therefore had
+		// no ownership anchor under the room-derived model.
+		userId: text("user_id").references(() => user.id, {
 			onDelete: "cascade",
 		}),
 		name: text("name").notNull(),
@@ -32,13 +41,20 @@ export const ringGame = sqliteTable(
 			.$onUpdate(() => /* @__PURE__ */ new Date())
 			.notNull(),
 	},
-	(table) => [index("ringGame_roomId_idx").on(table.roomId)]
+	(table) => [
+		index("ringGame_roomId_idx").on(table.roomId),
+		index("ringGame_userId_idx").on(table.userId),
+	]
 );
 
 export const ringGameRelations = relations(ringGame, ({ one }) => ({
 	room: one(room, {
 		fields: [ringGame.roomId],
 		references: [room.id],
+	}),
+	user: one(user, {
+		fields: [ringGame.userId],
+		references: [user.id],
 	}),
 	currency: one(currency, {
 		fields: [ringGame.currencyId],


### PR DESCRIPTION
## 概要

`dev` の現時点の全修正を **v3.2.1** としてリリースするためのPRです。`release/v3.2.1` ブランチは `origin/dev` から切り出しており、ツリーは `origin/dev` と完全一致します（バージョンを埋め込むコード差分はなし。バージョンはブランチ名から導出されます）。

## 含まれる主な変更（dev → main、53コミット）

- **セキュリティ (IDOR対応)**: オブジェクト所有権チェックの不備を網羅修正、参照FKの所有権検証追加、currency所有権検証の共有ヘルパー集約、ring-game に所有者 `user_id` を追加した構造的IDOR修正、ライブセッション/ライブトーナメント作成時の所有権検証 (SA2-175 / SA2-181 / SA2-102 / SA2-172)
- **セッション日付の不具合修正**: セッション日付をUTC暦日として一貫処理し一日ずれを解消、日跨ぎで終了<開始となり時間が消失する問題の修正と既存行のバックフィル補正 (SA2-145 / SA2-157 / SA2-184)
- **rooms**: トーナメントルールシートのStructureタブで保存が効かない不具合を修正、無効送信時にDetailsタブへ自動復帰 (SA2-97)
- **web**: サインアウト時のキャッシュ消去を await し失敗を握り潰さないよう修正、PWA start_url 対応、ライブP/Lチップのリカバリ (SA2-159 / SA2-163 / SA2-124)
- **db**: Drizzleマイグレーション台帳を0034へ再ベースライン、`db:generate` をスキーマ変更の第一選択とする方針変更とドキュメント整合 (SA2-158)
- その他: preview-deploy の並列制御・is_new_db 判定、テスト補強など

## マージ方法（重要）

- **必ずマージコミットでマージしてください（squash 禁止）。** squash すると `main` と `dev` の履歴が分岐し、次回リリースで大量の phantom conflict が発生します（CLAUDE.md 参照）。
- マージ時に `release.yml` が起動し、リリースノート自動生成 → タグ `v3.2.1` 作成 → GitHub Release 公開 → 本番デプロイ (`production-deploy.yml`) まで自動実行されます。

準備が整ったらこのPRを Ready にして、マージコミットでマージしてください。


---
_Generated by [Claude Code](https://claude.ai/code/session_0155nVNcLoyCTG4s5XcNP9vg)_