### PR TITLE
feat(ai): モデル ID を一箇所に集約し全 AI 機能を最新モデルに揃える

### DIFF
--- a/.claude/rules/ai-models.md
+++ b/.claude/rules/ai-models.md
@@ -31,7 +31,7 @@ Models API を引いて日付順で最新を選ぶ方式は採らない。モデ
 
 ## モデルを上げるときのチェックリスト
 
-1. `shared/model-migration.md` 相当の移行情報で、対象モデルの破壊的変更を確認する（`/claude-api migrate` が使える）。
+1. 対象モデルの破壊的変更を確認する。Claude Code なら `/claude-api migrate`、それ以外は公式の移行ガイド <https://platform.claude.com/docs/en/about-claude/models/migration-guide> を読む。
 2. `thinking` / `effort` / サンプリングパラメータの扱いが変わっていないか、既存の呼び出しを確認する。
 3. `max_tokens` に thinking の余地があるか確認する。
 4. プロンプトの挙動変化（冗長さ、ツール呼び出し頻度）を実機で確認する。プロンプト文言はテストで固定しない（実装詳細なので、調整のたびにテストを直す手間だけが残る）。

--- a/.claude/rules/ai-models.md
+++ b/.claude/rules/ai-models.md
@@ -21,7 +21,7 @@ Models API を引いて日付順で最新を選ぶ方式は採らない。モデ
 
 - Opus 5 で thinking がデフォルト ON（`thinking` 未指定でも thinking が走る）
 - Opus 4.7 で `temperature` / `top_p` / `top_k` / `budget_tokens` が削除（送ると 400）
-- Sonnet 5 でトークナイザが変わり、同じ入力が約 1.3 倍のトークンになった
+- Opus 4.7 でトークナイザが変わり、それ以前のモデルと比べて同じ入力が約 1.3 倍のトークンになった（Opus 4.8 / Opus 5 / Sonnet 5 / Fable 5 はこの新トークナイザ。世代を跨がない更新ではトークン数の見積りは変わらない）
 
 日付順の自動選択は、単価やティアの違うモデル（preview 系、Haiku 系、$10/$50 の Fable 系）にも黙って乗り換わる。
 

--- a/.claude/rules/ai-models.md
+++ b/.claude/rules/ai-models.md
@@ -1,0 +1,37 @@
+---
+paths:
+  - "packages/api/**"
+  - "apps/web/**"
+  - "apps/server/**"
+---
+
+# Claude Model Selection
+
+Why this file exists: モデル ID がインラインリテラルで各所に散ると、機能ごとに世代がずれる。実際に `extractTablePlayers` を Opus 5 に上げた時点で `extractTournamentData` が Opus 4.8 に取り残された（PR #572）。方針は「**全 AI 機能が常に同じ最新モデルを使う**」。
+
+## モデル ID は `packages/api/src/ai/models.ts` にしか書かない
+
+- 新しいモデルが出たら [`LATEST_MODEL`](../../packages/api/src/ai/models.ts) を書き換える。それだけで全機能が追従する。
+- 呼び出し側は `AI_MODELS.<機能名>` を使う。新しい AI 機能を足すときは `AI_MODELS` にキーを 1 つ増やす。`satisfies Record<string, typeof LATEST_MODEL>` により、古いモデル ID を割り当てると **型エラー**になる。
+- `scripts/check-rules.ts` が `models.ts` 以外での `claude-*` リテラルを禁止する（Anthropic SDK の `Model` 型は `string & {}` を含む緩いユニオンなので、型チェックだけではタイポも旧モデルの直書きも検出できない）。
+
+## 実行時に「最新」を自動解決しない
+
+Models API を引いて日付順で最新を選ぶ方式は採らない。モデル更新は破壊的 API 変更を伴うため、人間のレビューを通す:
+
+- Opus 5 で thinking がデフォルト ON（`thinking` 未指定でも thinking が走る）
+- Opus 4.7 で `temperature` / `top_p` / `top_k` / `budget_tokens` が削除（送ると 400）
+- Sonnet 5 でトークナイザが変わり、同じ入力が約 1.3 倍のトークンになった
+
+日付順の自動選択は、単価やティアの違うモデル（preview 系、Haiku 系、$10/$50 の Fable 系）にも黙って乗り換わる。
+
+## `max_tokens` は thinking の分を含めて取る
+
+`max_tokens` は thinking と応答テキストの**合計**に対する上限で、Opus 5 以降 thinking はデフォルト ON。出力サイズぎりぎりに設定すると thinking が食い潰し、構造化出力が途中で切れて `parsed_output` が null になる（= `AI did not return structured data` で失敗）。抽出系は [`EXTRACTION_MAX_TOKENS`](../../packages/api/src/ai/models.ts) を使う。生成された分しか課金されないので、余裕を持たせてもコストは増えない。
+
+## モデルを上げるときのチェックリスト
+
+1. `shared/model-migration.md` 相当の移行情報で、対象モデルの破壊的変更を確認する（`/claude-api migrate` が使える）。
+2. `thinking` / `effort` / サンプリングパラメータの扱いが変わっていないか、既存の呼び出しを確認する。
+3. `max_tokens` に thinking の余地があるか確認する。
+4. プロンプトの挙動変化（冗長さ、ツール呼び出し頻度）を実機で確認する。プロンプト文言はテストで固定しない（実装詳細なので、調整のたびにテストを直す手間だけが残る）。

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -232,6 +232,9 @@ jobs:
         run: bun run --filter web build
         env:
           VITE_SERVER_URL: ${{ needs.setup.outputs.dev_api_url }}
+          # vite-plugin-github-releases が Releases API を叩く。未認証だと
+          # 60 req/時/IP の制限に共有ランナーで引っかかり、403 でビルドが落ちる。
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Cloudflare Pages
         run: |

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -276,6 +276,9 @@ jobs:
           VITE_PREVIEW_AUTO_LOGIN: "true"
           VITE_PREVIEW_LOGIN_EMAIL: ${{ secrets.PREVIEW_LOGIN_EMAIL }}
           VITE_PREVIEW_LOGIN_PASSWORD: ${{ secrets.PREVIEW_LOGIN_PASSWORD }}
+          # vite-plugin-github-releases が Releases API を叩く。未認証だと
+          # 60 req/時/IP の制限に共有ランナーで引っかかり、403 でビルドが落ちる。
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Cloudflare Pages
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,7 @@ The following rule files live in `.claude/rules/` and are loaded automatically w
 | `web-ui.md` | `apps/web/**` | PageHeader, shadcn primitives (Table / Badge / Avatar / RadioGroup), mobile = Drawer, tabler-icons. |
 | `web-data-fetching.md` | `apps/web/**` | Optimistic updates must go through `utils/optimistic-update.ts` helpers. |
 | `web-theme.md` | `apps/web/**` | Sapphire 2 Design System (single theme): token format, semantic colors, typography roles, sheet patterns. |
+| `ai-models.md` | `packages/api/**`, `apps/web/**`, `apps/server/**` | Claude のモデル ID は `packages/api/src/ai/models.ts` にのみ書く（全 AI 機能が常に同じ最新モデルを使う）。`max_tokens` は thinking の分を含める。 |
 | `api-security.md` | `packages/api/**`, `apps/server/**` | Object-level authorization: every input FK id ownership-checked, scoped bulk WHEREs / joins / cursors, uniform FORBIDDEN, no server-side fetch of user URLs. |
 | `api-data-integrity.md` | `packages/api/**`, `packages/db/**` | Zod input conventions (`.int().min(0)`, create/update refine parity, shared write/read schemas) and D1 hazards (100-bind-param chunking, `db.batch()`, N+1, keyset pagination). |
 | `datetime-and-numbers.md` | `apps/web/**`, `packages/api/**` | Date-only values are UTC midnight (read with UTC getters), day-crossing handling + backfill, period boundaries, shared locale-fixed number formatters. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,9 +90,8 @@ When adding a feature, create `apps/web/src/features/<name>/` and colocate every
 Detailed rules live in [`.claude/rules/`](.claude/rules/); the points below apply everywhere in `apps/web/` and are worth keeping top of mind:
 
 - **UI copy is English-only.** No Japanese in user-facing strings (labels, empty states, toasts, errors). Japanese is fine in comments, commit messages, and PR descriptions.
-- **Mobile forms are bottom sheets** (shadcn `Drawer`, not `Dialog`) and **pages start with [`PageHeader`](apps/web/src/shared/components/page-header/page-header.tsx)** — details in [`.claude/rules/web-ui.md`](.claude/rules/web-ui.md).
+- **Mobile forms are bottom sheets** (shadcn `Drawer`, not `Dialog`), **pages start with [`PageHeader`](apps/web/src/shared/components/page-header/page-header.tsx)**, and **the only theme is the Sapphire 2 Design System** (tokens in `apps/web/src/index.css`, referenced as `var(--token)` — the `hsl()` wrapper is already included) — [`.claude/rules/web-ui.md`](.claude/rules/web-ui.md), [`.claude/rules/web-theme.md`](.claude/rules/web-theme.md).
 - **Logic lives in `useXxx` hooks, not in components.** Components render JSX from destructured hook returns. Verification & full forbidden list: [`.claude/rules/web-hooks-separation.md`](.claude/rules/web-hooks-separation.md).
-- **Single theme: Sapphire 2 Design System.** Tokens live in `apps/web/src/index.css` (`:root` / `.dark`) and apply app-wide — there is no legacy theme and no `theme-v2` scope class. Color tokens include the `hsl()` wrapper: reference them as `var(--token)`, never `hsl(var(--token))`. Design rules: [`.claude/rules/web-theme.md`](.claude/rules/web-theme.md).
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,9 @@ packages/
 Detailed rules live in [`.claude/rules/`](.claude/rules/); the points below apply everywhere in `apps/web/` and are worth keeping top of mind:
 
 - **UI copy is English-only.** No Japanese in user-facing strings (labels, empty states, toasts, errors). Japanese is fine in comments, commit messages, and PR descriptions.
-- **Mobile forms are bottom sheets** (shadcn `Drawer`, not `Dialog`), **pages start with [`PageHeader`](apps/web/src/shared/components/page-header/page-header.tsx)**, and **the only theme is the Sapphire 2 Design System** (tokens in `apps/web/src/index.css`, referenced as `var(--token)` — the `hsl()` wrapper is already included) — [`.claude/rules/web-ui.md`](.claude/rules/web-ui.md), [`.claude/rules/web-theme.md`](.claude/rules/web-theme.md).
+- **Mobile forms are bottom sheets** (shadcn `Drawer`, not `Dialog`) and **pages start with [`PageHeader`](apps/web/src/shared/components/page-header/page-header.tsx)** — details in [`.claude/rules/web-ui.md`](.claude/rules/web-ui.md).
 - **Logic lives in `useXxx` hooks, not in components.** Components render JSX from destructured hook returns. Verification & full forbidden list: [`.claude/rules/web-hooks-separation.md`](.claude/rules/web-hooks-separation.md).
+- **Single theme: Sapphire 2 Design System.** Tokens live in `apps/web/src/index.css` (`:root` / `.dark`) and apply app-wide — there is no legacy theme and no `theme-v2` scope class. Color tokens include the `hsl()` wrapper: reference them as `var(--token)`, never `hsl(var(--token))`. Design rules: [`.claude/rules/web-theme.md`](.claude/rules/web-theme.md).
 
 ## Testing
 

--- a/packages/api/src/__tests__/ai-extract-sources.test.ts
+++ b/packages/api/src/__tests__/ai-extract-sources.test.ts
@@ -4,12 +4,6 @@ import {
 	TABLE_PLAYER_SOURCE_APPS,
 } from "../routers/ai-extract-sources";
 
-const SEAT_RE = /seat/i;
-const CLOCKWISE_RE = /clockwise/i;
-const IS_HERO_RE = /isHero/;
-const NULL_RE = /null/;
-const OMIT_RE = /omit/i;
-
 describe("ai-extract-sources constants", () => {
 	it("exposes dmm_waitinglist as the only known source app id", () => {
 		expect(TABLE_PLAYER_SOURCE_APP_IDS).toEqual(["dmm_waitinglist"]);
@@ -30,23 +24,6 @@ describe("ai-extract-sources constants", () => {
 			expect(typeof cfg.prompt).toBe("string");
 			expect(cfg.prompt.length).toBeGreaterThan(0);
 		}
-	});
-
-	it("dmm_waitinglist prompt mentions seat numbering convention", () => {
-		const prompt = TABLE_PLAYER_SOURCE_APPS.dmm_waitinglist.prompt;
-		expect(prompt).toMatch(SEAT_RE);
-		expect(prompt).toMatch(CLOCKWISE_RE);
-	});
-
-	it("dmm_waitinglist prompt includes hero detection guidance", () => {
-		const prompt = TABLE_PLAYER_SOURCE_APPS.dmm_waitinglist.prompt;
-		expect(prompt).toMatch(IS_HERO_RE);
-		expect(prompt).toMatch(NULL_RE);
-	});
-
-	it("dmm_waitinglist prompt instructs to omit empty/unreadable seats", () => {
-		const prompt = TABLE_PLAYER_SOURCE_APPS.dmm_waitinglist.prompt;
-		expect(prompt).toMatch(OMIT_RE);
 	});
 
 	it("exactly as many config entries as ids", () => {

--- a/packages/api/src/__tests__/ai-extract-sources.test.ts
+++ b/packages/api/src/__tests__/ai-extract-sources.test.ts
@@ -9,6 +9,7 @@ const CLOCKWISE_RE = /clockwise/i;
 const IS_HERO_RE = /isHero/;
 const NULL_RE = /null/;
 const OMIT_RE = /omit/i;
+const EMPTY_SEAT_NUMBER_ONLY_RE = /only its seat number/i;
 
 describe("ai-extract-sources constants", () => {
 	it("exposes dmm_waitinglist as the only known source app id", () => {
@@ -47,6 +48,11 @@ describe("ai-extract-sources constants", () => {
 	it("dmm_waitinglist prompt instructs to omit empty/unreadable seats", () => {
 		const prompt = TABLE_PLAYER_SOURCE_APPS.dmm_waitinglist.prompt;
 		expect(prompt).toMatch(OMIT_RE);
+	});
+
+	it("dmm_waitinglist prompt explains that an unoccupied seat shows only its seat number", () => {
+		const prompt = TABLE_PLAYER_SOURCE_APPS.dmm_waitinglist.prompt;
+		expect(prompt).toMatch(EMPTY_SEAT_NUMBER_ONLY_RE);
 	});
 
 	it("exactly as many config entries as ids", () => {

--- a/packages/api/src/__tests__/ai-extract-sources.test.ts
+++ b/packages/api/src/__tests__/ai-extract-sources.test.ts
@@ -9,7 +9,6 @@ const CLOCKWISE_RE = /clockwise/i;
 const IS_HERO_RE = /isHero/;
 const NULL_RE = /null/;
 const OMIT_RE = /omit/i;
-const EMPTY_SEAT_NUMBER_ONLY_RE = /only its seat number/i;
 
 describe("ai-extract-sources constants", () => {
 	it("exposes dmm_waitinglist as the only known source app id", () => {
@@ -48,11 +47,6 @@ describe("ai-extract-sources constants", () => {
 	it("dmm_waitinglist prompt instructs to omit empty/unreadable seats", () => {
 		const prompt = TABLE_PLAYER_SOURCE_APPS.dmm_waitinglist.prompt;
 		expect(prompt).toMatch(OMIT_RE);
-	});
-
-	it("dmm_waitinglist prompt explains that an unoccupied seat shows only its seat number", () => {
-		const prompt = TABLE_PLAYER_SOURCE_APPS.dmm_waitinglist.prompt;
-		expect(prompt).toMatch(EMPTY_SEAT_NUMBER_ONLY_RE);
 	});
 
 	it("exactly as many config entries as ids", () => {

--- a/packages/api/src/__tests__/ai-extract-truncation.test.ts
+++ b/packages/api/src/__tests__/ai-extract-truncation.test.ts
@@ -1,0 +1,194 @@
+import { TRPCError } from "@trpc/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	create: vi.fn(),
+	parse: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+	default: class {
+		messages = { create: mocks.create, parse: mocks.parse };
+	},
+}));
+
+vi.mock("@anthropic-ai/sdk/helpers/zod", () => ({
+	zodOutputFormat: () => ({ type: "json_schema" }),
+}));
+
+const { appRouter } = await import("../routers");
+
+const IMAGE_SOURCE = {
+	kind: "image" as const,
+	data: "base64data",
+	mediaType: "image/png" as const,
+};
+
+function makeCaller() {
+	return appRouter.createCaller({
+		session: { user: { id: "user-1" } },
+		anthropicApiKey: "test-key",
+	} as unknown as Parameters<typeof appRouter.createCaller>[0]).aiExtract;
+}
+
+async function expectMessage(
+	promise: Promise<unknown>,
+	message: string
+): Promise<void> {
+	try {
+		await promise;
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe("INTERNAL_SERVER_ERROR");
+		expect((error as TRPCError).message).toBe(message);
+		return;
+	}
+	throw new Error(`expected the call to throw "${message}" but it resolved`);
+}
+
+beforeEach(() => {
+	mocks.create.mockReset();
+	mocks.parse.mockReset();
+});
+
+describe("extractTablePlayers truncation reporting", () => {
+	it("reports truncation when the response hit max_tokens", async () => {
+		// Opus 5 以降 thinking はデフォルト ON で max_tokens を共有するため、
+		// 打ち切りは現実に起こりうる失敗経路。
+		mocks.parse.mockResolvedValue({
+			parsed_output: null,
+			stop_reason: "max_tokens",
+		});
+
+		await expectMessage(
+			makeCaller().extractTablePlayers({
+				sourceApp: "dmm_waitinglist",
+				sources: [IMAGE_SOURCE],
+			}),
+			"AI response was truncated (max_tokens reached)"
+		);
+	});
+
+	it("reports a missing structured output when the turn ended normally", async () => {
+		mocks.parse.mockResolvedValue({
+			parsed_output: null,
+			stop_reason: "end_turn",
+		});
+
+		await expectMessage(
+			makeCaller().extractTablePlayers({
+				sourceApp: "dmm_waitinglist",
+				sources: [IMAGE_SOURCE],
+			}),
+			"AI did not return structured data"
+		);
+	});
+
+	it("returns deduped seats on success", async () => {
+		mocks.parse.mockResolvedValue({
+			parsed_output: {
+				seats: [
+					{ seatNumber: 1, name: "Alice", isHero: true },
+					{ seatNumber: 1, name: "Duplicate", isHero: false },
+					{ seatNumber: 2, name: "Bob", isHero: false },
+				],
+			},
+			stop_reason: "end_turn",
+		});
+
+		const result = await makeCaller().extractTablePlayers({
+			sourceApp: "dmm_waitinglist",
+			sources: [IMAGE_SOURCE],
+		});
+
+		expect(result).toEqual({
+			seats: [
+				{ seatNumber: 1, name: "Alice", isHero: true },
+				{ seatNumber: 2, name: "Bob", isHero: false },
+			],
+		});
+	});
+});
+
+describe("extractTournamentData truncation reporting", () => {
+	it("reports truncation when no tool_use block came back at max_tokens", async () => {
+		mocks.create.mockResolvedValue({
+			content: [{ type: "text", text: "partial" }],
+			stop_reason: "max_tokens",
+		});
+
+		await expectMessage(
+			makeCaller().extractTournamentData({ sources: [IMAGE_SOURCE] }),
+			"AI response was truncated (max_tokens reached)"
+		);
+	});
+
+	it("reports missing structured data when the turn ended without a tool_use block", async () => {
+		mocks.create.mockResolvedValue({
+			content: [{ type: "text", text: "no tool call" }],
+			stop_reason: "end_turn",
+		});
+
+		await expectMessage(
+			makeCaller().extractTournamentData({ sources: [IMAGE_SOURCE] }),
+			"AI did not return structured data"
+		);
+	});
+
+	it("reports truncation when a tool_use block was cut off mid-input", async () => {
+		// 打ち切りでは tool_use ブロック自体は返るが input が途中で切れるため、
+		// スキーマ不一致と区別できる必要がある。
+		mocks.create.mockResolvedValue({
+			content: [
+				{
+					type: "tool_use",
+					name: "extract_tournament_data",
+					input: { buyIn: -1 },
+				},
+			],
+			stop_reason: "max_tokens",
+		});
+
+		await expectMessage(
+			makeCaller().extractTournamentData({ sources: [IMAGE_SOURCE] }),
+			"AI response was truncated (max_tokens reached)"
+		);
+	});
+
+	it("reports a parse failure when the schema rejects a complete response", async () => {
+		mocks.create.mockResolvedValue({
+			content: [
+				{
+					type: "tool_use",
+					name: "extract_tournament_data",
+					input: { buyIn: -1 },
+				},
+			],
+			stop_reason: "end_turn",
+		});
+
+		await expectMessage(
+			makeCaller().extractTournamentData({ sources: [IMAGE_SOURCE] }),
+			"Failed to parse AI response"
+		);
+	});
+
+	it("returns the parsed tournament data on success", async () => {
+		mocks.create.mockResolvedValue({
+			content: [
+				{
+					type: "tool_use",
+					name: "extract_tournament_data",
+					input: { name: "Daily", buyIn: 5000, tableSize: 9 },
+				},
+			],
+			stop_reason: "end_turn",
+		});
+
+		const result = await makeCaller().extractTournamentData({
+			sources: [IMAGE_SOURCE],
+		});
+
+		expect(result).toEqual({ name: "Daily", buyIn: 5000, tableSize: 9 });
+	});
+});

--- a/packages/api/src/__tests__/ai-extract-truncation.test.ts
+++ b/packages/api/src/__tests__/ai-extract-truncation.test.ts
@@ -84,6 +84,25 @@ describe("extractTablePlayers truncation reporting", () => {
 		);
 	});
 
+	it("reports truncation even when the partial output satisfies the schema", async () => {
+		// seats は `.default([])` なので、打ち切りで潰れた出力でも
+		// 「空席だけのテーブル」として成功扱いになりうる。
+		mocks.parse.mockResolvedValue({
+			parsed_output: {
+				seats: [{ seatNumber: 1, name: "Alice", isHero: null }],
+			},
+			stop_reason: "max_tokens",
+		});
+
+		await expectMessage(
+			makeCaller().extractTablePlayers({
+				sourceApp: "dmm_waitinglist",
+				sources: [IMAGE_SOURCE],
+			}),
+			"AI response was truncated (max_tokens reached)"
+		);
+	});
+
 	it("returns deduped seats on success", async () => {
 		mocks.parse.mockResolvedValue({
 			parsed_output: {
@@ -170,6 +189,50 @@ describe("extractTournamentData truncation reporting", () => {
 		await expectMessage(
 			makeCaller().extractTournamentData({ sources: [IMAGE_SOURCE] }),
 			"Failed to parse AI response"
+		);
+	});
+
+	it("reports truncation when a partial blind structure still satisfies the schema", async () => {
+		// max_tokens を食い潰す唯一の可変長フィールドが blindLevels なので、
+		// 打ち切りは「途中までしか入っていない配列」という schema-valid な形で
+		// 現れるのが最頻ケース。全フィールドが .optional() のため safeParse は
+		// 通ってしまい、stop_reason を見ないとブラインド構成が黙って欠ける。
+		mocks.create.mockResolvedValue({
+			content: [
+				{
+					type: "tool_use",
+					name: "extract_tournament_data",
+					input: {
+						name: "Daily",
+						blindLevels: [
+							{ isBreak: false, blind1: 100, blind2: 200 },
+							{ isBreak: false, blind1: 200, blind2: 400 },
+						],
+					},
+				},
+			],
+			stop_reason: "max_tokens",
+		});
+
+		await expectMessage(
+			makeCaller().extractTournamentData({ sources: [IMAGE_SOURCE] }),
+			"AI response was truncated (max_tokens reached)"
+		);
+	});
+
+	it("reports truncation when the tool input collapsed to an empty object", async () => {
+		// 全フィールド optional なので {} でも safeParse は success になり、
+		// 「抽出できたが空」というエラーより悪い出方をしうる。
+		mocks.create.mockResolvedValue({
+			content: [
+				{ type: "tool_use", name: "extract_tournament_data", input: {} },
+			],
+			stop_reason: "max_tokens",
+		});
+
+		await expectMessage(
+			makeCaller().extractTournamentData({ sources: [IMAGE_SOURCE] }),
+			"AI response was truncated (max_tokens reached)"
 		);
 	});
 

--- a/packages/api/src/__tests__/ai-extract.test.ts
+++ b/packages/api/src/__tests__/ai-extract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
 	ExtractedTournamentDataSchema,
+	TABLE_PLAYERS_MODEL,
 	TOOL_INPUT_SCHEMA,
 } from "../routers/ai-extract";
 import {
@@ -28,6 +29,10 @@ describe("aiExtract router", () => {
 		expect(Object.keys(appRouter.aiExtract).sort()).toEqual(
 			["extractTablePlayers", "extractTournamentData"].sort()
 		);
+	});
+
+	it("seats extraction runs on Opus 5", () => {
+		expect(TABLE_PLAYERS_MODEL).toBe("claude-opus-5");
 	});
 
 	it("both procedures are protected mutations", () => {

--- a/packages/api/src/__tests__/ai-extract.test.ts
+++ b/packages/api/src/__tests__/ai-extract.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import { appRouter } from "../routers";
 import {
 	ExtractedTournamentDataSchema,
-	TABLE_PLAYERS_MODEL,
 	TOOL_INPUT_SCHEMA,
 } from "../routers/ai-extract";
 import {
@@ -29,10 +28,6 @@ describe("aiExtract router", () => {
 		expect(Object.keys(appRouter.aiExtract).sort()).toEqual(
 			["extractTablePlayers", "extractTournamentData"].sort()
 		);
-	});
-
-	it("seats extraction runs on Opus 5", () => {
-		expect(TABLE_PLAYERS_MODEL).toBe("claude-opus-5");
 	});
 
 	it("both procedures are protected mutations", () => {

--- a/packages/api/src/ai/__tests__/models.test.ts
+++ b/packages/api/src/ai/__tests__/models.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { AI_MODELS, EXTRACTION_MAX_TOKENS, LATEST_MODEL } from "../models";
+
+describe("AI model registry", () => {
+	it("pins every AI feature to the latest model", () => {
+		const entries = Object.entries(AI_MODELS);
+		expect(entries.length).toBeGreaterThan(0);
+		for (const [feature, model] of entries) {
+			expect(model, `${feature} must use LATEST_MODEL`).toBe(LATEST_MODEL);
+		}
+	});
+
+	it("leaves room for thinking inside max_tokens", () => {
+		// Opus 5 以降 thinking はデフォルト ON で、max_tokens は thinking と
+		// 応答テキストの合計に対する上限。出力サイズぎりぎりだと thinking が
+		// 食い潰して構造化出力が途中で切れる。
+		expect(EXTRACTION_MAX_TOKENS).toBeGreaterThanOrEqual(4096);
+	});
+});

--- a/packages/api/src/ai/__tests__/models.test.ts
+++ b/packages/api/src/ai/__tests__/models.test.ts
@@ -1,15 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { AI_MODELS, EXTRACTION_MAX_TOKENS, LATEST_MODEL } from "../models";
+import { EXTRACTION_MAX_TOKENS } from "../models";
 
+// AI_MODELS の各エントリが LATEST_MODEL であることは models.ts の
+// `satisfies Record<string, typeof LATEST_MODEL>` が型で、呼び出し側に
+// リテラルを直書きしないことは scripts/check-rules.ts が担保している。
 describe("AI model registry", () => {
-	it("pins every AI feature to the latest model", () => {
-		const entries = Object.entries(AI_MODELS);
-		expect(entries.length).toBeGreaterThan(0);
-		for (const [feature, model] of entries) {
-			expect(model, `${feature} must use LATEST_MODEL`).toBe(LATEST_MODEL);
-		}
-	});
-
 	it("leaves room for thinking inside max_tokens", () => {
 		// Opus 5 以降 thinking はデフォルト ON で、max_tokens は thinking と
 		// 応答テキストの合計に対する上限。出力サイズぎりぎりだと thinking が

--- a/packages/api/src/ai/models.ts
+++ b/packages/api/src/ai/models.ts
@@ -3,11 +3,10 @@
  * `LATEST_MODEL` を書き換えるだけで全機能が追従する。
  * `scripts/check-rules.ts` がこのファイル以外での `claude-*` リテラルを禁止する。
  *
- * 実行時に Models API から「最新」を解決しない理由: モデル更新は破壊的な
- * API 変更を伴う（Opus 5 で thinking がデフォルト ON、Opus 4.7 で
- * `temperature` / `budget_tokens` 削除、Sonnet 5 でトークナイザ変更）。
- * 日付順の自動選択は単価やティアの違うモデル（preview 系、Haiku 系）にも
- * 黙って乗り換わるため、更新は人間のレビューを通す。
+ * 実行時に Models API から「最新」を解決しない。モデル更新は破壊的な API 変更を
+ * 伴い、日付順の自動選択は単価やティアの違うモデルにも黙って乗り換わるため、
+ * 更新は人間のレビューを通す。破壊的変更の実例とモデルを上げるときの手順は
+ * `.claude/rules/ai-models.md` に一本化してある（同じ列挙をここに複製しない）。
  */
 export const LATEST_MODEL = "claude-opus-5";
 

--- a/packages/api/src/ai/models.ts
+++ b/packages/api/src/ai/models.ts
@@ -1,0 +1,31 @@
+/**
+ * AI 機能で使うモデル ID の唯一の置き場所。新しいモデルが出たら
+ * `LATEST_MODEL` を書き換えるだけで全機能が追従する。
+ * `scripts/check-rules.ts` がこのファイル以外での `claude-*` リテラルを禁止する。
+ *
+ * 実行時に Models API から「最新」を解決しない理由: モデル更新は破壊的な
+ * API 変更を伴う（Opus 5 で thinking がデフォルト ON、Opus 4.7 で
+ * `temperature` / `budget_tokens` 削除、Sonnet 5 でトークナイザ変更）。
+ * 日付順の自動選択は単価やティアの違うモデル（preview 系、Haiku 系）にも
+ * 黙って乗り換わるため、更新は人間のレビューを通す。
+ */
+export const LATEST_MODEL = "claude-opus-5";
+
+/**
+ * 機能ごとのモデル。`satisfies` により、`LATEST_MODEL` 以外の ID を
+ * 割り当てると型エラーになる。
+ */
+export const AI_MODELS = {
+	/** シーティング（スクリーンショットからの着席者読み取り）。 */
+	seating: LATEST_MODEL,
+	/** トーナメント情報の抽出。 */
+	tournamentExtraction: LATEST_MODEL,
+} as const satisfies Record<string, typeof LATEST_MODEL>;
+
+/**
+ * 抽出系リクエストの出力上限。`max_tokens` は thinking と応答テキストの
+ * 合計に対する上限で、Opus 5 以降 thinking はデフォルト ON。出力サイズ
+ * ぎりぎりに設定すると thinking が食い潰して構造化出力が途中で切れるため、
+ * 実際の出力より十分大きく取る（生成された分しか課金されない）。
+ */
+export const EXTRACTION_MAX_TOKENS = 8192;

--- a/packages/api/src/routers/ai-extract-sources.ts
+++ b/packages/api/src/routers/ai-extract-sources.ts
@@ -28,6 +28,7 @@ Hero detection:
 
 Extraction rules:
 - Include only seats whose names are readable in the \`seats\` array.
+- A seat with nobody seated displays only its seat number and no player name. Treat those as empty seats.
 - Omit empty seats and seats whose names are unclear.
 - Return only the player name; strip surrounding symbols, decorations, and stack / chip count displays.
 - Player names may be in Japanese (hiragana, katakana, kanji), English, or a mix. Preserve the exact characters as shown, do not translate or romanize.`,

--- a/packages/api/src/routers/ai-extract.ts
+++ b/packages/api/src/routers/ai-extract.ts
@@ -62,28 +62,26 @@ export type ExtractedTournamentData = z.infer<
 const MAX_SEAT_NUMBER = 9;
 
 /**
+ * 打ち切られた応答は、スキーマを通っても不完全なので受け付けない。
  * thinking は `max_tokens` を応答テキストと共有するため（Opus 5 以降は
  * デフォルト ON）、枠を使い切ると構造化出力が途中で切れる。打ち切りと
- * 「モデルが構造化出力を返さなかった」は原因も対処も違うので、
- * `stop_reason` を見てメッセージを分ける。
+ * 「モデルが構造化出力を返さなかった」は原因も対処も違うので分けて報告する。
  */
-function structuredOutputError(
-	stopReason: string | null | undefined
-): TRPCError {
-	return new TRPCError({
-		code: "INTERNAL_SERVER_ERROR",
-		message:
-			stopReason === "max_tokens"
-				? "AI response was truncated (max_tokens reached)"
-				: "AI did not return structured data",
-	});
-}
-
-/** 打ち切られた応答は、スキーマを通っても不完全なので受け付けない。 */
 function assertNotTruncated(stopReason: string | null | undefined): void {
 	if (stopReason === "max_tokens") {
-		throw structuredOutputError(stopReason);
+		throw new TRPCError({
+			code: "INTERNAL_SERVER_ERROR",
+			message: "AI response was truncated (max_tokens reached)",
+		});
 	}
+}
+
+/** 打ち切り以外の理由で構造化出力が返らなかった場合。 */
+function missingStructuredOutputError(): TRPCError {
+	return new TRPCError({
+		code: "INTERNAL_SERVER_ERROR",
+		message: "AI did not return structured data",
+	});
 }
 
 const ExtractedTablePlayersSchema = z.object({
@@ -252,7 +250,7 @@ export const aiExtractRouter = router({
 
 			const toolUse = response.content.find((c) => c.type === "tool_use");
 			if (!toolUse || toolUse.type !== "tool_use") {
-				throw structuredOutputError(response.stop_reason);
+				throw missingStructuredOutputError();
 			}
 
 			const parsed = ExtractedTournamentDataSchema.safeParse(toolUse.input);
@@ -323,7 +321,7 @@ export const aiExtractRouter = router({
 
 			const parsedOutput = response.parsed_output;
 			if (!parsedOutput) {
-				throw structuredOutputError(response.stop_reason);
+				throw missingStructuredOutputError();
 			}
 
 			const seenSeatNumbers = new Set<number>();

--- a/packages/api/src/routers/ai-extract.ts
+++ b/packages/api/src/routers/ai-extract.ts
@@ -79,6 +79,13 @@ function structuredOutputError(
 	});
 }
 
+/** 打ち切られた応答は、スキーマを通っても不完全なので受け付けない。 */
+function assertNotTruncated(stopReason: string | null | undefined): void {
+	if (stopReason === "max_tokens") {
+		throw structuredOutputError(stopReason);
+	}
+}
+
 const ExtractedTablePlayersSchema = z.object({
 	seats: z
 		.array(
@@ -235,6 +242,14 @@ export const aiExtractRouter = router({
 				messages: [{ role: "user", content: contentBlocks }],
 			});
 
+			// 打ち切りは tool_use が返るかどうかにも parse の成否にもよらず起こる。
+			// ExtractedTournamentDataSchema は全フィールドが .optional() なので、
+			// 途中までの input（極端には {}）でも safeParse は通ってしまう。
+			// max_tokens を食い潰す可変長フィールドは blindLevels なので、打ち切りは
+			// 「途中までしか入っていない配列」として現れるのが最頻ケースであり、
+			// 先に stop_reason を見ないとブラインド構成が黙って欠けたまま保存される。
+			assertNotTruncated(response.stop_reason);
+
 			const toolUse = response.content.find((c) => c.type === "tool_use");
 			if (!toolUse || toolUse.type !== "tool_use") {
 				throw structuredOutputError(response.stop_reason);
@@ -242,11 +257,6 @@ export const aiExtractRouter = router({
 
 			const parsed = ExtractedTournamentDataSchema.safeParse(toolUse.input);
 			if (!parsed.success) {
-				// 打ち切られた場合は tool_use ブロックが返っても input が
-				// 途中で切れるため、スキーマ不一致と原因が異なる。
-				if (response.stop_reason === "max_tokens") {
-					throw structuredOutputError(response.stop_reason);
-				}
 				throw new TRPCError({
 					code: "INTERNAL_SERVER_ERROR",
 					message: "Failed to parse AI response",
@@ -305,6 +315,11 @@ export const aiExtractRouter = router({
 				},
 				messages: [{ role: "user", content: contentBlocks }],
 			});
+
+			// seats は .default([]) なので、打ち切りで潰れた出力でも
+			// 「空席だけのテーブル」として成功扱いになりうる。SDK の
+			// 不完全 JSON の扱いに依存しないよう、先に stop_reason を見る。
+			assertNotTruncated(response.stop_reason);
 
 			const parsedOutput = response.parsed_output;
 			if (!parsedOutput) {

--- a/packages/api/src/routers/ai-extract.ts
+++ b/packages/api/src/routers/ai-extract.ts
@@ -61,6 +61,24 @@ export type ExtractedTournamentData = z.infer<
 
 const MAX_SEAT_NUMBER = 9;
 
+/**
+ * thinking は `max_tokens` を応答テキストと共有するため（Opus 5 以降は
+ * デフォルト ON）、枠を使い切ると構造化出力が途中で切れる。打ち切りと
+ * 「モデルが構造化出力を返さなかった」は原因も対処も違うので、
+ * `stop_reason` を見てメッセージを分ける。
+ */
+function structuredOutputError(
+	stopReason: string | null | undefined
+): TRPCError {
+	return new TRPCError({
+		code: "INTERNAL_SERVER_ERROR",
+		message:
+			stopReason === "max_tokens"
+				? "AI response was truncated (max_tokens reached)"
+				: "AI did not return structured data",
+	});
+}
+
 const ExtractedTablePlayersSchema = z.object({
 	seats: z
 		.array(
@@ -219,14 +237,16 @@ export const aiExtractRouter = router({
 
 			const toolUse = response.content.find((c) => c.type === "tool_use");
 			if (!toolUse || toolUse.type !== "tool_use") {
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message: "AI did not return structured data",
-				});
+				throw structuredOutputError(response.stop_reason);
 			}
 
 			const parsed = ExtractedTournamentDataSchema.safeParse(toolUse.input);
 			if (!parsed.success) {
+				// 打ち切られた場合は tool_use ブロックが返っても input が
+				// 途中で切れるため、スキーマ不一致と原因が異なる。
+				if (response.stop_reason === "max_tokens") {
+					throw structuredOutputError(response.stop_reason);
+				}
 				throw new TRPCError({
 					code: "INTERNAL_SERVER_ERROR",
 					message: "Failed to parse AI response",
@@ -288,10 +308,7 @@ export const aiExtractRouter = router({
 
 			const parsedOutput = response.parsed_output;
 			if (!parsedOutput) {
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message: "AI did not return structured data",
-				});
+				throw structuredOutputError(response.stop_reason);
 			}
 
 			const seenSeatNumbers = new Set<number>();

--- a/packages/api/src/routers/ai-extract.ts
+++ b/packages/api/src/routers/ai-extract.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
 import { TRPCError } from "@trpc/server";
 import z from "zod";
+import { AI_MODELS, EXTRACTION_MAX_TOKENS } from "../ai/models";
 import { protectedProcedure, router } from "../index";
 import {
 	TABLE_PLAYER_SOURCE_APP_IDS,
@@ -59,9 +60,6 @@ export type ExtractedTournamentData = z.infer<
 >;
 
 const MAX_SEAT_NUMBER = 9;
-
-/** シーティング（着席者読み取り）に使うモデル。 */
-export const TABLE_PLAYERS_MODEL = "claude-opus-5";
 
 const ExtractedTablePlayersSchema = z.object({
 	seats: z
@@ -205,8 +203,8 @@ export const aiExtractRouter = router({
 			});
 
 			const response = await client.messages.create({
-				model: "claude-opus-4-8",
-				max_tokens: 2048,
+				model: AI_MODELS.tournamentExtraction,
+				max_tokens: EXTRACTION_MAX_TOKENS,
 				tools: [
 					{
 						name: "extract_tournament_data",
@@ -280,8 +278,8 @@ export const aiExtractRouter = router({
 			];
 
 			const response = await client.messages.parse({
-				model: TABLE_PLAYERS_MODEL,
-				max_tokens: 1024,
+				model: AI_MODELS.seating,
+				max_tokens: EXTRACTION_MAX_TOKENS,
 				output_config: {
 					format: zodOutputFormat(ExtractedTablePlayersSchema),
 				},

--- a/packages/api/src/routers/ai-extract.ts
+++ b/packages/api/src/routers/ai-extract.ts
@@ -60,6 +60,9 @@ export type ExtractedTournamentData = z.infer<
 
 const MAX_SEAT_NUMBER = 9;
 
+/** シーティング（着席者読み取り）に使うモデル。 */
+export const TABLE_PLAYERS_MODEL = "claude-opus-5";
+
 const ExtractedTablePlayersSchema = z.object({
 	seats: z
 		.array(
@@ -277,7 +280,7 @@ export const aiExtractRouter = router({
 			];
 
 			const response = await client.messages.parse({
-				model: "claude-opus-4-8",
+				model: TABLE_PLAYERS_MODEL,
 				max_tokens: 1024,
 				output_config: {
 					format: zodOutputFormat(ExtractedTablePlayersSchema),

--- a/scripts/check-rules.ts
+++ b/scripts/check-rules.ts
@@ -87,6 +87,13 @@ const CHECKS: Check[] = [
 		excludePath: /__tests__|\.test\./,
 	},
 	{
+		name: "inline Claude model id — import it from packages/api/src/ai/models.ts",
+		rule: ".claude/rules/ai-models.md",
+		globs: ["apps/**/*.{ts,tsx}", "packages/**/*.{ts,tsx}"],
+		pattern: /claude-(fable|mythos|opus|sonnet|haiku)-/,
+		excludePath: /packages\/api\/src\/ai\/models\.ts$/,
+	},
+	{
 		name: "GitHub pull-request head ref assigned inside a run script — pass it through step env",
 		rule: "GitHub Actions shell-injection prevention",
 		cwd: ".github",

--- a/scripts/check-rules.ts
+++ b/scripts/check-rules.ts
@@ -87,10 +87,20 @@ const CHECKS: Check[] = [
 		excludePath: /__tests__|\.test\./,
 	},
 	{
+		// クォート付きの `claude-*` リテラルを丸ごと禁止する。世代名の列挙だと
+		// 旧形式（claude-3-5-sonnet-20241022 のように claude- の直後が数字）を
+		// 取りこぼす。クォート必須なので .claude/rules/... のようなパス文字列や
+		// 散文中の claude-* には当たらない。ワークフロー YAML は対象外 —
+		// pre-merge-review.yml の `--model opus` は可動エイリアスで、
+		// 常に最新 Opus を指すため固定 ID の管理対象ではない。
 		name: "inline Claude model id — import it from packages/api/src/ai/models.ts",
 		rule: ".claude/rules/ai-models.md",
-		globs: ["apps/**/*.{ts,tsx}", "packages/**/*.{ts,tsx}"],
-		pattern: /claude-(fable|mythos|opus|sonnet|haiku)-/,
+		globs: [
+			"apps/**/*.{ts,tsx}",
+			"packages/**/*.{ts,tsx}",
+			"scripts/**/*.{ts,tsx}",
+		],
+		pattern: /["'`]claude-[\dA-Za-z._-]+["'`]/,
 		excludePath: /packages\/api\/src\/ai\/models\.ts$/,
 	},
 	{


### PR DESCRIPTION
## 概要

AI シーティングのモデルを Opus 5 に上げる依頼から始まり、「**全 AI 機能が常に最新モデルを使う**」仕組みまで含める形になりました。

1. モデル ID を `packages/api/src/ai/models.ts` に集約し、`LATEST_MODEL` の 1 行でアップグレードできるようにした
2. シーティングとトーナメント抽出の両方を `claude-opus-5` に統一
3. `max_tokens` を引き上げ、打ち切り時にそれと分かるようにした（Opus 5 の thinking デフォルト ON への対応）
4. AI シーティングのプロンプトに空席の判定基準を追記
5. 型・`check-rules`・ルールファイルで方針を維持する仕組みを追加

## 変更内容

### `packages/api/src/ai/models.ts`（新規）

```ts
export const LATEST_MODEL = "claude-opus-5";

export const AI_MODELS = {
	seating: LATEST_MODEL,
	tournamentExtraction: LATEST_MODEL,
} as const satisfies Record<string, typeof LATEST_MODEL>;

export const EXTRACTION_MAX_TOKENS = 8192;
```

モデル ID の唯一の置き場所です。新モデルが出たら `LATEST_MODEL` を書き換えるだけで全機能が追従し、新しい AI 機能を足すときは `AI_MODELS` にキーを 1 つ増やすだけでその時点の最新に乗ります。`satisfies` により古いモデル ID の割り当ては型エラーになります。

実行時に Models API から「最新」を解決する方式は採っていません。モデル更新は破壊的 API 変更を伴い（Opus 5 の thinking デフォルト ON、Opus 4.7 の `temperature` / `budget_tokens` 削除・トークナイザ変更）、日付順の自動選択は単価やティアの違うモデルにも黙って乗り換わるため、更新は人間のレビューを通します。

### `packages/api/src/routers/ai-extract.ts`

- `extractTablePlayers`（シーティング）: `claude-opus-4-8` → `AI_MODELS.seating`（= Opus 5）
- `extractTournamentData`（トーナメント抽出）: `claude-opus-4-8` → `AI_MODELS.tournamentExtraction`（= Opus 5）
- `max_tokens`: 1024 / 2048 → `EXTRACTION_MAX_TOKENS`（8192）
- 打ち切り（`stop_reason === "max_tokens"`）を通常の構造化出力失敗と区別

`max_tokens` の引き上げは挙動リスクの解消です。Opus 5 は thinking がデフォルト ON で、`max_tokens` は thinking と応答テキストの**合計**に対する上限なので、従来値では thinking が食い潰して構造化出力が途中で切れ、`parsed_output` が null になる経路がありました。生成された分しか課金されないため、余裕を持たせてもコストは増えません。

その失敗が実際に起きたときに打ち切りだと分かるよう、エラーメッセージを分けました:

| 状況 | メッセージ |
|---|---|
| thinking が枠を食い潰して切れた | `AI response was truncated (max_tokens reached)` |
| モデルが構造化出力を返さなかった | `AI did not return structured data` |
| スキーマ不一致（完全な応答） | `Failed to parse AI response` |

トーナメント側は打ち切りでも `tool_use` ブロック自体は返り `input` だけが切れるため、`safeParse` 失敗時にも `stop_reason` を見て区別しています。

### `packages/api/src/routers/ai-extract-sources.ts`

DMM Waitinglist 用プロンプトの Extraction rules に 1 行追加:

> A seat with nobody seated displays only its seat number and no player name. Treat those as empty seats.

既存の「空席・判読不能なシートは `seats` から除外する」ルールの直前に置き、何を空席と見なすかの基準を明示しています。

### `scripts/check-rules.ts`

`models.ts` 以外での `claude-*` リテラルを禁止するチェックを追加しました。Anthropic SDK の `Model` 型は `string & {}` を含む緩いユニオンなので、呼び出し側にモデル ID を直書きしても型チェックでは検出できません。

pattern はクォート付きの `claude-*` 全体を対象にしており、`claude-` の直後が数字の旧形式 ID（`claude-3-5-sonnet-20241022` 等）も捕まえます。追加時に green であることに加え、**実際に違反を検出するか**も確認済みです:

| 試したこと | 結果 |
|---|---|
| 呼び出し側に `model: "claude-opus-4-8"` を書き戻す | 該当行を指して FAIL |
| `const m = "claude-3-5-sonnet-20241022"` を含むファイルを追加 | 該当行を指して FAIL |

いずれも確認後に元へ戻しており、差分には残っていません。

### `.github/workflows/preview-deploy.yml` / `dev-deploy.yml`

**AI モデル集約とは独立した修正です。** この PR の CI で `deploy-web` が失敗し、調査したところリポジトリ既存の断続的な失敗でした。

ビルド時に走る `vite-plugin-github-releases` が GitHub Releases API を叩き、非 2xx で例外を投げてビルドを落とします。プラグインは `process.env.GITHUB_TOKEN` があれば認証しますが、preview / dev のビルドステップに渡っていませんでした。未認証の GitHub API は 60 req/時/IP なので、共有ランナーで枯渇すると 403 になります（同じジョブが同一ブランチで 2 回成功した後に失敗したのがその証拠です）。

`production-deploy.yml:95` は既に `GITHUB_TOKEN` を渡していたので、渡し漏れだった 2 ファイルを本番に揃えました。修正後 `deploy-web` は success になっています。

### `.claude/rules/ai-models.md`（新規）+ `AGENTS.md`

方針・理由・モデルを上げるときのチェックリストをルールファイルに残し、AGENTS.md の索引に 1 行追加しました（AGENTS.md への変更は索引 1 行のみ）。

## テスト

### 追加

- `packages/api/src/ai/__tests__/models.test.ts` — `EXTRACTION_MAX_TOKENS` が thinking の余地を持つこと（1024 / 2048 に戻せば red）
- `packages/api/src/__tests__/ai-extract-truncation.test.ts` — 打ち切り / 構造化出力なし / スキーマ不一致の各分岐と正常系。`@anthropic-ai/sdk` をモックし `appRouter.createCaller` で procedure を実行する形で、既存の `player.test.ts` / `stats.test.ts` と同じパターンです

いずれも TDD で先に red を確認してから実装しました。

### 置いていないテスト

値をテストに二重記述するだけのものは置いていません:

- プロンプト文言のテスト（regex 3 件）は削除しました。文言は実装詳細であり、調整のたびにテストを直す手間だけが残るためです。この判断は `.claude/rules/ai-models.md` に方針として明文化しています。
- `AI_MODELS` の各エントリが `LATEST_MODEL` であることのテストも置いていません。各エントリは `LATEST_MODEL` そのものを代入しているため構造上 red にならず、担保は `satisfies`（型）と `check-rules`（呼び出し側の直書き禁止）にあります。

### 検証結果

- `bunx vitest run --project api` → 1552 passed（42 files）
- `bun run lint` → 1256 files checked, no fixes applied
- `bun run check-types` → server / web ともに exit 0
- `bun run check:rules` → all checks passed

## 補足

- `dev`（`a74f625`）をマージ済みです。取り込んだルールに従い、この PR 向けに設定していた自己チェックインは削除しました。
- `effort` は既定（`high`）のままにしています。この種の narrow な抽出は `low` / `medium` でも精度が出るため、コストとレイテンシを詰めたい場合は別途調整できます。
- 実 API での動作確認は行っていません（この環境に `ANTHROPIC_API_KEY` がないため）。強制ツール利用と Opus 5 の thinking デフォルト ON の互換性は公式ドキュメントで確認済みです（制約は手動 extended thinking 限定 / adaptive は強制ツール利用をサポート）。