### PR TITLE
fix(live-sessions): ライブセッション開始カードの Confirm が効かない問題を修正

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "Bash(bunx vitest *)",
       "mcp__7d3661ac-8fa2-4e4c-b904-cddf640bd4ac__get_issue",
       "mcp__7d3661ac-8fa2-4e4c-b904-cddf640bd4ac__list_comments",
-      "mcp__Linear__get_issue"
+      "mcp__Linear__get_issue",
+      "mcp__Claude_Code_Remote__send_later"
     ]
   },
   "enabledPlugins": {

--- a/apps/web/src/features/live-sessions/components/create-session-dialog/live-session-form/__tests__/use-live-session-form.test.ts
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/live-session-form/__tests__/use-live-session-form.test.ts
@@ -183,4 +183,49 @@ describe("useLiveSessionForm — submit", () => {
 			expect.objectContaining({ type: "cash_game" })
 		);
 	});
+
+	it("confirms a cash session with only the initial buy-in — the live form never shows a cash-out field", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderForm(onSubmit);
+
+		// Mirror the real UI: the user fills the initial buy-in and taps ✓.
+		// There is no cash-out input on the live form, so it stays empty.
+		act(() => {
+			result.current.state.form.setFieldValue("buyIn", "100");
+		});
+		act(() => {
+			result.current.onFormSubmit({
+				preventDefault: vi.fn(),
+				stopPropagation: vi.fn(),
+			} as unknown as FormEvent);
+		});
+
+		await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+		expect(onSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "cash_game", buyIn: 100 })
+		);
+	});
+
+	it("opens the collapsed rules section when submit fails on a rule field", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderForm(onSubmit);
+
+		// A tournament needs a buy-in, which lives behind the collapsed
+		// "Customize rules" section. Submitting it empty must surface the section
+		// instead of silently doing nothing.
+		act(() => {
+			result.current.state.setSessionType("tournament");
+		});
+		expect(result.current.rulesOpen).toBe(false);
+
+		act(() => {
+			result.current.onFormSubmit({
+				preventDefault: vi.fn(),
+				stopPropagation: vi.fn(),
+			} as unknown as FormEvent);
+		});
+
+		await waitFor(() => expect(result.current.rulesOpen).toBe(true));
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
 });

--- a/apps/web/src/features/live-sessions/components/create-session-dialog/live-session-form/use-live-session-form.ts
+++ b/apps/web/src/features/live-sessions/components/create-session-dialog/live-session-form/use-live-session-form.ts
@@ -1,5 +1,5 @@
 import type { FormEvent } from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSessionWizard } from "@/features/sessions/components/session-wizard/use-session-wizard";
 import type {
 	RingGameOption,
@@ -41,6 +41,16 @@ export function useLiveSessionForm({
 	// session that keeps the master's rules starts without opening them. The
 	// user expands the section only to tweak the rules.
 	const [rulesOpen, setRulesOpen] = useState(false);
+
+	// A failed submit whose invalid field lives in the rules section (e.g. a
+	// tournament with no buy-in) routes the wizard's currentStep to "rules".
+	// The single-screen live form has no step nav, so reveal the collapsed
+	// section instead — otherwise ✓ Confirm looks like it does nothing.
+	useEffect(() => {
+		if (state.currentStep === "rules") {
+			setRulesOpen(true);
+		}
+	}, [state.currentStep]);
 
 	const selectedMaster = state.isCashGame
 		? state.selectedRingGame

--- a/apps/web/src/features/sessions/components/session-wizard/__tests__/use-session-form-state.test.ts
+++ b/apps/web/src/features/sessions/components/session-wizard/__tests__/use-session-form-state.test.ts
@@ -264,6 +264,72 @@ describe("useSessionFormState", () => {
 		);
 	});
 
+	it("blocks a manual cash submit when the cash-out is left empty", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(
+			() =>
+				useSessionFormState({
+					onSubmit,
+					defaultValues: { type: "cash_game", sessionDate: "2026-04-10" },
+					ringGames: RING_GAMES,
+				}),
+			{ wrapper: withQueryClient() }
+		);
+		act(() => {
+			result.current.form.setFieldValue("buyIn", "100");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("submits a live cash session with only the initial buy-in (no cash-out)", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(
+			() =>
+				useSessionFormState({
+					mode: "live",
+					onSubmit,
+					defaultValues: { type: "cash_game", sessionDate: "2026-04-10" },
+					ringGames: RING_GAMES,
+				}),
+			{ wrapper: withQueryClient() }
+		);
+		act(() => {
+			result.current.form.setFieldValue("buyIn", "100");
+		});
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).toHaveBeenCalledTimes(1);
+		expect(onSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "cash_game",
+				buyIn: 100,
+				sessionDate: "2026-04-10",
+			})
+		);
+	});
+
+	it("still requires the initial buy-in in live mode", async () => {
+		const onSubmit = vi.fn();
+		const { result } = renderHook(
+			() =>
+				useSessionFormState({
+					mode: "live",
+					onSubmit,
+					defaultValues: { type: "cash_game", sessionDate: "2026-04-10" },
+					ringGames: RING_GAMES,
+				}),
+			{ wrapper: withQueryClient() }
+		);
+		await act(async () => {
+			await result.current.form.handleSubmit();
+		});
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
 	it("seeds selectedGameId from defaultValues.ringGameId for cash and .tournamentId for tournament", () => {
 		const onSubmit = vi.fn();
 		const { result: cash } = renderHook(

--- a/apps/web/src/features/sessions/components/session-wizard/use-session-form-state.ts
+++ b/apps/web/src/features/sessions/components/session-wizard/use-session-form-state.ts
@@ -5,6 +5,7 @@ import type { BlindLevelRow } from "@/features/rooms/hooks/use-blind-levels";
 import {
 	buildDefaults,
 	cashSessionFormSchema,
+	liveCashSessionFormSchema,
 	numStrOrEmpty,
 	parseOptInt,
 	type RingGameOption,
@@ -43,6 +44,12 @@ interface UseSessionFormStateArgs {
 	 */
 	defaultRoomId?: string;
 	defaultValues?: SessionFormDefaults;
+	/**
+	 * "live" starts a session before it ends (result fields unknown); "manual"
+	 * records a completed session. Selects the cash validation schema so the
+	 * live form isn't gated on a cash-out it never renders.
+	 */
+	mode?: "manual" | "live";
 	onRoomChange?: (roomId: string | undefined) => void;
 	onSubmit: (values: SessionFormValues) => void;
 	onSubmitInvalid?: (fieldNames: string[]) => void;
@@ -69,6 +76,7 @@ function withoutPerLevelGames(levels: BlindLevelRow[]): BlindLevelRow[] {
 export function useSessionFormState({
 	defaultRoomId,
 	defaultValues,
+	mode = "manual",
 	onRoomChange,
 	onSubmit,
 	onSubmitInvalid,
@@ -145,6 +153,11 @@ export function useSessionFormState({
 	const isCashGame = sessionType === "cash_game";
 	const gameOptions = isCashGame ? ringGames : tournaments;
 	const gameLabel = isCashGame ? "Cash game" : "Tournament";
+	// Live cash sessions start before they end, so the cash-out is unknown and
+	// the live form never renders it — validate against the schema that keeps it
+	// optional, otherwise ✓ Confirm silently fails.
+	const cashGameSchema =
+		mode === "live" ? liveCashSessionFormSchema : cashSessionFormSchema;
 
 	// Extracted from onSubmit to keep its cognitive complexity in budget.
 	const buildCashSubmitValues = (value: SessionFormFieldValues) => {
@@ -248,9 +261,7 @@ export function useSessionFormState({
 			});
 		},
 		validators: {
-			onSubmit: isCashGame
-				? cashSessionFormSchema
-				: tournamentSessionFormSchema,
+			onSubmit: isCashGame ? cashGameSchema : tournamentSessionFormSchema,
 		},
 	});
 

--- a/apps/web/src/features/sessions/utils/__tests__/session-form-helpers.test.ts
+++ b/apps/web/src/features/sessions/utils/__tests__/session-form-helpers.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	buildDefaults,
 	cashOverriddenFields,
+	cashSessionFormSchema,
 	getTodayDateString,
+	liveCashSessionFormSchema,
 	NONE_VALUE,
 	numStrOrEmpty,
 	parseOptInt,
@@ -204,6 +206,76 @@ describe("sessionFormSchema", () => {
 				sessionFormSchema.safeParse(validPayload({ tableSize: value })).success
 			).toBe(false);
 		}
+	});
+});
+
+describe("liveCashSessionFormSchema", () => {
+	function livePayload(overrides: Record<string, unknown> = {}) {
+		return {
+			sessionDate: "2026-04-01",
+			startTime: "",
+			endTime: "",
+			breakMinutes: "",
+			memo: "",
+			ruleName: "",
+			buyIn: "100",
+			// The live "Start Live Session" form never renders a cash-out field —
+			// the session hasn't ended yet — so it always submits empty here.
+			cashOut: "",
+			evCashOut: "",
+			variant: "nlh",
+			blind1: "",
+			blind2: "",
+			blind3: "",
+			ante: "",
+			anteType: "none",
+			tableSize: "",
+			minBuyIn: "",
+			maxBuyIn: "",
+			tournamentBuyIn: "",
+			entryFee: "",
+			startingStack: "",
+			bountyAmount: "",
+			beforeDeadline: false,
+			timerStartedAt: "",
+			placement: "",
+			totalEntries: "",
+			prizeMoney: "",
+			bountyPrizes: "",
+			...overrides,
+		};
+	}
+
+	it("accepts a live cash payload with an empty cash-out (session not ended yet)", () => {
+		expect(liveCashSessionFormSchema.safeParse(livePayload()).success).toBe(
+			true
+		);
+	});
+
+	it("still requires the initial buy-in", () => {
+		expect(
+			liveCashSessionFormSchema.safeParse(livePayload({ buyIn: "" })).success
+		).toBe(false);
+	});
+
+	it("still requires a session date", () => {
+		expect(
+			liveCashSessionFormSchema.safeParse(livePayload({ sessionDate: "" }))
+				.success
+		).toBe(false);
+	});
+
+	it("still rejects a negative cash-out when one is supplied", () => {
+		expect(
+			liveCashSessionFormSchema.safeParse(livePayload({ cashOut: "-1" }))
+				.success
+		).toBe(false);
+	});
+
+	it("diverges from cashSessionFormSchema, which requires the cash-out", () => {
+		const payload = livePayload();
+		expect(cashSessionFormSchema.safeParse(payload).success).toBe(false);
+		expect(liveCashSessionFormSchema.safeParse(payload).success).toBe(true);
 	});
 });
 

--- a/apps/web/src/features/sessions/utils/session-form-helpers.ts
+++ b/apps/web/src/features/sessions/utils/session-form-helpers.ts
@@ -206,6 +206,18 @@ export const cashSessionFormSchema = sessionFormSchema.extend({
 	tournamentBuyIn: optionalNumericString({ integer: true, min: 0 }),
 });
 
+/**
+ * Cash schema for the live "Start Live Session" flow. A live session is
+ * created before it ends, so the result-only cash-out is unknown and the live
+ * form never renders it — keeping the shared `cashOut` requirement made the
+ * ✓ Confirm silently fail (the empty field always failed validation and the
+ * error routed to a "result" step that the single-screen live form doesn't
+ * render). The initial buy-in stays required.
+ */
+export const liveCashSessionFormSchema = cashSessionFormSchema.extend({
+	cashOut: optionalNumericString({ integer: true, min: 0 }),
+});
+
 export const tournamentSessionFormSchema = sessionFormSchema.extend({
 	buyIn: optionalNumericString({ integer: true, min: 0 }),
 	cashOut: optionalNumericString({ integer: true, min: 0 }),


### PR DESCRIPTION
## 概要

「Start Live Session」フォーム（キャッシュゲーム）で ✓（Confirm）をタップしても何も起きず、セッションを開始できない不具合を修正します。

## 原因

- ライブ開始フォームは単一画面で、キャッシュゲームでは初期バイイン `buyIn` のみを入力欄として描画する（`start-step-body.tsx`）。
- しかしバリデーションは、完了済みセッションを記録する手動ウィザードと共有の `cashSessionFormSchema` を使用しており、精算額 `cashOut` を `requiredNumericString`（必須）のまま要求していた。
- ライブUIには `cashOut` の入力欄が存在しないため値は常に空文字 → 検証失敗 → `onSubmitInvalid` が発火して `currentStep` を "start"（cashOutは非ルール項目）へ移すだけで、送信は行われない。
- ライブフォームはウィザードのステップ遷移を使わない単一画面のため、遷移先ステップは可視化されず、結果として「Confirmを押しても無反応」となっていた。

既存テスト `use-live-session-form.test.ts` が送信を通すために `cashOut` を手動セットしていたことが、この構造上の欠陥の裏付けになっている（実UIでは設定不可能）。

## 変更内容

- `liveCashSessionFormSchema` を追加。`cashOut` を任意化し、`buyIn`（初期バイイン）は必須のまま維持。
- `useSessionFormState` に `mode`（`"manual" | "live"`）を受け渡し、`mode === "live"` のキャッシュゲームではライブ用スキーマを選択。手動モードは従来どおり `cashOut` 必須。
- `useLiveSessionForm`: ルール項目（例: トーナメントのバイイン）で検証失敗した際、単一画面のライブフォームには step ナビが無いため、折りたたみの「Customize rules」を自動展開し、同種のサイレント失敗を防止。

## テスト（TDD）

- `session-form-helpers.test.ts`: `liveCashSessionFormSchema` の受理/拒否（空 cashOut は受理、buyIn・sessionDate は必須維持、負の cashOut は拒否、`cashSessionFormSchema` との差分）。
- `use-session-form-state.test.ts`: 手動キャッシュは cashOut 空で送信ブロック、ライブは buyIn のみで送信成功、ライブでも buyIn は必須。
- `use-live-session-form.test.ts`: cashOut 入力なしでキャッシュセッションが Confirm 可能、ルール項目エラー時に「Customize rules」が自動展開。

`bun run lint` / `check-types` / `check:rules` および関連テスト（wizard・session-edit-form・create-session-dialog）はローカルで green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqW443UMhcRMj6CrvxJLGB

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqW443UMhcRMj6CrvxJLGB)_