### PR TITLE
perf(api): ライブセッション一覧の events 取得を単一バッチクエリ化 (SA2-151)

### DIFF
--- a/packages/api/src/__tests__/live-cash-game-session.test.ts
+++ b/packages/api/src/__tests__/live-cash-game-session.test.ts
@@ -3,6 +3,7 @@ import { ringGame } from "@sapphire2/db/schema/ring-game";
 import { room } from "@sapphire2/db/schema/room";
 import { gameSession } from "@sapphire2/db/schema/session";
 import { sessionCashDetail } from "@sapphire2/db/schema/session-cash-detail";
+import { sessionEvent } from "@sapphire2/db/schema/session-event";
 import { TRPCError } from "@trpc/server";
 import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
@@ -909,5 +910,181 @@ describe("liveCashGameSession.list composite keyset cursor (SA2-150)", () => {
 		const result = await listCaller(db).list({ limit: 2 });
 		expect(result.items).toEqual([]);
 		expect(result.nextCursor).toBeUndefined();
+	});
+});
+
+// SA2-151: the list endpoint fetched session_event with one query per page item
+// (an N+1 that D1's per-query latency made expensive at page size). It now
+// collects the page's session ids and fetches every event in ONE inArray batch,
+// then buckets rows by session id. These tests pin the single-query shape, the
+// per-session bucketing, and the (occurredAt, sortOrder) ordering the latest-
+// stack derivation depends on.
+function sessionEventRow(
+	sessionId: string,
+	eventType: string,
+	payload: Record<string, unknown>,
+	occurredAt: number,
+	sortOrder: number
+): Record<string, unknown> {
+	return {
+		sessionId,
+		eventType,
+		payload: JSON.stringify(payload),
+		occurredAt: new Date(occurredAt),
+		sortOrder,
+	};
+}
+
+/**
+ * Mock db for the list-enrichment path: `select().from(gameSession)` resolves
+ * to the page rows, `select().from(sessionEvent)` resolves to every event row
+ * (the mock ignores the `inArray` filter, so bucketing must be done in app
+ * code). It records which table each `.from(...)` targeted and the conditions
+ * bound to the sessionEvent `.where(...)` so a single batched IN can be proven.
+ */
+function createEventBatchMockDb(sessions: Rows, events: Rows) {
+	const fromCalls: unknown[] = [];
+	const eventWhere: unknown[] = [];
+	const makeChain = (table: unknown) => {
+		const rows = table === sessionEvent ? events : sessions;
+		const chain = Promise.resolve(rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.where = (cond: unknown) => {
+			if (table === sessionEvent) {
+				eventWhere.push(cond);
+			}
+			return chain;
+		};
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.leftJoin = () => chain;
+		chain.innerJoin = () => chain;
+		chain.groupBy = () => chain;
+		return chain;
+	};
+	const db = {
+		select: () => ({
+			from: (table: unknown) => {
+				fromCalls.push(table);
+				return makeChain(table);
+			},
+		}),
+	};
+	return { db, fromCalls, eventWhere };
+}
+
+function sessionEventFromCount(fromCalls: unknown[]): number {
+	return fromCalls.filter((t) => t === sessionEvent).length;
+}
+
+describe("liveCashGameSession.list event batching (SA2-151)", () => {
+	it("fetches the whole page's events in a single inArray query, not one per session", async () => {
+		const sessions: Rows = [{ id: "s1" }, { id: "s2" }, { id: "s3" }];
+		const events: Rows = [
+			sessionEventRow("s1", "session_start", { buyInAmount: 100 }, 1000, 0),
+			sessionEventRow("s2", "session_start", { buyInAmount: 200 }, 1000, 0),
+		];
+		const { db, fromCalls, eventWhere } = createEventBatchMockDb(
+			sessions,
+			events
+		);
+
+		const result = await listCaller(db).list({ limit: 20 });
+
+		expect(sessionEventFromCount(fromCalls)).toBe(1);
+		const query = dialect.sqlToQuery(eventWhere[0] as never);
+		expect(query.sql).toContain("in (");
+		expect(query.params).toEqual(["s1", "s2", "s3"]);
+		expect(result.items).toHaveLength(3);
+	});
+
+	it("buckets events by session id so each item counts only its own events", async () => {
+		const sessions: Rows = [{ id: "s1" }, { id: "s2" }, { id: "s3" }];
+		const events: Rows = [
+			sessionEventRow("s1", "session_start", { buyInAmount: 100 }, 1000, 0),
+			sessionEventRow("s1", "update_stack", { stackAmount: 500 }, 2000, 1),
+			sessionEventRow("s1", "update_stack", { stackAmount: 800 }, 3000, 2),
+			sessionEventRow("s2", "session_start", { buyInAmount: 200 }, 1000, 0),
+			// s2's stack update occurs LATER than any s1 event — a naive scan over
+			// the un-bucketed page would leak 1200 into s1's latest stack.
+			sessionEventRow("s2", "update_stack", { stackAmount: 1200 }, 9000, 1),
+		];
+		const { db } = createEventBatchMockDb(sessions, events);
+
+		const result = await listCaller(db).list({ limit: 20 });
+		const byId = Object.fromEntries(result.items.map((i) => [i.id, i]));
+
+		expect(byId.s1?.eventCount).toBe(3);
+		expect(byId.s1?.latestStackAmount).toBe(800);
+		expect(byId.s2?.eventCount).toBe(2);
+		expect(byId.s2?.latestStackAmount).toBe(1200);
+		expect(byId.s3?.eventCount).toBe(0);
+		expect(byId.s3?.latestStackAmount).toBeNull();
+	});
+
+	it("derives the latest stack from (occurredAt, sortOrder) order, not array order", async () => {
+		const sessions: Rows = [{ id: "s1" }];
+		const events: Rows = [
+			sessionEventRow("s1", "update_stack", { stackAmount: 300 }, 3000, 1),
+			sessionEventRow("s1", "update_stack", { stackAmount: 100 }, 1000, 1),
+			sessionEventRow("s1", "update_stack", { stackAmount: 200 }, 2000, 1),
+		];
+		const { db } = createEventBatchMockDb(sessions, events);
+
+		const result = await listCaller(db).list({ limit: 20 });
+
+		expect(result.items[0]?.latestStackAmount).toBe(300);
+	});
+
+	it("breaks occurredAt ties by sortOrder when picking the latest stack", async () => {
+		const sessions: Rows = [{ id: "s1" }];
+		const events: Rows = [
+			sessionEventRow("s1", "update_stack", { stackAmount: 111 }, 5000, 2),
+			sessionEventRow("s1", "update_stack", { stackAmount: 222 }, 5000, 1),
+		];
+		const { db } = createEventBatchMockDb(sessions, events);
+
+		const result = await listCaller(db).list({ limit: 20 });
+
+		expect(result.items[0]?.latestStackAmount).toBe(111);
+	});
+
+	it("batches once and derives the stack for a single-session page", async () => {
+		const sessions: Rows = [{ id: "only" }];
+		const events: Rows = [
+			sessionEventRow("only", "session_start", { buyInAmount: 500 }, 1000, 0),
+			sessionEventRow("only", "update_stack", { stackAmount: 750 }, 2000, 1),
+		];
+		const { db, fromCalls } = createEventBatchMockDb(sessions, events);
+
+		const result = await listCaller(db).list({ limit: 20 });
+
+		expect(sessionEventFromCount(fromCalls)).toBe(1);
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]?.eventCount).toBe(2);
+		expect(result.items[0]?.latestStackAmount).toBe(750);
+	});
+
+	it("returns null latest stack when a session has only non-stack events", async () => {
+		const sessions: Rows = [{ id: "s1" }];
+		const events: Rows = [
+			sessionEventRow("s1", "session_start", { buyInAmount: 400 }, 1000, 0),
+		];
+		const { db } = createEventBatchMockDb(sessions, events);
+
+		const result = await listCaller(db).list({ limit: 20 });
+
+		expect(result.items[0]?.eventCount).toBe(1);
+		expect(result.items[0]?.latestStackAmount).toBeNull();
+	});
+
+	it("issues no event query and returns no items for an empty page", async () => {
+		const { db, fromCalls } = createEventBatchMockDb([], []);
+
+		const result = await listCaller(db).list({ limit: 20 });
+
+		expect(result.items).toEqual([]);
+		expect(result.nextCursor).toBeUndefined();
+		expect(sessionEventFromCount(fromCalls)).toBe(0);
 	});
 });

--- a/packages/api/src/__tests__/live-tournament-session.test.ts
+++ b/packages/api/src/__tests__/live-tournament-session.test.ts
@@ -1,6 +1,7 @@
 import { currency } from "@sapphire2/db/schema/currency";
 import { room } from "@sapphire2/db/schema/room";
 import { gameSession } from "@sapphire2/db/schema/session";
+import { sessionEvent } from "@sapphire2/db/schema/session-event";
 import { TRPCError } from "@trpc/server";
 import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it, vi } from "vitest";
@@ -974,5 +975,177 @@ describe("liveTournamentSession.list composite keyset cursor (SA2-150)", () => {
 		const result = await listCaller(db).list({ limit: 2 });
 		expect(result.items).toEqual([]);
 		expect(result.nextCursor).toBeUndefined();
+	});
+});
+
+// SA2-151: the list endpoint fetched session_event with one query per page item
+// (an N+1 that D1's per-query latency made expensive at page size). It now
+// collects the page's session ids and fetches every event in ONE inArray batch,
+// then buckets rows by session id. These tests pin the single-query shape, the
+// per-session bucketing (eventCount + the computeStackStats-derived fields), and
+// the (occurredAt, sortOrder) ordering the current-stack derivation depends on.
+const listEventBatchDialect = new SQLiteSyncDialect();
+
+function sessionEventRow(
+	sessionId: string,
+	eventType: string,
+	payload: Record<string, unknown>,
+	occurredAt: number,
+	sortOrder: number
+): Record<string, unknown> {
+	return {
+		sessionId,
+		eventType,
+		payload: JSON.stringify(payload),
+		occurredAt: new Date(occurredAt),
+		sortOrder,
+	};
+}
+
+/**
+ * Mock db for the list-enrichment path: `select().from(gameSession)` resolves
+ * to the page rows, `select().from(sessionEvent)` resolves to every event row
+ * (the mock ignores the `inArray` filter, so bucketing must be done in app
+ * code). It records which table each `.from(...)` targeted and the conditions
+ * bound to the sessionEvent `.where(...)` so a single batched IN can be proven.
+ */
+function createEventBatchMockDb(sessions: Rows, events: Rows) {
+	const fromCalls: unknown[] = [];
+	const eventWhere: unknown[] = [];
+	const makeChain = (table: unknown) => {
+		const rows = table === sessionEvent ? events : sessions;
+		const chain = Promise.resolve(rows) as Promise<Rows> &
+			Record<string, (...args: unknown[]) => unknown>;
+		chain.where = (cond: unknown) => {
+			if (table === sessionEvent) {
+				eventWhere.push(cond);
+			}
+			return chain;
+		};
+		chain.orderBy = () => chain;
+		chain.limit = () => chain;
+		chain.leftJoin = () => chain;
+		chain.innerJoin = () => chain;
+		chain.groupBy = () => chain;
+		return chain;
+	};
+	const db = {
+		select: () => ({
+			from: (table: unknown) => {
+				fromCalls.push(table);
+				return makeChain(table);
+			},
+		}),
+	};
+	return { db, fromCalls, eventWhere };
+}
+
+function sessionEventFromCount(fromCalls: unknown[]): number {
+	return fromCalls.filter((t) => t === sessionEvent).length;
+}
+
+describe("liveTournamentSession.list event batching (SA2-151)", () => {
+	it("fetches the whole page's events in a single inArray query, not one per session", async () => {
+		const sessions: Rows = [
+			{ id: "s1", startingStack: 20_000 },
+			{ id: "s2", startingStack: 20_000 },
+			{ id: "s3", startingStack: null },
+		];
+		const events: Rows = [
+			sessionEventRow("s1", "session_start", {}, 1000, 0),
+			sessionEventRow("s2", "session_start", {}, 1000, 0),
+		];
+		const { db, fromCalls, eventWhere } = createEventBatchMockDb(
+			sessions,
+			events
+		);
+
+		const result = await listCaller(db).list({ limit: 20 });
+
+		expect(sessionEventFromCount(fromCalls)).toBe(1);
+		const query = listEventBatchDialect.sqlToQuery(eventWhere[0] as never);
+		expect(query.sql).toContain("in (");
+		expect(query.params).toEqual(["s1", "s2", "s3"]);
+		expect(result.items).toHaveLength(3);
+	});
+
+	it("buckets events by session id so each item derives from only its own events", async () => {
+		const sessions: Rows = [
+			{ id: "s1", startingStack: 20_000 },
+			{ id: "s2", startingStack: 20_000 },
+		];
+		const events: Rows = [
+			sessionEventRow("s1", "session_start", {}, 1000, 0),
+			sessionEventRow(
+				"s1",
+				"update_stack",
+				{ stackAmount: 25_000, remainingPlayers: 100, totalEntries: 100 },
+				2000,
+				1
+			),
+			sessionEventRow(
+				"s1",
+				"update_stack",
+				{ stackAmount: 30_000, remainingPlayers: 50 },
+				3000,
+				2
+			),
+			// s2 has no events.
+		];
+		const { db } = createEventBatchMockDb(sessions, events);
+
+		const result = await listCaller(db).list({ limit: 20 });
+		const byId = Object.fromEntries(result.items.map((i) => [i.id, i]));
+
+		expect(byId.s1?.eventCount).toBe(3);
+		expect(byId.s1?.latestStackAmount).toBe(30_000);
+		expect(byId.s1?.remainingPlayers).toBe(50);
+		// (startingStack * totalEntries + chipTotal) / remainingPlayers
+		// = (20000 * 100 + 0) / 50 = 40000.
+		expect(byId.s1?.averageStack).toBe(40_000);
+		expect(byId.s2?.eventCount).toBe(0);
+		expect(byId.s2?.latestStackAmount).toBeNull();
+		expect(byId.s2?.remainingPlayers).toBeNull();
+		expect(byId.s2?.averageStack).toBeNull();
+	});
+
+	it("derives the current stack from (occurredAt, sortOrder) order, not array order", async () => {
+		const sessions: Rows = [{ id: "s1", startingStack: null }];
+		const events: Rows = [
+			sessionEventRow("s1", "update_stack", { stackAmount: 3000 }, 3000, 1),
+			sessionEventRow("s1", "update_stack", { stackAmount: 1000 }, 1000, 1),
+			sessionEventRow("s1", "update_stack", { stackAmount: 2000 }, 2000, 1),
+		];
+		const { db } = createEventBatchMockDb(sessions, events);
+
+		const result = await listCaller(db).list({ limit: 20 });
+
+		expect(result.items[0]?.latestStackAmount).toBe(3000);
+	});
+
+	it("batches once for a single-session page", async () => {
+		const sessions: Rows = [{ id: "only", startingStack: 15_000 }];
+		const events: Rows = [
+			sessionEventRow("only", "session_start", {}, 1000, 0),
+			sessionEventRow("only", "update_stack", { stackAmount: 18_000 }, 2000, 1),
+		];
+		const { db, fromCalls } = createEventBatchMockDb(sessions, events);
+
+		const result = await listCaller(db).list({ limit: 20 });
+
+		expect(sessionEventFromCount(fromCalls)).toBe(1);
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]?.eventCount).toBe(2);
+		expect(result.items[0]?.latestStackAmount).toBe(18_000);
+	});
+
+	it("issues no event query and returns no items for an empty page", async () => {
+		const { db, fromCalls } = createEventBatchMockDb([], []);
+
+		const result = await listCaller(db).list({ limit: 20 });
+
+		expect(result.items).toEqual([]);
+		expect(result.nextCursor).toBeUndefined();
+		expect(sessionEventFromCount(fromCalls)).toBe(0);
 	});
 });

--- a/packages/api/src/routers/live-cash-game-session.ts
+++ b/packages/api/src/routers/live-cash-game-session.ts
@@ -23,6 +23,7 @@ import {
 import { floorToMinute } from "../utils/session-event-time";
 import {
 	encodeSessionCursor,
+	getSessionEventMap,
 	resolveCashRuleSnapshot,
 	sessionKeysetCondition,
 	sessionOrderKeySql,
@@ -305,36 +306,34 @@ export const liveCashGameSessionRouter = router({
 			const nextCursor =
 				hasMore && last ? encodeSessionCursor(last) : undefined;
 
-			const enrichedItems = await Promise.all(
-				items.map(async (item) => {
-					const events = await ctx.db
-						.select({
-							eventType: sessionEvent.eventType,
-							payload: sessionEvent.payload,
-							sortOrder: sessionEvent.sortOrder,
-						})
-						.from(sessionEvent)
-						.where(eq(sessionEvent.sessionId, item.id))
-						.orderBy(asc(sessionEvent.occurredAt), asc(sessionEvent.sortOrder));
+			// SA2-151: fetch every page item's events in one batched inArray
+			// query, then bucket by session id, instead of a per-item query
+			// (an N+1 whose per-query latency dominated under D1). getSessionEventMap
+			// preserves the (occurredAt, sortOrder) ordering the reverse scan needs.
+			const eventMap = await getSessionEventMap(
+				ctx.db,
+				items.map((item) => item.id)
+			);
 
-					const eventCount = events.length;
-					let latestStackAmount: number | null = null;
+			const enrichedItems = items.map((item) => {
+				const events = eventMap.get(item.id) ?? [];
+				const eventCount = events.length;
+				let latestStackAmount: number | null = null;
 
-					for (const event of [...events].reverse()) {
-						if (event.eventType === "update_stack") {
-							const parsed = updateStackPayload.safeParse(
-								JSON.parse(event.payload)
-							);
-							if (parsed.success) {
-								latestStackAmount = parsed.data.stackAmount;
-								break;
-							}
+				for (const event of [...events].reverse()) {
+					if (event.eventType === "update_stack") {
+						const parsed = updateStackPayload.safeParse(
+							JSON.parse(event.payload)
+						);
+						if (parsed.success) {
+							latestStackAmount = parsed.data.stackAmount;
+							break;
 						}
 					}
+				}
 
-					return { ...item, eventCount, latestStackAmount };
-				})
-			);
+				return { ...item, eventCount, latestStackAmount };
+			});
 
 			return { items: enrichedItems, nextCursor };
 		}),

--- a/packages/api/src/routers/live-tournament-session.ts
+++ b/packages/api/src/routers/live-tournament-session.ts
@@ -23,6 +23,7 @@ import {
 import { floorToMinute } from "../utils/session-event-time";
 import {
 	encodeSessionCursor,
+	getSessionEventMap,
 	persistSessionBlindLevels,
 	persistSessionChipPurchases,
 	resnapshotTournamentStructure,
@@ -536,36 +537,28 @@ export const liveTournamentSessionRouter = router({
 			const nextCursor =
 				hasMore && last ? encodeSessionCursor(last) : undefined;
 
-			const enrichedItems = await Promise.all(
-				items.map(async (item) => {
-					const events = await ctx.db
-						.select({
-							eventType: sessionEvent.eventType,
-							payload: sessionEvent.payload,
-							sortOrder: sessionEvent.sortOrder,
-						})
-						.from(sessionEvent)
-						.where(eq(sessionEvent.sessionId, item.id))
-						.orderBy(asc(sessionEvent.occurredAt), asc(sessionEvent.sortOrder));
-
-					const eventCount = events.length;
-					const statsForList = computeStackStats(
-						events.map((e) => ({
-							eventType: e.eventType,
-							payload: e.payload,
-						})),
-						item.startingStack
-					);
-
-					return {
-						...item,
-						eventCount,
-						latestStackAmount: statsForList.currentStack,
-						remainingPlayers: statsForList.remainingPlayers,
-						averageStack: statsForList.averageStack,
-					};
-				})
+			// SA2-151: fetch every page item's events in one batched inArray
+			// query, then bucket by session id, instead of a per-item query
+			// (an N+1 whose per-query latency dominated under D1). getSessionEventMap
+			// preserves the (occurredAt, sortOrder) ordering computeStackStats needs.
+			const eventMap = await getSessionEventMap(
+				ctx.db,
+				items.map((item) => item.id)
 			);
+
+			const enrichedItems = items.map((item) => {
+				const events = eventMap.get(item.id) ?? [];
+				const eventCount = events.length;
+				const statsForList = computeStackStats(events, item.startingStack);
+
+				return {
+					...item,
+					eventCount,
+					latestStackAmount: statsForList.currentStack,
+					remainingPlayers: statsForList.remainingPlayers,
+					averageStack: statsForList.averageStack,
+				};
+			});
 
 			return { items: enrichedItems, nextCursor };
 		}),

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -10,6 +10,7 @@ import { sessionBlindLevel } from "@sapphire2/db/schema/session-blind-level";
 import { sessionCashDetail } from "@sapphire2/db/schema/session-cash-detail";
 import { sessionChipPurchase } from "@sapphire2/db/schema/session-chip-purchase";
 import { sessionChipPurchaseResult } from "@sapphire2/db/schema/session-chip-purchase-result";
+import { sessionEvent } from "@sapphire2/db/schema/session-event";
 import {
 	sessionTag,
 	sessionToSessionTag,
@@ -271,6 +272,79 @@ async function getSessionBlindLevelMap(
 		} else {
 			map.set(r.sessionId, [entry]);
 		}
+	}
+	return map;
+}
+
+interface SessionEventForList {
+	eventType: string;
+	payload: string;
+}
+
+/**
+ * Batched lookup of session events for the live-session `list` endpoints, keyed
+ * by session id and ordered by (occurredAt asc, sortOrder asc) — the exact order
+ * the per-session query used before SA2-151 collapsed the N+1 (one
+ * `WHERE session_id = ?` query per page item, up to limit+1 ≈ 100 extra
+ * round-trips that D1's per-query latency made expensive) into a single
+ * `inArray` fetch via {@link selectInChunks}. Each bucket is re-sorted in
+ * application code so per-session ordering holds even though selectInChunks
+ * concatenates chunk results (and a mocked db may ignore ORDER BY). Sessions
+ * with no events are absent from the map.
+ */
+export async function getSessionEventMap(
+	db: DbInstance,
+	sessionIds: string[]
+): Promise<Map<string, SessionEventForList[]>> {
+	const map = new Map<string, SessionEventForList[]>();
+	if (sessionIds.length === 0) {
+		return map;
+	}
+	const rows = await selectInChunks(sessionIds, (chunk) =>
+		db
+			.select({
+				sessionId: sessionEvent.sessionId,
+				eventType: sessionEvent.eventType,
+				payload: sessionEvent.payload,
+				occurredAt: sessionEvent.occurredAt,
+				sortOrder: sessionEvent.sortOrder,
+			})
+			.from(sessionEvent)
+			.where(inArray(sessionEvent.sessionId, chunk))
+			.orderBy(asc(sessionEvent.occurredAt), asc(sessionEvent.sortOrder))
+	);
+	const buckets = new Map<
+		string,
+		{
+			eventType: string;
+			occurredAt: Date;
+			payload: string;
+			sortOrder: number;
+		}[]
+	>();
+	for (const r of rows) {
+		const entry = {
+			eventType: r.eventType,
+			payload: r.payload,
+			occurredAt: r.occurredAt,
+			sortOrder: r.sortOrder,
+		};
+		const existing = buckets.get(r.sessionId);
+		if (existing) {
+			existing.push(entry);
+		} else {
+			buckets.set(r.sessionId, [entry]);
+		}
+	}
+	for (const [sessionId, events] of buckets) {
+		events.sort(
+			(a, b) =>
+				Number(a.occurredAt) - Number(b.occurredAt) || a.sortOrder - b.sortOrder
+		);
+		map.set(
+			sessionId,
+			events.map((e) => ({ eventType: e.eventType, payload: e.payload }))
+		);
 	}
 	return map;
 }


### PR DESCRIPTION
## 概要

ライブキャッシュ / トーナメントの `list` は、ページ内のセッションごとに `sessionEvent` を個別 SELECT しており、`Promise.all(items.map(async ...))` の中で最大 `limit+1`(約100+)回のクエリが走る N+1 になっていました。1クエリあたりのレイテンシが支配的な D1 では顕著な遅延要因です(機能バグではなく性能上の懸念、low severity)。

Linear: SA2-151 / closes #468

## 変更内容

`session.ts` の既存パターン `selectInChunks` + `inArray` を再利用します。

- `packages/api/src/routers/session.ts`: 共有ヘルパー `getSessionEventMap` を追加・export。ページ全セッションの ID をまとめて1回のバッチクエリ(`selectInChunks` + `inArray`)で取得し、`sessionId` でバケット化。各バケットを `(occurredAt asc, sortOrder asc)` で再ソートして返します。
- `live-cash-game-session.ts` / `live-tournament-session.ts`: `list` が `getSessionEventMap` を一度だけ呼び、同期的な `items.map` に変更。per-item クエリ(`Promise.all(items.map(async …))`)を除去。
- 純粋な性能改善で、各セッションの派生値(`eventCount` / `latestStackAmount` / `remainingPlayers` / `averageStack`)は従来と完全に一致します。

## テスト

TDD(先にテスト追加し red→green を確認、12件)。

- 単一バッチ `inArray` クエリであることの検証(`from` 呼び出し1回 + SQL に `in (` + パラメータがページ全 ID と一致)
- `sessionId` ごとのバケット化(各セッションは自分のイベントのみ集計、events ゼロのセッション、共有なしのセッション、他セッションの `update_stack` が最新スタックに混入しない cross-session leak ガード)
- 派生値の正しさ(cash `eventCount`/`latestStackAmount`、tournament `eventCount`/`latestStackAmount`/`remainingPlayers`/`averageStack`=40000)
- `(occurredAt, sortOrder)` 順序、occurredAt 同値時の sortOrder タイブレーク、単一セッションページ、空ページ(イベントクエリ発行なし)

検証コマンド:
- `bunx vitest run --project api <両ファイル> -t "SA2-151"` → 実装前 `7 failed | 5 passed`(red)、実装後 12 passed
- `bunx vitest run --project api <両ファイル>` → 147 passed / `--project api`(全体)→ 894 passed
- `bun run check-types` → server / web ともに exit 0
- `bunx ultracite check packages/api/src` → clean

## 補足

- **イベント順序の保持**: 旧実装の per-session クエリは `(occurredAt asc, sortOrder asc)` でソートしていました。`getSessionEventMap` は DB レベルの `ORDER BY` を維持しつつ、各バケットをアプリ側でも `Number(a.occurredAt) - Number(b.occurredAt) || a.sortOrder - b.sortOrder` で再ソート(belt-and-suspenders)。`selectInChunks` のチャンク連結やドライバの `ORDER BY` 尊重に依存せず、cash の最新 `update_stack` 走査・tournament の `computeStackStats` が pre-refactor とバイト一致することを担保します。
- SA2-150(別 open PR)も同 `list` 手続きの cursor/order を触ります。本 PR は指示どおり `dev` から分岐(SA2-150 を含まない)しており、マージ時にコンフリクト解消予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LESXQVaQyiQbai6YYWQzYn)_