### PR TITLE
Fableレビューの知見をClaudeルールへ反映し既存ルールを刷新

### DIFF
--- a/.claude/rules/api-data-integrity.md
+++ b/.claude/rules/api-data-integrity.md
@@ -1,0 +1,26 @@
+---
+paths:
+  - "packages/api/**"
+  - "packages/db/**"
+---
+
+# API Data Integrity (Zod Inputs & D1 Writes)
+
+Why this file exists: the Fable review found a cluster of data-corruption bugs from permissive input schemas and D1-specific write hazards (SA2-115, 116, 136, 148, 150, 151, 156, 161, 165).
+
+## Zod input conventions
+
+- **Money, chip, and count fields default to `z.number().int().min(0)`.** A bare `z.number()` let negative chip costs inflate P/L (SA2-136) and non-integer `wins` corrupt EV stats (SA2-156). Deviate only with a comment saying why.
+- **Cross-field constraints go on `create` AND `update`.** `placement <= totalEntries` existed only on create, so update could persist "50th of 10" (SA2-161). When adding a `.refine`, grep for the sibling procedure and apply it there too.
+- **Write-side and read-side schemas must be the same object.** `initialBuyIn` was accepted as a decimal on create but re-read through a payload schema requiring `.int()`, making the session permanently unreadable (SA2-148). If a stored payload is later re-`parse`d, validate the write with that exact schema — never a looser inline copy.
+
+## D1 write hazards
+
+- **100 bound parameters per statement.** A multi-row `.insert().values(rows)` binds `rows × columns` params; ≥12 blind-level rows blew the limit and — because the preceding DELETE had already committed — destroyed the data (SA2-115). Use the shared helpers in [`packages/api/src/routers/session.ts`](packages/api/src/routers/session.ts): `chunkForInsert` for inserts, `selectInChunks` for `IN (…)` selects.
+- **Multi-statement writes go through `db.batch()`** so they commit atomically. Sequential awaited statements auto-commit one by one and a mid-way failure strands partial state (SA2-116). DELETE-then-reINSERT is the highest-risk shape — always batch it.
+- **Cascade-aware deletes.** Before writing a `delete` procedure, read the schema for `onDelete: "cascade"` on referencing FKs. Deleting a currency silently cascade-deleted session-generated transactions (SA2-165). Either guard ("in use → reject") or make the cascade an explicit, documented decision.
+
+## List endpoints
+
+- **No N+1.** Fetch child rows for a page with one `inArray(parentId, ids)` query (chunked via `selectInChunks`), not one query per row — per-query latency dominates on D1 (SA2-151).
+- **Keyset pagination** uses `paginate` from [`packages/api/src/routers/_pagination.ts`](packages/api/src/routers/_pagination.ts) and its comparison must (a) survive the cursor row being deleted (a subquery returning `NULL` silently ends paging, SA2-150), (b) break ties on `id`, and (c) carry the caller's ownership scope (see [`api-security.md`](api-security.md)).

--- a/.claude/rules/api-security.md
+++ b/.claude/rules/api-security.md
@@ -1,0 +1,38 @@
+---
+paths:
+  - "packages/api/**"
+  - "apps/server/**"
+---
+
+# API Security (Object-Level Authorization)
+
+Why this file exists: the Fable review found ~15 IDOR bugs with one shared root cause — procedures validated *existence* of an input id but not *ownership* (SA2-175 umbrella; SA2-102, 111, 123, 129, 149, 172, 174, 176–183).
+
+## Every foreign-key id in an input must be ownership-checked
+
+Before any write, link, snapshot, or read that uses an id from `input` (`currencyId`, `roomId`, `tournamentId`, `ringGameId`, `tagIds`, `transactionTypeId`, ids in bulk arrays, cursor ids, …), verify the referenced row belongs to `ctx.session.user.id`.
+
+- **An existence check (`WHERE id = ?`) is not authorization.** The `ringGame`/`tournament` branches of `validateEntityOwnership` had exactly this bug (SA2-111, 174).
+- Use the shared helpers in [`packages/api/src/routers/session.ts`](packages/api/src/routers/session.ts): `validateEntityOwnership`, `validateTagsOwnership`, `validateLiveLinkOwnership`. For a new entity type, extend the helper — do not hand-roll a one-off existence query inside the router.
+- Entities without a direct `userId` column (e.g. `ring_game` → `room.userId`) must resolve ownership through the full chain; a nullable link in that chain (`roomId = null`) must **fail closed**, not skip the check (SA2-181).
+
+## Bulk / reorder mutations: re-bind every row to the validated parent
+
+Validating `input.tournamentId` and then running `UPDATE … WHERE id = ?` per element of `input.ids` is a write-IDOR — any UUID can be passed in the array. Every per-row `WHERE` must also bind the parent: `WHERE id = ? AND tournament_id = ?` (SA2-123, 176).
+
+## List queries: scope joins and cursor subqueries to the caller
+
+- Every JOIN that can surface another table's columns must carry the `userId` filter — an unfiltered `innerJoin` leaks other users' tag names / type names (SA2-177–179).
+- Keyset-pagination cursor subqueries must include the same ownership predicates as the outer query (`AND user_id = ?`), or the cursor becomes an existence/boundary oracle for other users' rows (SA2-182).
+
+## Ownership failures return FORBIDDEN, never NOT_FOUND
+
+Distinguishing "does not exist" from "owned by someone else" is an existence oracle. All ownership helpers throw a uniform `FORBIDDEN` (SA2-183).
+
+## Never fetch user-supplied URLs server-side
+
+`z.string().url()` is not SSRF protection. A Worker fetching arbitrary `input.url` values can be aimed at internal hosts (SA2-170). If a feature genuinely needs remote fetch, allowlist hosts explicitly.
+
+## Self-check for every new/edited procedure
+
+List every id that appears in the input schema. For each one, point to the line where its ownership is validated. If you cannot, the procedure is not done.

--- a/.claude/rules/datetime-and-numbers.md
+++ b/.claude/rules/datetime-and-numbers.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - "apps/web/**"
+  - "packages/api/**"
+---
+
+# Dates, Times & Number Formatting
+
+Why this file exists: the Fable review found repeated one-day-off and negative-duration bugs from mixing UTC storage with local-time reads (SA2-117, 133, 145, 157, 184), plus inconsistent number rendering (SA2-160, 164).
+
+## Date-only values are UTC midnight — read them with UTC getters
+
+`sessionDate`, transaction dates, and any other date-only field are stored as UTC midnight and travel as UTC ISO strings. **Display, editing, and grouping must use `getUTCFullYear` / `getUTCMonth` / `getUTCDate`** (or an explicit `timeZone: "UTC"` formatter). Local getters show the previous day for users west of UTC, and a local-read → save round-trip shifts the stored date one more day per edit (SA2-145, 133).
+
+## Composing times from one date: handle day crossing
+
+When start and end times are combined with a single date (e.g. 22:00–02:00), an `end < start` result means the session crossed midnight — add 24h to the end (`computeSessionTimes` in [`use-sessions.ts`](apps/web/src/features/sessions/hooks/use-sessions.ts) is the reference). Never clamp a negative duration to 0 to hide the symptom (SA2-157).
+
+**Fixing a write path is only half the fix**: rows written before the fix stay corrupted. Whenever you correct how data is computed on write, decide explicitly whether existing rows need a backfill migration, and say so in the PR (SA2-184, migration `0034`).
+
+## Period-filter boundaries
+
+An exclusive upper bound (`dateTo` = next-day 00:00) must be compared with `lt`, an inclusive one with `lte` on the last instant. Mixing next-day-midnight with `lte` leaks next-day rows into "last N days" filters (SA2-117).
+
+## Number formatting
+
+- Render numbers through the shared formatters in [`apps/web/src/utils/format-number.ts`](apps/web/src/utils/format-number.ts) — do not add new bare `toLocaleString()` / ad-hoc `Intl.NumberFormat` calls; device-locale output diverges between screens (SA2-160).
+- Exactly **one** compact (K/M) implementation. A second copy for share text drifted from the in-app one and showed different amounts for the same value (SA2-164). Extend the shared formatter instead of forking it.

--- a/.claude/rules/web-data-fetching.md
+++ b/.claude/rules/web-data-fetching.md
@@ -15,15 +15,33 @@ Use [`apps/web/src/utils/optimistic-update.ts`](apps/web/src/utils/optimistic-up
 - `cancelTargets` — cancel in-flight queries on the same keys.
 - `restoreSnapshots` — call from `onError`.
 - `invalidateTargets` — call from `onSettled` with an array of targets.
-- `updateInfiniteQueryItems` — optimistically `map` (edit) / `filter` (delete) the items of every page in a `useInfiniteQuery` cache entry while preserving the page envelope. Pair with `snapshotQuery` + `restoreSnapshots` for rollback. Reference: [`use-currencies.ts`](apps/web/src/features/currencies/hooks/use-currencies.ts) (`editTransaction` / `deleteTransaction`).
-- `updateQueryEntity` — shallow-merge a `patch` (partial object, or a function of the current entity) into a **single-object** query cache entry; no-ops when the entry is unfetched (`undefined` / `null`). The single-object analog of `updateQueryItems`. Reference: [`use-poker-table-interaction.ts`](apps/web/src/features/players/hooks/use-poker-table-interaction.ts) (`heroMutation`), [`use-player-detail.ts`](apps/web/src/features/players/hooks/use-player-detail.ts) (`updateMutation`).
-- `updateQueryItems` — `map` (edit) / `filter` (delete) a **plain-array** (`TItem[]`) query cache entry; no-ops when unfetched. The single-query analog of `updateInfiniteQueryItems`. Reference: [`use-session-events.ts`](apps/web/src/features/live-sessions/hooks/use-session-events.ts) (`updateMutation` / `deleteMutation`).
+- `updateInfiniteQueryItems` — optimistically `map` (edit) / `filter` (delete) the items of every page in a `useInfiniteQuery` cache entry while preserving the page envelope. Reference: [`use-sessions.ts`](apps/web/src/features/sessions/hooks/use-sessions.ts).
+- `prependInfiniteQueryItem` — optimistically prepend a new item to the first page of a `useInfiniteQuery` entry. Reference: [`use-sessions.ts`](apps/web/src/features/sessions/hooks/use-sessions.ts).
+- `updateQueryEntity` — shallow-merge a `patch` (partial object, or a function of the current entity) into a **single-object** query cache entry; no-ops when the entry is unfetched. Reference: [`use-player-detail.ts`](apps/web/src/features/players/hooks/use-player-detail.ts), [`use-active-session-scene-state.ts`](apps/web/src/features/live-sessions/components/active-session-scene/use-active-session-scene-state.ts).
+- `updateQueryItems` — `map` (edit) / `filter` (delete) a **plain-array** (`TItem[]`) query cache entry; no-ops when unfetched. Reference: [`use-session-events.ts`](apps/web/src/features/live-sessions/hooks/use-session-events.ts).
 
-**Do not** hand-roll `queryClient.setQueryData` + `invalidateQueries` chains, even inside hooks. If a case is not covered by the helpers, extend the helpers instead of bypassing them.
+[`optimistic-session-event.ts`](apps/web/src/features/live-sessions/utils/optimistic-session-event.ts) is a sanctioned feature-level wrapper built on these helpers for the session-event timeline.
+
+**Do not** hand-roll `queryClient.setQueryData` + `invalidateQueries` chains, even inside hooks (SA2-162 tracks migrating the remaining legacy call sites). If a case is not covered by the helpers, extend the helpers instead of bypassing them.
+
+## Optimistic-update pitfalls (each caused a shipped bug)
+
+- **Clearing a field**: `null` means "cleared" — merging with `updated.memo ?? old.memo` resurrects the old value. Use `updateQueryEntity`'s function-form patch and decide by key presence, not nullish-ness (SA2-132).
+- **Optimistic ids**: use `crypto.randomUUID()`. `optimistic-${Date.now()}` collides within one millisecond and corrupts keyed rendering (SA2-143).
+- **Edit ≠ create**: do not reuse create-oriented aggregation logic in an update mutation's `onMutate` — edited events double-counted EV and dropped deltas (SA2-147).
+- **Polling coexistence**: with `refetchInterval` active, one `cancelTargets` in `onMutate` is not enough — a poll landing mid-mutation overwrites the optimistic state. Pause the poll (or guard the overwrite) until `onSettled` (SA2-152).
+- **Invalidation completeness**: if the server recalculates derived state (e.g. editing a pause event updates `gameSession.status`), invalidate the queries that render that derived state too, not just the entity you mutated (SA2-167).
 
 ## Paginated lists use `useInfiniteQuery`
 
-For cursor-paginated tRPC procedures (`{ items, nextCursor }`), drive the list with `trpc.<proc>.infiniteQueryOptions(input, { getNextPageParam: (last) => last.nextCursor })` + `useInfiniteQuery` — not `useQuery` plus a local-state accumulator. Keeping every page in one cache entry means a focus / reconnect / `staleTime` / invalidate / remount refetch re-fetches all loaded pages instead of collapsing back to page 1, and `fetchNextPage()` replaces hand-rolled load-more (`txCursor` / `isLoadingMore` state). Reference: [`use-currencies.ts`](apps/web/src/features/currencies/hooks/use-currencies.ts).
+For cursor-paginated tRPC procedures (`{ items, nextCursor }`), drive the list with `trpc.<proc>.infiniteQueryOptions(input, { getNextPageParam: (last) => last.nextCursor })` + `useInfiniteQuery` — not `useQuery` plus a local-state accumulator. Keeping every page in one cache entry means a focus / reconnect / invalidate refetch re-fetches all loaded pages instead of collapsing back to page 1, and `fetchNextPage()` replaces hand-rolled load-more state. Reference: [`use-sessions.ts`](apps/web/src/features/sessions/hooks/use-sessions.ts).
+
+## Persisted cache & sign-out
+
+The query cache is persisted to IndexedDB (24h) and keyed by procedure name, not per-user.
+
+- **Every sign-out entry point calls [`useSignOut`](apps/web/src/shared/hooks/use-sign-out.ts)** — never `authClient.signOut` directly. It clears the in-memory cache and the persisted store so the next account on a shared device cannot see the previous user's data (SA2-159).
+- When a change alters a procedure's **output shape**, remember deployed clients rehydrate up to 24h of old-shaped cache into the new code — coordinate a `buster` / cache-invalidation strategy in the persister config (SA2-154).
 
 ## Mutation hook shape
 

--- a/.claude/rules/web-forms.md
+++ b/.claude/rules/web-forms.md
@@ -12,11 +12,11 @@ All forms in `apps/web` are built with [`@tanstack/react-form`](https://tanstack
 1. **`useForm({ defaultValues, onSubmit, validators })` lives in the hook.** The component consumes `form` and renders `<form.Field>` / `<form.Subscribe>` + shadcn primitives only.
 2. **Validate with `validators.onSubmit: zodSchema`** (and per-field `onChange` when useful). Keep the schema next to the hook.
 3. **Never use `<input type="number">`.** Use `type="text" inputMode="numeric"` and validate / convert via Zod. Helpers: `requiredNumericString`, `optionalNumericString`, `parseOptionalInt` from [`apps/web/src/shared/lib/form-fields.ts`](apps/web/src/shared/lib/form-fields.ts).
-4. **No placeholder UI copy.** `placeholder="e.g. …"` is banned, and example text must not be moved into `Field.description` either — drop it entirely.
-5. **Required / optional visibility**: required fields are marked with `<Field required>` (renders a red `*`). Unmarked fields are implicitly optional.
-6. **Clearable selects use [`SelectWithClear`](apps/web/src/shared/components/ui/select/select-with-clear.tsx)**, not raw shadcn `Select`. The native `<SelectValue placeholder>` prop is permitted only where the Radix primitive's own rendering requires it.
-7. **Mobile form dialogs are bottom sheets.** Use shadcn `Drawer` for mobile-first forms, not `Dialog`.
-8. **Zod imports**: `import z from "zod"` (default import). A Vite bundler issue breaks the namespace import.
+4. **Numeric field constraints mirror the server schema.** If the procedure requires `z.number().int()`, the field passes `{ integer: true }` so the user gets a field-level error instead of an opaque server rejection (SA2-137). Integer checks validate the full string via `Number()` — `Number.parseInt` silently truncates "100.5" and lets it through (SA2-103).
+5. **No placeholder UI copy.** `placeholder="e.g. …"` is banned, and example text must not be moved into `Field.description` either — drop it entirely.
+6. **Required / optional visibility**: required fields are marked with `<Field required>` (renders a red `*`). Unmarked fields are implicitly optional. **The mark and the schema must agree**: a field rendered required must use a required validator — `optionalNumericString` under a red `*` let blanks save as 0 and corrupted P/L (SA2-113).
+7. **Clearable selects use [`SelectWithClear`](apps/web/src/shared/components/ui/select/select-with-clear.tsx)**, not raw shadcn `Select`. The native `<SelectValue placeholder>` prop is permitted only where the Radix primitive's own rendering requires it.
+8. **Mobile form dialogs are bottom sheets** — see [`web-ui.md`](web-ui.md) (Drawer, not Dialog) and the sheet-mode taxonomy in [`web-theme.md`](web-theme.md).
 
 ## Reference implementations
 

--- a/.claude/rules/web-hooks-separation.md
+++ b/.claude/rules/web-hooks-separation.md
@@ -36,7 +36,7 @@ Components and route pages under `apps/web/src` **must not call React builtin or
 This check must return 0 hits (it also runs in the Stop hook via `scripts/check-rules.ts`). The globs go in `-g` flags — passing `**` paths as positional args makes `rg` error out without scanning anything:
 
 ```sh
-rg '\b(useState|useEffect|useMemo|useRef|useCallback|useForm|useQuery|useMutation|useQueryClient|useReducer|useDeferredValue|useTransition|useLayoutEffect|useIsMutating)\b' apps/web/src -g '**/components/**/*.tsx' -g '**/pages/**/*.tsx' -g 'routes/**/*.tsx' -g '!**/__tests__/**' -g '!**/*.test.tsx' -g '!**/use-*.tsx'
+rg '\b(useState|useEffect|useMemo|useRef|useCallback|useForm|useQuery|useMutation|useQueryClient|useReducer|useDeferredValue|useTransition|useLayoutEffect|useIsMutating)\b' apps/web/src -g '**/components/**/*.tsx' -g '**/pages/**/*.tsx' -g '**/routes/**/*.tsx' -g '!**/__tests__/**' -g '!**/*.test.tsx' -g '!**/use-*.tsx'
 ```
 
 > `**/pages/**` covers page components that have been lifted out of route files

--- a/.claude/rules/web-hooks-separation.md
+++ b/.claude/rules/web-hooks-separation.md
@@ -33,10 +33,10 @@ Components and route pages under `apps/web/src` **must not call React builtin or
 
 ## Verification
 
-This check must return 0 hits:
+This check must return 0 hits (it also runs in the Stop hook via `scripts/check-rules.ts`). The globs go in `-g` flags — passing `**` paths as positional args makes `rg` error out without scanning anything:
 
 ```sh
-rg '\b(useState|useEffect|useMemo|useRef|useCallback|useForm|useQuery|useMutation|useQueryClient|useReducer|useDeferredValue|useTransition|useLayoutEffect|useIsMutating)\b' 'apps/web/src/**/components/**/*.tsx' 'apps/web/src/**/pages/**/*.tsx' 'apps/web/src/routes/**/*.tsx' -g '!**/__tests__/**' -g '!**/*.test.tsx' -g '!**/use-*.tsx'
+rg '\b(useState|useEffect|useMemo|useRef|useCallback|useForm|useQuery|useMutation|useQueryClient|useReducer|useDeferredValue|useTransition|useLayoutEffect|useIsMutating)\b' apps/web/src -g '**/components/**/*.tsx' -g '**/pages/**/*.tsx' -g 'routes/**/*.tsx' -g '!**/__tests__/**' -g '!**/*.test.tsx' -g '!**/use-*.tsx'
 ```
 
 > `**/pages/**` covers page components that have been lifted out of route files

--- a/.claude/rules/web-theme.md
+++ b/.claude/rules/web-theme.md
@@ -40,14 +40,9 @@ Typography roles are global classes — `t-display / t-h1 … t-h4 / t-body / t-
 
 ## Design source-of-truth
 
-The Sapphire 2 Design System handoff bundle drives design decisions (colors, radius, typography scale, motion durations, component composition rules — buttons, alerts, cards, sheets, toasts, etc.). It lives at `/tmp/design/sapphire-2-design-system/sapphire-2-design-system/` when extracted (HTML/CSS/JS prototypes, not production code — recreate visually, do NOT copy markup). The primary references are:
-
-- `project/README.md` — design philosophy, content rules, component composition.
-- `project/colors_and_type.css` — token contract; the `:root` / `.dark` blocks in `apps/web/src/index.css` are a faithful subset.
-- `project/components.css` — plain-CSS primitives (`.btn`, `.card`, `.sheet`, `.toast`, …); use as reference for sizing and spacing.
+The token contract in `apps/web/src/index.css` (`:root` / `.dark`) is the source of truth. The original Sapphire 2 Design System handoff bundle lives outside this repository; if a design decision is not expressible via the tokens and rules in this file, raise it for discussion rather than guessing from memory of the bundle.
 
 ## Don'ts
 
 - **Don't fork `shared/components/ui/`** for theming. Components stay single-source; tuning happens via tokens. If a surface needs different markup, raise it for discussion before duplicating.
 - **Don't introduce a second theme** or a `theme-*` scope class. If a route needs a one-off accent, scope it to that route with CSS variables.
-- **Don't put Japanese into UI copy.** Same rule as [`web-ui.md`](web-ui.md) ("Direct, terse, neutral. Sentence case.").

--- a/.claude/rules/web-ui.md
+++ b/.claude/rules/web-ui.md
@@ -30,3 +30,12 @@ Mobile-first dialogs are bottom sheets — use shadcn `Drawer`, not `Dialog`.
 ## Icons
 
 Use `@tabler/icons-react` exclusively for new icons. Do not add `lucide-react` imports in new code.
+
+## Accessibility
+
+Each of these gaps shipped and was flagged by review (SA2-121, 140, 153, 155):
+
+- **Current-page indication**: nav items (tab bar, sidebar) set `aria-current="page"` on the active link — color/weight alone is invisible to screen readers.
+- **Field errors**: validation messages are tied to their input via `aria-describedby` and announced with `role="alert"` (belongs in the shared `Field` wrapper, not per-form).
+- **Clickable non-buttons**: anything with `onClick` that isn't a `<button>`/`<a>` (e.g. a `Badge`) must be keyboard-operable — prefer rendering a real `<button>`; otherwise add `role="button"`, `tabIndex={0}`, and a key handler.
+- **Charts**: provide a text alternative (visually-hidden summary or accompanying table) — a bare `ResponsiveContainer` conveys nothing to screen readers.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun x ultracite fix && bun x vitest run --changed HEAD && bun x ultracite check"
+            "command": "bun x ultracite fix && bun x vitest run --changed HEAD && bun x ultracite check && bun scripts/check-rules.ts"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,7 @@ When adding a feature, create `apps/web/src/features/<name>/` and colocate every
 Detailed rules live in [`.claude/rules/`](.claude/rules/); the points below apply everywhere in `apps/web/` and are worth keeping top of mind:
 
 - **UI copy is English-only.** No Japanese in user-facing strings (labels, empty states, toasts, errors). Japanese is fine in comments, commit messages, and PR descriptions.
-- **Mobile forms are bottom sheets.** Use shadcn `Drawer`, not `Dialog`.
-- **Pages start with [`PageHeader`](apps/web/src/shared/components/page-header/page-header.tsx).** Do not hand-roll titles / action rows.
+- **Mobile forms are bottom sheets** (shadcn `Drawer`, not `Dialog`) and **pages start with [`PageHeader`](apps/web/src/shared/components/page-header/page-header.tsx)** — details in [`.claude/rules/web-ui.md`](.claude/rules/web-ui.md).
 - **Logic lives in `useXxx` hooks, not in components.** Components render JSX from destructured hook returns. Verification & full forbidden list: [`.claude/rules/web-hooks-separation.md`](.claude/rules/web-hooks-separation.md).
 - **Single theme: Sapphire 2 Design System.** Tokens live in `apps/web/src/index.css` (`:root` / `.dark`) and apply app-wide — there is no legacy theme and no `theme-v2` scope class. Color tokens include the `hsl()` wrapper: reference them as `var(--token)`, never `hsl(var(--token))`. Design rules: [`.claude/rules/web-theme.md`](.claude/rules/web-theme.md).
 
@@ -111,7 +110,7 @@ Every code change must be test-driven. The quality bar is set by the comprehensi
 1. **Write tests first.** Before editing any implementation file, author (or extend) the corresponding `__tests__/*.test.ts(x)`. Verify the new tests fail against the existing code (red).
 2. **Implement until green.** Iterate on the minimum code needed to pass.
 3. **Run only the scoped project**, not the full suite. See "Do NOT run the full test suite during a task" below.
-4. **The Claude Code Stop hook** (`ultracite fix && vitest run --changed HEAD && ultracite check`) gives the final green signal; no hand-waving.
+4. **The Claude Code Stop hook** (see below) gives the final green signal; no hand-waving.
 
 **Quality bar (non-negotiable)**:
 
@@ -152,11 +151,12 @@ If a target does not match any pattern above, extend the relevant `test-utils` f
 - Pure-function / schema tests → `bunx vitest run --project web-node [path]`
 - Hook / component / route tests → `bunx vitest run --project web-dom [path]`
 - API router tests → `bunx vitest run --project api [path]`
+- Server worker tests → `bunx vitest run --project server [path]`
 - DB schema tests → `bunx vitest run --project db [path]`
 - Env tests → `bunx vitest run --project env`
 - Related to current staged files → `bunx vitest related --run $(git diff --cached --name-only ...)` — already automated by pre-commit for human commits.
 
-The full suite is enforced by the Claude Code **Stop hook** (`bun x ultracite fix && bun x vitest run --changed HEAD && bun x ultracite check`) at the end of a turn, not by every intermediate step. Pre-commit is skipped when `CLAUDECODE=1` for the same reason.
+The full suite is enforced by the Claude Code **Stop hook** (`bun x ultracite fix && bun x vitest run --changed HEAD && bun x ultracite check && bun scripts/check-rules.ts` — see [`.claude/settings.json`](.claude/settings.json)) at the end of a turn, not by every intermediate step. `scripts/check-rules.ts` (`bun run check:rules`) mechanically enforces greppable rules from this file and `.claude/rules/`. Pre-commit is skipped when `CLAUDECODE=1` for the same reason.
 
 ## Path-scoped Rule Files
 
@@ -169,6 +169,9 @@ The following rule files live in `.claude/rules/` and are loaded automatically w
 | `web-ui.md` | `apps/web/**` | PageHeader, shadcn primitives (Table / Badge / Avatar / RadioGroup), mobile = Drawer, tabler-icons. |
 | `web-data-fetching.md` | `apps/web/**` | Optimistic updates must go through `utils/optimistic-update.ts` helpers. |
 | `web-theme.md` | `apps/web/**` | Sapphire 2 Design System (single theme): token format, semantic colors, typography roles, sheet patterns. |
+| `api-security.md` | `packages/api/**`, `apps/server/**` | Object-level authorization: every input FK id ownership-checked, scoped bulk WHEREs / joins / cursors, uniform FORBIDDEN, no server-side fetch of user URLs. |
+| `api-data-integrity.md` | `packages/api/**`, `packages/db/**` | Zod input conventions (`.int().min(0)`, create/update refine parity, shared write/read schemas) and D1 hazards (100-bind-param chunking, `db.batch()`, N+1, keyset pagination). |
+| `datetime-and-numbers.md` | `apps/web/**`, `packages/api/**` | Date-only values are UTC midnight (read with UTC getters), day-crossing handling + backfill, period boundaries, shared locale-fixed number formatters. |
 | `db-migrations.md` | `packages/db/**` | Applied by `wrangler`; `db:generate` is the default for schema-shape changes, hand-write data/rename/destructive ones; how the Drizzle `meta/` ledger works and how to keep it from drifting. |
 
 ## Maintaining This File (Self-Evolution)
@@ -183,15 +186,15 @@ This file evolves as the codebase evolves. Claude should **propose an update to 
 
 ### Procedure for adding a rule
 
-1. **Verify it is not already enforced** by Ultracite, TypeScript, a pre-commit hook, or a route-level constraint. If it is, reference the enforcement instead of duplicating the rule.
+1. **Verify it is not already enforced** by Ultracite, TypeScript, a pre-commit hook, `scripts/check-rules.ts`, or a route-level constraint. If it is, reference the enforcement instead of duplicating the rule.
 2. **Decide scope**: narrow path (e.g., `apps/web/**`, `apps/server/**`, `packages/db/**`) → `.claude/rules/<topic>.md` with a `paths:` frontmatter. Truly cross-cutting → this file.
-3. **Write the rule with a one-line "why"** — the incident, PR, or decision that created it — so future edits can judge edge cases instead of blindly following the letter.
+3. **Write the rule with a one-line "why"** — the incident, issue (SA2-xxx), or decision that created it — so future edits can judge edge cases instead of blindly following the letter.
 4. **Prefer concrete over abstract.** "Use `SelectWithClear` for clearable selects" beats "prefer consistent select behavior". Include explicit file paths and commands.
-5. **If you add a new file under `.claude/rules/`**, update the index table above.
-6. **For large rewrites or ambiguous scope**, propose the change in chat before writing it — this file is shared across the team.
+5. **If the rule is mechanically greppable, add a check to `scripts/check-rules.ts`** (Stop hook) — prose alone gets re-violated; a check must be green at the moment it is added.
+6. **If you add a new file under `.claude/rules/`**, update the index table above.
+7. **For large rewrites or ambiguous scope**, propose the change in chat before writing it — this file is shared across the team.
 
 ### Hygiene
 
 - Keep `CLAUDE.md` ≤200 lines. If a new top-level rule would push it over, split the lowest-value existing section into a path-scoped rule file.
-- Delete rules that no longer apply. Historical context belongs in git / PR descriptions, not here.
-- If two rules overlap, merge them; cross-link rule files that reference each other.
+- Delete rules that no longer apply (historical context belongs in git / PR descriptions). If two rules overlap, keep one home and cross-link it from the others.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:ci": "vitest run --reporter=verbose",
     "lint": "ultracite check",
     "check": "ultracite check",
+    "check:rules": "bun scripts/check-rules.ts",
     "fix": "ultracite fix",
     "prepare": "husky"
   },

--- a/scripts/check-rules.ts
+++ b/scripts/check-rules.ts
@@ -1,0 +1,112 @@
+/**
+ * Deterministic conformance checks for the rules in CLAUDE.md and
+ * .claude/rules/*.md. Run by the Claude Code Stop hook (see
+ * .claude/settings.json) and manually via `bun run check:rules`.
+ *
+ * Only checks that are currently green may live here — a red check would
+ * block every turn. Once their Linear issues are fixed, add:
+ *   - ColorBadge / PlayerAvatar wrapper bans (SA2-112, SA2-119)
+ *   - raw queryClient.setQueryData outside utils helpers (SA2-162)
+ */
+import { readFile } from "node:fs/promises";
+import { Glob } from "bun";
+
+interface Check {
+	excludeLine?: RegExp;
+	excludePath?: RegExp;
+	globs: string[];
+	name: string;
+	pattern: RegExp;
+	rule: string;
+}
+
+const IGNORED_DIRS = /(^|\/)(node_modules|dist|\.wrangler|coverage|\.git)\//;
+
+const CHECKS: Check[] = [
+	{
+		name: 'named zod import — use `import z from "zod"`',
+		rule: "CLAUDE.md (Vite bundler breaks the namespace import)",
+		globs: ["apps/**/*.{ts,tsx}", "packages/**/*.{ts,tsx}"],
+		pattern: /import \{ z \} from "zod"/,
+	},
+	{
+		name: "lucide-react import — use @tabler/icons-react",
+		rule: ".claude/rules/web-ui.md",
+		globs: ["apps/web/src/**/*.{ts,tsx}"],
+		pattern: /from "lucide-react"|require\("lucide-react"\)/,
+	},
+	{
+		name: "hsl(var(--token)) — tokens already include the hsl() wrapper",
+		rule: ".claude/rules/web-theme.md",
+		globs: ["apps/web/src/**/*.{ts,tsx,css}"],
+		pattern: /hsl\(var\(/,
+		excludeLine: /never hsl/,
+	},
+	{
+		name: '<input type="number"> — use type="text" inputMode="numeric"',
+		rule: ".claude/rules/web-forms.md",
+		globs: ["apps/web/src/**/*.tsx"],
+		pattern: /<[Ii]nput[^>]*type="number"/,
+		excludePath: /__tests__|\.test\./,
+	},
+	{
+		name: "React/library hooks called directly in a component file — move into a use-*.ts hook",
+		rule: ".claude/rules/web-hooks-separation.md",
+		globs: [
+			"apps/web/src/**/components/**/*.tsx",
+			"apps/web/src/**/pages/**/*.tsx",
+			"apps/web/src/routes/**/*.tsx",
+		],
+		pattern:
+			/\b(useState|useEffect|useMemo|useRef|useCallback|useForm|useQuery|useMutation|useQueryClient|useReducer|useDeferredValue|useTransition|useLayoutEffect|useIsMutating)\b/,
+		excludePath: /__tests__|\.test\.tsx$|\/use-[^/]*\.tsx$/,
+	},
+];
+
+let failed = false;
+
+for (const check of CHECKS) {
+	const hits: string[] = [];
+	const seen = new Set<string>();
+	for (const glob of check.globs) {
+		for await (const path of new Glob(glob).scan(".")) {
+			if (
+				seen.has(path) ||
+				IGNORED_DIRS.test(path) ||
+				check.excludePath?.test(path)
+			) {
+				continue;
+			}
+			seen.add(path);
+			const text = await readFile(path, "utf8");
+			// Multiline patterns (e.g. an <input> whose attributes span lines)
+			// match against the whole file; single-line hits are reported per line.
+			if (!check.pattern.test(text)) {
+				continue;
+			}
+			const hitsBefore = hits.length;
+			const lines = text.split("\n");
+			for (const [i, line] of lines.entries()) {
+				if (check.pattern.test(line) && !check.excludeLine?.test(line)) {
+					hits.push(`${path}:${i + 1}: ${line.trim()}`);
+				}
+			}
+			if (hits.length === hitsBefore && !check.excludeLine) {
+				hits.push(`${path}: (multiline match)`);
+			}
+		}
+	}
+	if (hits.length > 0) {
+		failed = true;
+		console.error(`\ncheck-rules FAIL: ${check.name}`);
+		console.error(`  rule: ${check.rule}`);
+		for (const hit of hits) {
+			console.error(`  ${hit}`);
+		}
+	}
+}
+
+if (failed) {
+	process.exit(1);
+}
+console.log("check-rules: all checks passed");

--- a/scripts/check-rules.ts
+++ b/scripts/check-rules.ts
@@ -85,13 +85,23 @@ for (const check of CHECKS) {
 				continue;
 			}
 			const hitsBefore = hits.length;
+			let anyLineMatched = false;
 			const lines = text.split("\n");
 			for (const [i, line] of lines.entries()) {
-				if (check.pattern.test(line) && !check.excludeLine?.test(line)) {
+				if (!check.pattern.test(line)) {
+					continue;
+				}
+				anyLineMatched = true;
+				if (!check.excludeLine?.test(line)) {
 					hits.push(`${path}:${i + 1}: ${line.trim()}`);
 				}
 			}
-			if (hits.length === hitsBefore && !check.excludeLine) {
+			// The file matched as a whole but no single line did → a genuine
+			// multiline violation. Guarding on `!anyLineMatched` (not
+			// `!check.excludeLine`) keeps this sound once a check combines an
+			// excludeLine with a multiline pattern: an all-excluded file is not
+			// reported, but a real cross-line hit still is.
+			if (hits.length === hitsBefore && !anyLineMatched) {
 				hits.push(`${path}: (multiline match)`);
 			}
 		}


### PR DESCRIPTION
## 概要

Linearプロジェクト「Fableレビュー」の全83件(SA2-102〜SA2-184)を分析し、同じクラスのバグをClaudeが再び作り込まないための再発防止ルールを `CLAUDE.md` / `.claude/rules/` に整備しました。あわせて、公式のCLAUDE.mdベストプラクティス(code.claude.com/docs の memory / best-practices / large-codebases)を調査し、それに沿って既存ルールの陳腐化・重複・破損を修正しています。バグ自体の修正は各Issueで行い、本PRには含みません。

## 準拠したベストプラクティス

- `.claude/rules/*.md` + `paths:` frontmatter は公式機能で現行のまま維持
- 1ファイル200行以下・具体的かつ命令形・1行の「why」(SA2-xxx参照)を付与
- ルールの重複は「家」を1つに決めて他はリンク参照(公式のアンチパターン回避)
- **確実に守らせたいルールはメモリではなくhookへ** → `scripts/check-rules.ts` を新設しStop hookで決定的に強制

## 新規ルール ↔ Fableレビュー Issue対応

| ルール | 防止するバグクラス | 該当Issue |
|---|---|---|
| `api-security.md` | IDOR/BOLA: 入力FK idの所有権未検証、bulk/reorderの親スコープ漏れ、JOIN/cursor未スコープ、存在オラクル、SSRF | SA2-102, 111, 123, 129, 149, 170, 172, 174, 175(親), 176〜183 |
| `api-data-integrity.md` | Zod検証の穴(`.int().min(0)`欠落、create/update不一致、書込/読出スキーマ非対称)、D1の100バインド上限、`db.batch()`未使用、N+1、不安定なkeysetページネーション、cascade削除 | SA2-115, 116, 136, 148, 150, 151, 156, 161, 165 |
| `datetime-and-numbers.md` | UTC真夜中保存×ローカル読みの1日ずれ、日跨ぎの負時間、バックフィル漏れ、期間境界、ロケール依存の数値表示 | SA2-117, 133, 145, 157, 160, 164, 184 |
| `web-data-fetching.md`(追記) | 楽観的更新の落とし穴(null-clear、id衝突、edit≠create、ポーリング上書き、無効化漏れ)、サインアウト時のキャッシュ残留、persist buster | SA2-132, 143, 147, 152, 154, 159, 162, 167 |
| `web-forms.md`(追記) | クライアント/サーバー数値制約の不一致、必須表示とスキーマの乖離 | SA2-103, 113, 137 |
| `web-ui.md`(Accessibility節) | aria-current、フィールドエラーのaria-describedby、キーボード操作、チャート代替テキスト | SA2-121, 140, 153, 155 |
| `scripts/check-rules.ts` + Stop hook | **ルールの再違反**(既存ルールがあったのに破られたクラス) | SA2-112, 119, 127, 134, 162 |

## 既存ルールのブラッシュアップ(監査で発見・修正)

- **`web-data-fetching.md`**: 存在しない `use-poker-table-interaction.ts`(`heroMutation`)への参照を実在の `use-player-detail.ts` / `use-active-session-scene-state.ts` に差し替え。`prependInfiniteQueryItem` を目録に追加し、`optimistic-session-event.ts` を公認の姉妹ヘルパーとして明記。模範例も違反ゼロのファイル(`use-sessions.ts` 等)へ変更
- **`web-hooks-separation.md`**: 検証rgコマンドが `**` を位置引数として渡しており**exit 2でエラー終了して何も検査していなかった**のを `-g` glob形式に修正(修正版で実行し違反0件を確認済み)
- **`web-theme.md`**: この環境に存在しない `/tmp/design/...` を指す「Design source-of-truth」節を削除し、`index.css` が唯一のソースであることを明記
- **重複の一本化**: Drawer-not-Dialog(4箇所→1箇所+リンク)、zodインポート(2箇所→CLAUDE.mdのみ)等
- **`CLAUDE.md`**: Stop hook表記の統一(`bun x` 付きに一本化+check-rules追加)、vitest `server` プロジェクトの追記、ルール索引の更新、ルール追加手順に「greppableならcheck-rules.tsへ」を追加。200行以内を維持

## `scripts/check-rules.ts`(Stop hookに組み込み)

機械的に検証可能なルールをまとめて検査するスクリプト。`bun run check:rules` でも実行可能。**現時点でグリーンなチェックのみ**収録:

- zod named import禁止 / `lucide-react` 禁止 / `hsl(var(--…))` 禁止 / `<input type="number">` 禁止(複数行対応) / hooks分離違反

現在違反が残る `ColorBadge`・`PlayerAvatar`・生 `setQueryData` は、SA2-112 / SA2-119 / SA2-162 の修正後に追加する旨をスクリプト冒頭コメントに記載しています(REDなチェックを入れると全ターンがブロックされるため)。

## 検証

- `bun run check:rules` → 全チェック通過(違反を一時注入してFAIL検知することも確認済み)
- `bun run lint` → 1088ファイル、エラーなし
- CLAUDE.md 200行ちょうど(上限内)、全ルール内のファイル参照パスの解決を機械チェック済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrjZ2xwuF16YpDLhATwsBz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrjZ2xwuF16YpDLhATwsBz)_