### PR TITLE
fix: allInPayload の wins が trials を超える入力を拒否する (SA2-156)

### DIFF
--- a/apps/web/src/features/live-sessions/components/all-in-bottom-sheet/__tests__/use-all-in-form.test.ts
+++ b/apps/web/src/features/live-sessions/components/all-in-bottom-sheet/__tests__/use-all-in-form.test.ts
@@ -81,6 +81,62 @@ describe("useAllInForm", () => {
 		});
 	});
 
+	it("rejects wins greater than trials on submit", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(() =>
+			useAllInForm({ open: false, onSubmit })
+		);
+		act(() => {
+			result.current.form.setFieldValue("potSize", "1000");
+			result.current.form.setFieldValue("trials", "1");
+			result.current.form.setFieldValue("equity", "50");
+			result.current.form.setFieldValue("wins", "2");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("rejects a non-integer wins on submit", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(() =>
+			useAllInForm({ open: false, onSubmit })
+		);
+		act(() => {
+			result.current.form.setFieldValue("potSize", "1000");
+			result.current.form.setFieldValue("trials", "3");
+			result.current.form.setFieldValue("equity", "50");
+			result.current.form.setFieldValue("wins", "1.5");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("accepts wins equal to trials on submit (upper boundary)", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(() =>
+			useAllInForm({ open: false, onSubmit })
+		);
+		act(() => {
+			result.current.form.setFieldValue("potSize", "1000");
+			result.current.form.setFieldValue("trials", "3");
+			result.current.form.setFieldValue("equity", "50");
+			result.current.form.setFieldValue("wins", "3");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).toHaveBeenCalledWith({
+			potSize: 1000,
+			trials: 3,
+			equity: 50,
+			wins: 3,
+		});
+	});
+
 	it("resets to defaults whenever open transitions with no initialValues", () => {
 		const onSubmit = vi.fn();
 		const { result, rerender } = renderHook(

--- a/apps/web/src/features/live-sessions/components/all-in-bottom-sheet/__tests__/use-all-in-form.test.ts
+++ b/apps/web/src/features/live-sessions/components/all-in-bottom-sheet/__tests__/use-all-in-form.test.ts
@@ -98,7 +98,7 @@ describe("useAllInForm", () => {
 		expect(onSubmit).not.toHaveBeenCalled();
 	});
 
-	it("rejects a non-integer wins on submit", async () => {
+	it("accepts a fractional wins on submit (a chopped pot counts as a partial win)", async () => {
 		const onSubmit = vi.fn();
 		const { result } = renderHook(() =>
 			useAllInForm({ open: false, onSubmit })
@@ -112,7 +112,12 @@ describe("useAllInForm", () => {
 		await act(async () => {
 			await result.current.form.handleSubmit();
 		});
-		expect(onSubmit).not.toHaveBeenCalled();
+		expect(onSubmit).toHaveBeenCalledWith({
+			potSize: 1000,
+			trials: 3,
+			equity: 50,
+			wins: 1.5,
+		});
 	});
 
 	it("accepts wins equal to trials on submit (upper boundary)", async () => {

--- a/apps/web/src/features/live-sessions/components/all-in-bottom-sheet/use-all-in-form.ts
+++ b/apps/web/src/features/live-sessions/components/all-in-bottom-sheet/use-all-in-form.ts
@@ -1,6 +1,7 @@
 import { useForm } from "@tanstack/react-form";
 import { useEffect } from "react";
 import z from "zod";
+import { refineWinsNotExceedingTrials } from "@/features/live-sessions/utils/all-in-validation";
 import { requiredNumericString } from "@/shared/lib/form-fields";
 
 interface AllIn {
@@ -17,13 +18,10 @@ const DEFAULT_VALUES = {
 	wins: "0",
 };
 
-// `wins` is the number of favorable all-in run-outs and must not exceed
-// `trials` (SA2-156). It can be fractional — a chopped pot counts as a partial
-// win — so it is NOT constrained to whole numbers; only the `wins <= trials`
-// upper bound is enforced here (on the object schema so the comparison can see
-// both parsed values, attached to the `wins` field path so the error surfaces on
-// that input). Empty / non-numeric wins is left to the field-level rule to avoid
-// stacking a confusing second error.
+// `wins <= trials` is enforced through the shared refineWinsNotExceedingTrials so
+// the create sheet and the timeline editor can't drift, mirroring the
+// server-side allInPayload refine (SA2-156). `wins` may be fractional (a chopped
+// pot counts as a partial win), so only the upper bound is checked.
 const allInSchema = z
 	.object({
 		potSize: requiredNumericString({ min: 0 }),
@@ -31,20 +29,7 @@ const allInSchema = z
 		equity: requiredNumericString({ min: 0, max: 100 }),
 		wins: requiredNumericString({ min: 0 }),
 	})
-	.superRefine((value, ctx) => {
-		const wins = Number(value.wins.trim());
-		if (value.wins.trim() === "" || !Number.isFinite(wins)) {
-			return;
-		}
-		const trials = Number.parseInt(value.trials.trim(), 10);
-		if (Number.isFinite(trials) && wins > trials) {
-			ctx.addIssue({
-				code: "custom",
-				message: "Wins must not exceed trials",
-				path: ["wins"],
-			});
-		}
-	});
+	.superRefine(refineWinsNotExceedingTrials);
 
 function toFormDefaults(initial: AllIn | undefined) {
 	if (!initial) {

--- a/apps/web/src/features/live-sessions/components/all-in-bottom-sheet/use-all-in-form.ts
+++ b/apps/web/src/features/live-sessions/components/all-in-bottom-sheet/use-all-in-form.ts
@@ -17,12 +17,43 @@ const DEFAULT_VALUES = {
 	wins: "0",
 };
 
-const allInSchema = z.object({
-	potSize: requiredNumericString({ min: 0 }),
-	trials: requiredNumericString({ integer: true, min: 1 }),
-	equity: requiredNumericString({ min: 0, max: 100 }),
-	wins: requiredNumericString({ min: 0 }),
-});
+// `wins` is a non-negative integer that must not exceed `trials` (SA2-156).
+// These two checks live on the object schema so the comparison can see both
+// parsed values, and both attach their issue to the `wins` field path so the
+// error surfaces on that input. The integer check is done here (not via the
+// field's `integer` rule) because `requiredNumericString`'s integer mode
+// truncates with `parseInt` rather than rejecting a fractional string, so
+// "1.5" would otherwise pass as 1. Empty / non-numeric wins is left to the
+// field-level rule to avoid stacking a confusing second error.
+const allInSchema = z
+	.object({
+		potSize: requiredNumericString({ min: 0 }),
+		trials: requiredNumericString({ integer: true, min: 1 }),
+		equity: requiredNumericString({ min: 0, max: 100 }),
+		wins: requiredNumericString({ min: 0 }),
+	})
+	.superRefine((value, ctx) => {
+		const wins = Number(value.wins.trim());
+		if (value.wins.trim() === "" || !Number.isFinite(wins)) {
+			return;
+		}
+		if (!Number.isInteger(wins)) {
+			ctx.addIssue({
+				code: "custom",
+				message: "Wins must be a whole number",
+				path: ["wins"],
+			});
+			return;
+		}
+		const trials = Number.parseInt(value.trials.trim(), 10);
+		if (Number.isFinite(trials) && wins > trials) {
+			ctx.addIssue({
+				code: "custom",
+				message: "Wins must not exceed trials",
+				path: ["wins"],
+			});
+		}
+	});
 
 function toFormDefaults(initial: AllIn | undefined) {
 	if (!initial) {

--- a/apps/web/src/features/live-sessions/components/all-in-bottom-sheet/use-all-in-form.ts
+++ b/apps/web/src/features/live-sessions/components/all-in-bottom-sheet/use-all-in-form.ts
@@ -17,14 +17,13 @@ const DEFAULT_VALUES = {
 	wins: "0",
 };
 
-// `wins` is a non-negative integer that must not exceed `trials` (SA2-156).
-// These two checks live on the object schema so the comparison can see both
-// parsed values, and both attach their issue to the `wins` field path so the
-// error surfaces on that input. The integer check is done here (not via the
-// field's `integer` rule) because `requiredNumericString`'s integer mode
-// truncates with `parseInt` rather than rejecting a fractional string, so
-// "1.5" would otherwise pass as 1. Empty / non-numeric wins is left to the
-// field-level rule to avoid stacking a confusing second error.
+// `wins` is the number of favorable all-in run-outs and must not exceed
+// `trials` (SA2-156). It can be fractional — a chopped pot counts as a partial
+// win — so it is NOT constrained to whole numbers; only the `wins <= trials`
+// upper bound is enforced here (on the object schema so the comparison can see
+// both parsed values, attached to the `wins` field path so the error surfaces on
+// that input). Empty / non-numeric wins is left to the field-level rule to avoid
+// stacking a confusing second error.
 const allInSchema = z
 	.object({
 		potSize: requiredNumericString({ min: 0 }),
@@ -35,14 +34,6 @@ const allInSchema = z
 	.superRefine((value, ctx) => {
 		const wins = Number(value.wins.trim());
 		if (value.wins.trim() === "" || !Number.isFinite(wins)) {
-			return;
-		}
-		if (!Number.isInteger(wins)) {
-			ctx.addIssue({
-				code: "custom",
-				message: "Wins must be a whole number",
-				path: ["wins"],
-			});
 			return;
 		}
 		const trials = Number.parseInt(value.trials.trim(), 10);

--- a/apps/web/src/features/live-sessions/components/event-editors/all-in-editor/__tests__/use-all-in-editor.test.ts
+++ b/apps/web/src/features/live-sessions/components/event-editors/all-in-editor/__tests__/use-all-in-editor.test.ts
@@ -130,7 +130,7 @@ describe("useAllInEditor", () => {
 		expect(onSubmit).not.toHaveBeenCalled();
 	});
 
-	it("rejects submission when wins is not an integer", async () => {
+	it("accepts a fractional wins (a chopped pot counts as a partial win)", async () => {
 		const onSubmit = vi.fn();
 		const { result } = renderHook(() =>
 			useAllInEditor({
@@ -150,7 +150,13 @@ describe("useAllInEditor", () => {
 		await act(async () => {
 			await result.current.form.handleSubmit();
 		});
-		expect(onSubmit).not.toHaveBeenCalled();
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0]).toEqual({
+			potSize: 1000,
+			trials: 3,
+			equity: 50,
+			wins: 1.5,
+		});
 	});
 
 	it("accepts submission when wins equals trials (upper boundary)", async () => {

--- a/apps/web/src/features/live-sessions/components/event-editors/all-in-editor/__tests__/use-all-in-editor.test.ts
+++ b/apps/web/src/features/live-sessions/components/event-editors/all-in-editor/__tests__/use-all-in-editor.test.ts
@@ -107,6 +107,81 @@ describe("useAllInEditor", () => {
 		expect(typeof ts).toBe("number");
 	});
 
+	it("rejects submission when wins exceeds trials", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(() =>
+			useAllInEditor({
+				event: baseEvent({}),
+				isLoading: false,
+				maxTime: null,
+				minTime: null,
+				onSubmit,
+			})
+		);
+		act(() => {
+			result.current.form.setFieldValue("potSize", "1000");
+			result.current.form.setFieldValue("trials", "1");
+			result.current.form.setFieldValue("equity", "50");
+			result.current.form.setFieldValue("wins", "2");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("rejects submission when wins is not an integer", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(() =>
+			useAllInEditor({
+				event: baseEvent({}),
+				isLoading: false,
+				maxTime: null,
+				minTime: null,
+				onSubmit,
+			})
+		);
+		act(() => {
+			result.current.form.setFieldValue("potSize", "1000");
+			result.current.form.setFieldValue("trials", "3");
+			result.current.form.setFieldValue("equity", "50");
+			result.current.form.setFieldValue("wins", "1.5");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("accepts submission when wins equals trials (upper boundary)", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(() =>
+			useAllInEditor({
+				event: baseEvent({}, "2026-04-10T12:30:00"),
+				isLoading: false,
+				maxTime: null,
+				minTime: null,
+				onSubmit,
+			})
+		);
+		act(() => {
+			result.current.form.setFieldValue("potSize", "1000");
+			result.current.form.setFieldValue("trials", "3");
+			result.current.form.setFieldValue("equity", "50");
+			result.current.form.setFieldValue("wins", "3");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit.mock.calls[0][0]).toEqual({
+			potSize: 1000,
+			trials: 3,
+			equity: 50,
+			wins: 3,
+		});
+	});
+
 	it("timeValidator surfaces an error when time is before minTime", () => {
 		const event = baseEvent({}, "2026-04-10T12:30:00");
 		const minTime = new Date("2026-04-10T12:30:00");

--- a/apps/web/src/features/live-sessions/components/event-editors/all-in-editor/use-all-in-editor.ts
+++ b/apps/web/src/features/live-sessions/components/event-editors/all-in-editor/use-all-in-editor.ts
@@ -8,13 +8,42 @@ import {
 } from "@/features/live-sessions/utils/stack-editor-time";
 import { requiredNumericString } from "@/shared/lib/form-fields";
 
-const allInSchema = z.object({
-	time: z.string(),
-	potSize: requiredNumericString({ min: 0 }),
-	trials: requiredNumericString({ integer: true, min: 1 }),
-	equity: requiredNumericString({ min: 0, max: 100 }),
-	wins: requiredNumericString({ min: 0 }),
-});
+// `wins` is a non-negative integer that must not exceed `trials` (SA2-156),
+// mirroring the server-side `allInPayload` guard so editing an existing all-in
+// event cannot reintroduce EV-corrupting values. The integer check is done in
+// the refine (not via the field's `integer` rule) because
+// `requiredNumericString`'s integer mode truncates "1.5" to 1 rather than
+// rejecting it; both issues attach to the `wins` field path.
+const allInSchema = z
+	.object({
+		time: z.string(),
+		potSize: requiredNumericString({ min: 0 }),
+		trials: requiredNumericString({ integer: true, min: 1 }),
+		equity: requiredNumericString({ min: 0, max: 100 }),
+		wins: requiredNumericString({ min: 0 }),
+	})
+	.superRefine((value, ctx) => {
+		const wins = Number(value.wins.trim());
+		if (value.wins.trim() === "" || !Number.isFinite(wins)) {
+			return;
+		}
+		if (!Number.isInteger(wins)) {
+			ctx.addIssue({
+				code: "custom",
+				message: "Wins must be a whole number",
+				path: ["wins"],
+			});
+			return;
+		}
+		const trials = Number.parseInt(value.trials.trim(), 10);
+		if (Number.isFinite(trials) && wins > trials) {
+			ctx.addIssue({
+				code: "custom",
+				message: "Wins must not exceed trials",
+				path: ["wins"],
+			});
+		}
+	});
 
 interface UseAllInEditorOptions {
 	event: SessionEvent;

--- a/apps/web/src/features/live-sessions/components/event-editors/all-in-editor/use-all-in-editor.ts
+++ b/apps/web/src/features/live-sessions/components/event-editors/all-in-editor/use-all-in-editor.ts
@@ -1,6 +1,7 @@
 import { useForm } from "@tanstack/react-form";
 import z from "zod";
 import type { SessionEvent } from "@/features/live-sessions/hooks/use-session-events";
+import { refineWinsNotExceedingTrials } from "@/features/live-sessions/utils/all-in-validation";
 import {
 	toOccurredAtTimestamp,
 	toTimeInputValue,
@@ -8,11 +9,10 @@ import {
 } from "@/features/live-sessions/utils/stack-editor-time";
 import { requiredNumericString } from "@/shared/lib/form-fields";
 
-// `wins` must not exceed `trials` (SA2-156), mirroring the server-side
-// `allInPayload` guard so editing an existing all-in event cannot reintroduce
-// EV-corrupting values. It can be fractional — a chopped pot counts as a partial
-// win — so it is NOT constrained to whole numbers; only the `wins <= trials`
-// upper bound is enforced, attached to the `wins` field path.
+// `wins <= trials` is enforced through the shared refineWinsNotExceedingTrials so
+// editing an existing all-in event stays in lockstep with the create sheet and
+// the server-side allInPayload refine (SA2-156). `wins` may be fractional (a
+// chopped pot counts as a partial win), so only the upper bound is checked.
 const allInSchema = z
 	.object({
 		time: z.string(),
@@ -21,20 +21,7 @@ const allInSchema = z
 		equity: requiredNumericString({ min: 0, max: 100 }),
 		wins: requiredNumericString({ min: 0 }),
 	})
-	.superRefine((value, ctx) => {
-		const wins = Number(value.wins.trim());
-		if (value.wins.trim() === "" || !Number.isFinite(wins)) {
-			return;
-		}
-		const trials = Number.parseInt(value.trials.trim(), 10);
-		if (Number.isFinite(trials) && wins > trials) {
-			ctx.addIssue({
-				code: "custom",
-				message: "Wins must not exceed trials",
-				path: ["wins"],
-			});
-		}
-	});
+	.superRefine(refineWinsNotExceedingTrials);
 
 interface UseAllInEditorOptions {
 	event: SessionEvent;

--- a/apps/web/src/features/live-sessions/components/event-editors/all-in-editor/use-all-in-editor.ts
+++ b/apps/web/src/features/live-sessions/components/event-editors/all-in-editor/use-all-in-editor.ts
@@ -8,12 +8,11 @@ import {
 } from "@/features/live-sessions/utils/stack-editor-time";
 import { requiredNumericString } from "@/shared/lib/form-fields";
 
-// `wins` is a non-negative integer that must not exceed `trials` (SA2-156),
-// mirroring the server-side `allInPayload` guard so editing an existing all-in
-// event cannot reintroduce EV-corrupting values. The integer check is done in
-// the refine (not via the field's `integer` rule) because
-// `requiredNumericString`'s integer mode truncates "1.5" to 1 rather than
-// rejecting it; both issues attach to the `wins` field path.
+// `wins` must not exceed `trials` (SA2-156), mirroring the server-side
+// `allInPayload` guard so editing an existing all-in event cannot reintroduce
+// EV-corrupting values. It can be fractional — a chopped pot counts as a partial
+// win — so it is NOT constrained to whole numbers; only the `wins <= trials`
+// upper bound is enforced, attached to the `wins` field path.
 const allInSchema = z
 	.object({
 		time: z.string(),
@@ -25,14 +24,6 @@ const allInSchema = z
 	.superRefine((value, ctx) => {
 		const wins = Number(value.wins.trim());
 		if (value.wins.trim() === "" || !Number.isFinite(wins)) {
-			return;
-		}
-		if (!Number.isInteger(wins)) {
-			ctx.addIssue({
-				code: "custom",
-				message: "Wins must be a whole number",
-				path: ["wins"],
-			});
 			return;
 		}
 		const trials = Number.parseInt(value.trials.trim(), 10);

--- a/apps/web/src/features/live-sessions/utils/__tests__/all-in-validation.test.ts
+++ b/apps/web/src/features/live-sessions/utils/__tests__/all-in-validation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { refineWinsNotExceedingTrials } from "@/features/live-sessions/utils/all-in-validation";
+
+type RefineCtx = Parameters<typeof refineWinsNotExceedingTrials>[1];
+
+function run(value: { trials: string; wins: string }) {
+	const addIssue = vi.fn();
+	refineWinsNotExceedingTrials(value, { addIssue } as unknown as RefineCtx);
+	return addIssue;
+}
+
+const WINS_EXCEEDS_ISSUE = {
+	code: "custom",
+	message: "Wins must not exceed trials",
+	path: ["wins"],
+};
+
+describe("refineWinsNotExceedingTrials", () => {
+	it("flags wins greater than trials on the wins field path", () => {
+		const addIssue = run({ trials: "1", wins: "2" });
+		expect(addIssue).toHaveBeenCalledTimes(1);
+		expect(addIssue).toHaveBeenCalledWith(WINS_EXCEEDS_ISSUE);
+	});
+
+	it("flags wins exceeding trials by exactly one (off-by-one boundary)", () => {
+		const addIssue = run({ trials: "3", wins: "4" });
+		expect(addIssue).toHaveBeenCalledTimes(1);
+	});
+
+	it("flags a fractional wins that still exceeds trials", () => {
+		const addIssue = run({ trials: "1", wins: "1.5" });
+		expect(addIssue).toHaveBeenCalledTimes(1);
+	});
+
+	it("accepts wins equal to trials (upper boundary)", () => {
+		expect(run({ trials: "3", wins: "3" })).not.toHaveBeenCalled();
+	});
+
+	it("accepts wins less than trials", () => {
+		expect(run({ trials: "3", wins: "1" })).not.toHaveBeenCalled();
+	});
+
+	it("accepts a fractional wins within trials (a chopped pot)", () => {
+		expect(run({ trials: "3", wins: "1.5" })).not.toHaveBeenCalled();
+	});
+
+	it("ignores an empty wins (left to the field-level rule)", () => {
+		expect(run({ trials: "1", wins: "" })).not.toHaveBeenCalled();
+	});
+
+	it("ignores a non-numeric wins", () => {
+		expect(run({ trials: "1", wins: "abc" })).not.toHaveBeenCalled();
+	});
+
+	it("ignores a non-numeric trials (no comparison possible)", () => {
+		expect(run({ trials: "abc", wins: "5" })).not.toHaveBeenCalled();
+	});
+
+	it("trims surrounding whitespace before comparing", () => {
+		expect(run({ trials: " 3 ", wins: " 4 " })).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/features/live-sessions/utils/all-in-validation.ts
+++ b/apps/web/src/features/live-sessions/utils/all-in-validation.ts
@@ -1,0 +1,28 @@
+import type { RefinementCtx } from "zod";
+
+/**
+ * Shared `superRefine` for the all-in forms: `wins` must not exceed `trials`.
+ * Both the create sheet (`use-all-in-form`) and the timeline editor
+ * (`use-all-in-editor`) attach this so the invariant cannot drift between them —
+ * it mirrors the server-side `allInPayload` refine (SA2-156). `wins` may be
+ * fractional (a chopped pot counts as a partial win), so only the upper bound is
+ * enforced; empty / non-numeric input is left to the field-level rule to avoid
+ * stacking a confusing second error on the same field.
+ */
+export function refineWinsNotExceedingTrials(
+	value: { trials: string; wins: string },
+	ctx: RefinementCtx
+): void {
+	const wins = Number(value.wins.trim());
+	if (value.wins.trim() === "" || !Number.isFinite(wins)) {
+		return;
+	}
+	const trials = Number.parseInt(value.trials.trim(), 10);
+	if (Number.isFinite(trials) && wins > trials) {
+		ctx.addIssue({
+			code: "custom",
+			message: "Wins must not exceed trials",
+			path: ["wins"],
+		});
+	}
+}

--- a/packages/db/src/__tests__/session-event-types.test.ts
+++ b/packages/db/src/__tests__/session-event-types.test.ts
@@ -727,10 +727,20 @@ describe("payload schema edge cases", () => {
 			expect(result.success).toBe(false);
 		});
 
-		it("rejects a non-integer wins", () => {
-			const result = allInPayload.safeParse({
+		it("accepts a fractional wins (a chopped pot counts as a partial win)", () => {
+			const result = allInPayload.parse({
 				potSize: 1000,
 				trials: 3,
+				equity: 50,
+				wins: 1.5,
+			});
+			expect(result.wins).toBe(1.5);
+		});
+
+		it("rejects a fractional wins that still exceeds trials", () => {
+			const result = allInPayload.safeParse({
+				potSize: 1000,
+				trials: 1,
 				equity: 50,
 				wins: 1.5,
 			});

--- a/packages/db/src/__tests__/session-event-types.test.ts
+++ b/packages/db/src/__tests__/session-event-types.test.ts
@@ -707,16 +707,74 @@ describe("payload schema edge cases", () => {
 			).toThrow();
 		});
 
-		it("rejects wins > trials (logical boundary, may be schema or app-level)", () => {
+		it("rejects wins > trials (single trial)", () => {
 			const result = allInPayload.safeParse({
 				potSize: 1000,
 				trials: 1,
 				equity: 50,
 				wins: 2,
 			});
-			// If schema enforces it, should fail. If not, still boundary-tests the shape.
-			// This test accepts either behavior to match the schema's actual rules.
-			expect(typeof result.success).toBe("boolean");
+			expect(result.success).toBe(false);
+		});
+
+		it("rejects wins greater than trials by exactly one (off-by-one boundary)", () => {
+			const result = allInPayload.safeParse({
+				potSize: 1000,
+				trials: 3,
+				equity: 50,
+				wins: 4,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("rejects a non-integer wins", () => {
+			const result = allInPayload.safeParse({
+				potSize: 1000,
+				trials: 3,
+				equity: 50,
+				wins: 1.5,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("rejects a negative wins", () => {
+			const result = allInPayload.safeParse({
+				potSize: 1000,
+				trials: 3,
+				equity: 50,
+				wins: -1,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("accepts wins equal to trials (upper boundary)", () => {
+			const result = allInPayload.parse({
+				potSize: 1000,
+				trials: 3,
+				equity: 50,
+				wins: 3,
+			});
+			expect(result.wins).toBe(3);
+		});
+
+		it("accepts wins less than trials", () => {
+			const result = allInPayload.parse({
+				potSize: 1000,
+				trials: 3,
+				equity: 50,
+				wins: 1,
+			});
+			expect(result.wins).toBe(1);
+		});
+
+		it("accepts wins = 0 with trials = 1 (lower boundary)", () => {
+			const result = allInPayload.parse({
+				potSize: 1000,
+				trials: 1,
+				equity: 50,
+				wins: 0,
+			});
+			expect(result.wins).toBe(0);
 		});
 
 		it("accepts equity exactly at 0 and 100", () => {

--- a/packages/db/src/constants/session-event-types.ts
+++ b/packages/db/src/constants/session-event-types.ts
@@ -99,12 +99,22 @@ export const chipsAddRemovePayload = z.object({
 		.refine((n) => n !== 0, { message: "amount must be non-zero" }),
 });
 
-export const allInPayload = z.object({
-	potSize: z.number().min(0),
-	trials: z.number().int().min(1),
-	equity: z.number().min(0).max(100),
-	wins: z.number().min(0),
-});
+// `wins` is the number of favorable outcomes across `trials` all-in run-outs,
+// so it must be a non-negative integer that never exceeds `trials`. Without the
+// `.int()` and the object-level `wins <= trials` refine, a payload like
+// `{ potSize: 1000, trials: 1, wins: 5 }` validated and let the EV math compute a
+// wins-share larger than the pot, corrupting `evCashOut` / `evDiff` (SA2-156).
+export const allInPayload = z
+	.object({
+		potSize: z.number().min(0),
+		trials: z.number().int().min(1),
+		equity: z.number().min(0).max(100),
+		wins: z.number().int().min(0),
+	})
+	.refine((data) => data.wins <= data.trials, {
+		message: "wins must not exceed trials",
+		path: ["wins"],
+	});
 
 // Tournament event payloads
 //

--- a/packages/db/src/constants/session-event-types.ts
+++ b/packages/db/src/constants/session-event-types.ts
@@ -99,17 +99,19 @@ export const chipsAddRemovePayload = z.object({
 		.refine((n) => n !== 0, { message: "amount must be non-zero" }),
 });
 
-// `wins` is the number of favorable outcomes across `trials` all-in run-outs,
-// so it must be a non-negative integer that never exceeds `trials`. Without the
-// `.int()` and the object-level `wins <= trials` refine, a payload like
-// `{ potSize: 1000, trials: 1, wins: 5 }` validated and let the EV math compute a
-// wins-share larger than the pot, corrupting `evCashOut` / `evDiff` (SA2-156).
+// `wins` is the number of favorable all-in run-outs across `trials`, counted as
+// a fraction when the pot is chopped (a split counts as a partial win). It is
+// therefore a non-negative number — NOT necessarily an integer — that never
+// exceeds `trials`. The object-level `wins <= trials` refine blocks the real bug:
+// a payload like `{ potSize: 1000, trials: 1, wins: 5 }` used to validate and let
+// the EV math compute a wins-share larger than the pot, corrupting
+// `evCashOut` / `evDiff` (SA2-156).
 export const allInPayload = z
 	.object({
 		potSize: z.number().min(0),
 		trials: z.number().int().min(1),
 		equity: z.number().min(0).max(100),
-		wins: z.number().int().min(0),
+		wins: z.number().min(0),
 	})
 	.refine((data) => data.wins <= data.trials, {
 		message: "wins must not exceed trials",


### PR DESCRIPTION
## 概要

`allInPayload`(`packages/db/src/constants/session-event-types.ts`)の `wins` が `z.number().min(0)` のみで `trials` との大小関係チェックがなく、`wins > trials` のような入力が `sessionEvent.create` / `update` を通過して EV 計算 `(potSize/trials)*wins` がポットを超え、`evCashOut` / `evDiff` を含む EV 統計を破損させていました(例: `{potSize:1000, trials:1, equity:50, wins:5}` → 勝ち分 `5000` がポット `1000` を超過)。

Linear: SA2-156 / closes #473

## 変更内容

- `packages/db/src/constants/session-event-types.ts`: `allInPayload` にオブジェクトレベルの `.refine((d) => d.wins <= d.trials, …)` を追加し、`sessionEvent.create` / `update` 双方で `wins > trials` を弾きます。
- Web の作成フォーム(`use-all-in-form.ts`)・編集フォーム(`use-all-in-editor.ts`)にも同じ `wins <= trials` 制約を `superRefine` でミラーし、UI 上でもインラインエラーを返します(`update` 経路も issue が明示するため対応)。

### 整数制約は入れません(重要・レビュー指摘反映)

当初は `wins` に `.int()` を付けていましたが、**チョップ(スプリットポット)では 1 回の run-out の勝ちが小数になり得る**ため誤りでした。`wins` は非負の**小数を許容**し、`wins <= trials` の上限のみを強制します。`trials`(run-out 回数)は整数のまま。この修正で、小数 `wins` を送る既存コンポーネントテスト(`all-in-bottom-sheet.test.tsx`)を `.int()` が弾いていた CI 回帰も解消しました。

## テスト

TDD(red→green)。

- DB(`db`): `wins>trials`(単一trial/オフバイワン)を reject、**小数 `wins`(チョップ)を accept**、**小数でも `trials` 超過は reject**、負数 reject、`wins==trials` accept、`wins<trials` accept。
- 両 Web フォーム(`web-dom`): `wins>trials` を reject、**小数 `wins` を accept**、`wins==trials` を accept。

検証:
- `bunx vitest run --project db packages/db/src/__tests__/session-event-types.test.ts` → 115 passed
- `bunx vitest run --project web-dom <all-in form/editor/bottom-sheet>` → 24 passed(CI で失敗していた `all-in-bottom-sheet.test.tsx` を含む)
- `bun run check-types` → server / web ともに exit 0
- `bunx ultracite check <変更ファイル>` → clean

## 補足

- **ZodEffects**: `.refine` により `allInPayload` は `ZodEffects` になります。全消費側(`EVENT_PAYLOAD_SCHEMAS` / `validateEventPayload` / `live-session-pl.ts` / `session-timeline.ts`)は `.parse()` のみで `.shape`/`.extend` 等を使わず、`check-types` exit 0 で fallout なしを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)