### PR TITLE
ci(review): レビューが完走するようターン上限とツール許可を見直す

### DIFF
--- a/.github/workflows/pre-merge-review.yml
+++ b/.github/workflows/pre-merge-review.yml
@@ -26,6 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Claude review
+        id: claude_review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -47,7 +48,85 @@ jobs:
             The tracking comment on this PR is created and updated automatically from
             this session, so do NOT run `gh pr comment` to post the top-level summary
             yourself — just make the summary your final message.
+          # max-turns is a runaway guard, not a budget: a run that stops at the
+          # cap still costs ~$3.5 and produces nothing (SA2-216 / PR #576 hit it
+          # three times in a row), so it is cheaper to let a real review finish.
+          #
+          # allowedTools additions — every tool Claude reaches for that is not
+          # listed here is denied, and each denial burns a turn:
+          #   Skill        the prompt above is literally `/review`; without this
+          #                the skill can never load and Claude re-improvises the
+          #                whole review by hand.
+          #   Task / Agent subagent fan-out costs the main loop one turn per
+          #                delegated pass. The tool was renamed across CLI
+          #                versions, so allow both names.
+          #   TodoWrite    the review flow tracks its own progress with it.
+          #   git / rg     local history and search, instead of paying an API
+          #                round trip through `gh` for the same information.
+          # The action itself already grants Glob/Grep/LS/Read, the
+          # mcp__github_ci__* CI tools and its git commit/push wrappers.
+          # `gh api` is deliberately NOT allowed: the PR diff is untrusted input
+          # and the job's token can write to pull requests.
           claude_args: |
-            --max-turns 40
+            --max-turns 80
             --model opus
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Skill,Task,Agent,TodoWrite,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(rg:*)"
+
+      # Hitting the turn cap leaves the tracking comment as an empty checklist
+      # with no verdict, which reads exactly like "the review found nothing".
+      # Say out loud that the run was cut short so the empty summary is not
+      # mistaken for a pass.
+      - name: Report truncated review
+        if: failure() && steps.claude_review.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXECUTION_FILE: ${{ steps.claude_review.outputs.execution_file }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          log_file="$EXECUTION_FILE"
+          if [ ! -f "$log_file" ]; then
+            log_file="${RUNNER_TEMP}/claude-execution-output.json"
+          fi
+
+          # The execution log is a stream of JSON messages; the final `result`
+          # entry carries the subtype (`success`, `error_max_turns`, ...).
+          # `-s` plus recursive descent reads it whether the file is one JSON
+          # array or newline-delimited objects, and always yields a single line.
+          subtype=""
+          if [ -f "$log_file" ]; then
+            subtype=$(jq -rs '[.. | objects | select(.type == "result")] | last | .subtype // empty' "$log_file" 2>/dev/null || true)
+          fi
+
+          if [ "$subtype" != "error_max_turns" ]; then
+            echo "review failed with subtype='${subtype:-unknown}' (not a turn-limit cutoff); nothing to report."
+            exit 0
+          fi
+
+          {
+            cat <<'EOF'
+          <!-- pre-merge-review:truncated -->
+          ### ⚠️ 自動レビューはターン上限で打ち切られました
+
+          `review` ジョブが Claude のターン上限に達したため、レビューを最後まで実行できませんでした。
+
+          - インラインコメントが付いていても **レビューは網羅的ではありません**
+          - 要約は投稿されていないため、上のチェックリストが空でも「指摘なし」ではありません
+          - マージ可否は `ci` の結果と人手のレビューで判断してください
+
+          再実行する場合はこのジョブを re-run してください。
+          EOF
+            printf '\n[View job run](%s)\n' "$RUN_URL"
+          } > "${RUNNER_TEMP}/review-truncated.md"
+
+          # Refresh the existing notice instead of stacking one per push.
+          existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq '.[] | select(.body | startswith("<!-- pre-merge-review:truncated -->")) | .id' | tail -n 1 || true)
+
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" \
+              -F "body=@${RUNNER_TEMP}/review-truncated.md"
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -F "body=@${RUNNER_TEMP}/review-truncated.md"
+          fi


### PR DESCRIPTION
Closes SA2-216 / #578

## 背景

`pre-merge-review.yml` の `review` ジョブが `--max-turns 40` に到達して打ち切られ、要約が投稿されないまま赤くなる。PR #576 では 3 回連続で同じ形で失敗した (`"subtype": "error_max_turns"`)。

失敗したジョブのログを見ると、実際に SDK へ渡っていた `allowedTools` は次の通りだった:

```
Glob, Grep, LS, Read,
mcp__github_comment__update_claude_comment,
mcp__github_ci__{get_ci_status,get_workflow_run_details,download_job_log},
mcp__github_inline_comment__create_inline_comment,
Bash(git add:*), Bash(git commit:*), Bash(git-push.sh:*), Bash(git rm:*),
Bash(gh pr diff:*), Bash(gh pr view:*)
```

ここに `Skill` が無いのが効いている。プロンプト本文は `<custom_instructions>/review …</custom_instructions>` として渡されるので、`/review` はスラッシュコマンドとして展開されず、Claude が `Skill` ツールで読み込む必要がある。それが拒否されるため、レビュー手順を毎回ゼロから手作業で組み立てており、40 ターンでは差分を読み終わらない。サブエージェント (`Task` / `Agent`) も未許可なので、並列に投げて 1 ターンで済ませることもできていなかった。

## 変更内容

### 1. `--max-turns` 40 → 80

上限は暴走防止であって予算ではない。打ち切られた実行も 1 回 $3.5 程度かかり、しかも成果物がゼロなので、完走させたほうが結果的に安い。Issue の提案は 60 だが、再発したときのコストが大きいので少し余裕を持たせた。

### 2. `--allowedTools` の拡張

未許可ツールは拒否されるだけでなく、その試行がターンを消費する (`permission_denials_count: 3〜8`)。実際に使うものを追加した:

| 追加 | 理由 |
|---|---|
| `Skill` | プロンプトの `/review` を実際にロードさせる (上記) |
| `Task` / `Agent` | サブエージェントへの委譲は親ループの 1 ターンで済む。CLI のバージョンで名前が変わっているため両方許可 |
| `TodoWrite` | レビュー手順の進捗管理に使う |
| `Bash(git diff/log/show/merge-base:*)` | ローカルの履歴・差分参照。`gh` の API 往復を挟まずに済む |
| `Bash(rg:*)` | 検索 |

`Bash(gh api:*)` は**意図的に許可していない**。PR 差分は信頼できない入力で、このジョブのトークンは `pull-requests: write` を持つため、任意の GitHub API 呼び出しを渡すのは避けた。必要な CI 情報は既に `mcp__github_ci__*` が、インラインコメントは `mcp__github_inline_comment__*` が担当している。

### 3. 打ち切りを PR 上で明示する

上限に到達すると tracking コメントが「空のチェックリスト」のまま残り、指摘なしで通ったのと見分けが付かない。`Report truncated review` ステップを追加し、実行ログの `result.subtype` が `error_max_turns` のときだけ、打ち切られた旨を PR コメントとして投稿する。

- `error_max_turns` 以外の失敗 (通常のエラー、ログ欠損) では何も投稿しない
- マーカー `<!-- pre-merge-review:truncated -->` 付きの既存コメントがあれば PATCH で更新するので、push のたびに増えない
- ジョブ自体は従来どおり失敗する (チェックを緑にごまかさない)

## 確認

- `python3 -c "yaml.safe_load(...)"` で YAML パースを確認
- `run:` ブロックを抜き出し、`gh` をスタブして 5 パターンを実行 — 打ち切り (配列形式ログ / JSONL 形式ログ)、既存コメントあり (PATCH) / なし (POST)、`error_during_execution`、ログファイル無しをそれぞれ検証し、いずれも期待どおりの分岐になることを確認した
- `bun run check:rules` → all checks passed

ワークフローの実挙動 (`review` ジョブが完走し要約が投稿されること) は、この PR 自身の `review` チェックでは検証できない (ワークフローは base 側の定義で走るため)。マージ後の最初の PR で `result` が `error_max_turns` にならないことを確認したい。

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUJDFzaf7eSzxkuJjUNx6N)_