### PR TITLE
refactor: zod を named import から default import に統一 (SA2-134)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -58,6 +58,17 @@
         "noBarrelFile": "off"
       },
       "style": {
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "zod": {
+                "importNames": ["z"],
+                "message": "Import zod's `z` as a default import: `import z from \"zod\"`. The named import (`import { z } from \"zod\"`) breaks the Vite bundler. See CLAUDE.md > Stack > Validation."
+              }
+            }
+          }
+        },
         "noParameterAssign": "error",
         "useAsConstAssertion": "error",
         "useDefaultParameterLast": "error",

--- a/packages/api/src/routers/ai-extract.ts
+++ b/packages/api/src/routers/ai-extract.ts
@@ -7,7 +7,7 @@ import domino from "@mixmark-io/domino";
 import { TRPCError } from "@trpc/server";
 import TurndownService from "turndown";
 import { tables } from "turndown-plugin-gfm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 import {
 	TABLE_PLAYER_SOURCE_APP_IDS,

--- a/packages/api/src/routers/blind-level.ts
+++ b/packages/api/src/routers/blind-level.ts
@@ -2,7 +2,7 @@ import { room } from "@sapphire2/db/schema/room";
 import { blindLevel, tournament } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
 import { and, asc, eq } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 
 async function validateTournamentOwnership(

--- a/packages/api/src/routers/currency-transaction.ts
+++ b/packages/api/src/routers/currency-transaction.ts
@@ -8,7 +8,7 @@ import { sessionCashDetail } from "@sapphire2/db/schema/session-cash-detail";
 import { sessionTournamentDetail } from "@sapphire2/db/schema/session-tournament-detail";
 import { TRPCError } from "@trpc/server";
 import { and, desc, eq, sql } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 import { paginate } from "./_pagination";
 

--- a/packages/api/src/routers/currency.ts
+++ b/packages/api/src/routers/currency.ts
@@ -1,7 +1,7 @@
 import { currency, currencyTransaction } from "@sapphire2/db/schema/currency";
 import { TRPCError } from "@trpc/server";
 import { asc, desc, eq, sql } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 
 export const currencyRouter = router({

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -13,7 +13,7 @@ import { sessionCashDetail } from "@sapphire2/db/schema/session-cash-detail";
 import { sessionEvent } from "@sapphire2/db/schema/session-event";
 import { TRPCError } from "@trpc/server";
 import { and, asc, desc, eq, max, sql } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 import {
 	computeCashGamePLFromEvents,

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -13,7 +13,7 @@ import { sessionTournamentDetail } from "@sapphire2/db/schema/session-tournament
 import { tournament } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
 import { and, asc, desc, eq, max, sql } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 import {
 	computeHeroSeatPositionFromEvents,

--- a/packages/api/src/routers/location.ts
+++ b/packages/api/src/routers/location.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from "@trpc/server";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 
 // Short-link hosts are the only URLs we ever fetch server-side (to follow the

--- a/packages/api/src/routers/player-tag.ts
+++ b/packages/api/src/routers/player-tag.ts
@@ -2,7 +2,7 @@ import { TAG_COLOR_NAMES } from "@sapphire2/db/constants/player-tag-colors";
 import { playerTag, playerToPlayerTag } from "@sapphire2/db/schema/player";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 
 const colorSchema = z.enum(TAG_COLOR_NAMES);

--- a/packages/api/src/routers/player.ts
+++ b/packages/api/src/routers/player.ts
@@ -5,7 +5,7 @@ import {
 } from "@sapphire2/db/schema/player";
 import { TRPCError } from "@trpc/server";
 import { and, asc, eq, inArray, like } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 import { validateTagsOwnership } from "./session";
 

--- a/packages/api/src/routers/ring-game.ts
+++ b/packages/api/src/routers/ring-game.ts
@@ -2,7 +2,7 @@ import { ringGame } from "@sapphire2/db/schema/ring-game";
 import { room } from "@sapphire2/db/schema/room";
 import { TRPCError } from "@trpc/server";
 import { and, eq, isNotNull, isNull } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 import { validateEntityOwnership } from "./session";
 

--- a/packages/api/src/routers/room.ts
+++ b/packages/api/src/routers/room.ts
@@ -1,7 +1,7 @@
 import { room } from "@sapphire2/db/schema/room";
 import { TRPCError } from "@trpc/server";
 import { asc, desc, eq, sql } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 
 // Coordinates move as a pair: latitude and longitude must both be omitted

--- a/packages/api/src/routers/session-event.ts
+++ b/packages/api/src/routers/session-event.ts
@@ -13,7 +13,7 @@ import { sessionEvent } from "@sapphire2/db/schema/session-event";
 import { sessionTournamentDetail } from "@sapphire2/db/schema/session-tournament-detail";
 import { TRPCError } from "@trpc/server";
 import { asc, eq } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 import {
 	recalculateCashGameSession,

--- a/packages/api/src/routers/session-table-player.ts
+++ b/packages/api/src/routers/session-table-player.ts
@@ -16,7 +16,7 @@ import { sessionTournamentDetail } from "@sapphire2/db/schema/session-tournament
 import { tournament } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
 import { and, asc, eq, inArray } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 import { computeSeatedPlayersFromEvents } from "../services/live-session-pl";
 import {

--- a/packages/api/src/routers/session-tag.ts
+++ b/packages/api/src/routers/session-tag.ts
@@ -4,7 +4,7 @@ import {
 } from "@sapphire2/db/schema/session-tag";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 
 export const sessionTagRouter = router({

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -23,7 +23,7 @@ import {
 import { TRPCError } from "@trpc/server";
 import { and, asc, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import type { SQLiteColumn, SQLiteTable } from "drizzle-orm/sqlite-core";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 
 const PAGE_SIZE = 20;

--- a/packages/api/src/routers/stats.ts
+++ b/packages/api/src/routers/stats.ts
@@ -4,7 +4,7 @@ import { sessionCashDetail } from "@sapphire2/db/schema/session-cash-detail";
 import { sessionTournamentDetail } from "@sapphire2/db/schema/session-tournament-detail";
 import { TRPCError } from "@trpc/server";
 import { and, eq, gte, lte } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 import {
 	computeCashGamePL,

--- a/packages/api/src/routers/tournament-chip-purchase.ts
+++ b/packages/api/src/routers/tournament-chip-purchase.ts
@@ -5,7 +5,7 @@ import {
 } from "@sapphire2/db/schema/tournament";
 import { TRPCError } from "@trpc/server";
 import { and, asc, eq } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 
 async function validateTournamentOwnership(

--- a/packages/api/src/routers/tournament.ts
+++ b/packages/api/src/routers/tournament.ts
@@ -7,7 +7,7 @@ import {
 import { tournamentTag } from "@sapphire2/db/schema/tournament-tag";
 import { TRPCError } from "@trpc/server";
 import { and, asc, eq, isNotNull, isNull } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 import { validateEntityOwnership } from "./session";
 

--- a/packages/api/src/routers/transaction-type.ts
+++ b/packages/api/src/routers/transaction-type.ts
@@ -5,7 +5,7 @@ import {
 } from "@sapphire2/db/schema/currency";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 
 export const transactionTypeRouter = router({

--- a/packages/api/src/routers/update-note-view.ts
+++ b/packages/api/src/routers/update-note-view.ts
@@ -1,6 +1,6 @@
 import { updateNoteView } from "@sapphire2/db/schema/update-note-view";
 import { and, desc, eq } from "drizzle-orm";
-import { z } from "zod";
+import z from "zod";
 import { protectedProcedure, router } from "../index";
 
 export const updateNoteViewRouter = router({

--- a/packages/db/src/constants/session-event-types.ts
+++ b/packages/db/src/constants/session-event-types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import z from "zod";
 
 // Session statuses
 export const SESSION_STATUSES = ["active", "paused", "completed"] as const;

--- a/packages/env/src/web.ts
+++ b/packages/env/src/web.ts
@@ -1,5 +1,5 @@
 import { createEnv } from "@t3-oss/env-core";
-import { z } from "zod";
+import z from "zod";
 
 export const webEnvSchema = {
 	clientPrefix: "VITE_" as const,


### PR DESCRIPTION
## 概要

CLAUDE.md の Stack 規約では、Vite バンドラの不具合を避けるため zod を `import z from "zod";`(default import)で統一すると定めていますが、`packages/api` / `packages/db` / `packages/env` 配下の計22ファイルで `import { z } from "zod";`(named import)が使われていました。これらをすべて default import に統一します。純粋な規約違反(hygiene)の修正で、挙動変更はありません。

Linear: SA2-134 / closes #451

## 変更内容

- **22ファイル**で `import { z } from "zod";` → `import z from "zod";` に置換(各1行のみ、他の named export を併用しているファイルはなく import 分割は不要でした):
  - API ルーター20件(`ai-extract` / `blind-level` / `currency-transaction` / `currency` / `live-cash-game-session` / `live-tournament-session` / `location` / `player-tag` / `player` / `ring-game` / `room` / `session-event` / `session-table-player` / `session-tag` / `session` / `stats` / `tournament-chip-purchase` / `tournament` / `transaction-type` / `update-note-view`)
  - `packages/db/src/constants/session-event-types.ts`
  - `packages/env/src/web.ts`
- **再発防止(regression guard)**: `biome.json` の `linter.rules.style.noRestrictedImports` に、zod からの named `z` import を禁止するルールを追加(`importNames: ["z"]`、メッセージで CLAUDE.md を案内)。default import(Biome 上は name `"default"`)は許可されます。`bun run lint` / Stop フック / CI で自動的に強制されます。

## テスト・検証

lint ルールを guard(＝テスト相当)として採用しました。

- **RED**: 修正前に `bunx biome lint packages/api/src/routers packages/db/src/constants packages/env/src` → `Found 22 errors`(各対象ファイル1件の `lint/style/noRestrictedImports`)。
- **GREEN(grep)**: `git grep -n 'import { z } from "zod"'` → マッチ0件。リポジトリ全体の zod import 50件がすべて default import に統一。
- `bun run check-types` → server / web ともに exit 0(api/db/env は各アプリ経由で推移的に型検査)。
- `bunx vitest run --project api` → 882 passed / `--project db` → 380 passed / `--project env` → 12 passed。
- `bunx ultracite check <変更ファイル>` → clean。

## 補足

- guard はルート `biome.json`(リポジトリ全体スコープ)に置いたため、`apps/web` / `apps/server` も含めて保護されます(グローバル規約なので意図的)。
- スクラッチ環境で「named import のみを検出し default import は許容する」ことを検証済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LESXQVaQyiQbai6YYWQzYn)_