### PR TITLE
fix: PR #574 のレビュー指摘（0049 バックフィルの防御化ほか）に対応

### DIFF
--- a/.claude/rules/db-migrations.md
+++ b/.claude/rules/db-migrations.md
@@ -35,6 +35,48 @@ When you hand-write a migration, still run `db:generate` afterward (see below) s
 in sync — let it write the fresh snapshot, then replace/delete its auto `.sql` so `wrangler` applies
 your intended SQL.
 
+## A migration file is NOT one transaction in production
+
+`wrangler d1 migrations apply` streams the statements of a file to D1; there is no file-wide
+transaction, and `d1_migrations` only advances after the last statement succeeds. A statement that
+fails halfway therefore leaves the earlier objects created **and** the migration unrecorded, so the
+retry dies on `table already exists`. `migration-00NN.test.ts` helpers that wrap the file in
+`BEGIN` / `ROLLBACK` model the local (`bun:sqlite`) behavior, not production — never cite them as
+evidence that a migration rolls back.
+
+Consequences for any migration that touches existing rows:
+
+- **Make every statement re-runnable**: `CREATE TABLE / INDEX / TRIGGER IF NOT EXISTS`,
+  `INSERT OR IGNORE` for backfills. Cover it with a test that applies the file twice.
+- **Make backfills unable to abort.** Constraints introduced by the same migration are, by
+  definition, not enforced on the legacy rows being backfilled. Resolve references with an
+  `INNER JOIN` against the owning table, collapse duplicates with `GROUP BY`, renumber ordering
+  columns with `ROW_NUMBER() OVER (PARTITION BY …)`, and read possibly-malformed JSON through
+  `CASE WHEN json_valid(x) = 0 THEN '[]' WHEN json_type(x) <> 'array' THEN '[]' ELSE x END` —
+  `json_each()` raises on malformed input, and a `WHERE` clause cannot guard it because the
+  table-valued function is evaluated first.
+- **Audit production before merging** so the rows the backfill would drop are known, not
+  discovered later. `0049_normalize_game_mix_variants` normalized `game_mix.games` (a JSON id
+  array) into `game_mix_variant`; the shape below generalizes to any JSON-array → junction-table
+  normalization (run with `bunx wrangler d1 execute <db> --remote --command "…"`):
+
+  ```sql
+  -- 1. malformed or non-array payloads — run this FIRST: json_each() below
+  --    raises on malformed input, so a non-empty result invalidates 2 and 3.
+  SELECT id FROM game_mix WHERE json_valid(games) = 0 OR json_type(games) <> 'array';
+
+  -- 2. references that resolve to no variant owned by the same user
+  SELECT m.id, m.user_id, g.value
+  FROM game_mix AS m, json_each(m.games) AS g
+  LEFT JOIN game_variant AS v
+    ON v.id = CAST(g.value AS text) AND v.user_id = m.user_id
+  WHERE v.id IS NULL;
+
+  -- 3. the same id repeated inside one mix
+  SELECT m.id, g.value, COUNT(*) FROM game_mix AS m, json_each(m.games) AS g
+  GROUP BY m.id, g.value HAVING COUNT(*) > 1;
+  ```
+
 ## The Drizzle `meta/` ledger
 
 `bun run db:generate` (`drizzle-kit generate`) does **not** apply anything — it diffs the current

--- a/packages/api/src/__tests__/game-mix.test.ts
+++ b/packages/api/src/__tests__/game-mix.test.ts
@@ -882,7 +882,78 @@ describe("gameMix normalized membership persistence", () => {
 			OWNED_VARIANT_1.id,
 		]);
 		expect(selectedTables).toEqual([MIX_TABLE, MIX_VARIANT_TABLE]);
-		expect(selectWhereParams).toEqual([[CUR_OWNER], [CUR_OWNER]]);
+		expect(selectWhereParams).toEqual([
+			[CUR_OWNER],
+			[CUR_OWNER, "mix-a", "mix-b"],
+		]);
+	});
+
+	it("narrows the junction read to the listed mixes instead of scanning the owner", async () => {
+		const { caller, selectWhereParams } = gameMixCaller(CUR_OWNER, {
+			[GROUP_TABLE]: [OWNED_GROUP],
+			[VARIANT_TABLE]: [OWNED_VARIANT_1],
+			[MIX_TABLE]: [
+				{ id: "mix-a", userId: CUR_OWNER, builtinKey: null, label: "A" },
+				{ id: "mix-b", userId: CUR_OWNER, builtinKey: null, label: "B" },
+			],
+			[MIX_VARIANT_TABLE]: [
+				{
+					mixId: "mix-a",
+					variantId: OWNED_VARIANT_1.id,
+					userId: CUR_OWNER,
+					position: 0,
+				},
+			],
+		});
+
+		await caller.list();
+
+		expect(selectWhereParams.at(-1)).toEqual([CUR_OWNER, "mix-a", "mix-b"]);
+	});
+
+	it("keeps the junction read owner-scoped only when the id list would overflow D1's bind cap", async () => {
+		const mixes = Array.from({ length: 100 }, (_, index) => ({
+			id: `mix-${index}`,
+			userId: CUR_OWNER,
+			builtinKey: null,
+			label: `Mix ${index}`,
+		}));
+		const { caller, selectWhereParams } = gameMixCaller(CUR_OWNER, {
+			[GROUP_TABLE]: [OWNED_GROUP],
+			[VARIANT_TABLE]: [OWNED_VARIANT_1],
+			[MIX_TABLE]: mixes,
+			[MIX_VARIANT_TABLE]: [],
+		});
+
+		await caller.list();
+
+		expect(selectWhereParams.at(-1)).toEqual([CUR_OWNER]);
+	});
+
+	it("hydrates a label-only update from a single-mix junction read", async () => {
+		const { caller, selectWhereParams } = gameMixCaller(CUR_OWNER, {
+			[GROUP_TABLE]: [OWNED_GROUP],
+			[VARIANT_TABLE]: [OWNED_VARIANT_1],
+			[MIX_TABLE]: [
+				{ id: "mix-1", userId: CUR_OWNER, builtinKey: null, label: "Renamed" },
+			],
+			[MIX_VARIANT_TABLE]: [
+				{
+					mixId: "mix-1",
+					variantId: OWNED_VARIANT_1.id,
+					userId: CUR_OWNER,
+					position: 0,
+				},
+			],
+		});
+
+		const updated = (await caller.update({
+			id: "mix-1",
+			label: "Renamed",
+		})) as { games: string[] };
+
+		expect(updated.games).toEqual([OWNED_VARIANT_1.id]);
+		expect(selectWhereParams.at(-1)).toEqual([CUR_OWNER, "mix-1"]);
 	});
 
 	it("creates a 30-game mix with normalized rows and a compatibility mirror in one batch", async () => {
@@ -929,6 +1000,39 @@ describe("gameMix normalized membership persistence", () => {
 		expect(new Set(memberships.map((row) => row.mixId)).size).toBe(1);
 		expect(batch).toHaveBeenCalledTimes(1);
 		expect(batch.mock.calls[0]?.[0]).toHaveLength(4);
+	});
+
+	it("chunks membership inserts by the row's real column count, not a literal width", async () => {
+		const variants = Array.from({ length: 30 }, (_, index) => ({
+			id: `variant-${index}`,
+			userId: CUR_OWNER,
+			groupId: OWNED_GROUP.id,
+			label: `Variant ${index}`,
+		}));
+		const { caller, inserted } = gameMixCaller(CUR_OWNER, {
+			[GROUP_TABLE]: [OWNED_GROUP],
+			[VARIANT_TABLE]: variants,
+			[MIX_TABLE]: [{ id: "placeholder", userId: CUR_OWNER, label: "P" }],
+			[MIX_VARIANT_TABLE]: [],
+		});
+
+		await caller.create({
+			label: "Thirty Game",
+			games: variants.map((variant) => variant.id),
+		});
+
+		const chunks = (inserted[MIX_VARIANT_TABLE] ?? []).map((entry) =>
+			Array.isArray(entry) ? entry : [entry]
+		) as Record<string, unknown>[][];
+		const columnsPerRow = Object.keys(chunks[0]?.[0] ?? {}).length;
+		expect(columnsPerRow).toBeGreaterThan(0);
+		expect(chunks.map((chunk) => chunk.length)).toEqual([
+			Math.floor(100 / columnsPerRow),
+			30 - Math.floor(100 / columnsPerRow),
+		]);
+		for (const chunk of chunks) {
+			expect(chunk.length * columnsPerRow).toBeLessThanOrEqual(100);
+		}
 	});
 
 	it("replaces a 30-game composition and compatibility mirror atomically", async () => {

--- a/packages/api/src/__tests__/seed-game-data-unresolvable-variant.test.ts
+++ b/packages/api/src/__tests__/seed-game-data-unresolvable-variant.test.ts
@@ -1,0 +1,128 @@
+import { gameGroup } from "@sapphire2/db/schema/game-group";
+import { gameMix } from "@sapphire2/db/schema/game-mix";
+import { gameVariant } from "@sapphire2/db/schema/game-variant";
+import { getTableName } from "drizzle-orm";
+import { describe, expect, it, vi } from "vitest";
+import { seedDefaultGameData } from "../services/seed-game-data";
+import { createChainableMockDb } from "./test-utils";
+
+// A dedicated file because it replaces the seed constants module-wide: the
+// point is the failure mode where a mix's variantKeys do NOT all resolve to a
+// seeded variant, which cannot be expressed with the real (self-consistent)
+// DEFAULT_GAME_* data.
+vi.mock("@sapphire2/db/constants/game-variants", () => ({
+	DEFAULT_GAME_GROUPS: [
+		{
+			key: "limit",
+			label: "Limit",
+			blind1Label: "Small Bet",
+			blind2Label: "Big Bet",
+			blind3Label: null,
+		},
+	],
+	DEFAULT_GAME_VARIANTS: [
+		{
+			key: "lhe",
+			label: "Limit Hold'em",
+			shortLabel: "LHE",
+			groupKey: "limit",
+		},
+	],
+	DEFAULT_GAME_MIXES: [
+		// Every key resolves — the healthy control.
+		{ key: "solo", label: "Solo", variantKeys: ["lhe"] },
+		// No key resolves — `memberships` is empty for this mix.
+		{ key: "ghost", label: "Ghost", variantKeys: ["not-seeded"] },
+		// Partially resolvable — the known keys must still be seeded.
+		{ key: "partial", label: "Partial", variantKeys: ["not-seeded", "lhe"] },
+	],
+}));
+
+const USER_ID = "user-1";
+const GROUP_TABLE = getTableName(gameGroup);
+const VARIANT_TABLE = getTableName(gameVariant);
+const MIX_TABLE = getTableName(gameMix);
+const MIX_VARIANT_TABLE = "game_mix_variant";
+
+function emptyAccountDb() {
+	return createChainableMockDb({
+		select: { [GROUP_TABLE]: [], [VARIANT_TABLE]: [] },
+	});
+}
+
+function membershipRows(inserted: Record<string, unknown[]>) {
+	return (inserted[MIX_VARIANT_TABLE] ?? []).flatMap((entry) =>
+		Array.isArray(entry) ? entry : [entry]
+	) as Record<string, unknown>[];
+}
+
+describe("seedDefaultGameData with an unresolvable mix variantKey", () => {
+	it("never emits an insert with zero membership rows (Drizzle throws on values([]))", async () => {
+		const { db, inserted } = emptyAccountDb();
+
+		await seedDefaultGameData(db, USER_ID);
+
+		for (const write of inserted[MIX_VARIANT_TABLE] ?? []) {
+			expect(Array.isArray(write) ? write : [write]).not.toHaveLength(0);
+		}
+	});
+
+	it("still seeds the mix master row whose composition resolved to nothing", async () => {
+		const { db, inserted } = emptyAccountDb();
+
+		await seedDefaultGameData(db, USER_ID);
+
+		const mixes = inserted[MIX_TABLE] as Record<string, unknown>[];
+		expect(mixes.map((row) => row.builtinKey)).toEqual([
+			"solo",
+			"ghost",
+			"partial",
+		]);
+		expect(
+			membershipRows(inserted).map((row) => row.mixId as string)
+		).not.toContain(`${USER_ID}:builtin-mix:ghost`);
+	});
+
+	it("seeds the resolvable subset of a partially resolvable mix at dense positions", async () => {
+		const { db, inserted } = emptyAccountDb();
+
+		await seedDefaultGameData(db, USER_ID);
+
+		expect(
+			membershipRows(inserted).filter(
+				(row) => row.mixId === `${USER_ID}:builtin-mix:partial`
+			)
+		).toEqual([
+			{
+				mixId: `${USER_ID}:builtin-mix:partial`,
+				position: 0,
+				userId: USER_ID,
+				variantId: `${USER_ID}:builtin-variant:lhe`,
+			},
+		]);
+	});
+
+	it("batches one statement per emitted write and resolves without throwing", async () => {
+		const { db, batch } = emptyAccountDb();
+
+		await expect(seedDefaultGameData(db, USER_ID)).resolves.toBeUndefined();
+		expect(batch).toHaveBeenCalledTimes(1);
+		// 1 group + 1 variant + 3 mix masters + 3 mirror updates + 2 membership
+		// inserts (the empty "ghost" one is skipped).
+		expect(batch.mock.calls[0]?.[0]).toHaveLength(10);
+	});
+
+	it("still mirrors an empty composition into the legacy games column", async () => {
+		const { db, updated } = emptyAccountDb();
+
+		await seedDefaultGameData(db, USER_ID);
+
+		expect(
+			(updated[MIX_TABLE] as Record<string, unknown>[]).map((row) => row.games)
+		).toEqual([
+			[`${USER_ID}:builtin-variant:lhe`],
+			[],
+			[`${USER_ID}:builtin-variant:lhe`],
+		]);
+	});
+});

--- a/packages/api/src/lib/batch.ts
+++ b/packages/api/src/lib/batch.ts
@@ -12,6 +12,14 @@ type DbInstance = Database;
 export type BatchStatement = Parameters<DbInstance["batch"]>[0][number];
 
 /**
+ * D1 rejects any single statement binding more than 100 parameters. Lives here
+ * rather than in session.ts so a service can size its own `IN (…)` list against
+ * the same number without importing from a router (which would close an import
+ * cycle: routers/session.ts already imports services/game-mix.ts).
+ */
+export const D1_MAX_BOUND_PARAMS = 100;
+
+/**
  * Commit a group of writes atomically. D1's `db.batch` requires a NON-EMPTY
  * tuple; an empty array is treated as a no-op (nothing to write). Every
  * caller builds its statements first, then hands the whole group to a single

--- a/packages/api/src/routers/game-mix.ts
+++ b/packages/api/src/routers/game-mix.ts
@@ -88,6 +88,18 @@ function mixMembershipRows(
 }
 
 /**
+ * Split membership rows across INSERTs that stay under D1's 100-bind-param cap.
+ * The width comes from the row shape rather than a literal, so adding a column
+ * to gameMixVariant cannot silently overflow the cap (a 30-game mix is well
+ * under it today, but the next column would put 25-row chunks at 125 params).
+ */
+function chunkMembershipRows(
+	rows: (typeof gameMixVariant.$inferInsert)[]
+): (typeof gameMixVariant.$inferInsert)[][] {
+	return chunkForInsert(rows, Object.keys(rows[0] ?? {}).length || 1);
+}
+
+/**
  * A mix built from variants spanning more than `MAX_MIX_GROUPS` distinct game
  * groups can never be turned into a session's `mixGames` (that array is
  * itself capped at `MAX_MIX_GROUPS` groups via `mixGamesSchema` /
@@ -155,12 +167,16 @@ export const gameMixRouter = router({
 					}),
 				];
 				const rows = mixMembershipRows(id, userId, input.games);
-				for (const chunk of chunkForInsert(rows, 4)) {
+				for (const chunk of chunkMembershipRows(rows)) {
 					statements.push(ctx.db.insert(gameMixVariant).values(chunk));
 				}
 				// Keep the pre-0049 Worker contract valid until the later contract
-				// migration. This statement runs last so the compatibility trigger
-				// sees the complete normalized composition.
+				// migration. This statement runs last so 0049's compatibility trigger
+				// rebuilds the same rows from the mirror it just wrote. While that
+				// trigger exists the JSON column is the effective derivation source;
+				// the explicit junction writes above are what keeps this procedure
+				// correct once the contract migration drops the trigger, and both
+				// paths produce identical rows.
 				statements.push(
 					ctx.db
 						.update(gameMix)
@@ -239,14 +255,15 @@ export const gameMixRouter = router({
 							)
 					);
 					const rows = mixMembershipRows(input.id, userId, input.games);
-					for (const chunk of chunkForInsert(rows, 4)) {
+					for (const chunk of chunkMembershipRows(rows)) {
 						statements.push(ctx.db.insert(gameMixVariant).values(chunk));
 					}
 					updateData.games = input.games;
 				}
-				// Update the compatibility mirror last. 0049's trigger replaces the
-				// same normalized rows atomically, while old Workers can still write
-				// the legacy column during a rolling deployment or rollback.
+				// Update the compatibility mirror last. 0049's trigger then replaces
+				// the normalized rows written above with byte-identical ones, while
+				// old Workers can still write the legacy column during a rolling
+				// deployment or rollback (same expand-phase note as create()).
 				statements.push(
 					ctx.db
 						.update(gameMix)

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -47,7 +47,11 @@ import {
 import type { SQLiteColumn, SQLiteTable } from "drizzle-orm/sqlite-core";
 import z from "zod";
 import { protectedProcedure, router } from "../index";
-import { type BatchStatement, runBatch } from "../lib/batch";
+import {
+	type BatchStatement,
+	D1_MAX_BOUND_PARAMS,
+	runBatch,
+} from "../lib/batch";
 import { optionalUniqueTagIdsSchema } from "../lib/tag-ids";
 import { listOwnedGameMixes } from "../services/game-mix";
 import { ensureSessionResultTypeId } from "../services/session-result-type";
@@ -124,8 +128,8 @@ function computeTournamentPL(
  * stays under the cap. session_blind_level is at exactly 10 columns → 10 rows
  * per INSERT (10 × 10 = 100); adding an 11th column requires dropping the
  * chunk size to 9 or the re-INSERT overflows after the DELETE has committed.
+ * The cap itself lives in lib/batch.ts so services can share it.
  */
-const D1_MAX_BOUND_PARAMS = 100;
 
 export function chunkForInsert<T>(rows: T[], columnsPerRow: number): T[][] {
 	const perChunk = Math.max(1, Math.floor(D1_MAX_BOUND_PARAMS / columnsPerRow));

--- a/packages/api/src/services/game-mix.ts
+++ b/packages/api/src/services/game-mix.ts
@@ -1,15 +1,25 @@
 import type { Database } from "@sapphire2/db";
 import { gameMix, gameMixVariant } from "@sapphire2/db/schema/game-mix";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
+import { D1_MAX_BOUND_PARAMS } from "../lib/batch";
 
 export type GameMixWithGames = typeof gameMix.$inferSelect & {
 	games: string[];
 };
 
 /**
+ * How many mix ids may join the owner predicate in one `IN (…)`. The userId
+ * comparison binds the remaining parameter of D1's per-statement cap.
+ */
+const MAX_MIX_IDS_PER_LOOKUP = D1_MAX_BOUND_PARAMS - 1;
+
+/**
  * Reconstructs the public `games: string[]` contract from normalized rows.
  * Memberships are owner-scoped and fetched once for the whole input collection
- * rather than once per mix.
+ * rather than once per mix. The id list is bound too whenever it fits under
+ * D1's bind-param cap, so hydrating a single mix (gameMix.update's label-only
+ * path) does not read every membership row the caller owns; beyond that the
+ * query stays owner-scoped and the extra rows are bucketed away below.
  */
 export async function hydrateOwnedGameMixes(
 	db: Database,
@@ -22,17 +32,21 @@ export async function hydrateOwnedGameMixes(
 	}
 
 	const mixIds = new Set(ownedMixes.map((mix) => mix.id));
+	const ownerScope = eq(gameMixVariant.userId, userId);
 	const memberships = (
 		await db
 			.select({
 				mixId: gameMixVariant.mixId,
 				position: gameMixVariant.position,
-				userId: gameMixVariant.userId,
 				variantId: gameMixVariant.variantId,
 			})
 			.from(gameMixVariant)
-			.where(eq(gameMixVariant.userId, userId))
-	).filter((row) => row.userId === userId && mixIds.has(row.mixId));
+			.where(
+				mixIds.size <= MAX_MIX_IDS_PER_LOOKUP
+					? and(ownerScope, inArray(gameMixVariant.mixId, [...mixIds]))
+					: ownerScope
+			)
+	).filter((row) => mixIds.has(row.mixId));
 
 	const gamesByMixId = new Map<string, typeof memberships>();
 	for (const membership of memberships) {

--- a/packages/api/src/services/seed-game-data.ts
+++ b/packages/api/src/services/seed-game-data.ts
@@ -161,9 +161,16 @@ export async function seedDefaultGameData(
 			userId,
 			variantId,
 		}));
-		statements.push(
-			db.insert(gameMixVariant).values(memberships).onConflictDoNothing()
-		);
+		// Fail closed like the `groupId` guard above: if a future data-entry
+		// mistake leaves a mix with no resolvable variantKey, seed the master row
+		// with an empty composition rather than handing Drizzle `values([])`,
+		// which throws — and would turn gameGroup/gameVariant/gameMix `list` (all
+		// of which call this without a try/catch) into a 500 for that user.
+		if (memberships.length > 0) {
+			statements.push(
+				db.insert(gameMixVariant).values(memberships).onConflictDoNothing()
+			);
+		}
 		// Keep the physical games column synchronized for the pre-0049 Worker
 		// during migration-first deploys and rollback. The compatibility trigger
 		// applies the same ordered rows after this normalized insert.
@@ -175,8 +182,9 @@ export async function seedDefaultGameData(
 		);
 	}
 
-	// All 33 statements (3 groups + 21 variants + 3 mix masters + 3 membership
-	// batches + 3 mirror updates) commit atomically (SA2-116), so a failure cannot
+	// Every statement (3 groups + 21 variants + 3 mix masters + up to 3 membership
+	// batches + 3 mirror updates — 33 with the current constants, fewer if a mix
+	// resolves to no variants) commits atomically (SA2-116), so a failure cannot
 	// leave a user with partial built-in game data.
 	try {
 		await runBatch(db, statements);

--- a/packages/db/src/__tests__/migration-0049.test.ts
+++ b/packages/db/src/__tests__/migration-0049.test.ts
@@ -350,20 +350,108 @@ skipIfNotBun("migration 0049 — normalized game mix variants", () => {
 		expect(db.query("PRAGMA foreign_key_check").values()).toEqual([]);
 	});
 
-	it("rolls back instead of discarding duplicate legacy data", () => {
-		seedLegacyRows(db);
-		db.exec(`UPDATE game_mix SET games = '["variant-1","variant-1"]'
-			WHERE id = 'mix-ordered'`);
+	// Pre-0041 writes had no DB-side protection on game_mix.games, so legacy
+	// rows can still violate this table's PK / owner FK. The migration is not
+	// applied atomically in production (wrangler streams statements to D1), so
+	// the backfill must never abort — it drops what the API already treats as
+	// unusable instead.
+	describe("defensive backfill of legacy game_mix.games rows", () => {
+		it("collapses a repeated id to its first occurrence instead of aborting", () => {
+			seedLegacyRows(db);
+			db.exec(`UPDATE game_mix
+				SET games = '["variant-1","variant-2","variant-1"]'
+				WHERE id = 'mix-ordered'`);
 
-		expect(() => applyAtomically(db)).toThrow(UNIQUE_CONSTRAINT_PATTERN);
-		expect(
-			db.query("SELECT games FROM game_mix WHERE id = 'mix-ordered'").get()
-		).toEqual({ games: '["variant-1","variant-1"]' });
-		expect(
-			db
-				.query(`SELECT name FROM sqlite_master
-				WHERE type = 'table' AND name = 'game_mix_variant'`)
-				.values()
-		).toEqual([]);
+			expect(() => applyAtomically(db)).not.toThrow();
+			expect(
+				db
+					.query(`SELECT variant_id, position FROM game_mix_variant
+						WHERE mix_id = 'mix-ordered' ORDER BY position`)
+					.values()
+			).toEqual([
+				["variant-1", 0],
+				["variant-2", 1],
+			]);
+			expect(
+				db.query("SELECT games FROM game_mix WHERE id = 'mix-ordered'").get()
+			).toEqual({ games: '["variant-1","variant-2","variant-1"]' });
+		});
+
+		it("drops ids that resolve to no variant and renumbers positions densely", () => {
+			seedLegacyRows(db);
+			db.exec(`UPDATE game_mix
+				SET games = '["deleted-variant","variant-1","variant-2"]'
+				WHERE id = 'mix-ordered'`);
+
+			expect(() => applyAtomically(db)).not.toThrow();
+			expect(
+				db
+					.query(`SELECT variant_id, position FROM game_mix_variant
+						WHERE mix_id = 'mix-ordered' ORDER BY position`)
+					.values()
+			).toEqual([
+				["variant-1", 0],
+				["variant-2", 1],
+			]);
+			expect(db.query("PRAGMA foreign_key_check").values()).toEqual([]);
+		});
+
+		it("drops ids owned by another user", () => {
+			seedLegacyRows(db);
+			db.exec(`UPDATE game_mix
+				SET games = '["variant-3","variant-1"]'
+				WHERE id = 'mix-ordered'`);
+
+			expect(() => applyAtomically(db)).not.toThrow();
+			expect(
+				db
+					.query(`SELECT variant_id, position FROM game_mix_variant
+						WHERE mix_id = 'mix-ordered' ORDER BY position`)
+					.values()
+			).toEqual([["variant-1", 0]]);
+		});
+
+		it("skips malformed JSON, non-array JSON, and non-string entries", () => {
+			seedLegacyRows(db);
+			db.exec(`
+				UPDATE game_mix SET games = 'not json at all' WHERE id = 'mix-ordered';
+				UPDATE game_mix SET games = '{"variant-1":true}' WHERE id = 'mix-empty';
+				UPDATE game_mix SET games = '[1,null,"variant-1"]' WHERE id = 'mix-user-2';
+			`);
+
+			expect(() => applyAtomically(db)).not.toThrow();
+			expect(
+				db
+					.query(`SELECT mix_id, variant_id, position FROM game_mix_variant
+						ORDER BY mix_id, position`)
+					.values()
+			).toEqual([]);
+			expect(
+				db.query("SELECT games FROM game_mix WHERE id = 'mix-ordered'").get()
+			).toEqual({ games: "not json at all" });
+		});
+
+		it("re-applies cleanly after a partial application (no file-wide transaction)", () => {
+			seedLegacyRows(db);
+			applyAtomically(db);
+			const rowsAfterFirstApply = db
+				.query(`SELECT mix_id, variant_id, user_id, position
+					FROM game_mix_variant ORDER BY mix_id, position`)
+				.values();
+
+			expect(() => applyAtomically(db)).not.toThrow();
+			expect(
+				db
+					.query(`SELECT mix_id, variant_id, user_id, position
+						FROM game_mix_variant ORDER BY mix_id, position`)
+					.values()
+			).toEqual(rowsAfterFirstApply);
+			expect(
+				db
+					.query(`SELECT name, tbl_name FROM sqlite_master
+						WHERE type = 'trigger' ORDER BY name`)
+					.values()
+			).toEqual(FINAL_TRIGGERS);
+		});
 	});
 });

--- a/packages/db/src/migrations/0049_normalize_game_mix_variants.sql
+++ b/packages/db/src/migrations/0049_normalize_game_mix_variants.sql
@@ -1,6 +1,11 @@
-CREATE UNIQUE INDEX `game_mix_id_user_id_unique` ON `game_mix` (`id`,`user_id`);--> statement-breakpoint
-CREATE UNIQUE INDEX `game_variant_id_user_id_unique` ON `game_variant` (`id`,`user_id`);--> statement-breakpoint
-CREATE TABLE `game_mix_variant` (
+-- `wrangler d1 migrations apply` sends this file to D1 statement by statement;
+-- there is no file-wide transaction, so a mid-file failure would leave the new
+-- objects created while `d1_migrations` still points at 0048. Every statement is
+-- therefore written to be safely re-runnable (`IF NOT EXISTS` / `OR IGNORE`) and
+-- the backfill below is written so it cannot abort on legacy data.
+CREATE UNIQUE INDEX IF NOT EXISTS `game_mix_id_user_id_unique` ON `game_mix` (`id`,`user_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `game_variant_id_user_id_unique` ON `game_variant` (`id`,`user_id`);--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `game_mix_variant` (
 	`mix_id` text NOT NULL,
 	`variant_id` text NOT NULL,
 	`user_id` text NOT NULL,
@@ -11,20 +16,55 @@ CREATE TABLE `game_mix_variant` (
 	CONSTRAINT "game_mix_variant_position_nonnegative" CHECK("game_mix_variant"."position" >= 0)
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX `game_mix_variant_mix_position_unique` ON `game_mix_variant` (`mix_id`,`position`);--> statement-breakpoint
-CREATE INDEX `game_mix_variant_user_mix_position_idx` ON `game_mix_variant` (`user_id`,`mix_id`,`position`);--> statement-breakpoint
-CREATE INDEX `game_mix_variant_variant_user_idx` ON `game_mix_variant` (`variant_id`,`user_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `game_mix_variant_mix_position_unique` ON `game_mix_variant` (`mix_id`,`position`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `game_mix_variant_user_mix_position_idx` ON `game_mix_variant` (`user_id`,`mix_id`,`position`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `game_mix_variant_variant_user_idx` ON `game_mix_variant` (`variant_id`,`user_id`);--> statement-breakpoint
 
--- Preserve every ordered game reference. json_each.key is the zero-based
--- array position, so the normalized association retains exact display order.
-INSERT INTO `game_mix_variant` (`mix_id`, `variant_id`, `user_id`, `position`)
+-- Backfill the ordered composition of every mix, in legacy array order.
+--
+-- `game_mix.games` only gained DB-side referential protection in 0041, so rows
+-- written before it can still hold duplicate ids, ids of deleted or foreign
+-- variants, or malformed JSON — each of which would violate this table's PK,
+-- owner FK, or json_each() itself and abort the migration halfway. Because this
+-- file is not applied atomically (see the header), an abort would strand the
+-- deployment, so the backfill is defensive instead:
+--   * malformed / non-array `games` reads as an empty array,
+--   * only ids resolving to a variant owned by the SAME user are kept,
+--   * a repeated id collapses to its first occurrence,
+--   * positions are renumbered densely, so dropping an unusable reference
+--     leaves no gap.
+-- Anything dropped here was already unusable through the API (the 0041
+-- triggers reject writes referencing it). Run the audit queries in
+-- `.claude/rules/db-migrations.md` before applying to see exactly which rows
+-- this affects.
+INSERT OR IGNORE INTO `game_mix_variant` (`mix_id`, `variant_id`, `user_id`, `position`)
 SELECT
-	`mix`.`id`,
-	CAST(`game`.`value` AS text),
-	`mix`.`user_id`,
-	CAST(`game`.`key` AS integer)
-FROM `game_mix` AS `mix`, json_each(`mix`.`games`) AS `game`
-ORDER BY `mix`.`id`, CAST(`game`.`key` AS integer);--> statement-breakpoint
+	`resolved`.`mix_id`,
+	`resolved`.`variant_id`,
+	`resolved`.`user_id`,
+	ROW_NUMBER() OVER (
+		PARTITION BY `resolved`.`mix_id` ORDER BY `resolved`.`first_key`
+	) - 1
+FROM (
+	SELECT
+		`mix`.`id` AS `mix_id`,
+		`mix`.`user_id` AS `user_id`,
+		CAST(`game`.`value` AS text) AS `variant_id`,
+		MIN(CAST(`game`.`key` AS integer)) AS `first_key`
+	FROM `game_mix` AS `mix`
+	JOIN json_each(
+		CASE
+			WHEN json_valid(`mix`.`games`) = 0 THEN '[]'
+			WHEN json_type(`mix`.`games`) <> 'array' THEN '[]'
+			ELSE `mix`.`games`
+		END
+	) AS `game`
+	JOIN `game_variant` AS `variant`
+		ON `variant`.`id` = CAST(`game`.`value` AS text)
+		AND `variant`.`user_id` = `mix`.`user_id`
+	WHERE `game`.`type` = 'text'
+	GROUP BY `mix`.`id`, `mix`.`user_id`, CAST(`game`.`value` AS text)
+) AS `resolved`;--> statement-breakpoint
 
 -- production-deploy.yml applies migrations before deploying the new Worker.
 -- Keep the physical legacy column and synchronize old-Worker writes into the
@@ -32,7 +72,21 @@ ORDER BY `mix`.`id`, CAST(`game`.`key` AS integer);--> statement-breakpoint
 -- The new Worker reads game_mix_variant and only updates games as a temporary
 -- compatibility mirror; a later contract migration can remove this bridge
 -- after every deployed Worker has stopped depending on the JSON column.
-CREATE TRIGGER `game_mix_variants_compat_insert`
+--
+-- Direction of truth during this expand phase: these triggers rebuild the
+-- normalized rows from `games` on every write that touches it, so while they
+-- exist the JSON column is the effective derivation source even for the new
+-- Worker (which writes the junction rows first and the mirror last). The new
+-- Worker's explicit junction writes are still deliberate — they are what keeps
+-- it correct once the contract migration drops these triggers — and both paths
+-- produce byte-identical rows, which game-mix.test.ts and this migration's
+-- tests pin.
+--
+-- Unlike the backfill above, these triggers are intentionally strict: a live
+-- write carrying a duplicate id must fail loudly rather than silently store a
+-- composition that differs from its mirror (the 0041 reference triggers, plus
+-- assertNoDuplicateGames in the router, already reject every such write).
+CREATE TRIGGER IF NOT EXISTS `game_mix_variants_compat_insert`
 AFTER INSERT ON `game_mix`
 BEGIN
 	DELETE FROM `game_mix_variant`
@@ -45,7 +99,7 @@ BEGIN
 		CAST(`game`.`key` AS integer)
 	FROM json_each(NEW.`games`) AS `game`;
 END;--> statement-breakpoint
-CREATE TRIGGER `game_mix_variants_compat_update`
+CREATE TRIGGER IF NOT EXISTS `game_mix_variants_compat_update`
 AFTER UPDATE OF `id`, `user_id`, `games` ON `game_mix`
 BEGIN
 	DELETE FROM `game_mix_variant`

--- a/packages/db/src/schema/game-mix.ts
+++ b/packages/db/src/schema/game-mix.ts
@@ -14,12 +14,17 @@ import { gameVariant } from "./game-variant";
 
 // Per-user named-mix masters. A mix is a reusable mixed-game definition —
 // label + ordered game composition — not a session/game record itself. The
-// canonical composition lives in gameMixVariant, where ownership and references
-// use native foreign keys. Legacy JSON triggers only protect and synchronize the
-// temporary rolling-deploy mirror described below.
+// composition is read exclusively from gameMixVariant, where ownership and
+// references use native foreign keys.
+//
 // `games` remains temporarily as a rolling-deploy compatibility mirror for the
-// pre-0049 Worker. The normalized rows are the read model; 0049 keeps both in
-// sync so migration-first deploys and rollback stay safe.
+// pre-0049 Worker. Direction of truth during this expand phase: 0049's
+// game_mix_variants_compat_* triggers rebuild the normalized rows from `games`
+// on every write that touches it, so while those triggers exist the JSON column
+// is the effective derivation source even though the API never reads it. The
+// normalized rows become the sole source of truth at the contract migration
+// that drops the mirror and those triggers; the API already writes them
+// explicitly so that migration needs no further router change.
 // Historical session/rule columns elsewhere intentionally keep frozen labels
 // and value-object JSON, so editing or deleting a master never rewrites past
 // play.


### PR DESCRIPTION
PR #574 のレビュー指摘 5 件への修正です。マージ先を `codex/normalize-game-mix-membership` にしてあるので、マージすると #574 に取り込まれます。

## [高] 0049 のバックフィルが本番データで停止しうる（[#discussion_r3687327688](https://github.com/HIRO15254/sapphire2/pull/574#discussion_r3687327688)）

指摘のとおり、本番の適用経路（`wrangler d1 migrations apply`）はファイル全体を 1 トランザクションにしません。テストの `applyAtomically()` が担保していたのはローカル `bun:sqlite` の挙動だけで、途中で失敗すると新オブジェクトだけ作られて `d1_migrations` は 0048 のまま残り、再実行も `already exists` で落ちます。提案 1・2 の両方を採りました。

- **バックフィルを中断不能にした**: 不正 / 非配列 JSON は `CASE` で `'[]'` として読み（`json_each()` は WHERE より先に評価されるため WHERE では守れない）、同一ユーザー所有の variant に解決できる id だけを `INNER JOIN` で残し、重複 id は `GROUP BY` で初出に畳み、`ROW_NUMBER() OVER (PARTITION BY mix_id)` で position を詰め直します。落ちる行は 0041 のトリガーにより API 経由では既に書き込めない＝使用不能な参照だけです。
- **全文を再実行可能にした**: `CREATE TABLE/INDEX/TRIGGER IF NOT EXISTS` と `INSERT OR IGNORE`。部分適用後の再適用をテストで固定しています。
- **事前監査クエリを文書化した**: [`.claude/rules/db-migrations.md`](.claude/rules/db-migrations.md) に「マイグレーションファイルは本番では 1 トランザクションではない」節を新設し、指摘いただいた 3 本のクエリを（不正 JSON 検出を先に流す注記付きで）掲載しました。

トリガー側は意図的に厳格なままです（生き書き込みでミラーと構成がずれるくらいなら失敗すべき）。

## [中] 互換フェーズでは JSON が正のデータになっている（[#discussion_r3687328313](https://github.com/HIRO15254/sapphire2/pull/574#discussion_r3687328313)）

ご指摘のとおり実装と記述が逆でした。ルーター側の明示的な junction 書き込みは残します（縮退マイグレーションでトリガーを落とした後に正しくあり続けるための実装であり、両経路の結果は同一 — テストで固定済み）。そのうえで `schema/game-mix.ts` / 0049 / ルーターのコメントを「互換フェーズの間は `games` が実質の導出元、縮退フェーズで正規化行が唯一の正になる」と正確な記述に書き換えました。

## [中] `memberships` が空だと Drizzle が throw して `list` が 500（[#discussion_r3687329243](https://github.com/HIRO15254/sapphire2/pull/574#discussion_r3687329243)）

`groupId` ガードと同じ fail-closed で `memberships.length > 0` を条件にしました。「All 33 statements」のコメントも可変である旨に修正。定数を差し替えないと再現できない失敗モードなので、`seed-game-data-unresolvable-variant.test.ts` を追加（全解決 / 全未解決 / 部分解決の 3 ケース）。

## [低] チャンクサイズの列数ハードコード（[#discussion_r3687329621](https://github.com/HIRO15254/sapphire2/pull/574#discussion_r3687329621)）

`chunkMembershipRows()` を追加し、行の形から列数を導出するようにしました（create / update の両方）。列を 1 本足しても 100 bind param 上限を静かに超えないことをテストで固定しています。

## [低] 単件 hydrate でも全 membership を読む / 冗長なフィルタ（[#discussion_r3687329957](https://github.com/HIRO15254/sapphire2/pull/574#discussion_r3687329957)）

id 数が bind param 上限に収まるときだけ `inArray(mixId, …)` を足す分岐にしました。100 件超では従来どおり owner スコープのみで読みます。`D1_MAX_BOUND_PARAMS` は `lib/batch.ts` へ移し（`routers/session.ts` から services へ import すると循環するため）、冗長な `row.userId === userId` フィルタと不要になった projection の `userId` を削除しました。

## 検証

- `bunx vitest run --project api` → 44 files / 1657 tests pass
- `bunx vitest run --project db` → 616 pass
- `bun test packages/db/src/__tests__/migration-0041.test.ts migration-0049.test.ts` → 22 pass（新規 5 テストは旧 SQL に対して red を確認済み）
- `bun run lint` / `bun run check-types` / `bun run check:rules` → pass
- `bun run db:generate` → "No schema changes, nothing to migrate"（コメントのみの変更のため ledger は据え置き）

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwAKHN6mM3jRpKiyu2Uiq8)_