### PR TITLE
Preserve update-note sections (New Features / UI Improvements / Bug Fixes)

### DIFF
--- a/apps/web/src/features/update-notes/components/update-notes-sheet/update-notes-sheet.test.tsx
+++ b/apps/web/src/features/update-notes/components/update-notes-sheet/update-notes-sheet.test.tsx
@@ -28,9 +28,21 @@ vi.mock("@/features/update-notes/constants", () => ({
 			releasedAt: "2026-04-11",
 			title: "Update Notes Feature",
 			changes: [
-				"Added update notes modal to view past release information",
-				"Unviewed updates are highlighted with a NEW badge",
-				"Update notes sheet automatically opens after a new release",
+				{
+					section: "New Features",
+					items: ["Added update notes modal to view past release information"],
+				},
+				{
+					section: "UI Improvements",
+					items: [
+						"Unviewed updates are highlighted with a NEW badge",
+						"Update notes sheet automatically opens after a new release",
+					],
+				},
+				{
+					section: "",
+					items: ["orphan bullet"],
+				},
 			],
 		},
 	],
@@ -114,6 +126,21 @@ describe("UpdateNotesSheet", () => {
 				"Update notes sheet automatically opens after a new release"
 			)
 		).toBeInTheDocument();
+	});
+
+	it("renders each change section's heading", () => {
+		mocks.sheetState.isOpen = true;
+		render(<UpdateNotesSheet />);
+		expect(screen.getByText("New Features")).toBeInTheDocument();
+		expect(screen.getByText("UI Improvements")).toBeInTheDocument();
+	});
+
+	it("does not render a heading for an unlabeled section", () => {
+		mocks.sheetState.isOpen = true;
+		render(<UpdateNotesSheet />);
+		const orphanItem = screen.getByText("orphan bullet");
+		const group = orphanItem.closest("div");
+		expect(group?.querySelector("p")).toBeNull();
 	});
 
 	it("does not render drawer content when isOpen=false even if a version is viewed", () => {

--- a/apps/web/src/features/update-notes/components/update-notes-sheet/update-notes-sheet.tsx
+++ b/apps/web/src/features/update-notes/components/update-notes-sheet/update-notes-sheet.tsx
@@ -53,11 +53,20 @@ export function UpdateNotesSheet() {
 									</AccordionTrigger>
 									<AccordionContent>
 										<p className="mb-2 font-medium">{note.title}</p>
-										<ul className="list-disc space-y-1 pl-4 text-muted-foreground">
-											{note.changes.map((change) => (
-												<li key={change}>{change}</li>
+										<div className="space-y-3">
+											{note.changes.map((group) => (
+												<div key={group.section || "general"}>
+													{group.section && (
+														<p className="t-label mb-1">{group.section}</p>
+													)}
+													<ul className="list-disc space-y-1 pl-4 text-muted-foreground">
+														{group.items.map((item) => (
+															<li key={item}>{item}</li>
+														))}
+													</ul>
+												</div>
 											))}
-										</ul>
+										</div>
 									</AccordionContent>
 								</AccordionItem>
 							))}

--- a/apps/web/src/features/update-notes/constants.ts
+++ b/apps/web/src/features/update-notes/constants.ts
@@ -1,7 +1,12 @@
 export { LATEST_VERSION, UPDATE_NOTES } from "virtual:update-notes";
 
+export interface UpdateNoteChangeSection {
+	readonly items: readonly string[];
+	readonly section: string;
+}
+
 export interface UpdateNote {
-	readonly changes: readonly string[];
+	readonly changes: readonly UpdateNoteChangeSection[];
 	readonly releasedAt: string;
 	readonly title: string;
 	readonly version: string;

--- a/apps/web/src/features/update-notes/constants.ts
+++ b/apps/web/src/features/update-notes/constants.ts
@@ -1,13 +1,2 @@
 export { LATEST_VERSION, UPDATE_NOTES } from "virtual:update-notes";
-
-export interface UpdateNoteChangeSection {
-	readonly items: readonly string[];
-	readonly section: string;
-}
-
-export interface UpdateNote {
-	readonly changes: readonly UpdateNoteChangeSection[];
-	readonly releasedAt: string;
-	readonly title: string;
-	readonly version: string;
-}
+export type { UpdateNoteSection } from "@/features/update-notes/utils/parse-release-body";

--- a/apps/web/src/features/update-notes/utils/__tests__/parse-release-body.test.ts
+++ b/apps/web/src/features/update-notes/utils/__tests__/parse-release-body.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { parseReleaseBody } from "../parse-release-body";
+
+describe("parseReleaseBody", () => {
+	it("returns an empty array for null body", () => {
+		expect(parseReleaseBody(null)).toEqual([]);
+	});
+
+	it("returns an empty array for an empty string body", () => {
+		expect(parseReleaseBody("")).toEqual([]);
+	});
+
+	it("returns a section with no items when a heading has no bullets", () => {
+		expect(
+			parseReleaseBody("## v1.0.0 Release Notes\n\n### New Features\n")
+		).toEqual([{ section: "New Features", items: [] }]);
+	});
+
+	it("groups bullets under their ### heading", () => {
+		const body = [
+			"## v1.4.0 Release Notes",
+			"",
+			"### New Features",
+			"",
+			"- Players can now seat themselves (#154)",
+			"",
+			"### Bug Fixes",
+			"",
+			"- Fixed HTML parsing errors (#154)",
+		].join("\n");
+
+		expect(parseReleaseBody(body)).toEqual([
+			{
+				section: "New Features",
+				items: ["Players can now seat themselves (#154)"],
+			},
+			{
+				section: "Bug Fixes",
+				items: ["Fixed HTML parsing errors (#154)"],
+			},
+		]);
+	});
+
+	it("supports both - and * list markers within the same section", () => {
+		const body = ["### UI Improvements", "- Dash item", "* Star item"].join(
+			"\n"
+		);
+
+		expect(parseReleaseBody(body)).toEqual([
+			{ section: "UI Improvements", items: ["Dash item", "Star item"] },
+		]);
+	});
+
+	it("drops the top-level ## title without starting a section", () => {
+		const body = [
+			"## v1.4.0 Release Notes",
+			"- orphan bullet before any ### heading",
+		].join("\n");
+
+		expect(parseReleaseBody(body)).toEqual([
+			{ section: "", items: ["orphan bullet before any ### heading"] },
+		]);
+	});
+
+	it("skips blank lines between bullets within a section", () => {
+		const body = ["### New Features", "- first", "", "- second"].join("\n");
+
+		expect(parseReleaseBody(body)).toEqual([
+			{ section: "New Features", items: ["first", "second"] },
+		]);
+	});
+
+	it("starts a new section list even when a later ### heading has no items", () => {
+		const body = [
+			"### New Features",
+			"- only item",
+			"### UI Improvements",
+		].join("\n");
+
+		expect(parseReleaseBody(body)).toEqual([
+			{ section: "New Features", items: ["only item"] },
+			{ section: "UI Improvements", items: [] },
+		]);
+	});
+});

--- a/apps/web/src/features/update-notes/utils/parse-release-body.ts
+++ b/apps/web/src/features/update-notes/utils/parse-release-body.ts
@@ -1,0 +1,46 @@
+export interface UpdateNoteSection {
+	items: string[];
+	section: string;
+}
+
+const LIST_ITEM_PREFIX = /^[-*]\s+/;
+const SECTION_HEADING_PREFIX = /^###\s+/;
+
+export function parseReleaseBody(body: string | null): UpdateNoteSection[] {
+	if (!body) {
+		return [];
+	}
+
+	const sections: UpdateNoteSection[] = [];
+	let current: UpdateNoteSection | null = null;
+
+	for (const rawLine of body.split("\n")) {
+		const line = rawLine.trim();
+
+		if (SECTION_HEADING_PREFIX.test(line)) {
+			current = {
+				section: line.replace(SECTION_HEADING_PREFIX, "").trim(),
+				items: [],
+			};
+			sections.push(current);
+			continue;
+		}
+
+		if (line.startsWith("#")) {
+			continue;
+		}
+
+		const item = line.replace(LIST_ITEM_PREFIX, "").trim();
+		if (item.length === 0) {
+			continue;
+		}
+
+		if (!current) {
+			current = { section: "", items: [] };
+			sections.push(current);
+		}
+		current.items.push(item);
+	}
+
+	return sections;
+}

--- a/apps/web/src/plugins/vite-plugin-github-releases.ts
+++ b/apps/web/src/plugins/vite-plugin-github-releases.ts
@@ -1,4 +1,6 @@
 import type { Plugin } from "vite";
+import type { UpdateNoteSection } from "../features/update-notes/utils/parse-release-body";
+import { parseReleaseBody } from "../features/update-notes/utils/parse-release-body";
 
 interface GitHubRelease {
 	body: string | null;
@@ -10,22 +12,10 @@ interface GitHubRelease {
 }
 
 interface UpdateNote {
-	changes: string[];
+	changes: UpdateNoteSection[];
 	releasedAt: string;
 	title: string;
 	version: string;
-}
-
-const LIST_ITEM_PREFIX = /^[-*]\s+/;
-
-function parseReleaseBody(body: string | null): string[] {
-	if (!body) {
-		return [];
-	}
-	return body
-		.split("\n")
-		.map((line) => line.replace(LIST_ITEM_PREFIX, "").trim())
-		.filter((line) => line.length > 0 && !line.startsWith("#"));
 }
 
 async function fetchGitHubReleases(repo: string): Promise<UpdateNote[]> {

--- a/apps/web/src/virtual-update-notes.d.ts
+++ b/apps/web/src/virtual-update-notes.d.ts
@@ -3,7 +3,7 @@ declare module "virtual:update-notes" {
 		version: string;
 		releasedAt: string;
 		title: string;
-		changes: Array<{ section: string; items: string[] }>;
+		changes: import("./features/update-notes/utils/parse-release-body").UpdateNoteSection[];
 	}>;
 	export const LATEST_VERSION: string | null;
 }

--- a/apps/web/src/virtual-update-notes.d.ts
+++ b/apps/web/src/virtual-update-notes.d.ts
@@ -3,7 +3,7 @@ declare module "virtual:update-notes" {
 		version: string;
 		releasedAt: string;
 		title: string;
-		changes: string[];
+		changes: Array<{ section: string; items: string[] }>;
 	}>;
 	export const LATEST_VERSION: string | null;
 }


### PR DESCRIPTION
## Summary

- `parseReleaseBody` (in `apps/web/src/plugins/vite-plugin-github-releases.ts`) stripped every `#`-prefixed line, so the `### New Features` / `### UI Improvements` / `### Bug Fixes` headings emitted by the `create-update-notes` skill were discarded and `changes` became a flat `string[]` with no section info.
- Extracted the parsing logic into a new pure util, `apps/web/src/features/update-notes/utils/parse-release-body.ts`, which now models `### ` headings as section boundaries and returns `{ section: string; items: string[] }[]` (falls back to a single unlabeled section for bodies without headings, for backward compatibility).
- Updated `UpdateNote.changes` (both the ambient `virtual:update-notes` type declaration and the feature's `constants.ts`) to the new sectioned shape.
- `update-notes-sheet.tsx` now renders each section's items under its own heading (`t-label`) instead of flattening every change into a single `<ul>`.

## Test plan

- [x] Added `parse-release-body.test.ts` (web-node) covering: null/empty body, no-list-items body, multi-section grouping, `-`/`*` markers, orphan bullets before any heading, blank lines between bullets, and a heading with no items.
- [x] Updated `update-notes-sheet.test.tsx` fixtures/assertions for the sectioned shape and added tests asserting section headings render and an unlabeled section renders without a heading.
- [x] `bun run check-types` — passes (also fixed the stale `virtual-update-notes.d.ts` ambient type).
- [x] `bun run lint` — passes.
- [x] `bunx vitest related --run` over all touched files — 58 tests passing.

Linear: SA2-122

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01L1isx8w239fw1RWFuKTtxA)_