### PR TITLE
fix(update-notes): 表示履歴が無いユーザーで自動表示が動かない不具合を修正 (SA2-185)

### DIFF
--- a/apps/web/src/__tests__/settings-route.test.tsx
+++ b/apps/web/src/__tests__/settings-route.test.tsx
@@ -20,6 +20,10 @@ vi.mock("@/features/settings/pages/settings-page/linked-accounts", () => ({
 	LinkedAccounts: () => <div>Linked Accounts Content</div>,
 }));
 
+vi.mock("@/features/settings/pages/settings-page/about-section", () => ({
+	AboutSection: () => <div>About Content</div>,
+}));
+
 vi.mock("@/lib/auth-client", () => ({
 	authClient: {
 		signOut: mocks.signOut,
@@ -58,6 +62,15 @@ describe("SettingsComponent", () => {
 			screen.getByRole("heading", { name: "Settings" })
 		).toBeInTheDocument();
 		expect(screen.getByText("Linked accounts")).toBeInTheDocument();
+		expect(screen.getByText("About")).toBeInTheDocument();
+	});
+
+	it("renders the About section body", () => {
+		const Component = routeModule.Route.options.component as ComponentType;
+
+		render(<Component />);
+
+		expect(screen.getByText("About Content")).toBeInTheDocument();
 	});
 
 	it("signs out from the page header action", async () => {

--- a/apps/web/src/features/settings/pages/settings-page/about-section/__tests__/use-about-section.test.ts
+++ b/apps/web/src/features/settings/pages/settings-page/about-section/__tests__/use-about-section.test.ts
@@ -1,0 +1,47 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	open: vi.fn(),
+	latestVersion: "v3.2.2" as string | null,
+}));
+
+vi.mock("@/features/update-notes/components/update-notes-sheet", () => ({
+	useUpdateNotesSheet: () => ({
+		isOpen: false,
+		open: mocks.open,
+		close: vi.fn(),
+		setIsOpen: vi.fn(),
+	}),
+}));
+
+vi.mock("@/features/update-notes/constants", () => ({
+	get LATEST_VERSION() {
+		return mocks.latestVersion;
+	},
+}));
+
+import { useAboutSection } from "../use-about-section";
+
+describe("useAboutSection", () => {
+	it("returns the latest release version", () => {
+		mocks.latestVersion = "v3.2.2";
+		const { result } = renderHook(() => useAboutSection());
+		expect(result.current.version).toBe("v3.2.2");
+	});
+
+	it("returns null for version when there is no published release", () => {
+		mocks.latestVersion = null;
+		const { result } = renderHook(() => useAboutSection());
+		expect(result.current.version).toBeNull();
+	});
+
+	it("exposes the sheet's open handler as onViewUpdateNotes", () => {
+		mocks.open.mockClear();
+		const { result } = renderHook(() => useAboutSection());
+
+		result.current.onViewUpdateNotes();
+
+		expect(mocks.open).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/features/settings/pages/settings-page/about-section/about-section.test.tsx
+++ b/apps/web/src/features/settings/pages/settings-page/about-section/about-section.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AboutSection } from "./about-section";
+
+const mocks = vi.hoisted(() => ({
+	version: "v3.2.2" as string | null,
+	onViewUpdateNotes: vi.fn(),
+}));
+
+vi.mock("./use-about-section", () => ({
+	useAboutSection: () => ({
+		version: mocks.version,
+		onViewUpdateNotes: mocks.onViewUpdateNotes,
+	}),
+}));
+
+describe("AboutSection", () => {
+	it("renders the Version label and the current version", () => {
+		mocks.version = "v3.2.2";
+		render(<AboutSection />);
+
+		expect(screen.getByText("Version")).toBeInTheDocument();
+		expect(screen.getByText("v3.2.2")).toBeInTheDocument();
+	});
+
+	it("falls back to 'Unknown' when no version is available", () => {
+		mocks.version = null;
+		render(<AboutSection />);
+
+		expect(screen.getByText("Unknown")).toBeInTheDocument();
+	});
+
+	it("renders a 'View update notes' button", () => {
+		mocks.version = "v3.2.2";
+		render(<AboutSection />);
+
+		expect(
+			screen.getByRole("button", { name: "View update notes" })
+		).toBeInTheDocument();
+	});
+
+	it("calls onViewUpdateNotes once when the button is clicked", async () => {
+		mocks.version = "v3.2.2";
+		mocks.onViewUpdateNotes.mockClear();
+		const user = userEvent.setup();
+		render(<AboutSection />);
+
+		await user.click(screen.getByRole("button", { name: "View update notes" }));
+
+		expect(mocks.onViewUpdateNotes).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/features/settings/pages/settings-page/about-section/about-section.tsx
+++ b/apps/web/src/features/settings/pages/settings-page/about-section/about-section.tsx
@@ -1,0 +1,18 @@
+import { Button } from "@/shared/components/ui/button";
+import { useAboutSection } from "./use-about-section";
+
+export function AboutSection() {
+	const { version, onViewUpdateNotes } = useAboutSection();
+
+	return (
+		<div className="flex items-center justify-between gap-3">
+			<div className="space-y-0.5">
+				<p className="t-label text-muted-foreground">Version</p>
+				<p className="t-body font-medium">{version ?? "Unknown"}</p>
+			</div>
+			<Button onClick={onViewUpdateNotes} variant="outline">
+				View update notes
+			</Button>
+		</div>
+	);
+}

--- a/apps/web/src/features/settings/pages/settings-page/about-section/index.ts
+++ b/apps/web/src/features/settings/pages/settings-page/about-section/index.ts
@@ -1,0 +1,1 @@
+export { AboutSection } from "./about-section";

--- a/apps/web/src/features/settings/pages/settings-page/about-section/use-about-section.ts
+++ b/apps/web/src/features/settings/pages/settings-page/about-section/use-about-section.ts
@@ -1,0 +1,11 @@
+import { useUpdateNotesSheet } from "@/features/update-notes/components/update-notes-sheet";
+import { LATEST_VERSION } from "@/features/update-notes/constants";
+
+export function useAboutSection() {
+	const { open } = useUpdateNotesSheet();
+
+	return {
+		version: LATEST_VERSION,
+		onViewUpdateNotes: open,
+	};
+}

--- a/apps/web/src/features/settings/pages/settings-page/settings-page.tsx
+++ b/apps/web/src/features/settings/pages/settings-page/settings-page.tsx
@@ -1,4 +1,5 @@
 import { IconLogout } from "@tabler/icons-react";
+import { AboutSection } from "@/features/settings/pages/settings-page/about-section";
 import { LinkedAccounts } from "@/features/settings/pages/settings-page/linked-accounts";
 import { ThemeSetting } from "@/features/settings/pages/settings-page/theme-setting";
 import { PageHeader } from "@/shared/components/page-header";
@@ -29,6 +30,10 @@ export function SettingsPage() {
 
 					<PageSection heading="Linked accounts">
 						<LinkedAccounts />
+					</PageSection>
+
+					<PageSection heading="About">
+						<AboutSection />
 					</PageSection>
 				</div>
 			</div>

--- a/apps/web/src/features/update-notes/components/update-notes-sheet/__tests__/use-update-notes-sheet.test.tsx
+++ b/apps/web/src/features/update-notes/components/update-notes-sheet/__tests__/use-update-notes-sheet.test.tsx
@@ -1,0 +1,158 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+	latestVersion: "v3.2.2" as string | null,
+	viewedList: [] as Array<{ id: string; version: string; viewedAt: number }>,
+	hang: false,
+}));
+
+vi.mock("@/features/update-notes/constants", () => ({
+	get LATEST_VERSION() {
+		return state.latestVersion;
+	},
+	UPDATE_NOTES: [],
+}));
+
+const listKey = ["updateNoteView", "list"];
+
+vi.mock("@/utils/trpc", () => ({
+	trpc: {
+		updateNoteView: {
+			list: {
+				queryOptions: () => ({
+					queryKey: listKey,
+					queryFn: () =>
+						state.hang
+							? new Promise(() => {
+									/* never resolves — simulates the loading state */
+								})
+							: Promise.resolve(state.viewedList),
+				}),
+			},
+		},
+	},
+}));
+
+import {
+	UpdateNotesProvider,
+	useUpdateNotesSheet,
+} from "@/features/update-notes/components/update-notes-sheet/use-update-notes-sheet";
+
+function Probe() {
+	const { isOpen, close } = useUpdateNotesSheet();
+	return (
+		<div>
+			<span data-testid="state">{isOpen ? "open" : "closed"}</span>
+			<button onClick={close} type="button">
+				close
+			</button>
+		</div>
+	);
+}
+
+function createClient(): QueryClient {
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0, staleTime: Number.POSITIVE_INFINITY },
+		},
+	});
+}
+
+function renderProvider(client: QueryClient) {
+	return render(
+		createElement(
+			QueryClientProvider,
+			{ client },
+			createElement(UpdateNotesProvider, null, createElement(Probe))
+		) as ReactNode
+	);
+}
+
+describe("UpdateNotesProvider auto-open", () => {
+	beforeEach(() => {
+		state.latestVersion = "v3.2.2";
+		state.viewedList = [];
+		state.hang = false;
+	});
+
+	it("auto-opens for a user with no view records once the list loads", async () => {
+		state.viewedList = [];
+		const qc = createClient();
+		renderProvider(qc);
+
+		await waitFor(() =>
+			expect(screen.getByTestId("state")).toHaveTextContent("open")
+		);
+	});
+
+	it("auto-opens when the user has viewed older versions but not the latest", async () => {
+		state.viewedList = [
+			{ id: "1", version: "v3.2.1", viewedAt: 2 },
+			{ id: "2", version: "v3.2.0", viewedAt: 1 },
+		];
+		const qc = createClient();
+		renderProvider(qc);
+
+		await waitFor(() =>
+			expect(screen.getByTestId("state")).toHaveTextContent("open")
+		);
+	});
+
+	it("stays closed when the user has already viewed the latest version", () => {
+		state.viewedList = [{ id: "1", version: "v3.2.2", viewedAt: 1 }];
+		const qc = createClient();
+		qc.setQueryData(listKey, state.viewedList);
+		renderProvider(qc);
+
+		// Data is seeded synchronously, so the auto-open effect has already run.
+		expect(screen.getByTestId("state")).toHaveTextContent("closed");
+	});
+
+	it("stays closed while the list is still loading (no flash-open before data)", async () => {
+		state.viewedList = [];
+		state.hang = true;
+		const qc = createClient();
+		renderProvider(qc);
+
+		// The list never resolves; even though an empty list would open once
+		// loaded, the loading guard keeps it closed.
+		await waitFor(() =>
+			expect(screen.getByTestId("state")).toHaveTextContent("closed")
+		);
+	});
+
+	it("stays closed when there is no published release (LATEST_VERSION null)", () => {
+		state.latestVersion = null;
+		state.viewedList = [];
+		const qc = createClient();
+		qc.setQueryData(listKey, state.viewedList);
+		renderProvider(qc);
+
+		expect(screen.getByTestId("state")).toHaveTextContent("closed");
+	});
+
+	it("auto-opens only once — does not reopen after the user closes it and the list refetches", async () => {
+		state.viewedList = [];
+		const qc = createClient();
+		qc.setQueryData(listKey, state.viewedList);
+		renderProvider(qc);
+
+		expect(screen.getByTestId("state")).toHaveTextContent("open");
+
+		const user = userEvent.setup();
+		await user.click(screen.getByRole("button", { name: "close" }));
+		expect(screen.getByTestId("state")).toHaveTextContent("closed");
+
+		// A later cache update (e.g. after marking a note viewed) must not
+		// re-trigger the one-shot auto-open.
+		qc.setQueryData(listKey, [{ id: "1", version: "v3.2.2", viewedAt: 1 }]);
+
+		await waitFor(() =>
+			expect(screen.getByTestId("state")).toHaveTextContent("closed")
+		);
+	});
+});

--- a/apps/web/src/features/update-notes/components/update-notes-sheet/__tests__/use-update-notes-sheet.test.tsx
+++ b/apps/web/src/features/update-notes/components/update-notes-sheet/__tests__/use-update-notes-sheet.test.tsx
@@ -8,6 +8,7 @@ const state = vi.hoisted(() => ({
 	viewedVersions: new Set<string>(),
 	isViewedListLoaded: true,
 	markViewed: vi.fn(),
+	handleAccordionChange: vi.fn(),
 }));
 
 vi.mock("@/features/update-notes/constants", () => ({
@@ -22,7 +23,7 @@ vi.mock("@/features/update-notes/hooks/use-update-notes-viewed", () => ({
 		viewedVersions: state.viewedVersions,
 		isViewedListLoaded: state.isViewedListLoaded,
 		markViewed: state.markViewed,
-		handleAccordionChange: vi.fn(),
+		handleAccordionChange: state.handleAccordionChange,
 	}),
 }));
 
@@ -32,12 +33,17 @@ import {
 } from "@/features/update-notes/components/update-notes-sheet/use-update-notes-sheet";
 
 function Probe() {
-	const { isOpen, close } = useUpdateNotesSheet();
+	const { isOpen, close, viewedVersions, onAccordionChange } =
+		useUpdateNotesSheet();
 	return (
 		<div>
 			<span data-testid="state">{isOpen ? "open" : "closed"}</span>
+			<span data-testid="viewed-count">{viewedVersions.size}</span>
 			<button onClick={close} type="button">
 				close
+			</button>
+			<button onClick={() => onAccordionChange(["v3.2.1"])} type="button">
+				expand
 			</button>
 		</div>
 	);
@@ -53,6 +59,7 @@ describe("UpdateNotesProvider auto-open", () => {
 		state.viewedVersions = new Set();
 		state.isViewedListLoaded = true;
 		state.markViewed.mockClear();
+		state.handleAccordionChange.mockClear();
 	});
 
 	it("auto-opens for a user who has not viewed the latest release", () => {
@@ -115,5 +122,23 @@ describe("UpdateNotesProvider auto-open", () => {
 		expect(screen.getByTestId("state")).toHaveTextContent("closed");
 		// markViewed fired once on the initial auto-open, not again.
 		expect(state.markViewed).toHaveBeenCalledTimes(1);
+	});
+
+	it("shares the single viewed-versions set through context", () => {
+		state.viewedVersions = new Set(["v3.2.2", "v3.2.1"]);
+		renderProvider();
+
+		expect(screen.getByTestId("viewed-count")).toHaveTextContent("2");
+	});
+
+	it("forwards accordion changes to the shared hook's handler", async () => {
+		state.viewedVersions = new Set(["v3.2.2"]);
+		renderProvider();
+
+		const user = userEvent.setup();
+		await user.click(screen.getByRole("button", { name: "expand" }));
+
+		expect(state.handleAccordionChange).toHaveBeenCalledTimes(1);
+		expect(state.handleAccordionChange).toHaveBeenCalledWith(["v3.2.1"]);
 	});
 });

--- a/apps/web/src/features/update-notes/components/update-notes-sheet/__tests__/use-update-notes-sheet.test.tsx
+++ b/apps/web/src/features/update-notes/components/update-notes-sheet/__tests__/use-update-notes-sheet.test.tsx
@@ -1,13 +1,13 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createElement, type ReactNode } from "react";
+import { createElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const state = vi.hoisted(() => ({
 	latestVersion: "v3.2.2" as string | null,
-	viewedList: [] as Array<{ id: string; version: string; viewedAt: number }>,
-	hang: false,
+	viewedVersions: new Set<string>(),
+	isViewedListLoaded: true,
+	markViewed: vi.fn(),
 }));
 
 vi.mock("@/features/update-notes/constants", () => ({
@@ -17,24 +17,13 @@ vi.mock("@/features/update-notes/constants", () => ({
 	UPDATE_NOTES: [],
 }));
 
-const listKey = ["updateNoteView", "list"];
-
-vi.mock("@/utils/trpc", () => ({
-	trpc: {
-		updateNoteView: {
-			list: {
-				queryOptions: () => ({
-					queryKey: listKey,
-					queryFn: () =>
-						state.hang
-							? new Promise(() => {
-									/* never resolves — simulates the loading state */
-								})
-							: Promise.resolve(state.viewedList),
-				}),
-			},
-		},
-	},
+vi.mock("@/features/update-notes/hooks/use-update-notes-viewed", () => ({
+	useUpdateNotesViewed: () => ({
+		viewedVersions: state.viewedVersions,
+		isViewedListLoaded: state.isViewedListLoaded,
+		markViewed: state.markViewed,
+		handleAccordionChange: vi.fn(),
+	}),
 }));
 
 import {
@@ -54,105 +43,77 @@ function Probe() {
 	);
 }
 
-function createClient(): QueryClient {
-	return new QueryClient({
-		defaultOptions: {
-			queries: { retry: false, gcTime: 0, staleTime: Number.POSITIVE_INFINITY },
-		},
-	});
-}
-
-function renderProvider(client: QueryClient) {
-	return render(
-		createElement(
-			QueryClientProvider,
-			{ client },
-			createElement(UpdateNotesProvider, null, createElement(Probe))
-		) as ReactNode
-	);
+function renderProvider() {
+	return render(createElement(UpdateNotesProvider, null, createElement(Probe)));
 }
 
 describe("UpdateNotesProvider auto-open", () => {
 	beforeEach(() => {
 		state.latestVersion = "v3.2.2";
-		state.viewedList = [];
-		state.hang = false;
+		state.viewedVersions = new Set();
+		state.isViewedListLoaded = true;
+		state.markViewed.mockClear();
 	});
 
-	it("auto-opens for a user with no view records once the list loads", async () => {
-		state.viewedList = [];
-		const qc = createClient();
-		renderProvider(qc);
+	it("auto-opens for a user who has not viewed the latest release", () => {
+		state.viewedVersions = new Set();
+		renderProvider();
 
-		await waitFor(() =>
-			expect(screen.getByTestId("state")).toHaveTextContent("open")
-		);
+		expect(screen.getByTestId("state")).toHaveTextContent("open");
 	});
 
-	it("auto-opens when the user has viewed older versions but not the latest", async () => {
-		state.viewedList = [
-			{ id: "1", version: "v3.2.1", viewedAt: 2 },
-			{ id: "2", version: "v3.2.0", viewedAt: 1 },
-		];
-		const qc = createClient();
-		renderProvider(qc);
+	it("auto-opens when the user has viewed older versions but not the latest", () => {
+		state.viewedVersions = new Set(["v3.2.1", "v3.2.0"]);
+		renderProvider();
 
-		await waitFor(() =>
-			expect(screen.getByTestId("state")).toHaveTextContent("open")
-		);
+		expect(screen.getByTestId("state")).toHaveTextContent("open");
 	});
 
-	it("stays closed when the user has already viewed the latest version", () => {
-		state.viewedList = [{ id: "1", version: "v3.2.2", viewedAt: 1 }];
-		const qc = createClient();
-		qc.setQueryData(listKey, state.viewedList);
-		renderProvider(qc);
+	it("marks the latest release viewed exactly once when it auto-opens", () => {
+		state.viewedVersions = new Set();
+		renderProvider();
 
-		// Data is seeded synchronously, so the auto-open effect has already run.
+		expect(state.markViewed).toHaveBeenCalledTimes(1);
+		expect(state.markViewed).toHaveBeenCalledWith("v3.2.2");
+	});
+
+	it("stays closed and does not mark anything when the latest is already viewed", () => {
+		state.viewedVersions = new Set(["v3.2.2"]);
+		renderProvider();
+
 		expect(screen.getByTestId("state")).toHaveTextContent("closed");
+		expect(state.markViewed).not.toHaveBeenCalled();
 	});
 
-	it("stays closed while the list is still loading (no flash-open before data)", async () => {
-		state.viewedList = [];
-		state.hang = true;
-		const qc = createClient();
-		renderProvider(qc);
+	it("stays closed while the viewed list is still loading", () => {
+		state.viewedVersions = new Set();
+		state.isViewedListLoaded = false;
+		renderProvider();
 
-		// The list never resolves; even though an empty list would open once
-		// loaded, the loading guard keeps it closed.
-		await waitFor(() =>
-			expect(screen.getByTestId("state")).toHaveTextContent("closed")
-		);
+		expect(screen.getByTestId("state")).toHaveTextContent("closed");
+		expect(state.markViewed).not.toHaveBeenCalled();
 	});
 
-	it("stays closed when there is no published release (LATEST_VERSION null)", () => {
+	it("stays closed and does not mark when there is no published release", () => {
 		state.latestVersion = null;
-		state.viewedList = [];
-		const qc = createClient();
-		qc.setQueryData(listKey, state.viewedList);
-		renderProvider(qc);
+		state.viewedVersions = new Set();
+		renderProvider();
 
 		expect(screen.getByTestId("state")).toHaveTextContent("closed");
+		expect(state.markViewed).not.toHaveBeenCalled();
 	});
 
-	it("auto-opens only once — does not reopen after the user closes it and the list refetches", async () => {
-		state.viewedList = [];
-		const qc = createClient();
-		qc.setQueryData(listKey, state.viewedList);
-		renderProvider(qc);
+	it("auto-opens only once — does not reopen after the user closes it", async () => {
+		state.viewedVersions = new Set();
+		renderProvider();
 
 		expect(screen.getByTestId("state")).toHaveTextContent("open");
 
 		const user = userEvent.setup();
 		await user.click(screen.getByRole("button", { name: "close" }));
+
 		expect(screen.getByTestId("state")).toHaveTextContent("closed");
-
-		// A later cache update (e.g. after marking a note viewed) must not
-		// re-trigger the one-shot auto-open.
-		qc.setQueryData(listKey, [{ id: "1", version: "v3.2.2", viewedAt: 1 }]);
-
-		await waitFor(() =>
-			expect(screen.getByTestId("state")).toHaveTextContent("closed")
-		);
+		// markViewed fired once on the initial auto-open, not again.
+		expect(state.markViewed).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/web/src/features/update-notes/components/update-notes-sheet/update-notes-sheet.test.tsx
+++ b/apps/web/src/features/update-notes/components/update-notes-sheet/update-notes-sheet.test.tsx
@@ -55,11 +55,6 @@ vi.mock("@/utils/trpc", () => ({
 			markViewed: {
 				mutationOptions: (opts: unknown) => opts,
 			},
-			getLatestViewedVersion: {
-				queryOptions: () => ({
-					queryKey: ["updateNoteView", "getLatestViewedVersion"],
-				}),
-			},
 		},
 	},
 }));

--- a/apps/web/src/features/update-notes/components/update-notes-sheet/update-notes-sheet.test.tsx
+++ b/apps/web/src/features/update-notes/components/update-notes-sheet/update-notes-sheet.test.tsx
@@ -9,9 +9,9 @@ const mocks = vi.hoisted(() => ({
 		open: vi.fn(),
 		close: vi.fn(),
 		setIsOpen: vi.fn(),
+		viewedVersions: new Set<string>(),
+		onAccordionChange: vi.fn(),
 	},
-	viewedList: [] as Array<{ id: string; version: string; viewedAt: Date }>,
-	markViewedMutate: vi.fn(),
 }));
 
 vi.mock(
@@ -20,17 +20,6 @@ vi.mock(
 		useUpdateNotesSheet: () => mocks.sheetState,
 	})
 );
-
-vi.mock("@tanstack/react-query", () => ({
-	useQuery: () => ({ data: mocks.viewedList }),
-	useMutation: () => ({ mutate: mocks.markViewedMutate }),
-	useQueryClient: () => ({
-		cancelQueries: vi.fn(),
-		getQueryData: vi.fn(),
-		setQueryData: vi.fn(),
-		invalidateQueries: vi.fn(),
-	}),
-}));
 
 vi.mock("@/features/update-notes/constants", () => ({
 	UPDATE_NOTES: [
@@ -46,17 +35,6 @@ vi.mock("@/features/update-notes/constants", () => ({
 		},
 	],
 	LATEST_VERSION: "1.0.0",
-}));
-
-vi.mock("@/utils/trpc", () => ({
-	trpc: {
-		updateNoteView: {
-			list: { queryOptions: () => ({ queryKey: ["updateNoteView", "list"] }) },
-			markViewed: {
-				mutationOptions: (opts: unknown) => opts,
-			},
-		},
-	},
 }));
 
 vi.mock("@/shared/components/ui/accordion", () => ({
@@ -95,7 +73,7 @@ describe("UpdateNotesSheet", () => {
 
 	it("renders accordion items for update notes", () => {
 		mocks.sheetState.isOpen = true;
-		mocks.viewedList = [];
+		mocks.sheetState.viewedVersions = new Set();
 		render(<UpdateNotesSheet />);
 		expect(screen.getByText("1.0.0")).toBeInTheDocument();
 		expect(screen.getByText("2026-04-11")).toBeInTheDocument();
@@ -103,14 +81,14 @@ describe("UpdateNotesSheet", () => {
 
 	it("shows NEW badge for unviewed versions", () => {
 		mocks.sheetState.isOpen = true;
-		mocks.viewedList = [];
+		mocks.sheetState.viewedVersions = new Set();
 		render(<UpdateNotesSheet />);
 		expect(screen.getByTestId("badge")).toHaveTextContent("NEW");
 	});
 
 	it("does not show NEW badge for viewed versions", () => {
 		mocks.sheetState.isOpen = true;
-		mocks.viewedList = [{ id: "1", version: "1.0.0", viewedAt: new Date() }];
+		mocks.sheetState.viewedVersions = new Set(["1.0.0"]);
 		render(<UpdateNotesSheet />);
 		expect(screen.queryByTestId("badge")).not.toBeInTheDocument();
 	});
@@ -138,9 +116,9 @@ describe("UpdateNotesSheet", () => {
 		).toBeInTheDocument();
 	});
 
-	it("does not render drawer content when isOpen=false even if viewedList is populated", () => {
+	it("does not render drawer content when isOpen=false even if a version is viewed", () => {
 		mocks.sheetState.isOpen = false;
-		mocks.viewedList = [{ id: "1", version: "1.0.0", viewedAt: new Date() }];
+		mocks.sheetState.viewedVersions = new Set(["1.0.0"]);
 		render(<UpdateNotesSheet />);
 		expect(screen.queryByText("Update notes")).not.toBeInTheDocument();
 	});

--- a/apps/web/src/features/update-notes/components/update-notes-sheet/update-notes-sheet.tsx
+++ b/apps/web/src/features/update-notes/components/update-notes-sheet/update-notes-sheet.tsx
@@ -1,5 +1,4 @@
 import { UPDATE_NOTES } from "@/features/update-notes/constants";
-import { useUpdateNotesViewed } from "@/features/update-notes/hooks/use-update-notes-viewed";
 import {
 	Accordion,
 	AccordionContent,
@@ -16,8 +15,8 @@ import {
 import { useUpdateNotesSheet } from "./use-update-notes-sheet";
 
 export function UpdateNotesSheet() {
-	const { isOpen, setIsOpen } = useUpdateNotesSheet();
-	const { viewedVersions, handleAccordionChange } = useUpdateNotesViewed();
+	const { isOpen, setIsOpen, viewedVersions, onAccordionChange } =
+		useUpdateNotesSheet();
 
 	return (
 		<Drawer onOpenChange={setIsOpen} open={isOpen}>
@@ -38,7 +37,7 @@ export function UpdateNotesSheet() {
 							No update notes available.
 						</p>
 					) : (
-						<Accordion onValueChange={handleAccordionChange} type="multiple">
+						<Accordion onValueChange={onAccordionChange} type="multiple">
 							{UPDATE_NOTES.map((note) => (
 								<AccordionItem key={note.version} value={note.version}>
 									<AccordionTrigger>

--- a/apps/web/src/features/update-notes/components/update-notes-sheet/use-update-notes-sheet.tsx
+++ b/apps/web/src/features/update-notes/components/update-notes-sheet/use-update-notes-sheet.tsx
@@ -6,8 +6,10 @@ import { shouldAutoOpenUpdateNotes } from "@/features/update-notes/utils/should-
 interface UpdateNotesSheetContextValue {
 	close: () => void;
 	isOpen: boolean;
+	onAccordionChange: (value: string[]) => void;
 	open: () => void;
 	setIsOpen: (open: boolean) => void;
+	viewedVersions: ReadonlySet<string>;
 }
 
 const UpdateNotesSheetContext =
@@ -20,8 +22,16 @@ export function UpdateNotesProvider({
 }) {
 	const [isOpen, setIsOpen] = useState(false);
 	const [hasAutoOpened, setHasAutoOpened] = useState(false);
-	const { viewedVersions, isViewedListLoaded, markViewed } =
-		useUpdateNotesViewed();
+	// Single source of truth for viewed state, shared with UpdateNotesSheet via
+	// context. Holding one instance here (rather than the provider and the sheet
+	// each calling useUpdateNotesViewed) keeps the auto-open optimistic mark in
+	// sync with the sheet's NEW badges — no cross-instance flicker (SA2-185).
+	const {
+		viewedVersions,
+		isViewedListLoaded,
+		markViewed,
+		handleAccordionChange,
+	} = useUpdateNotesViewed();
 
 	useEffect(() => {
 		// Wait until the viewed list has loaded before deciding once.
@@ -53,6 +63,8 @@ export function UpdateNotesProvider({
 				open: () => setIsOpen(true),
 				close: () => setIsOpen(false),
 				setIsOpen,
+				viewedVersions,
+				onAccordionChange: handleAccordionChange,
 			}}
 		>
 			{children}

--- a/apps/web/src/features/update-notes/components/update-notes-sheet/use-update-notes-sheet.tsx
+++ b/apps/web/src/features/update-notes/components/update-notes-sheet/use-update-notes-sheet.tsx
@@ -1,8 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
 import { createContext, useContext, useEffect, useState } from "react";
 import { LATEST_VERSION } from "@/features/update-notes/constants";
+import { useUpdateNotesViewed } from "@/features/update-notes/hooks/use-update-notes-viewed";
 import { shouldAutoOpenUpdateNotes } from "@/features/update-notes/utils/should-auto-open-update-notes";
-import { trpc } from "@/utils/trpc";
 
 interface UpdateNotesSheetContextValue {
 	close: () => void;
@@ -21,27 +20,31 @@ export function UpdateNotesProvider({
 }) {
 	const [isOpen, setIsOpen] = useState(false);
 	const [hasAutoOpened, setHasAutoOpened] = useState(false);
-
-	const { data: viewedList } = useQuery(
-		trpc.updateNoteView.list.queryOptions()
-	);
+	const { viewedVersions, isViewedListLoaded, markViewed } =
+		useUpdateNotesViewed();
 
 	useEffect(() => {
 		// Wait until the viewed list has loaded before deciding once.
-		if (hasAutoOpened || viewedList === undefined) {
+		if (hasAutoOpened || !isViewedListLoaded) {
 			return;
 		}
 
 		if (
 			shouldAutoOpenUpdateNotes({
 				latestVersion: LATEST_VERSION,
-				viewedVersions: viewedList.map((view) => view.version),
+				viewedVersions: [...viewedVersions],
 			})
 		) {
 			setIsOpen(true);
+			// Record the latest release as viewed on auto-open so the sheet
+			// surfaces once per release instead of every session until the user
+			// happens to expand its accordion (SA2-185 review follow-up).
+			if (LATEST_VERSION) {
+				markViewed(LATEST_VERSION);
+			}
 		}
 		setHasAutoOpened(true);
-	}, [viewedList, hasAutoOpened]);
+	}, [isViewedListLoaded, viewedVersions, hasAutoOpened, markViewed]);
 
 	return (
 		<UpdateNotesSheetContext.Provider

--- a/apps/web/src/features/update-notes/components/update-notes-sheet/use-update-notes-sheet.tsx
+++ b/apps/web/src/features/update-notes/components/update-notes-sheet/use-update-notes-sheet.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { createContext, useContext, useEffect, useState } from "react";
 import { LATEST_VERSION } from "@/features/update-notes/constants";
+import { shouldAutoOpenUpdateNotes } from "@/features/update-notes/utils/should-auto-open-update-notes";
 import { trpc } from "@/utils/trpc";
 
 interface UpdateNotesSheetContextValue {
@@ -21,29 +22,26 @@ export function UpdateNotesProvider({
 	const [isOpen, setIsOpen] = useState(false);
 	const [hasAutoOpened, setHasAutoOpened] = useState(false);
 
-	const { data: latestViewed } = useQuery(
-		trpc.updateNoteView.getLatestViewedVersion.queryOptions()
+	const { data: viewedList } = useQuery(
+		trpc.updateNoteView.list.queryOptions()
 	);
 
 	useEffect(() => {
-		if (hasAutoOpened || !latestViewed || !LATEST_VERSION) {
+		// Wait until the viewed list has loaded before deciding once.
+		if (hasAutoOpened || viewedList === undefined) {
 			return;
 		}
 
-		// First-time user (never viewed any version) — skip auto-open
-		if (latestViewed.version === null) {
-			setHasAutoOpened(true);
-			return;
-		}
-
-		// User has viewed before but not the latest version — auto-open
-		if (latestViewed.version === LATEST_VERSION) {
-			setHasAutoOpened(true);
-		} else {
+		if (
+			shouldAutoOpenUpdateNotes({
+				latestVersion: LATEST_VERSION,
+				viewedVersions: viewedList.map((view) => view.version),
+			})
+		) {
 			setIsOpen(true);
-			setHasAutoOpened(true);
 		}
-	}, [latestViewed, hasAutoOpened]);
+		setHasAutoOpened(true);
+	}, [viewedList, hasAutoOpened]);
 
 	return (
 		<UpdateNotesSheetContext.Provider

--- a/apps/web/src/features/update-notes/hooks/__tests__/use-update-notes-viewed.test.ts
+++ b/apps/web/src/features/update-notes/hooks/__tests__/use-update-notes-viewed.test.ts
@@ -268,4 +268,76 @@ describe("useUpdateNotesViewed", () => {
 			});
 		});
 	});
+
+	describe("markViewed", () => {
+		it("marks an unviewed version optimistically and fires the mutation", async () => {
+			const qc = createClient();
+			qc.setQueryData(listKey, []);
+			trpcMocks.markViewed.mockResolvedValue({ id: "x" });
+			const { result } = renderHook(() => useUpdateNotesViewed(), {
+				wrapper: makeWrapper(qc),
+			});
+			act(() => {
+				result.current.markViewed("4.0.0");
+			});
+			await waitFor(() => {
+				expect(result.current.viewedVersions.has("4.0.0")).toBe(true);
+			});
+			expect(trpcMocks.markViewed).toHaveBeenCalledTimes(1);
+			expect(trpcMocks.markViewed).toHaveBeenCalledWith({ version: "4.0.0" });
+		});
+
+		it("skips the mutation when the version is already in the server viewed list", async () => {
+			const qc = createClient();
+			qc.setQueryData(listKey, [{ id: "1", version: "1.0.0" }]);
+			const { result } = renderHook(() => useUpdateNotesViewed(), {
+				wrapper: makeWrapper(qc),
+			});
+			await waitFor(() =>
+				expect(result.current.viewedVersions.has("1.0.0")).toBe(true)
+			);
+			act(() => {
+				result.current.markViewed("1.0.0");
+			});
+			expect(trpcMocks.markViewed).not.toHaveBeenCalled();
+		});
+
+		it("skips the mutation on a repeated call for the same version (optimistic dedup)", async () => {
+			const qc = createClient();
+			qc.setQueryData(listKey, []);
+			trpcMocks.markViewed.mockResolvedValue({ id: "x" });
+			const { result } = renderHook(() => useUpdateNotesViewed(), {
+				wrapper: makeWrapper(qc),
+			});
+			act(() => {
+				result.current.markViewed("4.0.0");
+			});
+			await waitFor(() =>
+				expect(result.current.viewedVersions.has("4.0.0")).toBe(true)
+			);
+			act(() => {
+				result.current.markViewed("4.0.0");
+			});
+			expect(trpcMocks.markViewed).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("isViewedListLoaded", () => {
+		it("is false before the list query resolves", () => {
+			const qc = createClient();
+			const { result } = renderHook(() => useUpdateNotesViewed(), {
+				wrapper: makeWrapper(qc),
+			});
+			expect(result.current.isViewedListLoaded).toBe(false);
+		});
+
+		it("is true once the list query has data (including an empty list)", async () => {
+			const qc = createClient();
+			qc.setQueryData(listKey, []);
+			const { result } = renderHook(() => useUpdateNotesViewed(), {
+				wrapper: makeWrapper(qc),
+			});
+			await waitFor(() => expect(result.current.isViewedListLoaded).toBe(true));
+		});
+	});
 });

--- a/apps/web/src/features/update-notes/hooks/__tests__/use-update-notes-viewed.test.ts
+++ b/apps/web/src/features/update-notes/hooks/__tests__/use-update-notes-viewed.test.ts
@@ -33,16 +33,6 @@ vi.mock("@/utils/trpc", () => {
 				markViewed: {
 					mutationOptions: markViewedOptions,
 				},
-				getLatestViewedVersion: {
-					queryOptions: () => ({
-						queryKey: buildKey(
-							"updateNoteView",
-							"getLatestViewedVersion",
-							undefined
-						),
-						queryFn: () => Promise.resolve(null),
-					}),
-				},
 			},
 		},
 	};
@@ -214,10 +204,9 @@ describe("useUpdateNotesViewed", () => {
 	});
 
 	describe("onSettled invalidation", () => {
-		it("invalidates both list and getLatestViewedVersion queries after mutation settles", async () => {
+		it("invalidates the list query after mutation settles", async () => {
 			const qc = createClient();
 			qc.setQueryData(listKey, []);
-			qc.setQueryData(latestKey, null);
 			const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
 			trpcMocks.markViewed.mockResolvedValue({ id: "ok" });
 
@@ -231,8 +220,29 @@ describe("useUpdateNotesViewed", () => {
 				const calls = invalidateSpy.mock.calls.map(
 					(c) => (c[0] as { queryKey: unknown[] } | undefined)?.queryKey
 				);
-				expect(calls).toEqual(expect.arrayContaining([listKey, latestKey]));
+				expect(calls).toEqual(expect.arrayContaining([listKey]));
 			});
+		});
+
+		it("does not invalidate the removed getLatestViewedVersion query", async () => {
+			const qc = createClient();
+			qc.setQueryData(listKey, []);
+			const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+			trpcMocks.markViewed.mockResolvedValue({ id: "ok" });
+
+			const { result } = renderHook(() => useUpdateNotesViewed(), {
+				wrapper: makeWrapper(qc),
+			});
+			act(() => {
+				result.current.handleAccordionChange(["9.9.9"]);
+			});
+			await waitFor(() => {
+				expect(invalidateSpy).toHaveBeenCalled();
+			});
+			const invalidatedKeys = invalidateSpy.mock.calls.map(
+				(c) => (c[0] as { queryKey: unknown[] } | undefined)?.queryKey
+			);
+			expect(invalidatedKeys).not.toContainEqual(latestKey);
 		});
 
 		it("also invalidates after a failed mutation (onSettled runs regardless)", async () => {

--- a/apps/web/src/features/update-notes/hooks/use-update-notes-viewed.ts
+++ b/apps/web/src/features/update-notes/hooks/use-update-notes-viewed.ts
@@ -28,14 +28,24 @@ export function useUpdateNotesViewed() {
 		})
 	);
 
+	const markViewed = (version: string) => {
+		if (viewedVersions.has(version)) {
+			return;
+		}
+		setOptimisticallyViewed((prev) => new Set([...prev, version]));
+		markViewedMutation.mutate({ version });
+	};
+
 	const handleAccordionChange = (value: string[]) => {
 		for (const version of value) {
-			if (!viewedVersions.has(version)) {
-				setOptimisticallyViewed((prev) => new Set([...prev, version]));
-				markViewedMutation.mutate({ version });
-			}
+			markViewed(version);
 		}
 	};
 
-	return { viewedVersions, handleAccordionChange };
+	return {
+		viewedVersions,
+		isViewedListLoaded: viewedList !== undefined,
+		markViewed,
+		handleAccordionChange,
+	};
 }

--- a/apps/web/src/features/update-notes/hooks/use-update-notes-viewed.ts
+++ b/apps/web/src/features/update-notes/hooks/use-update-notes-viewed.ts
@@ -24,11 +24,6 @@ export function useUpdateNotesViewed() {
 			onSettled: () =>
 				invalidateTargets(queryClient, [
 					{ queryKey: trpc.updateNoteView.list.queryOptions().queryKey },
-					{
-						queryKey:
-							trpc.updateNoteView.getLatestViewedVersion.queryOptions()
-								.queryKey,
-					},
 				]),
 		})
 	);

--- a/apps/web/src/features/update-notes/utils/__tests__/should-auto-open-update-notes.test.ts
+++ b/apps/web/src/features/update-notes/utils/__tests__/should-auto-open-update-notes.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { shouldAutoOpenUpdateNotes } from "@/features/update-notes/utils/should-auto-open-update-notes";
+
+describe("shouldAutoOpenUpdateNotes", () => {
+	describe("when there is no latest release", () => {
+		it("returns false when latestVersion is null (no releases published)", () => {
+			expect(
+				shouldAutoOpenUpdateNotes({
+					latestVersion: null,
+					viewedVersions: [],
+				})
+			).toBe(false);
+		});
+
+		it("returns false when latestVersion is null even if the list is still loading", () => {
+			expect(
+				shouldAutoOpenUpdateNotes({
+					latestVersion: null,
+					viewedVersions: undefined,
+				})
+			).toBe(false);
+		});
+
+		it("returns false when latestVersion is an empty string", () => {
+			expect(
+				shouldAutoOpenUpdateNotes({
+					latestVersion: "",
+					viewedVersions: [],
+				})
+			).toBe(false);
+		});
+	});
+
+	describe("while the viewed list is still loading", () => {
+		it("returns false when viewedVersions is undefined (avoids flashing open before data arrives)", () => {
+			expect(
+				shouldAutoOpenUpdateNotes({
+					latestVersion: "v3.2.2",
+					viewedVersions: undefined,
+				})
+			).toBe(false);
+		});
+	});
+
+	describe("once the viewed list has loaded", () => {
+		it("returns true when the user has no view records at all (first-ever load with a release)", () => {
+			expect(
+				shouldAutoOpenUpdateNotes({
+					latestVersion: "v3.2.2",
+					viewedVersions: [],
+				})
+			).toBe(true);
+		});
+
+		it("returns true when the user has viewed older versions but not the latest", () => {
+			expect(
+				shouldAutoOpenUpdateNotes({
+					latestVersion: "v3.2.2",
+					viewedVersions: ["v3.2.1", "v3.2.0"],
+				})
+			).toBe(true);
+		});
+
+		it("returns false when the user has already viewed the latest version", () => {
+			expect(
+				shouldAutoOpenUpdateNotes({
+					latestVersion: "v3.2.2",
+					viewedVersions: ["v3.2.2"],
+				})
+			).toBe(false);
+		});
+
+		it("returns false when the latest is viewed alongside other versions", () => {
+			expect(
+				shouldAutoOpenUpdateNotes({
+					latestVersion: "v3.2.2",
+					viewedVersions: ["v3.2.0", "v3.2.2", "v3.2.1"],
+				})
+			).toBe(false);
+		});
+
+		it("matches versions exactly (a differing case is treated as unviewed)", () => {
+			expect(
+				shouldAutoOpenUpdateNotes({
+					latestVersion: "v3.2.2",
+					viewedVersions: ["V3.2.2"],
+				})
+			).toBe(true);
+		});
+
+		it("does not treat a prefix match as a view (v3.2 is not v3.2.2)", () => {
+			expect(
+				shouldAutoOpenUpdateNotes({
+					latestVersion: "v3.2.2",
+					viewedVersions: ["v3.2"],
+				})
+			).toBe(true);
+		});
+	});
+});

--- a/apps/web/src/features/update-notes/utils/should-auto-open-update-notes.ts
+++ b/apps/web/src/features/update-notes/utils/should-auto-open-update-notes.ts
@@ -1,0 +1,31 @@
+/**
+ * Decide whether the update-notes sheet should auto-open on app load.
+ *
+ * Auto-open iff there is a latest release the user has not yet viewed. The
+ * previous implementation compared the user's *most recently viewed* version
+ * against the latest and, critically, skipped every user with no view records
+ * at all — which is the common case (all existing users right after the feature
+ * shipped, plus anyone who never expanded a note). That left the sheet never
+ * auto-opening for the majority of users (SA2-185). Checking membership in the
+ * full viewed set fixes that and also covers the edge case of the latest being
+ * viewed before an older note.
+ *
+ * Returns false while the viewed list is still loading (`undefined`) so the
+ * sheet never flashes open before we know what the user has already seen.
+ */
+export function shouldAutoOpenUpdateNotes(params: {
+	latestVersion: string | null;
+	viewedVersions: readonly string[] | undefined;
+}): boolean {
+	const { latestVersion, viewedVersions } = params;
+
+	if (!latestVersion) {
+		return false;
+	}
+
+	if (viewedVersions === undefined) {
+		return false;
+	}
+
+	return !viewedVersions.includes(latestVersion);
+}

--- a/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/__tests__/use-user-menu.test.ts
+++ b/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/__tests__/use-user-menu.test.ts
@@ -3,25 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
 	useSession: vi.fn(),
-	updateNotesSheet: {
-		isOpen: false,
-		open: vi.fn(),
-		close: vi.fn(),
-		setIsOpen: vi.fn(),
-	},
 	onSignOut: vi.fn(),
 	useSignOut: vi.fn(),
-	useUpdateNotesSheet: vi.fn(),
 }));
 
 vi.mock("@/lib/auth-client", () => ({
 	authClient: {
 		useSession: mocks.useSession,
 	},
-}));
-
-vi.mock("@/features/update-notes/components/update-notes-sheet", () => ({
-	useUpdateNotesSheet: mocks.useUpdateNotesSheet,
 }));
 
 vi.mock("@/shared/hooks/use-sign-out", () => ({
@@ -35,12 +24,10 @@ describe("useUserMenu", () => {
 		mocks.useSession.mockReset();
 		mocks.onSignOut.mockReset();
 		mocks.useSignOut.mockReset();
-		mocks.useUpdateNotesSheet.mockReset();
 		mocks.useSignOut.mockReturnValue({ onSignOut: mocks.onSignOut });
-		mocks.useUpdateNotesSheet.mockReturnValue(mocks.updateNotesSheet);
 	});
 
-	it("exposes the authenticated session and update-notes controls", () => {
+	it("exposes the authenticated session", () => {
 		const session = {
 			data: { user: { email: "hero@example.com", name: "Hero User" } },
 			isPending: false,
@@ -51,7 +38,6 @@ describe("useUserMenu", () => {
 
 		expect(result.current.session).toBe(session.data);
 		expect(result.current.isPending).toBe(false);
-		expect(result.current.updateNotesSheet).toBe(mocks.updateNotesSheet);
 	});
 
 	it("surfaces isPending while the session is loading", () => {

--- a/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/use-user-menu.ts
+++ b/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/use-user-menu.ts
@@ -1,11 +1,9 @@
-import { useUpdateNotesSheet } from "@/features/update-notes/components/update-notes-sheet";
 import { authClient } from "@/lib/auth-client";
 import { useSignOut } from "@/shared/hooks/use-sign-out";
 
 export function useUserMenu() {
 	const { data: session, isPending } = authClient.useSession();
-	const updateNotesSheet = useUpdateNotesSheet();
 	const { onSignOut } = useSignOut();
 
-	return { session, isPending, updateNotesSheet, onSignOut };
+	return { session, isPending, onSignOut };
 }

--- a/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/user-menu.test.tsx
+++ b/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/user-menu.test.tsx
@@ -7,12 +7,6 @@ const mocks = vi.hoisted(() => ({
 	menuState: {
 		session: null as null | { user: { email: string; name: string } },
 		isPending: false,
-		updateNotesSheet: {
-			isOpen: false,
-			open: vi.fn(),
-			close: vi.fn(),
-			setIsOpen: vi.fn(),
-		},
 		onSignOut: vi.fn(),
 	},
 	useUserMenu: vi.fn(),
@@ -30,7 +24,6 @@ vi.mock("./use-user-menu", () => ({
 
 describe("UserMenu", () => {
 	beforeEach(() => {
-		mocks.menuState.updateNotesSheet.open.mockReset();
 		mocks.menuState.onSignOut.mockReset();
 		mocks.useUserMenu.mockReset();
 		mocks.useUserMenu.mockImplementation(() => mocks.menuState);

--- a/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/user-menu.tsx
+++ b/apps/web/src/shared/components/authenticated-shell/sidebar-nav/user-menu/user-menu.tsx
@@ -13,7 +13,7 @@ import { Skeleton } from "@/shared/components/ui/skeleton";
 import { useUserMenu } from "./use-user-menu";
 
 export function UserMenu() {
-	const { session, isPending, updateNotesSheet, onSignOut } = useUserMenu();
+	const { session, isPending, onSignOut } = useUserMenu();
 
 	if (isPending) {
 		return <Skeleton className="h-8 w-24" />;
@@ -41,9 +41,6 @@ export function UserMenu() {
 					<DropdownMenuLabel>My Account</DropdownMenuLabel>
 					<DropdownMenuSeparator />
 					<DropdownMenuItem>{session.user.email}</DropdownMenuItem>
-					<DropdownMenuItem onClick={updateNotesSheet.open}>
-						Update Notes
-					</DropdownMenuItem>
 					<DropdownMenuItem onClick={onSignOut} variant="destructive">
 						Sign Out
 					</DropdownMenuItem>

--- a/packages/api/src/__tests__/update-note-view.test.ts
+++ b/packages/api/src/__tests__/update-note-view.test.ts
@@ -14,15 +14,13 @@ describe("updateNoteView router", () => {
 
 	it("exposes exactly the expected procedure set", () => {
 		expect(Object.keys(appRouter.updateNoteView).sort()).toEqual(
-			["getLatestViewedVersion", "list", "markViewed"].sort()
+			["list", "markViewed"].sort()
 		);
 	});
 
-	it("list / getLatestViewedVersion are protected queries", () => {
+	it("list is a protected query", () => {
 		expectProtected(appRouter.updateNoteView.list);
 		expectType(appRouter.updateNoteView.list, "query");
-		expectProtected(appRouter.updateNoteView.getLatestViewedVersion);
-		expectType(appRouter.updateNoteView.getLatestViewedVersion, "query");
 	});
 
 	it("markViewed is a protected mutation", () => {

--- a/packages/api/src/routers/update-note-view.ts
+++ b/packages/api/src/routers/update-note-view.ts
@@ -43,20 +43,4 @@ export const updateNoteViewRouter = router({
 				.where(eq(updateNoteView.id, id));
 			return created;
 		}),
-
-	getLatestViewedVersion: protectedProcedure.query(async ({ ctx }) => {
-		const userId = ctx.session.user.id;
-		const [latest] = await ctx.db
-			.select()
-			.from(updateNoteView)
-			.where(eq(updateNoteView.userId, userId))
-			.orderBy(desc(updateNoteView.viewedAt))
-			.limit(1);
-
-		if (!latest) {
-			return { version: null, viewedAt: null };
-		}
-
-		return { version: latest.version, viewedAt: latest.viewedAt };
-	}),
 });


### PR DESCRIPTION
## 概要

アップデートノート機能の不具合を修正します。

1. **自動表示が機能していない**（本来の SA2-185）
2. **モバイルで手動導線・バージョン表示が存在しない**（調査中に発覚した関連不具合）

Fixes SA2-185 / #518

---

## 1. 自動表示が機能していない

### 原因

`UpdateNotesProvider`（`use-update-notes-sheet.tsx`）の自動表示判定が `getLatestViewedVersion`（= 最後に閲覧したバージョン）に依存しており、**閲覧履歴が1件も無いユーザー（`version === null`）を「初回ユーザー」として一律スキップ**していました。

```ts
// First-time user (never viewed any version) — skip auto-open
if (latestViewed.version === null) {
  setHasAutoOpened(true);
  return;
}
```

閲覧履歴は「手動でシートを開いてアコーディオンを展開した」ときにしか記録されません。そのため機能導入直後の既存ユーザー全員や、一度もアコーディオンを展開していないユーザーでは、新しいリリースが出ても履歴が空 → スキップされ、事実上ほとんどのユーザーで自動表示が発火していませんでした。

### 修正

判定基準を **「閲覧済み集合に `LATEST_VERSION` が含まれるか」** に変更。最新版が未読であれば履歴の有無に関わらず自動表示します（新規サインアップ直後のユーザーも対象 — 方針を確認済み）。

さらに、**自動表示した時点で `LATEST_VERSION` を既読として記録**します。既読記録はアコーディオン展開時のみだったため、自動表示されたシートを最新版を展開せずに閉じると次回も自動表示され続けていました（レビュー指摘）。これにより **新リリースごとに1回だけ**自動表示されます。

- 判定を純粋関数 `shouldAutoOpenUpdateNotes` に切り出し、ロード中は開かないガードを明示。
- 既読記録ロジックを `useUpdateNotesViewed` の `markViewed` / `isViewedListLoaded` として公開し、Provider が再利用（mutation はフックに集約する規約に準拠）。
- 自動オープン時に `markViewed(LATEST_VERSION)` を実行。
- 本バグの温床だった `getLatestViewedVersion` プロシージャと `onSettled` の無効化対象を削除。

---

## 2. モバイルで手動導線・バージョン表示が存在しない

### 原因

アップデートノートを手動で開く導線は `UserMenu` の "Update Notes" 項目のみですが、`UserMenu` は `SidebarNav` 内にあり `hidden md:flex` です。本アプリはモバイル専用（md 以上では「Use on your phone」画面を表示）のため、この導線は**実機（モバイル）では常に不可視**で、バージョン一覧のボトムシートを開く手段が存在しませんでした。設定画面にもアプリのバージョン表示がありませんでした。

### 修正

モバイルで到達可能な設定画面（下部ナビ → Settings）に **About セクション**を追加しました。

- 現在のバージョン（`LATEST_VERSION`）を表示。
- "View update notes" ボタンでアップデートノートのボトムシートを開く。
- 既存の `theme-setting` / `linked-accounts` と同じ子フォルダ＋コロケーション hook パターンに準拠。
- 二重導線を残さないよう、常に不可視だった `UserMenu` の "Update Notes" 項目は削除。

---

## テスト

- `should-auto-open-update-notes.test.ts`（web-node）: 判定純粋関数の分岐・境界を網羅。
- `use-update-notes-sheet.test.tsx`（web-dom）: Provider の自動表示ワイヤリングを検証（開く / 開かない / ロード中は開かない / 自動表示時に最新版を1回だけ既読化 / 一度きり）。
- `use-update-notes-viewed.test.ts`（web-dom）: `markViewed` / `isViewedListLoaded` を含む網羅テスト。
- `about-section.test.tsx` / `use-about-section.test.ts`（web-dom）: バージョン表示・"Unknown" フォールバック・シートを開く導線を検証。
- `settings-route.test.tsx` に About セクションの描画アサーションを追加。
- `getLatestViewedVersion` 削除に伴い API ルーター / フックのテストを更新。

`bun run check-types` / `ultracite check` / 対象テスト（web-node・web-dom・api）いずれもパスしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdPtAWXN39gH83ZKCX3ZfQ