### PR TITLE
fix(api): ライブセッション一覧のカーソルページネーションを複合キーセットに修正 (SA2-150)

### DIFF
--- a/packages/api/src/__tests__/live-cash-game-session.test.ts
+++ b/packages/api/src/__tests__/live-cash-game-session.test.ts
@@ -7,6 +7,7 @@ import { TRPCError } from "@trpc/server";
 import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
+import { encodeSessionCursor } from "../routers/session";
 import {
 	expectAccepts,
 	expectProtected,
@@ -745,54 +746,168 @@ describe("liveCashGameSession.updateSnapshot input validation", () => {
 
 const dialect = new SQLiteSyncDialect();
 
+type ChainableAny = Promise<Rows> &
+	Record<string, (...args: unknown[]) => ChainableAny>;
+
 /**
- * Mock db that records the SQL params bound to the list query's `.where(...)`
- * so the cursor-boundary subquery can be shown to be scoped to the caller
- * (SA2-182). `select().from()` resolves to no rows; the enrichment loop is
- * skipped because there are no items.
+ * Mock db that captures the list query's `.where(...)` (SQL + bound params) and
+ * `.orderBy(...)` (SQL), and resolves the `game_session` select to `listRows`
+ * while every other read (the per-item enrichment) resolves to `[]`. Lets the
+ * composite-keyset cursor (SA2-150) be inspected end-to-end: the boundary must
+ * embed the cursor's `(timestamp, id)` directly rather than run a subquery on
+ * the raw id (which returned NULL — and dropped the whole page — once the cursor
+ * row was discarded), and `nextCursor` must echo the last kept row's composite.
  */
-function createListWhereMockDb() {
-	const selectWhereParams: unknown[][] = [];
-	const makeChain = () => {
-		const chain = Promise.resolve([] as Rows) as Promise<Rows> &
-			Record<string, (...args: unknown[]) => unknown>;
-		chain.from = () => chain;
+function createListMockDb(listRows: Rows = []) {
+	const listWhere: { params: unknown[]; sql: string }[] = [];
+	const listOrderBy: string[] = [];
+	const makeChain = (rows: Rows, isList: boolean): ChainableAny => {
+		const chain = Promise.resolve(rows) as ChainableAny;
+		chain.from = (table: unknown) => {
+			const list = table === gameSession;
+			return makeChain(list ? listRows : [], list);
+		};
 		chain.where = (cond: unknown) => {
-			selectWhereParams.push(dialect.sqlToQuery(cond as never).params);
+			if (isList) {
+				const q = dialect.sqlToQuery(cond as never);
+				listWhere.push({ sql: q.sql, params: q.params });
+			}
 			return chain;
 		};
-		chain.orderBy = () => chain;
+		chain.orderBy = (...cols: unknown[]) => {
+			if (isList) {
+				listOrderBy.push(
+					cols.map((c) => dialect.sqlToQuery(c as never).sql).join(", ")
+				);
+			}
+			return chain;
+		};
 		chain.limit = () => chain;
 		chain.leftJoin = () => chain;
 		chain.innerJoin = () => chain;
 		return chain;
 	};
-	const db = { select: () => makeChain() };
-	return { db, selectWhereParams };
+	const db = { select: () => makeChain([], false) };
+	return { db, listOrderBy, listWhere };
 }
 
-describe("liveCashGameSession.list cursor scoping (SA2-182)", () => {
-	it("scopes the cursor boundary subquery to the caller's user id", async () => {
-		const { db, selectWhereParams } = createListWhereMockDb();
-		const caller = appRouter.createCaller({
-			session: { user: { id: OWNER } },
-			db,
-		} as unknown as Parameters<typeof appRouter.createCaller>[0]);
-		await caller.liveCashGameSession.list({ cursor: "s-cursor", limit: 10 });
-		const listWhere = selectWhereParams.find((p) => p.includes("s-cursor"));
-		expect(listWhere).toBeDefined();
-		// userId appears twice: the base filter + the cursor subquery scope.
-		expect((listWhere as unknown[]).filter((p) => p === OWNER)).toHaveLength(2);
+function listCaller(db: unknown) {
+	return appRouter.createCaller({
+		session: { user: { id: OWNER } },
+		db,
+	} as unknown as Parameters<typeof appRouter.createCaller>[0])
+		.liveCashGameSession;
+}
+
+interface CursorRow {
+	id: string;
+	sessionDate: Date;
+	startedAt: Date | null;
+}
+
+function makeCashRows(n: number): Rows {
+	return Array.from({ length: n }, (_, i) => ({
+		id: `s${i}`,
+		userId: OWNER,
+		status: "active",
+		startedAt: new Date((i + 1) * 1_000_000),
+		sessionDate: new Date((i + 1) * 1_000_000),
+	}));
+}
+
+describe("liveCashGameSession.list composite keyset cursor (SA2-150)", () => {
+	it("orders by the coalesced start key then id descending (stable tiebreak)", async () => {
+		const { db, listOrderBy } = createListMockDb();
+		await listCaller(db).list({ limit: 10 });
+		expect(listOrderBy).toHaveLength(1);
+		const order = listOrderBy[0]?.toLowerCase() ?? "";
+		expect(order).toContain("coalesce");
+		expect(order).toContain('"game_session"."id" desc');
 	});
 
-	it("does not add a cursor subquery when no cursor is supplied", async () => {
-		const { db, selectWhereParams } = createListWhereMockDb();
-		const caller = appRouter.createCaller({
-			session: { user: { id: OWNER } },
-			db,
-		} as unknown as Parameters<typeof appRouter.createCaller>[0]);
-		await caller.liveCashGameSession.list({ limit: 10 });
-		const base = selectWhereParams[0] as unknown[];
-		expect(base.filter((p) => p === OWNER)).toHaveLength(1);
+	it("adds no keyset condition when no cursor is supplied", async () => {
+		const { db, listWhere } = createListMockDb();
+		await listCaller(db).list({ limit: 10 });
+		const base = listWhere[0];
+		expect(base).toBeDefined();
+		// Only the base filter binds the user id (once); no keyset expression.
+		expect(base?.params.filter((p) => p === OWNER)).toHaveLength(1);
+		expect(base?.sql.toLowerCase()).not.toContain("coalesce");
+	});
+
+	it("treats a malformed cursor as no cursor (does not filter every row out)", async () => {
+		const { db, listWhere } = createListMockDb();
+		// "no-separator" has no `_`, so parseSessionCursor returns null.
+		await listCaller(db).list({ cursor: "no-separator", limit: 10 });
+		const base = listWhere[0];
+		expect(base?.params).not.toContain("no-separator");
+		expect(base?.params.filter((p) => p === OWNER)).toHaveLength(1);
+		expect(base?.sql.toLowerCase()).not.toContain("coalesce");
+	});
+
+	it("embeds the cursor's (timestamp, id) as a keyset, not a subquery on the id", async () => {
+		const { db, listWhere } = createListMockDb();
+		const cursor = encodeSessionCursor({
+			id: "cur-id",
+			startedAt: new Date(5_000_000),
+			sessionDate: new Date(5_000_000),
+		});
+		await listCaller(db).list({ cursor, limit: 10 });
+		const where = listWhere[0];
+		// No correlated subquery — the old `SELECT started_at FROM game_session
+		// WHERE id = cursor` is the exact statement that broke on a deleted row.
+		expect(where?.sql.toLowerCase()).not.toContain("select");
+		// 5_000_000 ms floored to 5000 s is bound twice (the `<` arm and the
+		// `=` tiebreak arm); the id is bound once.
+		expect(where?.params.filter((p) => p === 5000)).toHaveLength(2);
+		expect(where?.params).toContain("cur-id");
+		// The raw composite string is never bound as a parameter.
+		expect(where?.params).not.toContain(cursor);
+	});
+
+	it("keeps paginating from the same keyset even when the cursor row was deleted", async () => {
+		// The boundary is derived purely from the cursor value, so a since-deleted
+		// cursor row cannot collapse the page (the SA2-150 regression).
+		const { db, listWhere } = createListMockDb(makeCashRows(2));
+		const cursor = encodeSessionCursor({
+			id: "deleted-id",
+			startedAt: new Date(9_000_000),
+			sessionDate: new Date(9_000_000),
+		});
+		const result = await listCaller(db).list({ cursor, limit: 10 });
+		const where = listWhere[0];
+		expect(where?.sql.toLowerCase()).not.toContain("select");
+		expect(where?.params.filter((p) => p === 9000)).toHaveLength(2);
+		expect(where?.params).toContain("deleted-id");
+		expect(result.items).toHaveLength(2);
+	});
+
+	it("returns nextCursor as the last kept row's composite value when more rows exist", async () => {
+		const rows = makeCashRows(3);
+		const { db } = createListMockDb(rows);
+		const result = await listCaller(db).list({ limit: 2 });
+		expect(result.items).toHaveLength(2);
+		expect(result.nextCursor).toBe(encodeSessionCursor(rows[1] as CursorRow));
+	});
+
+	it("returns no nextCursor at exactly the page-size boundary", async () => {
+		const { db } = createListMockDb(makeCashRows(2));
+		const result = await listCaller(db).list({ limit: 2 });
+		expect(result.items).toHaveLength(2);
+		expect(result.nextCursor).toBeUndefined();
+	});
+
+	it("returns no nextCursor for a partial single page", async () => {
+		const { db } = createListMockDb(makeCashRows(1));
+		const result = await listCaller(db).list({ limit: 2 });
+		expect(result.items).toHaveLength(1);
+		expect(result.nextCursor).toBeUndefined();
+	});
+
+	it("returns empty items and no nextCursor when there are no sessions", async () => {
+		const { db } = createListMockDb([]);
+		const result = await listCaller(db).list({ limit: 2 });
+		expect(result.items).toEqual([]);
+		expect(result.nextCursor).toBeUndefined();
 	});
 });

--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -6,7 +6,10 @@ import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it, vi } from "vitest";
 import { t } from "../index";
 import { appRouter } from "../routers";
-import { persistSessionBlindLevels } from "../routers/session";
+import {
+	encodeSessionCursor,
+	persistSessionBlindLevels,
+} from "../routers/session";
 import {
 	createChainableMockDb,
 	expectAccepts,
@@ -812,50 +815,158 @@ describe("liveTournamentSession.create tournament ownership (IDOR guard)", () =>
 
 const listCursorDialect = new SQLiteSyncDialect();
 
+type ChainableAny = Promise<Rows> &
+	Record<string, (...args: unknown[]) => ChainableAny>;
+
 /**
- * Mock db recording the SQL params bound to the list query's `.where(...)` so
- * the cursor-boundary subquery can be shown to be scoped to the caller
- * (SA2-182). `select().from()` resolves to no rows; enrichment is skipped.
+ * Mock db that captures the list query's `.where(...)` (SQL + bound params) and
+ * `.orderBy(...)` (SQL), and resolves the `game_session` select to `listRows`
+ * while every other read (the per-item enrichment) resolves to `[]`. Lets the
+ * composite-keyset cursor (SA2-150) be inspected end-to-end: the boundary must
+ * embed the cursor's `(timestamp, id)` directly rather than run a subquery on
+ * the raw id (which returned NULL — and dropped the whole page — once the cursor
+ * row was discarded), and `nextCursor` must echo the last kept row's composite.
  */
-function createListWhereMockDb() {
-	const selectWhereParams: unknown[][] = [];
-	const makeChain = () => {
-		const chain = Promise.resolve([] as Rows) as Promise<Rows> &
-			Record<string, (...args: unknown[]) => unknown>;
-		chain.from = () => chain;
+function createListMockDb(listRows: Rows = []) {
+	const listWhere: { params: unknown[]; sql: string }[] = [];
+	const listOrderBy: string[] = [];
+	const makeChain = (rows: Rows, isList: boolean): ChainableAny => {
+		const chain = Promise.resolve(rows) as ChainableAny;
+		chain.from = (table: unknown) => {
+			const list = table === gameSession;
+			return makeChain(list ? listRows : [], list);
+		};
 		chain.where = (cond: unknown) => {
-			selectWhereParams.push(
-				listCursorDialect.sqlToQuery(cond as never).params
-			);
+			if (isList) {
+				const q = listCursorDialect.sqlToQuery(cond as never);
+				listWhere.push({ sql: q.sql, params: q.params });
+			}
 			return chain;
 		};
-		chain.orderBy = () => chain;
+		chain.orderBy = (...cols: unknown[]) => {
+			if (isList) {
+				listOrderBy.push(
+					cols
+						.map((c) => listCursorDialect.sqlToQuery(c as never).sql)
+						.join(", ")
+				);
+			}
+			return chain;
+		};
 		chain.limit = () => chain;
 		chain.leftJoin = () => chain;
 		chain.innerJoin = () => chain;
 		return chain;
 	};
-	const db = { select: () => makeChain() };
-	return { db, selectWhereParams };
+	const db = { select: () => makeChain([], false) };
+	return { db, listOrderBy, listWhere };
 }
 
-describe("liveTournamentSession.list cursor scoping (SA2-182)", () => {
-	it("scopes the cursor boundary subquery to the caller's user id", async () => {
-		const { db, selectWhereParams } = createListWhereMockDb();
-		await callerFor(db, OWNER).liveTournamentSession.list({
-			cursor: "s-cursor",
-			limit: 10,
-		});
-		const listWhere = selectWhereParams.find((p) => p.includes("s-cursor"));
-		expect(listWhere).toBeDefined();
-		// userId appears twice: the base filter + the cursor subquery scope.
-		expect((listWhere as unknown[]).filter((p) => p === OWNER)).toHaveLength(2);
+function listCaller(db: unknown) {
+	return callerFor(db, OWNER).liveTournamentSession;
+}
+
+interface CursorRow {
+	id: string;
+	sessionDate: Date;
+	startedAt: Date | null;
+}
+
+function makeTournamentRows(n: number): Rows {
+	return Array.from({ length: n }, (_, i) => ({
+		id: `s${i}`,
+		userId: OWNER,
+		status: "active",
+		startedAt: new Date((i + 1) * 1_000_000),
+		sessionDate: new Date((i + 1) * 1_000_000),
+		startingStack: null,
+	}));
+}
+
+describe("liveTournamentSession.list composite keyset cursor (SA2-150)", () => {
+	it("orders by the coalesced start key then id descending (stable tiebreak)", async () => {
+		const { db, listOrderBy } = createListMockDb();
+		await listCaller(db).list({ limit: 10 });
+		expect(listOrderBy).toHaveLength(1);
+		const order = listOrderBy[0]?.toLowerCase() ?? "";
+		expect(order).toContain("coalesce");
+		expect(order).toContain('"game_session"."id" desc');
 	});
 
-	it("does not add a cursor subquery when no cursor is supplied", async () => {
-		const { db, selectWhereParams } = createListWhereMockDb();
-		await callerFor(db, OWNER).liveTournamentSession.list({ limit: 10 });
-		const base = selectWhereParams[0] as unknown[];
-		expect(base.filter((p) => p === OWNER)).toHaveLength(1);
+	it("adds no keyset condition when no cursor is supplied", async () => {
+		const { db, listWhere } = createListMockDb();
+		await listCaller(db).list({ limit: 10 });
+		const base = listWhere[0];
+		expect(base).toBeDefined();
+		expect(base?.params.filter((p) => p === OWNER)).toHaveLength(1);
+		expect(base?.sql.toLowerCase()).not.toContain("coalesce");
+	});
+
+	it("treats a malformed cursor as no cursor (does not filter every row out)", async () => {
+		const { db, listWhere } = createListMockDb();
+		await listCaller(db).list({ cursor: "no-separator", limit: 10 });
+		const base = listWhere[0];
+		expect(base?.params).not.toContain("no-separator");
+		expect(base?.params.filter((p) => p === OWNER)).toHaveLength(1);
+		expect(base?.sql.toLowerCase()).not.toContain("coalesce");
+	});
+
+	it("embeds the cursor's (timestamp, id) as a keyset, not a subquery on the id", async () => {
+		const { db, listWhere } = createListMockDb();
+		const cursor = encodeSessionCursor({
+			id: "cur-id",
+			startedAt: new Date(5_000_000),
+			sessionDate: new Date(5_000_000),
+		});
+		await listCaller(db).list({ cursor, limit: 10 });
+		const where = listWhere[0];
+		expect(where?.sql.toLowerCase()).not.toContain("select");
+		expect(where?.params.filter((p) => p === 5000)).toHaveLength(2);
+		expect(where?.params).toContain("cur-id");
+		expect(where?.params).not.toContain(cursor);
+	});
+
+	it("keeps paginating from the same keyset even when the cursor row was deleted", async () => {
+		const { db, listWhere } = createListMockDb(makeTournamentRows(2));
+		const cursor = encodeSessionCursor({
+			id: "deleted-id",
+			startedAt: new Date(9_000_000),
+			sessionDate: new Date(9_000_000),
+		});
+		const result = await listCaller(db).list({ cursor, limit: 10 });
+		const where = listWhere[0];
+		expect(where?.sql.toLowerCase()).not.toContain("select");
+		expect(where?.params.filter((p) => p === 9000)).toHaveLength(2);
+		expect(where?.params).toContain("deleted-id");
+		expect(result.items).toHaveLength(2);
+	});
+
+	it("returns nextCursor as the last kept row's composite value when more rows exist", async () => {
+		const rows = makeTournamentRows(3);
+		const { db } = createListMockDb(rows);
+		const result = await listCaller(db).list({ limit: 2 });
+		expect(result.items).toHaveLength(2);
+		expect(result.nextCursor).toBe(encodeSessionCursor(rows[1] as CursorRow));
+	});
+
+	it("returns no nextCursor at exactly the page-size boundary", async () => {
+		const { db } = createListMockDb(makeTournamentRows(2));
+		const result = await listCaller(db).list({ limit: 2 });
+		expect(result.items).toHaveLength(2);
+		expect(result.nextCursor).toBeUndefined();
+	});
+
+	it("returns no nextCursor for a partial single page", async () => {
+		const { db } = createListMockDb(makeTournamentRows(1));
+		const result = await listCaller(db).list({ limit: 2 });
+		expect(result.items).toHaveLength(1);
+		expect(result.nextCursor).toBeUndefined();
+	});
+
+	it("returns empty items and no nextCursor when there are no sessions", async () => {
+		const { db } = createListMockDb([]);
+		const result = await listCaller(db).list({ limit: 2 });
+		expect(result.items).toEqual([]);
+		expect(result.nextCursor).toBeUndefined();
 	});
 });

--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -1,5 +1,6 @@
 import { sessionTag } from "@sapphire2/db/schema/session-tag";
 import { TRPCError } from "@trpc/server";
+import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
@@ -10,6 +11,7 @@ import {
 	type ProfitLossSeriesRow,
 	parseSessionCursor,
 	selectInChunks,
+	sessionKeysetCondition,
 	toProfitLossSeriesPoint,
 	validateEntityOwnership,
 	validateTagsOwnership,
@@ -359,6 +361,42 @@ describe("session router input validation", () => {
 
 		it("returns null for an empty id", () => {
 			expect(parseSessionCursor("1000_")).toBeNull();
+		});
+	});
+
+	describe("sessionKeysetCondition (SA2-150)", () => {
+		const keysetDialect = new SQLiteSyncDialect();
+
+		it("returns undefined for an omitted cursor (start from the beginning)", () => {
+			expect(sessionKeysetCondition(undefined)).toBeUndefined();
+		});
+
+		it("returns undefined for an empty-string cursor", () => {
+			expect(sessionKeysetCondition("")).toBeUndefined();
+		});
+
+		it("returns undefined for a malformed cursor instead of filtering everything", () => {
+			// A garbage / deleted-row cursor must degrade to 'no cursor', never to
+			// a boundary that drops the whole page (the SA2-150 regression).
+			expect(sessionKeysetCondition("no-separator")).toBeUndefined();
+			expect(sessionKeysetCondition("abc_s1")).toBeUndefined();
+		});
+
+		it("binds the floored-seconds order key twice and the id once, with no subquery", () => {
+			const cursor = encodeSessionCursor({
+				id: "cur-id",
+				startedAt: new Date(5_000_000),
+				sessionDate: new Date(5_000_000),
+			});
+			const condition = sessionKeysetCondition(cursor);
+			expect(condition).toBeDefined();
+			const query = keysetDialect.sqlToQuery(condition as never);
+			// The comparison embeds the value directly — no `SELECT ... WHERE id`.
+			expect(query.sql.toLowerCase()).not.toContain("select");
+			// 5_000_000 ms floored to 5000 s, bound in both the `<` and `=` arms.
+			expect(query.params.filter((p) => p === 5000)).toHaveLength(2);
+			expect(query.params).toContain("cur-id");
+			expect(query.params).not.toContain(cursor);
 		});
 	});
 

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -22,7 +22,10 @@ import {
 } from "../services/live-session-pl";
 import { floorToMinute } from "../utils/session-event-time";
 import {
+	encodeSessionCursor,
 	resolveCashRuleSnapshot,
+	sessionKeysetCondition,
+	sessionOrderKeySql,
 	validateEntityOwnership,
 	validateLiveLinkOwnership,
 } from "./session";
@@ -199,10 +202,12 @@ export const liveCashGameSessionRouter = router({
 			if (input.status) {
 				conditions.push(eq(gameSession.status, input.status));
 			}
-			if (input.cursor) {
-				conditions.push(
-					sql`${gameSession.startedAt} < (SELECT started_at FROM game_session WHERE id = ${input.cursor} AND user_id = ${userId})`
-				);
+			// Composite (startedAt, id) keyset — a malformed / deleted-row cursor
+			// degrades to "no cursor" instead of silently emptying the page
+			// (SA2-150). Shared with session.list so both stay in lockstep.
+			const keyset = sessionKeysetCondition(input.cursor);
+			if (keyset) {
+				conditions.push(keyset);
 			}
 
 			const rows = await ctx.db
@@ -218,6 +223,7 @@ export const liveCashGameSessionRouter = router({
 					currencyName: currency.name,
 					currencyUnit: currency.unit,
 					startedAt: gameSession.startedAt,
+					sessionDate: gameSession.sessionDate,
 					endedAt: gameSession.endedAt,
 					memo: gameSession.memo,
 					createdAt: gameSession.createdAt,
@@ -231,12 +237,14 @@ export const liveCashGameSessionRouter = router({
 				.leftJoin(room, eq(room.id, gameSession.roomId))
 				.leftJoin(currency, eq(currency.id, gameSession.currencyId))
 				.where(and(...conditions))
-				.orderBy(desc(gameSession.startedAt))
+				.orderBy(desc(sessionOrderKeySql()), desc(gameSession.id))
 				.limit(input.limit + 1);
 
 			const hasMore = rows.length > input.limit;
 			const items = hasMore ? rows.slice(0, input.limit) : rows;
-			const nextCursor = hasMore ? items.at(-1)?.id : undefined;
+			const last = items.at(-1);
+			const nextCursor =
+				hasMore && last ? encodeSessionCursor(last) : undefined;
 
 			const enrichedItems = await Promise.all(
 				items.map(async (item) => {

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -22,10 +22,13 @@ import {
 } from "../services/live-session-pl";
 import { floorToMinute } from "../utils/session-event-time";
 import {
+	encodeSessionCursor,
 	persistSessionBlindLevels,
 	persistSessionChipPurchases,
 	resnapshotTournamentStructure,
 	resolveTournamentRuleSnapshot,
+	sessionKeysetCondition,
+	sessionOrderKeySql,
 	snapshotTournamentStructure,
 	validateEntityOwnership,
 	validateLiveLinkOwnership,
@@ -488,10 +491,12 @@ export const liveTournamentSessionRouter = router({
 			if (input.status) {
 				conditions.push(eq(gameSession.status, input.status));
 			}
-			if (input.cursor) {
-				conditions.push(
-					sql`${gameSession.startedAt} < (SELECT started_at FROM game_session WHERE id = ${input.cursor} AND user_id = ${userId})`
-				);
+			// Composite (startedAt, id) keyset — a malformed / deleted-row cursor
+			// degrades to "no cursor" instead of silently emptying the page
+			// (SA2-150). Shared with session.list so both stay in lockstep.
+			const keyset = sessionKeysetCondition(input.cursor);
+			if (keyset) {
+				conditions.push(keyset);
 			}
 
 			const rows = await ctx.db
@@ -508,6 +513,7 @@ export const liveTournamentSessionRouter = router({
 					currencyName: currency.name,
 					currencyUnit: currency.unit,
 					startedAt: gameSession.startedAt,
+					sessionDate: gameSession.sessionDate,
 					endedAt: gameSession.endedAt,
 					memo: gameSession.memo,
 					createdAt: gameSession.createdAt,
@@ -521,12 +527,14 @@ export const liveTournamentSessionRouter = router({
 				.leftJoin(room, eq(room.id, gameSession.roomId))
 				.leftJoin(currency, eq(currency.id, gameSession.currencyId))
 				.where(and(...conditions))
-				.orderBy(desc(gameSession.startedAt))
+				.orderBy(desc(sessionOrderKeySql()), desc(gameSession.id))
 				.limit(input.limit + 1);
 
 			const hasMore = rows.length > input.limit;
 			const items = hasMore ? rows.slice(0, input.limit) : rows;
-			const nextCursor = hasMore ? items.at(-1)?.id : undefined;
+			const last = items.at(-1);
+			const nextCursor =
+				hasMore && last ? encodeSessionCursor(last) : undefined;
 
 			const enrichedItems = await Promise.all(
 				items.map(async (item) => {

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -21,7 +21,17 @@ import {
 	tournamentChipPurchase,
 } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
-import { and, asc, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
+import {
+	and,
+	asc,
+	desc,
+	eq,
+	gte,
+	inArray,
+	lte,
+	type SQL,
+	sql,
+} from "drizzle-orm";
 import type { SQLiteColumn, SQLiteTable } from "drizzle-orm/sqlite-core";
 import { z } from "zod";
 import { protectedProcedure, router } from "../index";
@@ -1037,7 +1047,7 @@ interface ListFilters {
  * a seemingly arbitrary order. `startedAt` is optional (older / quick-add
  * sessions may not have one), so it falls back to `sessionDate`.
  */
-function sessionOrderKeySql() {
+export function sessionOrderKeySql() {
 	return sql`coalesce(${gameSession.startedAt}, ${gameSession.sessionDate})`;
 }
 
@@ -1081,6 +1091,30 @@ export function parseSessionCursor(
 	return { id, sortKey: new Date(ms) };
 }
 
+/**
+ * Build the composite-keyset WHERE condition for a session-list cursor, matching
+ * the `(sessionOrderKey DESC, id DESC)` ordering: rows strictly after the cursor
+ * in that order. Returns `undefined` for a missing / malformed cursor so the
+ * caller starts from the beginning instead of filtering every row out — the
+ * SA2-150 regression, where the old keyset ran a subquery on the raw cursor id,
+ * and a since-deleted cursor row made that subquery return NULL (so
+ * `started_at < NULL` dropped the whole page). The order key is stored in
+ * seconds (sqlite "timestamp" mode), so the cursor's ms value is floored.
+ */
+export function sessionKeysetCondition(
+	cursor: string | undefined
+): SQL | undefined {
+	if (!cursor) {
+		return undefined;
+	}
+	const parsed = parseSessionCursor(cursor);
+	if (!parsed) {
+		return undefined;
+	}
+	const cursorSeconds = Math.floor(parsed.sortKey.getTime() / 1000);
+	return sql`(${sessionOrderKeySql()} < ${cursorSeconds}) or (${sessionOrderKeySql()} = ${cursorSeconds} and ${gameSession.id} < ${parsed.id})`;
+}
+
 function buildSessionListConditions(userId: string, filters: ListFilters) {
 	const conditions = [eq(gameSession.userId, userId)];
 	if (filters.type) {
@@ -1103,17 +1137,9 @@ function buildSessionListConditions(userId: string, filters: ListFilters) {
 		);
 	}
 	const paginationConditions = [...conditions];
-	if (filters.cursor) {
-		const parsed = parseSessionCursor(filters.cursor);
-		if (parsed) {
-			// Keyset must match the (sessionOrderKey DESC, id DESC) ordering:
-			// take rows strictly after the cursor in that order. The order key
-			// is stored in seconds (sqlite "timestamp" mode), so the cursor's ms
-			// value is floored to seconds before comparing.
-			const cursorSeconds = Math.floor(parsed.sortKey.getTime() / 1000);
-			const keyset = sql`(${sessionOrderKeySql()} < ${cursorSeconds}) or (${sessionOrderKeySql()} = ${cursorSeconds} and ${gameSession.id} < ${parsed.id})`;
-			paginationConditions.push(keyset);
-		}
+	const keyset = sessionKeysetCondition(filters.cursor);
+	if (keyset) {
+		paginationConditions.push(keyset);
 	}
 	return { conditions, paginationConditions };
 }


### PR DESCRIPTION
## 概要

`live-cash-game-session.ts` と `live-tournament-session.ts` の `list` は、`startedAt` を「生の `cursor` id を引くサブクエリ」と比較するキーセットページネーションでした。そのため、cursor 対象の `game_session` 行が `discard` でハードデリートされているとサブクエリが `NULL` を返し、`started_at < NULL` が常に false になって残り全行が除外され、2ページ目以降が静かに空になっていました。加えて `id` によるタイブレークもサブクエリのスコープもありませんでした。

Linear: SA2-150 / closes #467

## 変更内容

- `session.ts` にある `(timestamp, id)` 複合カーソル方式へ統一。共有ヘルパー `sessionKeysetCondition(cursor)` を新設し、`sessionOrderKeySql` を export しました。`buildSessionListConditions` も挙動を変えずにこの共有ヘルパーを利用するようリファクタ（既存のインラインロジックをそのまま抽出）。
- 両ライブ router は `encodeSessionCursor` / `sessionKeysetCondition` / `sessionOrderKeySql` を再利用:
  - キーセット条件・`ORDER BY` の両方に `desc(id)` のタイブレークを追加（`ORDER BY coalesce(startedAt, sessionDate) DESC, id DESC`）。
  - `nextCursor` を複合値（`encodeSessionCursor`）で返却。
  - 不正・デコード不能・削除済みの cursor は「cursor なし」として先頭から取得するため、一覧が静かに空になる不具合が解消。
- 複合カーソル生成に必要な `sessionDate` を `select` に追加（additive・後方互換。web 消費側は一覧をクエリキー無効化にのみ使用）。

## テスト

TDD（先にテストを書いて red を確認 → 実装で green）で実装しました。red フェーズでは対象テストが `10 failed | 139 passed`（orderBy / malformed-cursor / keyset-embed / deleted-row / composite-nextCursor 各5件×2ファイル）で失敗することを確認済み。

- `session.test.ts`: `sessionKeysetCondition (SA2-150)` を追加（undefined/空/不正 cursor → undefined、正常 cursor は floored-seconds を2回 + id を1回バインドしサブクエリを使わない）。
- `live-cash-game-session.test.ts` / `live-tournament-session.test.ts`: 複合キーセット cursor のテスト（各9件）に置換。

検証コマンド（すべて pass）:
- `bunx vitest run --project api <live 3ファイル>` → `Test Files 3 passed, Tests 244 passed`
- `bunx vitest run --project api`（プロジェクト全体）→ `Test Files 24 passed, Tests 900 passed`
- `bun run check-types` → server / web ともに exit 0
- `bunx ultracite check packages/api/src` → clean

## 補足

- カーソルロジックは重複ではなく **共有**（`session.ts` から export）にしました。`sessionKeysetCondition` を util モジュールではなく `session.ts` に置く方針で問題ないかは確認ポイントです。
- ライブセッションは `startedAt` が作成時に必ず設定されるため、`coalesce(startedAt, sessionDate)` による並び順は実運用上これまでと変わりません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LESXQVaQyiQbai6YYWQzYn)_