### PR TITLE
fix: 完了済みセッションのP/Lにチップ除去(chip remove)分を反映する

### DIFF
--- a/packages/api/src/__tests__/live-session-pl.test.ts
+++ b/packages/api/src/__tests__/live-session-pl.test.ts
@@ -981,6 +981,40 @@ describe("recalculateCashGameSession — completed session", () => {
 		expect(inserted.cashOut).toBe(700);
 	});
 
+	it("persists chipRemoveTotal on sessionCashDetail so completed-session P/L includes chip removes (insert path)", async () => {
+		const startedAt = new Date("2024-01-01T10:00:00Z");
+		const endedAt = new Date("2024-01-01T12:00:00Z");
+		const events = [
+			makeSessionEvent("session_start", { buyInAmount: 500 }, startedAt, 0),
+			makeSessionEvent(
+				"chips_add_remove",
+				{ amount: -100 },
+				new Date("2024-01-01T11:00:00Z"),
+				1
+			),
+			makeSessionEvent("session_end", { cashOutAmount: 600 }, endedAt, 2),
+		];
+		const session = makeGameSession({ currencyId: null });
+
+		const db = makeChainableDb([events, [session], [], []]);
+
+		await recalculateCashGameSession(
+			db as unknown as Parameters<typeof recalculateCashGameSession>[0],
+			"session-1",
+			"user-1"
+		);
+
+		const insertCalls = db._insertChain.values.mock.calls;
+		const cashDetailInsert = insertCalls.find((args: unknown[]) => {
+			const arg = args[0] as Record<string, unknown>;
+			return "buyIn" in arg || "cashOut" in arg;
+		});
+		const inserted = cashDetailInsert?.[0] as Record<string, unknown>;
+		expect(inserted.buyIn).toBe(500);
+		expect(inserted.cashOut).toBe(600);
+		expect(inserted.chipRemoveTotal).toBe(100);
+	});
+
 	it("updates existing sessionCashDetail when it already exists", async () => {
 		const startedAt = new Date("2024-01-01T10:00:00Z");
 		const endedAt = new Date("2024-01-01T12:00:00Z");
@@ -1002,6 +1036,43 @@ describe("recalculateCashGameSession — completed session", () => {
 		);
 
 		expect(db.update).toHaveBeenCalledTimes(3);
+	});
+
+	it("persists chipRemoveTotal on sessionCashDetail so completed-session P/L includes chip removes (update path)", async () => {
+		const startedAt = new Date("2024-01-01T10:00:00Z");
+		const endedAt = new Date("2024-01-01T12:00:00Z");
+		const events = [
+			makeSessionEvent("session_start", { buyInAmount: 200 }, startedAt, 0),
+			makeSessionEvent(
+				"chips_add_remove",
+				{ amount: -50 },
+				new Date("2024-01-01T11:00:00Z"),
+				1
+			),
+			makeSessionEvent("session_end", { cashOutAmount: 300 }, endedAt, 2),
+		];
+		const session = makeGameSession({ currencyId: null });
+		const existingDetail = [
+			{
+				sessionId: "session-1",
+				buyIn: 200,
+				cashOut: null,
+				evCashOut: null,
+				chipRemoveTotal: null,
+			},
+		];
+
+		const db = makeChainableDb([events, [session], existingDetail, []]);
+
+		await recalculateCashGameSession(
+			db as unknown as Parameters<typeof recalculateCashGameSession>[0],
+			"session-1",
+			"user-1"
+		);
+
+		expect(db._updateChain.set).toHaveBeenCalledWith(
+			expect.objectContaining({ buyIn: 200, cashOut: 300, chipRemoveTotal: 50 })
+		);
 	});
 
 	it("skips currencyTransaction sync when currencyId is null", async () => {

--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -6,6 +6,7 @@ import { appRouter } from "../routers";
 import {
 	assertNoLiveLinkedRestrictedEdits,
 	chunkForInsert,
+	computeCashGamePL,
 	computeTournamentPL,
 	encodeSessionCursor,
 	type ProfitLossSeriesRow,
@@ -25,6 +26,31 @@ const SESSION_DATE_RE = /sessionDate/;
 const PLACEMENT_RE = /placement/;
 const PRIZE_MONEY_RE = /prizeMoney/;
 const TOURNAMENT_ID_RE = /tournamentId/;
+
+describe("computeCashGamePL", () => {
+	it("returns cashOut - buyIn when no chips were removed early", () => {
+		expect(computeCashGamePL(500, 700)).toBe(200);
+	});
+
+	it("adds a positive chipRemoveTotal back into profit/loss (chip remove bug)", () => {
+		// Removing 100 in chips mid-session and cashing out 600 at the table
+		// nets the same 200 profit as never removing anything and cashing out
+		// 700 — the removed chips are already in the player's pocket.
+		expect(computeCashGamePL(500, 600, 100)).toBe(200);
+	});
+
+	it("defaults chipRemoveTotal to 0 when the third argument is omitted", () => {
+		expect(computeCashGamePL(500, 300)).toBe(computeCashGamePL(500, 300, 0));
+	});
+
+	it("handles a zero chipRemoveTotal explicitly the same as omitting it", () => {
+		expect(computeCashGamePL(500, 700, 0)).toBe(200);
+	});
+
+	it("computes a loss when cashOut + chipRemoveTotal is below buyIn", () => {
+		expect(computeCashGamePL(1000, 200, 50)).toBe(-750);
+	});
+});
 
 describe("chunkForInsert", () => {
 	it("keeps each chunk under D1's 100 bound-parameter cap for 9-column rows", () => {
@@ -578,6 +604,7 @@ describe("session router input validation", () => {
 				buyIn: null,
 				cashOut: null,
 				chipPurchaseCost: 0,
+				chipRemoveTotal: null,
 				endedAt: null,
 				entryFee: null,
 				evCashOut: null,
@@ -617,6 +644,58 @@ describe("session router input validation", () => {
 				})
 			);
 			expect(point.sessionDate).toBe(1_700_000_000);
+		});
+	});
+
+	describe("toProfitLossSeriesPoint cash game profitLoss includes chipRemoveTotal", () => {
+		function row(overrides: Partial<ProfitLossSeriesRow>): ProfitLossSeriesRow {
+			return {
+				bountyPrizes: null,
+				breakMinutes: null,
+				buyIn: null,
+				cashOut: null,
+				chipPurchaseCost: 0,
+				chipRemoveTotal: null,
+				endedAt: null,
+				entryFee: null,
+				evCashOut: null,
+				id: "s1",
+				prizeMoney: null,
+				ringGameBlind2: null,
+				sessionDate: new Date(1_700_000_000_000),
+				startedAt: null,
+				tournamentBuyIn: null,
+				type: "cash_game",
+				...overrides,
+			};
+		}
+
+		it("adds chipRemoveTotal on top of cashOut - buyIn", () => {
+			const point = toProfitLossSeriesPoint(
+				row({ buyIn: 500, cashOut: 700, chipRemoveTotal: 100 })
+			);
+			// 700 + 100 - 500, not the chip-remove-blind 700 - 500 = 200.
+			expect(point.profitLoss).toBe(300);
+		});
+
+		it("treats a null chipRemoveTotal (no chips_add_remove events, or a manual session) as 0", () => {
+			const point = toProfitLossSeriesPoint(
+				row({ buyIn: 500, cashOut: 700, chipRemoveTotal: null })
+			);
+			expect(point.profitLoss).toBe(200);
+		});
+
+		it("adds the same chipRemoveTotal into evProfitLoss so evDiff stays isolated to all-in equity", () => {
+			const point = toProfitLossSeriesPoint(
+				row({
+					buyIn: 500,
+					cashOut: 700,
+					evCashOut: 750,
+					chipRemoveTotal: 100,
+				})
+			);
+			expect(point.profitLoss).toBe(300);
+			expect(point.evProfitLoss).toBe(350);
 		});
 	});
 
@@ -1926,6 +2005,51 @@ describe("session.update cash variant / mixGames persistence invariant", () => {
 			{ sessionId: "session-1", sessionTagId: "tag-1" },
 			{ sessionId: "session-1", sessionTagId: "tag-2" },
 		]);
+	});
+
+	it("re-syncs currencyTransaction.amount with chipRemoveTotal included, not just cashOut - buyIn", async () => {
+		const { db, updated } = createChainableMockDb({
+			select: {
+				game_session: [
+					{
+						id: "session-1",
+						userId: "user-1",
+						kind: "cash_game",
+						source: "live",
+						currencyId: "currency-1",
+						sessionDate: new Date(1_700_000_000_000),
+					},
+				],
+				session_cash_detail: [
+					{
+						sessionId: "session-1",
+						variant: "NL Hold'em",
+						mixGames: null,
+						buyIn: 100,
+						cashOut: 200,
+						evCashOut: null,
+						// 50 in chips racked off the table mid-session — already in the
+						// player's pocket on top of the 200 they cashed out at the end.
+						chipRemoveTotal: 50,
+					},
+				],
+				session_tournament_detail: [],
+				session_chip_purchase: [],
+				game_mix: [],
+			},
+		});
+		const caller = appRouter.createCaller({
+			session: { user: { id: "user-1" } },
+			db,
+		} as unknown as Parameters<typeof appRouter.createCaller>[0]);
+
+		await caller.session.update({ id: "session-1", memo: "edited" });
+
+		// Editing a live-sourced session (e.g. its memo) must not regress the
+		// currency ledger back to the chip-remove-blind cashOut - buyIn (150,
+		// not 100): the true P/L is cashOut + chipRemoveTotal - buyIn = 150.
+		expect(updated.currency_transaction).toHaveLength(1);
+		expect(updated.currency_transaction?.[0]).toMatchObject({ amount: 150 });
 	});
 });
 

--- a/packages/api/src/__tests__/stats.test.ts
+++ b/packages/api/src/__tests__/stats.test.ts
@@ -933,6 +933,49 @@ describe("fetchStatsRows variant mapping", () => {
 		const rows = await fetchStatsRows(db, "user-1", { normalized: false });
 		expect(rows[0]?.variant).toBeNull();
 	});
+
+	it("adds chipRemoveTotal into a cash_game row's profitLoss and evProfitLoss (chip remove bug)", async () => {
+		const { db } = createChainableMockDb({
+			select: {
+				game_session: [
+					rawRow({
+						id: "cash-3",
+						type: "cash_game",
+						buyIn: 500,
+						cashOut: 600,
+						evCashOut: 650,
+						chipRemoveTotal: 100,
+					}),
+				],
+			},
+		});
+
+		const rows = await fetchStatsRows(db, "user-1", { normalized: false });
+		expect(rows).toHaveLength(1);
+		// 600 + 100 - 500, not the chip-remove-blind 600 - 500 = 100.
+		expect(rows[0]?.profitLoss).toBe(200);
+		expect(rows[0]?.evProfitLoss).toBe(250);
+		expect(rows[0]?.evDiff).toBe(50);
+	});
+
+	it("treats a null chipRemoveTotal as 0 for a cash_game row's profitLoss", async () => {
+		const { db } = createChainableMockDb({
+			select: {
+				game_session: [
+					rawRow({
+						id: "cash-4",
+						type: "cash_game",
+						buyIn: 500,
+						cashOut: 600,
+						chipRemoveTotal: null,
+					}),
+				],
+			},
+		});
+
+		const rows = await fetchStatsRows(db, "user-1", { normalized: false });
+		expect(rows[0]?.profitLoss).toBe(100);
+	});
 });
 
 describe("stats ownership scoping", () => {

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -95,8 +95,12 @@ async function validateSessionOwnership(
 	return found;
 }
 
-function computeCashGamePL(buyIn: number, cashOut: number): number {
-	return cashOut - buyIn;
+function computeCashGamePL(
+	buyIn: number,
+	cashOut: number,
+	chipRemoveTotal = 0
+): number {
+	return cashOut + chipRemoveTotal - buyIn;
 }
 
 function computeTournamentPL(
@@ -1074,6 +1078,7 @@ interface SummarySessionRow {
 	buyIn: number | null;
 	cashOut: number | null;
 	chipPurchaseCost: number;
+	chipRemoveTotal: number | null;
 	entryFee: number | null;
 	evCashOut: number | null;
 	placement: number | null;
@@ -1084,7 +1089,7 @@ interface SummarySessionRow {
 
 function computeSessionPLFromRow(s: SummarySessionRow): number {
 	if (s.type === "cash_game" && s.buyIn !== null && s.cashOut !== null) {
-		return computeCashGamePL(s.buyIn, s.cashOut);
+		return computeCashGamePL(s.buyIn, s.cashOut, s.chipRemoveTotal ?? 0);
 	}
 	return computeTournamentPL(
 		s.buyIn,
@@ -1112,7 +1117,7 @@ function accumulateEvMetrics(
 	if (s.type !== "cash_game" || s.evCashOut === null || s.buyIn === null) {
 		return;
 	}
-	const evPl = s.evCashOut - s.buyIn;
+	const evPl = s.evCashOut + (s.chipRemoveTotal ?? 0) - s.buyIn;
 	update({
 		totalEvProfitLoss: current.totalEvProfitLoss + evPl,
 		totalEvDiff: current.totalEvDiff + (evPl - pl),
@@ -1230,6 +1235,7 @@ async function computeSummary(
 			buyIn: sessionCashDetail.buyIn,
 			cashOut: sessionCashDetail.cashOut,
 			evCashOut: sessionCashDetail.evCashOut,
+			chipRemoveTotal: sessionCashDetail.chipRemoveTotal,
 			entryFee: sessionTournamentDetail.entryFee,
 			prizeMoney: sessionTournamentDetail.prizeMoney,
 			bountyPrizes: sessionTournamentDetail.bountyPrizes,
@@ -1522,6 +1528,7 @@ interface ListItemRaw {
 	buyIn: number | null;
 	cashOut: number | null;
 	chipPurchaseCost: number;
+	chipRemoveTotal: number | null;
 	entryFee: number | null;
 	evCashOut: number | null;
 	id: string;
@@ -1537,6 +1544,7 @@ export interface ProfitLossSeriesRow {
 	buyIn: number | null;
 	cashOut: number | null;
 	chipPurchaseCost: number;
+	chipRemoveTotal: number | null;
 	endedAt: Date | null;
 	entryFee: number | null;
 	evCashOut: number | null;
@@ -1559,10 +1567,13 @@ function computeCashStats(r: ProfitLossSeriesRow): CashGameStats {
 	if (r.buyIn === null || r.cashOut === null) {
 		return { profitLoss: 0, evProfitLoss: null, buyInTotal: null };
 	}
+	const chipRemoveTotal = r.chipRemoveTotal ?? 0;
 	return {
-		profitLoss: computeCashGamePL(r.buyIn, r.cashOut),
+		profitLoss: computeCashGamePL(r.buyIn, r.cashOut, chipRemoveTotal),
 		evProfitLoss:
-			r.evCashOut === null ? null : computeCashGamePL(r.buyIn, r.evCashOut),
+			r.evCashOut === null
+				? null
+				: computeCashGamePL(r.buyIn, r.evCashOut, chipRemoveTotal),
 		buyInTotal: r.buyIn,
 	};
 }
@@ -1651,6 +1662,7 @@ export async function fetchProfitLossSeries(
 			buyIn: sessionCashDetail.buyIn,
 			cashOut: sessionCashDetail.cashOut,
 			evCashOut: sessionCashDetail.evCashOut,
+			chipRemoveTotal: sessionCashDetail.chipRemoveTotal,
 			ringGameBlind2: sessionCashDetail.blind2,
 			tournamentBuyIn: sessionTournamentDetail.tournamentBuyIn,
 			entryFee: sessionTournamentDetail.entryFee,
@@ -1726,9 +1738,10 @@ function enrichItemWithPL<T extends ListItemRaw>(item: T) {
 		item.buyIn !== null &&
 		item.cashOut !== null
 	) {
-		profitLoss = computeCashGamePL(item.buyIn, item.cashOut);
+		const chipRemoveTotal = item.chipRemoveTotal ?? 0;
+		profitLoss = computeCashGamePL(item.buyIn, item.cashOut, chipRemoveTotal);
 		if (item.evCashOut !== null) {
-			evProfitLoss = item.evCashOut - item.buyIn;
+			evProfitLoss = item.evCashOut + chipRemoveTotal - item.buyIn;
 			evDiff = evProfitLoss - profitLoss;
 		}
 	} else if (item.type === "tournament") {
@@ -1773,6 +1786,7 @@ function selectEnrichedSessionRows(db: DbInstance, userId: string) {
 			buyIn: sessionCashDetail.buyIn,
 			cashOut: sessionCashDetail.cashOut,
 			evCashOut: sessionCashDetail.evCashOut,
+			chipRemoveTotal: sessionCashDetail.chipRemoveTotal,
 			tournamentBuyIn: sessionTournamentDetail.tournamentBuyIn,
 			entryFee: sessionTournamentDetail.entryFee,
 			placement: sessionTournamentDetail.placement,
@@ -3056,7 +3070,13 @@ async function buildCreateCurrencyTxStatements(
 
 function computeSessionPLFromDetails(
 	kind: string,
-	cashDetail: { buyIn: number | null; cashOut: number | null } | undefined,
+	cashDetail:
+		| {
+				buyIn: number | null;
+				cashOut: number | null;
+				chipRemoveTotal: number | null;
+		  }
+		| undefined,
 	tournamentDetail:
 		| {
 				tournamentBuyIn: number | null;
@@ -3072,7 +3092,11 @@ function computeSessionPLFromDetails(
 		cashDetail?.buyIn != null &&
 		cashDetail?.cashOut != null
 	) {
-		return computeCashGamePL(cashDetail.buyIn, cashDetail.cashOut);
+		return computeCashGamePL(
+			cashDetail.buyIn,
+			cashDetail.cashOut,
+			cashDetail.chipRemoveTotal ?? 0
+		);
 	}
 	if (kind === "tournament" && tournamentDetail) {
 		return computeTournamentPL(

--- a/packages/api/src/routers/stats.ts
+++ b/packages/api/src/routers/stats.ts
@@ -126,6 +126,7 @@ interface RawStatsRow {
 	buyIn: number | null;
 	cashOut: number | null;
 	cashVariant: string | null;
+	chipRemoveTotal: number | null;
 	endedAt: Date | null;
 	entryFee: number | null;
 	evCashOut: number | null;
@@ -176,14 +177,15 @@ function mapStatsRow(
 	};
 
 	if (r.type === "cash_game") {
+		const chipRemoveTotal = r.chipRemoveTotal ?? 0;
 		const profitLoss =
 			r.buyIn === null || r.cashOut === null
 				? 0
-				: computeCashGamePL(r.buyIn, r.cashOut);
+				: computeCashGamePL(r.buyIn, r.cashOut, chipRemoveTotal);
 		const evProfitLoss =
 			r.evCashOut === null || r.buyIn === null
 				? null
-				: computeCashGamePL(r.buyIn, r.evCashOut);
+				: computeCashGamePL(r.buyIn, r.evCashOut, chipRemoveTotal);
 		const evDiff = evProfitLoss === null ? null : evProfitLoss - profitLoss;
 		return {
 			...base,
@@ -253,6 +255,7 @@ export async function fetchStatsRows(
 			buyIn: sessionCashDetail.buyIn,
 			cashOut: sessionCashDetail.cashOut,
 			evCashOut: sessionCashDetail.evCashOut,
+			chipRemoveTotal: sessionCashDetail.chipRemoveTotal,
 			blind1: sessionCashDetail.blind1,
 			blind2: sessionCashDetail.blind2,
 			cashVariant: sessionCashDetail.variant,

--- a/packages/api/src/services/live-session-pl.ts
+++ b/packages/api/src/services/live-session-pl.ts
@@ -329,6 +329,7 @@ export async function recalculateCashGameSession(
 				buyIn: pl.totalBuyIn,
 				cashOut: pl.cashOut,
 				evCashOut: pl.evCashOut,
+				chipRemoveTotal: pl.chipRemoveTotal,
 			})
 			.where(eq(sessionCashDetail.sessionId, sessionId));
 	} else {
@@ -337,6 +338,7 @@ export async function recalculateCashGameSession(
 			buyIn: pl.totalBuyIn,
 			cashOut: pl.cashOut,
 			evCashOut: pl.evCashOut,
+			chipRemoveTotal: pl.chipRemoveTotal,
 		});
 	}
 

--- a/packages/db/src/__tests__/session-cash-detail-schema.test.ts
+++ b/packages/db/src/__tests__/session-cash-detail-schema.test.ts
@@ -15,6 +15,7 @@ describe("SessionCashDetail schema — columns", () => {
 				"buyIn",
 				"cashOut",
 				"evCashOut",
+				"chipRemoveTotal",
 				"ruleName",
 				"variant",
 				"blind1",
@@ -37,16 +38,18 @@ describe("SessionCashDetail schema — columns", () => {
 		expect(columns.ringGameId.notNull).toBe(false);
 	});
 
-	it("buyIn / cashOut / evCashOut are nullable", () => {
+	it("buyIn / cashOut / evCashOut / chipRemoveTotal are nullable", () => {
 		expect(columns.buyIn.notNull).toBe(false);
 		expect(columns.cashOut.notNull).toBe(false);
 		expect(columns.evCashOut.notNull).toBe(false);
+		expect(columns.chipRemoveTotal.notNull).toBe(false);
 	});
 
-	it("buyIn / cashOut / evCashOut are integer type", () => {
+	it("buyIn / cashOut / evCashOut / chipRemoveTotal are integer type", () => {
 		expect(columns.buyIn.dataType).toBe("number");
 		expect(columns.cashOut.dataType).toBe("number");
 		expect(columns.evCashOut.dataType).toBe("number");
+		expect(columns.chipRemoveTotal.dataType).toBe("number");
 	});
 
 	it("ringGameId is string type", () => {

--- a/packages/db/src/migrations/0047_gigantic_energizer.sql
+++ b/packages/db/src/migrations/0047_gigantic_energizer.sql
@@ -14,10 +14,12 @@ SET `chip_remove_total` = (
 		AND CAST(json_extract(`session_event`.`payload`, '$.amount') AS INTEGER) < 0
 );
 --> statement-breakpoint
--- 上のバックフィルで chip_remove_total が確定した完了済みセッションのうち、
--- 完了後の編集 (session.update) でチップ除去抜きの値に上書きされてしまった
--- currency_transaction.amount を正しい P/L に再同期する。
--- (chip_remove_total = 0 の行はそもそも影響を受けていないため対象外)
+-- 上のバックフィルで chip_remove_total が確定した完了済みセッション全件に
+-- ついて、currency_transaction.amount を正しい P/L (cashOut + chipRemoveTotal
+-- - buyIn) に再同期する。完了後の編集 (session.update) でチップ除去抜きの
+-- 値に上書きされていた行はここで修正され、未編集の行は元々の正しい値を
+-- 再計算するだけなので無害 (= 冪等)。chip_remove_total = 0 の行はそもそも
+-- 影響を受けていないため対象外。
 UPDATE `currency_transaction`
 SET `amount` = (
 	SELECT `session_cash_detail`.`cash_out` + `session_cash_detail`.`chip_remove_total` - `session_cash_detail`.`buy_in`

--- a/packages/db/src/migrations/0047_gigantic_energizer.sql
+++ b/packages/db/src/migrations/0047_gigantic_energizer.sql
@@ -1,0 +1,40 @@
+ALTER TABLE `session_cash_detail` ADD `chip_remove_total` integer;
+--> statement-breakpoint
+-- チップ除去 (chips_add_remove の負値イベント) 分が完了済みセッションのP/Lに
+-- 反映されないバグの遡及修正。session_cash_detail に chip_remove_total を
+-- 保存していなかったため、一覧・詳細・統計側の再計算 (cashOut - buyIn) が
+-- チップ除去分を無視していた。既存行の chip_remove_total を session_event
+-- から再構成する。冪等 (何度再実行しても同じ値になる)。
+UPDATE `session_cash_detail`
+SET `chip_remove_total` = (
+	SELECT COALESCE(SUM(-CAST(json_extract(`session_event`.`payload`, '$.amount') AS INTEGER)), 0)
+	FROM `session_event`
+	WHERE `session_event`.`session_id` = `session_cash_detail`.`session_id`
+		AND `session_event`.`event_type` = 'chips_add_remove'
+		AND CAST(json_extract(`session_event`.`payload`, '$.amount') AS INTEGER) < 0
+);
+--> statement-breakpoint
+-- 上のバックフィルで chip_remove_total が確定した完了済みセッションのうち、
+-- 完了後の編集 (session.update) でチップ除去抜きの値に上書きされてしまった
+-- currency_transaction.amount を正しい P/L に再同期する。
+-- (chip_remove_total = 0 の行はそもそも影響を受けていないため対象外)
+UPDATE `currency_transaction`
+SET `amount` = (
+	SELECT `session_cash_detail`.`cash_out` + `session_cash_detail`.`chip_remove_total` - `session_cash_detail`.`buy_in`
+	FROM `session_cash_detail`
+	JOIN `game_session` ON `game_session`.`id` = `session_cash_detail`.`session_id`
+	WHERE `session_cash_detail`.`session_id` = `currency_transaction`.`session_id`
+		AND `game_session`.`status` = 'completed'
+		AND `session_cash_detail`.`buy_in` IS NOT NULL
+		AND `session_cash_detail`.`cash_out` IS NOT NULL
+)
+WHERE `session_id` IN (
+	SELECT `session_cash_detail`.`session_id`
+	FROM `session_cash_detail`
+	JOIN `game_session` ON `game_session`.`id` = `session_cash_detail`.`session_id`
+	WHERE `game_session`.`status` = 'completed'
+		AND `session_cash_detail`.`buy_in` IS NOT NULL
+		AND `session_cash_detail`.`cash_out` IS NOT NULL
+		AND `session_cash_detail`.`chip_remove_total` IS NOT NULL
+		AND `session_cash_detail`.`chip_remove_total` != 0
+);

--- a/packages/db/src/migrations/meta/0047_snapshot.json
+++ b/packages/db/src/migrations/meta/0047_snapshot.json
@@ -1,0 +1,2691 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ac7582a8-635b-47a2-848b-3ee9f41840e7",
+  "prevId": "cb76cb8a-3848-412d-a1f4-6d27223b9fa9",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": ["identifier"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "currency": {
+      "name": "currency",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "currency_userId_idx": {
+          "name": "currency_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "currency_user_id_user_id_fk": {
+          "name": "currency_user_id_user_id_fk",
+          "tableFrom": "currency",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "currency_transaction": {
+      "name": "currency_transaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency_id": {
+          "name": "currency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transaction_type_id": {
+          "name": "transaction_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transacted_at": {
+          "name": "transacted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "currencyTransaction_currencyId_idx": {
+          "name": "currencyTransaction_currencyId_idx",
+          "columns": ["currency_id"],
+          "isUnique": false
+        },
+        "currencyTransaction_sessionId_idx": {
+          "name": "currencyTransaction_sessionId_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        },
+        "currencyTransaction_transactionTypeId_idx": {
+          "name": "currencyTransaction_transactionTypeId_idx",
+          "columns": ["transaction_type_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "currency_transaction_currency_id_currency_id_fk": {
+          "name": "currency_transaction_currency_id_currency_id_fk",
+          "tableFrom": "currency_transaction",
+          "tableTo": "currency",
+          "columnsFrom": ["currency_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "currency_transaction_transaction_type_id_transaction_type_id_fk": {
+          "name": "currency_transaction_transaction_type_id_transaction_type_id_fk",
+          "tableFrom": "currency_transaction",
+          "tableTo": "transaction_type",
+          "columnsFrom": ["transaction_type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "currency_transaction_session_id_game_session_id_fk": {
+          "name": "currency_transaction_session_id_game_session_id_fk",
+          "tableFrom": "currency_transaction",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_type": {
+      "name": "transaction_type",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactionType_userId_idx": {
+          "name": "transactionType_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "transactionType_sessionResultPerUser_idx": {
+          "name": "transactionType_sessionResultPerUser_idx",
+          "columns": ["user_id"],
+          "isUnique": true,
+          "where": "\"transaction_type\".\"name\" = 'Session Result'"
+        }
+      },
+      "foreignKeys": {
+        "transaction_type_user_id_user_id_fk": {
+          "name": "transaction_type_user_id_user_id_fk",
+          "tableFrom": "transaction_type",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_group": {
+      "name": "game_group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "builtin_key": {
+          "name": "builtin_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blind1_label": {
+          "name": "blind1_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind2_label": {
+          "name": "blind2_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind3_label": {
+          "name": "blind3_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "gameGroup_userId_idx": {
+          "name": "gameGroup_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "gameGroup_userId_builtinKey_idx": {
+          "name": "gameGroup_userId_builtinKey_idx",
+          "columns": ["user_id", "builtin_key"],
+          "isUnique": true
+        },
+        "gameGroup_userId_label_idx": {
+          "name": "gameGroup_userId_label_idx",
+          "columns": ["user_id", "label"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "game_group_user_id_user_id_fk": {
+          "name": "game_group_user_id_user_id_fk",
+          "tableFrom": "game_group",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_mix": {
+      "name": "game_mix",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "builtin_key": {
+          "name": "builtin_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "games": {
+          "name": "games",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "gameMix_userId_idx": {
+          "name": "gameMix_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "gameMix_userId_builtinKey_idx": {
+          "name": "gameMix_userId_builtinKey_idx",
+          "columns": ["user_id", "builtin_key"],
+          "isUnique": true
+        },
+        "gameMix_userId_label_idx": {
+          "name": "gameMix_userId_label_idx",
+          "columns": ["user_id", "label"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "game_mix_user_id_user_id_fk": {
+          "name": "game_mix_user_id_user_id_fk",
+          "tableFrom": "game_mix",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_variant": {
+      "name": "game_variant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "builtin_key": {
+          "name": "builtin_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "short_label": {
+          "name": "short_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "gameVariant_userId_idx": {
+          "name": "gameVariant_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "gameVariant_groupId_idx": {
+          "name": "gameVariant_groupId_idx",
+          "columns": ["group_id"],
+          "isUnique": false
+        },
+        "gameVariant_userId_builtinKey_idx": {
+          "name": "gameVariant_userId_builtinKey_idx",
+          "columns": ["user_id", "builtin_key"],
+          "isUnique": true
+        },
+        "gameVariant_userId_label_idx": {
+          "name": "gameVariant_userId_label_idx",
+          "columns": ["user_id", "label"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "game_variant_user_id_user_id_fk": {
+          "name": "game_variant_user_id_user_id_fk",
+          "tableFrom": "game_variant",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_variant_group_id_game_group_id_fk": {
+          "name": "game_variant_group_id_game_group_id_fk",
+          "tableFrom": "game_variant",
+          "tableTo": "game_group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player": {
+      "name": "player",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_temporary": {
+          "name": "is_temporary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "player_userId_idx": {
+          "name": "player_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_user_id_user_id_fk": {
+          "name": "player_user_id_user_id_fk",
+          "tableFrom": "player",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_tag": {
+      "name": "player_tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gray'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "playerTag_userId_idx": {
+          "name": "playerTag_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_tag_user_id_user_id_fk": {
+          "name": "player_tag_user_id_user_id_fk",
+          "tableFrom": "player_tag",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "player_to_player_tag": {
+      "name": "player_to_player_tag",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_tag_id": {
+          "name": "player_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "playerToPlayerTag_playerTagId_idx": {
+          "name": "playerToPlayerTag_playerTagId_idx",
+          "columns": ["player_tag_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "player_to_player_tag_player_id_player_id_fk": {
+          "name": "player_to_player_tag_player_id_player_id_fk",
+          "tableFrom": "player_to_player_tag",
+          "tableTo": "player",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_to_player_tag_player_tag_id_player_tag_id_fk": {
+          "name": "player_to_player_tag_player_tag_id_player_tag_id_fk",
+          "tableFrom": "player_to_player_tag",
+          "tableTo": "player_tag",
+          "columnsFrom": ["player_tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_to_player_tag_player_id_player_tag_id_pk": {
+          "columns": ["player_id", "player_tag_id"],
+          "name": "player_to_player_tag_player_id_player_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ring_game": {
+      "name": "ring_game",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NL Hold''em'"
+        },
+        "mix_games": {
+          "name": "mix_games",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind1": {
+          "name": "blind1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind2": {
+          "name": "blind2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind3": {
+          "name": "blind3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante": {
+          "name": "ante",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante_type": {
+          "name": "ante_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_buy_in": {
+          "name": "min_buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_buy_in": {
+          "name": "max_buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "table_size": {
+          "name": "table_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency_id": {
+          "name": "currency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ringGame_roomId_idx": {
+          "name": "ringGame_roomId_idx",
+          "columns": ["room_id"],
+          "isUnique": false
+        },
+        "ringGame_userId_idx": {
+          "name": "ringGame_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "ringGame_currencyId_idx": {
+          "name": "ringGame_currencyId_idx",
+          "columns": ["currency_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ring_game_room_id_room_id_fk": {
+          "name": "ring_game_room_id_room_id_fk",
+          "tableFrom": "ring_game",
+          "tableTo": "room",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ring_game_user_id_user_id_fk": {
+          "name": "ring_game_user_id_user_id_fk",
+          "tableFrom": "ring_game",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ring_game_currency_id_currency_id_fk": {
+          "name": "ring_game_currency_id_currency_id_fk",
+          "tableFrom": "ring_game",
+          "tableTo": "currency",
+          "columnsFrom": ["currency_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "room": {
+      "name": "room",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "room_userId_idx": {
+          "name": "room_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "room_user_id_user_id_fk": {
+          "name": "room_user_id_user_id_fk",
+          "tableFrom": "room",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_blind_level": {
+      "name": "session_blind_level",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_break": {
+          "name": "is_break",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "blind1": {
+          "name": "blind1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind2": {
+          "name": "blind2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind3": {
+          "name": "blind3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante": {
+          "name": "ante",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "minutes": {
+          "name": "minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "games": {
+          "name": "games",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_blind_level_session_idx": {
+          "name": "session_blind_level_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_blind_level_session_id_game_session_id_fk": {
+          "name": "session_blind_level_session_id_game_session_id_fk",
+          "tableFrom": "session_blind_level",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_cash_detail": {
+      "name": "session_cash_detail",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ring_game_id": {
+          "name": "ring_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "buy_in": {
+          "name": "buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cash_out": {
+          "name": "cash_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ev_cash_out": {
+          "name": "ev_cash_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chip_remove_total": {
+          "name": "chip_remove_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Untitled'"
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NL Hold''em'"
+        },
+        "mix_games": {
+          "name": "mix_games",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind1": {
+          "name": "blind1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind2": {
+          "name": "blind2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind3": {
+          "name": "blind3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante": {
+          "name": "ante",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante_type": {
+          "name": "ante_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_buy_in": {
+          "name": "min_buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_buy_in": {
+          "name": "max_buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "table_size": {
+          "name": "table_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_cash_ring_idx": {
+          "name": "session_cash_ring_idx",
+          "columns": ["ring_game_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_cash_detail_session_id_game_session_id_fk": {
+          "name": "session_cash_detail_session_id_game_session_id_fk",
+          "tableFrom": "session_cash_detail",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_cash_detail_ring_game_id_ring_game_id_fk": {
+          "name": "session_cash_detail_ring_game_id_ring_game_id_fk",
+          "tableFrom": "session_cash_detail",
+          "tableTo": "ring_game",
+          "columnsFrom": ["ring_game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_chip_purchase_result": {
+      "name": "session_chip_purchase_result",
+      "columns": {
+        "session_chip_purchase_id": {
+          "name": "session_chip_purchase_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_chip_purchase_result_session_chip_purchase_id_session_chip_purchase_id_fk": {
+          "name": "session_chip_purchase_result_session_chip_purchase_id_session_chip_purchase_id_fk",
+          "tableFrom": "session_chip_purchase_result",
+          "tableTo": "session_chip_purchase",
+          "columnsFrom": ["session_chip_purchase_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_chip_purchase": {
+      "name": "session_chip_purchase",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chips": {
+          "name": "chips",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "session_chip_purchase_session_idx": {
+          "name": "session_chip_purchase_session_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_chip_purchase_session_id_game_session_id_fk": {
+          "name": "session_chip_purchase_session_id_game_session_id_fk",
+          "tableFrom": "session_chip_purchase",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_event": {
+      "name": "session_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessionEvent_sessionId_sortOrder_idx": {
+          "name": "sessionEvent_sessionId_sortOrder_idx",
+          "columns": ["session_id", "sort_order"],
+          "isUnique": true
+        },
+        "sessionEvent_eventType_idx": {
+          "name": "sessionEvent_eventType_idx",
+          "columns": ["event_type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_event_session_id_game_session_id_fk": {
+          "name": "session_event_session_id_game_session_id_fk",
+          "tableFrom": "session_event",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_tag": {
+      "name": "session_tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "sessionTag_userId_idx": {
+          "name": "sessionTag_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_tag_user_id_user_id_fk": {
+          "name": "session_tag_user_id_user_id_fk",
+          "tableFrom": "session_tag",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_to_session_tag": {
+      "name": "session_to_session_tag",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_tag_id": {
+          "name": "session_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessionToSessionTag_sessionTagId_idx": {
+          "name": "sessionToSessionTag_sessionTagId_idx",
+          "columns": ["session_tag_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_to_session_tag_session_id_game_session_id_fk": {
+          "name": "session_to_session_tag_session_id_game_session_id_fk",
+          "tableFrom": "session_to_session_tag",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_to_session_tag_session_tag_id_session_tag_id_fk": {
+          "name": "session_to_session_tag_session_tag_id_session_tag_id_fk",
+          "tableFrom": "session_to_session_tag",
+          "tableTo": "session_tag",
+          "columnsFrom": ["session_tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_to_session_tag_session_id_session_tag_id_pk": {
+          "columns": ["session_id", "session_tag_id"],
+          "name": "session_to_session_tag_session_id_session_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_tournament_detail": {
+      "name": "session_tournament_detail",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tournament_buy_in": {
+          "name": "tournament_buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_entries": {
+          "name": "total_entries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "before_deadline": {
+          "name": "before_deadline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prize_money": {
+          "name": "prize_money",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bounty_prizes": {
+          "name": "bounty_prizes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timer_started_at": {
+          "name": "timer_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Untitled'"
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NL Hold''em'"
+        },
+        "starting_stack": {
+          "name": "starting_stack",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bounty_amount": {
+          "name": "bounty_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "table_size": {
+          "name": "table_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_tournament_tournament_idx": {
+          "name": "session_tournament_tournament_idx",
+          "columns": ["tournament_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_tournament_detail_session_id_game_session_id_fk": {
+          "name": "session_tournament_detail_session_id_game_session_id_fk",
+          "tableFrom": "session_tournament_detail",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_tournament_detail_tournament_id_tournament_id_fk": {
+          "name": "session_tournament_detail_tournament_id_tournament_id_fk",
+          "tableFrom": "session_tournament_detail",
+          "tableTo": "tournament",
+          "columnsFrom": ["tournament_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_session": {
+      "name": "game_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_date": {
+          "name": "session_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency_id": {
+          "name": "currency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_one_unfinished_live_per_user_idx": {
+          "name": "session_one_unfinished_live_per_user_idx",
+          "columns": ["user_id"],
+          "isUnique": true,
+          "where": "\"game_session\".\"source\" = 'live' AND \"game_session\".\"status\" != 'completed'"
+        },
+        "session_user_kind_status_idx": {
+          "name": "session_user_kind_status_idx",
+          "columns": ["user_id", "kind", "status"],
+          "isUnique": false
+        },
+        "session_user_date_idx": {
+          "name": "session_user_date_idx",
+          "columns": ["user_id", "session_date"],
+          "isUnique": false
+        },
+        "session_room_idx": {
+          "name": "session_room_idx",
+          "columns": ["room_id"],
+          "isUnique": false
+        },
+        "session_currency_idx": {
+          "name": "session_currency_idx",
+          "columns": ["currency_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_session_user_id_user_id_fk": {
+          "name": "game_session_user_id_user_id_fk",
+          "tableFrom": "game_session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_session_room_id_room_id_fk": {
+          "name": "game_session_room_id_room_id_fk",
+          "tableFrom": "game_session",
+          "tableTo": "room",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "game_session_currency_id_currency_id_fk": {
+          "name": "game_session_currency_id_currency_id_fk",
+          "tableFrom": "game_session",
+          "tableTo": "currency",
+          "columnsFrom": ["currency_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "session_manual_completed_check": {
+          "name": "session_manual_completed_check",
+          "value": "(source != 'manual') OR (status = 'completed')"
+        }
+      }
+    },
+    "tournament_tag": {
+      "name": "tournament_tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "tournamentTag_tournamentId_idx": {
+          "name": "tournamentTag_tournamentId_idx",
+          "columns": ["tournament_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tournament_tag_tournament_id_tournament_id_fk": {
+          "name": "tournament_tag_tournament_id_tournament_id_fk",
+          "tableFrom": "tournament_tag",
+          "tableTo": "tournament",
+          "columnsFrom": ["tournament_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blind_level": {
+      "name": "blind_level",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_break": {
+          "name": "is_break",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "blind1": {
+          "name": "blind1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind2": {
+          "name": "blind2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blind3": {
+          "name": "blind3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ante": {
+          "name": "ante",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "minutes": {
+          "name": "minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "games": {
+          "name": "games",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blindLevel_tournamentId_idx": {
+          "name": "blindLevel_tournamentId_idx",
+          "columns": ["tournament_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blind_level_tournament_id_tournament_id_fk": {
+          "name": "blind_level_tournament_id_tournament_id_fk",
+          "tableFrom": "blind_level",
+          "tableTo": "tournament",
+          "columnsFrom": ["tournament_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tournament": {
+      "name": "tournament",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NL Hold''em'"
+        },
+        "buy_in": {
+          "name": "buy_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "starting_stack": {
+          "name": "starting_stack",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bounty_amount": {
+          "name": "bounty_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "table_size": {
+          "name": "table_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency_id": {
+          "name": "currency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tournament_roomId_idx": {
+          "name": "tournament_roomId_idx",
+          "columns": ["room_id"],
+          "isUnique": false
+        },
+        "tournament_currencyId_idx": {
+          "name": "tournament_currencyId_idx",
+          "columns": ["currency_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tournament_room_id_room_id_fk": {
+          "name": "tournament_room_id_room_id_fk",
+          "tableFrom": "tournament",
+          "tableTo": "room",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tournament_currency_id_currency_id_fk": {
+          "name": "tournament_currency_id_currency_id_fk",
+          "tableFrom": "tournament",
+          "tableTo": "currency",
+          "columnsFrom": ["currency_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tournament_chip_purchase": {
+      "name": "tournament_chip_purchase",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chips": {
+          "name": "chips",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "tournamentChipPurchase_tournamentId_idx": {
+          "name": "tournamentChipPurchase_tournamentId_idx",
+          "columns": ["tournament_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tournament_chip_purchase_tournament_id_tournament_id_fk": {
+          "name": "tournament_chip_purchase_tournament_id_tournament_id_fk",
+          "tableFrom": "tournament_chip_purchase",
+          "tableTo": "tournament",
+          "columnsFrom": ["tournament_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "update_note_view": {
+      "name": "update_note_view",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "update_note_view_user_id_idx": {
+          "name": "update_note_view_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "update_note_view_user_version_idx": {
+          "name": "update_note_view_user_version_idx",
+          "columns": ["user_id", "version"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "update_note_view_user_id_user_id_fk": {
+          "name": "update_note_view_user_id_user_id_fk",
+          "tableFrom": "update_note_view",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1784120410467,
       "tag": "0046_session_event_sort_order_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "6",
+      "when": 1784384318449,
+      "tag": "0047_gigantic_energizer",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/session-cash-detail.ts
+++ b/packages/db/src/schema/session-cash-detail.ts
@@ -17,6 +17,11 @@ export const sessionCashDetail = sqliteTable(
 		buyIn: integer("buy_in"),
 		cashOut: integer("cash_out"),
 		evCashOut: integer("ev_cash_out"),
+		// Σ of chips racked off the table across every negative chips_add_remove
+		// event (early cash-out). Persisted separately from cashOut so completed-
+		// session P/L (list/detail/stats) can add it back in, matching the live
+		// session's own `cashOut + chipRemoveTotal - buyIn` formula.
+		chipRemoveTotal: integer("chip_remove_total"),
 		// Snapshot fields — copied from ring_game at session create time and
 		// frozen thereafter. Parent rename / blind change does not propagate.
 		ruleName: text("rule_name").notNull().default("Untitled"),


### PR DESCRIPTION
## 概要

ライブセッション中にチップを除去(早期回収)した場合、**セッション完了直後のライブ画面**では正しく反映されていた一方、**セッション完了後に表示されるP/L**(セッション一覧・詳細ページ、統計ダッシュボード、P/L推移グラフ)からはその分が欠落していたバグを修正しました。

### 原因

- `session_cash_detail` テーブルに `chips_add_remove` イベントの除去分累計(`chipRemoveTotal`)を保存するカラムが存在せず、セッション完了時に `buyIn` / `cashOut` のみが保存されていました。
- 一覧・詳細・統計・P/L推移グラフはすべて `session_cash_detail.buyIn/cashOut` から `computeCashGamePL = cashOut - buyIn` として**再計算**しており、除去済みチップ(＝既に手元に回収済みの価値)が反映されずP/Lが実際より過小に表示されていました。
- さらに、そのセッションを編集(`session.update`)すると、この誤った式で再計算した値が `currencyTransaction.amount` に再同期され、完了時点では正しかった通貨台帳の値まで壊れていました。

### 修正内容

- `session_cash_detail` に `chip_remove_total` カラムを追加し、`recalculateCashGameSession` でライブ集計時に永続化するように変更。
- `computeCashGamePL(buyIn, cashOut, chipRemoveTotal = 0)` に統一し、`session.ts` / `stats.ts` 内の全呼び出し箇所(セッション一覧・詳細・統計・P/L推移グラフ・編集時の通貨トランザクション再同期)を修正。
- 既存の完了済みセッションについて、`session_event` からチップ除去分を再計算して `session_cash_detail.chip_remove_total` をバックフィルし、影響を受けていた `currency_transaction.amount` も併せて再同期するマイグレーションを追加(冪等)。

手動作成セッション(チップ除去イベントが存在しない)には影響ありません。

## テスト

- `computeCashGamePL` の単体テストを追加。
- `toProfitLossSeriesPoint` / `fetchStatsRows` がチップ除去分をP/L・EV損益に反映することを検証するテストを追加。
- `recalculateCashGameSession` が `chipRemoveTotal` を insert / update 双方のパスで永続化することを検証するテストを追加。
- `session.update` によるセッション編集後も `currencyTransaction.amount` がチップ除去分を含んだ値に再同期されることを検証するテストを追加。
- `session_cash_detail` スキーマテストを新カラムに合わせて更新。
- マイグレーションをローカルD1に適用し、既存の全マイグレーション履歴からエラーなく最新まで到達することを確認。

```
bun run lint && bun run check-types && bun run check:rules && bun run test
```
すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QbQUjVujRQ6ZXD3Q7TUeYD)_