### PR TITLE
fix(live-sessions): SessionFormの状態をセッション切替時にリセット (SA2-171)

### DIFF
--- a/apps/web/src/features/live-sessions/hooks/__tests__/use-session-form.test.tsx
+++ b/apps/web/src/features/live-sessions/hooks/__tests__/use-session-form.test.tsx
@@ -1,0 +1,194 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import {
+	SessionFormProvider,
+	useStackFormContext,
+	useTournamentFormContext,
+} from "@/features/live-sessions/hooks/use-session-form";
+
+/**
+ * Exercise both contexts through a single render so one `renderHook` covers the
+ * whole provider surface (cash + tournament state) and the session-change reset.
+ */
+function useBothContexts() {
+	return {
+		stack: useStackFormContext(),
+		tournament: useTournamentFormContext(),
+	};
+}
+
+/**
+ * Renders the provider with a mutable `sessionId` closure. `setSessionId`
+ * updates the closure and re-renders, so the wrapper feeds the new id into the
+ * provider exactly like `AuthenticatedShell` does when the active session flips.
+ */
+function renderWithSession(initialSessionId?: string | null) {
+	let sessionId = initialSessionId;
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<SessionFormProvider sessionId={sessionId}>{children}</SessionFormProvider>
+	);
+	const view = renderHook(() => useBothContexts(), { wrapper });
+	return {
+		...view,
+		setSessionId(next?: string | null) {
+			sessionId = next;
+			view.rerender();
+		},
+	};
+}
+
+const CHIP_COUNTS = [
+	{ name: "Rebuy", count: 3, chipsPerUnit: 5000 },
+	{ name: "Addon", count: 1, chipsPerUnit: 10_000 },
+];
+
+function fillTournamentA(result: {
+	current: ReturnType<typeof useBothContexts>;
+}) {
+	act(() => {
+		result.current.tournament.setStackAmount("150000");
+		result.current.tournament.setRemainingPlayers("20");
+		result.current.tournament.setTotalEntries("300");
+		result.current.tournament.setChipPurchaseCounts(CHIP_COUNTS);
+		result.current.stack.setStackAmount("88000");
+		result.current.stack.setAllIns([
+			{ id: 1, equity: 0.5, potSize: 1000, trials: 100, wins: 50 },
+		]);
+	});
+}
+
+describe("SessionFormProvider", () => {
+	it("provides empty defaults for both the cash and tournament forms", () => {
+		const { result } = renderWithSession("session-a");
+		expect(result.current.stack.state).toEqual({ stackAmount: "", allIns: [] });
+		expect(result.current.tournament.state).toEqual({
+			stackAmount: "",
+			remainingPlayers: "",
+			totalEntries: "",
+			chipPurchaseCounts: [],
+		});
+	});
+
+	it("updates cash-game stackAmount and allIns through its setters", () => {
+		const { result } = renderWithSession("session-a");
+		act(() => {
+			result.current.stack.setStackAmount("42000");
+			result.current.stack.setAllIns([
+				{ id: 7, equity: 0.33, potSize: 500, trials: 10, wins: 3 },
+			]);
+		});
+		expect(result.current.stack.state.stackAmount).toBe("42000");
+		expect(result.current.stack.state.allIns).toEqual([
+			{ id: 7, equity: 0.33, potSize: 500, trials: 10, wins: 3 },
+		]);
+	});
+
+	it("updates all four tournament fields through their setters", () => {
+		const { result } = renderWithSession("session-a");
+		act(() => {
+			result.current.tournament.setStackAmount("150000");
+			result.current.tournament.setRemainingPlayers("20");
+			result.current.tournament.setTotalEntries("300");
+			result.current.tournament.setChipPurchaseCounts(CHIP_COUNTS);
+		});
+		expect(result.current.tournament.state).toEqual({
+			stackAmount: "150000",
+			remainingPlayers: "20",
+			totalEntries: "300",
+			chipPurchaseCounts: CHIP_COUNTS,
+		});
+	});
+
+	it("clears ALL cash and tournament state when the active session id changes", () => {
+		const { result, setSessionId } = renderWithSession("session-a");
+		fillTournamentA(result);
+
+		act(() => {
+			setSessionId("session-b");
+		});
+
+		expect(result.current.tournament.state).toEqual({
+			stackAmount: "",
+			remainingPlayers: "",
+			totalEntries: "",
+			chipPurchaseCounts: [],
+		});
+		expect(result.current.stack.state).toEqual({ stackAmount: "", allIns: [] });
+	});
+
+	it("resets chipPurchaseCounts to an empty array on session change so previous rebuys never leak into the next payload", () => {
+		const { result, setSessionId } = renderWithSession("session-a");
+		act(() => {
+			result.current.tournament.setChipPurchaseCounts(CHIP_COUNTS);
+		});
+		expect(result.current.tournament.state.chipPurchaseCounts).toHaveLength(2);
+
+		act(() => {
+			setSessionId("session-b");
+		});
+
+		expect(result.current.tournament.state.chipPurchaseCounts).toEqual([]);
+	});
+
+	it("keeps all values when re-rendered with the SAME session id (no spurious reset)", () => {
+		const { result, setSessionId } = renderWithSession("session-a");
+		fillTournamentA(result);
+
+		act(() => {
+			setSessionId("session-a");
+		});
+
+		expect(result.current.tournament.state).toEqual({
+			stackAmount: "150000",
+			remainingPlayers: "20",
+			totalEntries: "300",
+			chipPurchaseCounts: CHIP_COUNTS,
+		});
+		expect(result.current.stack.state.stackAmount).toBe("88000");
+	});
+
+	it("resets when the session id transitions to undefined (session finished, none active)", () => {
+		const { result, setSessionId } = renderWithSession("session-a");
+		fillTournamentA(result);
+
+		act(() => {
+			setSessionId(undefined);
+		});
+
+		expect(result.current.tournament.state).toEqual({
+			stackAmount: "",
+			remainingPlayers: "",
+			totalEntries: "",
+			chipPurchaseCounts: [],
+		});
+		expect(result.current.stack.state).toEqual({ stackAmount: "", allIns: [] });
+	});
+
+	it("does not reset while the session id stays undefined across renders", () => {
+		const { result, setSessionId } = renderWithSession(undefined);
+		act(() => {
+			result.current.tournament.setStackAmount("12345");
+			result.current.stack.setStackAmount("54321");
+		});
+
+		act(() => {
+			setSessionId(undefined);
+		});
+
+		expect(result.current.tournament.state.stackAmount).toBe("12345");
+		expect(result.current.stack.state.stackAmount).toBe("54321");
+	});
+
+	it("throws when the tournament context hook is used outside the provider", () => {
+		expect(() => renderHook(() => useTournamentFormContext())).toThrow(
+			"useTournamentFormContext must be used within SessionFormProvider"
+		);
+	});
+
+	it("throws when the cash context hook is used outside the provider", () => {
+		expect(() => renderHook(() => useStackFormContext())).toThrow(
+			"useStackFormContext must be used within SessionFormProvider"
+		);
+	});
+});

--- a/apps/web/src/features/live-sessions/hooks/use-session-form.tsx
+++ b/apps/web/src/features/live-sessions/hooks/use-session-form.tsx
@@ -76,8 +76,19 @@ export function useTournamentFormContext() {
 
 export function SessionFormProvider({
 	children,
+	sessionId,
 }: {
 	children: React.ReactNode;
+	/**
+	 * Id of the currently active live session. The provider is mounted once at
+	 * app shell scope, so without this key its state would survive across
+	 * sessions and prefill the next session's Record Stack sheet with the
+	 * previous one's values — and carry a finished tournament's
+	 * `chipPurchaseCounts` into the next `update_stack` payload, corrupting the
+	 * average-stack calculation (SA2-171). Passing the active session id lets us
+	 * clear every field the moment the session changes.
+	 */
+	sessionId?: string | null;
 }) {
 	// Cash game state
 	const [stackAmount, setStackAmount] = useState("");
@@ -90,6 +101,23 @@ export function SessionFormProvider({
 	const [chipPurchaseCounts, setChipPurchaseCounts] = useState<
 		Array<{ name: string; count: number; chipsPerUnit: number }>
 	>([]);
+
+	// Reset every cash + tournament field whenever the active session changes,
+	// including when it clears to null (session finished / discarded). Adjusting
+	// state during render is React's recommended pattern for "reset on prop
+	// change" — it avoids the extra effect pass (and the stale-value flash) a
+	// `useEffect` would introduce, and it keeps children mounted (a `key` on the
+	// provider would remount the whole app shell). See SA2-171.
+	const [trackedSessionId, setTrackedSessionId] = useState(sessionId);
+	if (sessionId !== trackedSessionId) {
+		setTrackedSessionId(sessionId);
+		setStackAmount("");
+		setAllIns([]);
+		setTStackAmount("");
+		setRemainingPlayers("");
+		setTotalEntries("");
+		setChipPurchaseCounts([]);
+	}
 
 	return (
 		<StackFormContext.Provider

--- a/apps/web/src/shared/components/authenticated-shell/__tests__/use-authenticated-shell.test.ts
+++ b/apps/web/src/shared/components/authenticated-shell/__tests__/use-authenticated-shell.test.ts
@@ -3,10 +3,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
 	useMediaQuery: vi.fn(),
+	useActiveSession: vi.fn(),
 }));
 
 vi.mock("@/shared/hooks/use-media-query", () => ({
 	useMediaQuery: mocks.useMediaQuery,
+}));
+
+vi.mock("@/features/live-sessions/hooks/use-active-session", () => ({
+	useActiveSession: mocks.useActiveSession,
 }));
 
 import { useAuthenticatedShell } from "@/shared/components/authenticated-shell/use-authenticated-shell";
@@ -14,6 +19,12 @@ import { useAuthenticatedShell } from "@/shared/components/authenticated-shell/u
 describe("useAuthenticatedShell", () => {
 	beforeEach(() => {
 		mocks.useMediaQuery.mockReset();
+		mocks.useActiveSession.mockReset();
+		mocks.useActiveSession.mockReturnValue({
+			activeSession: null,
+			hasActive: false,
+			isLoading: false,
+		});
 	});
 
 	it("queries the 768px-min desktop breakpoint", () => {
@@ -26,12 +37,34 @@ describe("useAuthenticatedShell", () => {
 	it("returns isDesktop=true when the media query matches", () => {
 		mocks.useMediaQuery.mockReturnValue(true);
 		const { result } = renderHook(() => useAuthenticatedShell());
-		expect(result.current).toEqual({ isDesktop: true });
+		expect(result.current.isDesktop).toBe(true);
 	});
 
 	it("returns isDesktop=false when the media query does not match", () => {
 		mocks.useMediaQuery.mockReturnValue(false);
 		const { result } = renderHook(() => useAuthenticatedShell());
-		expect(result.current).toEqual({ isDesktop: false });
+		expect(result.current.isDesktop).toBe(false);
+	});
+
+	it("exposes the active session id so the form provider can key its state", () => {
+		mocks.useMediaQuery.mockReturnValue(false);
+		mocks.useActiveSession.mockReturnValue({
+			activeSession: { id: "session-42", type: "tournament", status: "active" },
+			hasActive: true,
+			isLoading: false,
+		});
+		const { result } = renderHook(() => useAuthenticatedShell());
+		expect(result.current.activeSessionId).toBe("session-42");
+	});
+
+	it("exposes a null active session id when no session is live", () => {
+		mocks.useMediaQuery.mockReturnValue(false);
+		mocks.useActiveSession.mockReturnValue({
+			activeSession: null,
+			hasActive: false,
+			isLoading: false,
+		});
+		const { result } = renderHook(() => useAuthenticatedShell());
+		expect(result.current.activeSessionId).toBeNull();
 	});
 });

--- a/apps/web/src/shared/components/authenticated-shell/authenticated-shell.tsx
+++ b/apps/web/src/shared/components/authenticated-shell/authenticated-shell.tsx
@@ -14,7 +14,7 @@ import { EmptyState } from "@/shared/components/ui/empty-state";
 import { useAuthenticatedShell } from "./use-authenticated-shell";
 
 export function AuthenticatedShell({ children }: { children: ReactNode }) {
-	const { isDesktop } = useAuthenticatedShell();
+	const { isDesktop, activeSessionId } = useAuthenticatedShell();
 
 	if (isDesktop) {
 		return (
@@ -30,7 +30,7 @@ export function AuthenticatedShell({ children }: { children: ReactNode }) {
 	}
 
 	return (
-		<SessionFormProvider>
+		<SessionFormProvider sessionId={activeSessionId}>
 			<StackSheetProvider>
 				<UpdateNotesProvider>
 					<div className="min-h-svh bg-background">

--- a/apps/web/src/shared/components/authenticated-shell/use-authenticated-shell.ts
+++ b/apps/web/src/shared/components/authenticated-shell/use-authenticated-shell.ts
@@ -1,8 +1,13 @@
+import { useActiveSession } from "@/features/live-sessions/hooks/use-active-session";
 import { useMediaQuery } from "@/shared/hooks/use-media-query";
 
 const DESKTOP_BREAKPOINT = "(min-width: 768px)";
 
 export function useAuthenticatedShell() {
 	const isDesktop = useMediaQuery(DESKTOP_BREAKPOINT);
-	return { isDesktop };
+	// Expose the active session id so the shell can key SessionFormProvider's
+	// state by it — clearing the Record Stack form (and its chipPurchaseCounts)
+	// whenever the live session changes (SA2-171).
+	const { activeSession } = useActiveSession();
+	return { isDesktop, activeSessionId: activeSession?.id ?? null };
 }


### PR DESCRIPTION
## 概要

`SessionFormProvider`（`apps/web/src/features/live-sessions/hooks/use-session-form.tsx`）は `AuthenticatedShell` 直下にアプリ全体で1度だけマウントされ、`stackAmount` / `remainingPlayers` / `totalEntries` / `chipPurchaseCounts` をリセット手段なしで保持していました。そのため、トーナメントAを終了してBを開始すると（ページリロードなし）、Aの値が Record Stack シートに残留し、さらにAの `chipPurchaseCounts` がBの `update_stack` ペイロードに混入して平均スタック計算を破壊していました。

Linear: SA2-171 / closes #488

## 変更内容

- `SessionFormProvider` に `sessionId?: string | null` を追加。アクティブセッションの id が変わった瞬間（完了・破棄で `null` になる場合を含む）に cash / tournament の全フィールド（`stackAmount` / `allIns` / トーナメント側 `stackAmount` / `remainingPlayers` / `totalEntries` / `chipPurchaseCounts`）をクリアします。
- リセットは React 公式の「レンダー中に state を調整する」パターンで実装。`useEffect` の余計な1パス（値の一瞬のちらつき）を避け、Provider に `key` を付ける方式（app shell 全体が再マウントされてしまう）も回避しています。同一セッション id の間は値がそのまま保持されます。
- `useAuthenticatedShell` が `useActiveSession()` からアクティブセッション id を取得し、`activeSessionId` として公開。`AuthenticatedShell` がこれを `SessionFormProvider` に渡します。

## テスト

TDD（先にテストを書いて red を確認 → 実装で green）で実装しました。

- `use-session-form.test.tsx`（新規, 10ケース）: 両フォームの初期値、cash / tournament の setter、id 変化時に全フィールドがクリアされること、`chipPurchaseCounts`→`[]`、同一 id では非リセット、`undefined` への遷移でのリセット、Provider 外での throw ガード。
- `use-authenticated-shell.test.ts`（拡張）: `useActiveSession` をモックし `activeSessionId` の公開を検証（id あり／ライブセッションなしで null）。

検証コマンド:
- `bunx vitest run --project web-dom`（新規テスト＋関連: `use-tournament-stack-form` / `use-cash-game-stack-form` / `authenticated-shell` / ライフサイクル系）→ 全 pass
- `bun run check-types` → 両ワークスペース exit 0
- `bun x ultracite check`（変更ファイル）→ clean
- `web-hooks-separation.md` の検証スクリプト → 0 hits

## 補足

- サーバー側（`packages/api/.../live-tournament-session.ts` の `averageStack` 算出）は変更なし。原因はクライアント側の状態ライフサイクル管理の欠如でした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LESXQVaQyiQbai6YYWQzYn)_