### PR TITLE
fix(ci): プレビュー DB の seed 中はトリガを退避する

### DIFF
--- a/.claude/rules/db-migrations.md
+++ b/.claude/rules/db-migrations.md
@@ -155,8 +155,9 @@ pins both halves (the collision is real; stashing fixes it without leaving the D
 It needs `bun:sqlite`, so like the `migration-*` specs it is listed explicitly in
 [`ci.yml`](../../.github/workflows/ci.yml) — a bun:sqlite spec that is not listed runs nowhere and
 reports green, because `skipIfNotBun` makes Vitest skip it rather than fail. `bun run check:rules`
-enforces the listing (every `packages/db/src/__tests__/*.test.ts` mentioning `bun:sqlite` must be
-named in that step), so this paragraph is documentation, not the guard.
+enforces the listing (every `packages/**/__tests__/*.test.ts` mentioning `bun:sqlite` must be
+named in that step, wherever in the workspace it lives), so this paragraph is documentation, not
+the guard.
 
 ## Keeping the ledger from drifting again
 

--- a/.claude/rules/db-migrations.md
+++ b/.claude/rules/db-migrations.md
@@ -153,8 +153,10 @@ that seeded preview data comes from the dump, not from the trigger.
 [`preview-seed-restore.test.ts`](../../packages/db/src/__tests__/preview-seed-restore.test.ts)
 pins both halves (the collision is real; stashing fixes it without leaving the DB trigger-less).
 It needs `bun:sqlite`, so like the `migration-*` specs it is listed explicitly in
-[`ci.yml`](../../.github/workflows/ci.yml) — a bun:sqlite spec that is not listed silently never
-runs.
+[`ci.yml`](../../.github/workflows/ci.yml) — a bun:sqlite spec that is not listed runs nowhere and
+reports green, because `skipIfNotBun` makes Vitest skip it rather than fail. `bun run check:rules`
+enforces the listing (every `packages/db/src/__tests__/*.test.ts` mentioning `bun:sqlite` must be
+named in that step), so this paragraph is documentation, not the guard.
 
 ## Keeping the ledger from drifting again
 

--- a/.claude/rules/db-migrations.md
+++ b/.claude/rules/db-migrations.md
@@ -155,9 +155,8 @@ pins both halves (the collision is real; stashing fixes it without leaving the D
 It needs `bun:sqlite`, so like the `migration-*` specs it is listed explicitly in
 [`ci.yml`](../../.github/workflows/ci.yml) — a bun:sqlite spec that is not listed runs nowhere and
 reports green, because `skipIfNotBun` makes Vitest skip it rather than fail. `bun run check:rules`
-enforces the listing (every `packages/**/__tests__/*.test.ts` mentioning `bun:sqlite` must be
-named in that step, wherever in the workspace it lives), so this paragraph is documentation, not
-the guard.
+enforces the listing (every `{apps,packages}/**/__tests__/*.test.ts` mentioning `bun:sqlite` must
+be named in that step), so this paragraph is documentation, not the guard.
 
 ## Keeping the ledger from drifting again
 

--- a/.claude/rules/db-migrations.md
+++ b/.claude/rules/db-migrations.md
@@ -135,6 +135,27 @@ numbered migration from an empty database and asserts the final trigger names an
 Keep this full-history guard intact and run it after touching these tables; `db:generate` reporting
 no schema changes does not verify manual triggers.
 
+## Triggers must not be armed while the preview DB is seeded
+
+A trigger keeps a derived table in sync with **application writes**. Restoring a dump is not an
+application write: `preview-deploy.yml` seeds a brand-new preview D1 by applying every migration
+and then replaying a `--no-schema` export of production, which already contains the derived rows.
+An armed trigger derives them a second time — 0049's compat triggers rebuilt `game_mix_variant`
+from the legacy `games` mirror on each `game_mix` insert, and the dump's own junction rows then hit
+`UNIQUE constraint failed: game_mix_variant.mix_id, game_mix_variant.position`, taking `db-migrate`
+down for every PR that created a preview DB after 0049 reached production.
+
+The seed step therefore reads the live trigger DDL out of `sqlite_master`, drops every trigger,
+replays the dump, and recreates them — reading from `sqlite_master` rather than re-running a
+migration so it stays correct as migrations add or drop triggers. **Adding a trigger needs no
+workflow change; do not special-case one there.** What a new trigger does need is the awareness
+that seeded preview data comes from the dump, not from the trigger.
+[`preview-seed-restore.test.ts`](../../packages/db/src/__tests__/preview-seed-restore.test.ts)
+pins both halves (the collision is real; stashing fixes it without leaving the DB trigger-less).
+It needs `bun:sqlite`, so like the `migration-*` specs it is listed explicitly in
+[`ci.yml`](../../.github/workflows/ci.yml) — a bun:sqlite spec that is not listed silently never
+runs.
+
 ## Keeping the ledger from drifting again
 
 `bun run db:generate` must report **"No schema changes, nothing to migrate"** whenever

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,11 @@ jobs:
       - name: Test
         run: bun run test:ci
 
+      # These specs need bun:sqlite, so their bodies are skipped under Vitest's
+      # Node projects (see the `skipIfNotBun` guard in each file). Add any new
+      # bun:sqlite-backed spec here or it silently never runs.
       - name: Test migrations with Bun SQLite
-        run: bun test packages/db/src/__tests__/migration-*.test.ts
+        run: |
+          bun test \
+            packages/db/src/__tests__/migration-*.test.ts \
+            packages/db/src/__tests__/preview-seed-restore.test.ts

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -241,12 +241,24 @@ jobs:
           # exists a later run resolves it as existing and skips straight past
           # here. A seed that failed after the DROP would otherwise leave the
           # preview permanently trigger-less — rows intact, but nothing syncing
-          # game_mix_variant and no 0041 integrity checks. The trap keeps the
-          # step's own exit status, so a failed seed still fails the job.
+          # game_mix_variant and no 0041 integrity checks.
+          #
+          # Both exits are decided explicitly: a failed seed keeps its own
+          # status (a half-seeded preview must not go green), and a failed
+          # re-arm fails the step even when the seed succeeded — the outcome
+          # there is a trigger-less preview that no later run will repair, so
+          # it must not be silent. Under `bash -e` a failing command in the
+          # handler already propagates, but saying it outright survives a shell
+          # without -e and names the consequence in the log.
           restore_triggers() {
+            seed_status=$?
             if [ -s rearm-triggers.sql ]; then
-              bunx wrangler d1 execute "${{ needs.setup.outputs.d1_db_name }}" --remote --file=rearm-triggers.sql
+              if ! bunx wrangler d1 execute "${{ needs.setup.outputs.d1_db_name }}" --remote --file=rearm-triggers.sql; then
+                echo "::error::failed to re-arm the stashed triggers — ${{ needs.setup.outputs.d1_db_name }} is left trigger-less"
+                exit 1
+              fi
             fi
+            exit "$seed_status"
           }
           trap restore_triggers EXIT
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -230,6 +230,20 @@ jobs:
           jq -r '.[0].results[] | .sql + ";"' triggers.json > restore-triggers.sql
           echo "Stashing $(wc -l < drop-triggers.sql) trigger(s) for the restore"
 
+          # Re-arm on the way out however we leave, because there is no second
+          # chance: this whole step is gated on is_new_db, so once the database
+          # exists a later run resolves it as existing and skips straight past
+          # here. A seed that failed after the DROP would otherwise leave the
+          # preview permanently trigger-less — rows intact, but nothing syncing
+          # game_mix_variant and no 0041 integrity checks. The trap keeps the
+          # step's own exit status, so a failed seed still fails the job.
+          restore_triggers() {
+            if [ -s restore-triggers.sql ]; then
+              bunx wrangler d1 execute "${{ needs.setup.outputs.d1_db_name }}" --remote --file=restore-triggers.sql
+            fi
+          }
+          trap restore_triggers EXIT
+
           if [ -s drop-triggers.sql ]; then
             bunx wrangler d1 execute "${{ needs.setup.outputs.d1_db_name }}" --remote --file=drop-triggers.sql
           fi
@@ -239,10 +253,6 @@ jobs:
           # missed something — fail the job so we notice instead of shipping
           # a preview with incomplete data.
           bunx wrangler d1 execute "${{ needs.setup.outputs.d1_db_name }}" --remote --file=dump.sql
-
-          if [ -s restore-triggers.sql ]; then
-            bunx wrangler d1 execute "${{ needs.setup.outputs.d1_db_name }}" --remote --file=restore-triggers.sql
-          fi
 
       - name: Restore and apply stashed migrations (new DB only)
         if: needs.d1-setup.outputs.is_new_db == 'true'

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -228,6 +228,12 @@ jobs:
             > triggers.json
           jq -r '.[0].results[] | "DROP TRIGGER IF EXISTS `" + .name + "`;"' triggers.json > drop-triggers.sql
           jq -r '.[0].results[] | .sql + ";"' triggers.json > restore-triggers.sql
+          # SQLite strips `IF NOT EXISTS` before storing DDL in sqlite_master,
+          # so the read-back CREATEs are NOT idempotent — re-running them over
+          # a surviving trigger aborts the file and every CREATE behind it is
+          # skipped. Prefix the drops so the re-arm converges from ANY state,
+          # including a DROP batch that only partially applied.
+          cat drop-triggers.sql restore-triggers.sql > rearm-triggers.sql
           echo "Stashing $(wc -l < drop-triggers.sql) trigger(s) for the restore"
 
           # Re-arm on the way out however we leave, because there is no second
@@ -238,8 +244,8 @@ jobs:
           # game_mix_variant and no 0041 integrity checks. The trap keeps the
           # step's own exit status, so a failed seed still fails the job.
           restore_triggers() {
-            if [ -s restore-triggers.sql ]; then
-              bunx wrangler d1 execute "${{ needs.setup.outputs.d1_db_name }}" --remote --file=restore-triggers.sql
+            if [ -s rearm-triggers.sql ]; then
+              bunx wrangler d1 execute "${{ needs.setup.outputs.d1_db_name }}" --remote --file=rearm-triggers.sql
             fi
           }
           trap restore_triggers EXIT

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -135,7 +135,9 @@ jobs:
       #   2. Stash every migration file in the repo that is newer than that.
       #   3. Apply only the migrations master already has → preview DB
       #      schema matches master.
-      #   4. Seed from master (must succeed cleanly now).
+      #   4. Disarm every trigger, seed from master (must succeed cleanly
+      #      now), then re-arm them — a bulk restore is not an application
+      #      write, so triggers must not derive rows the dump already has.
       #   5. Restore the stashed migrations and apply them, running their
       #      own backfills against the seeded data.
       - name: Stash unreleased migrations (new DB only)
@@ -207,11 +209,40 @@ jobs:
 
           sed -i "s/database_id = \".*\"/database_id = \"${{ needs.d1-setup.outputs.d1_database_id }}\"/" wrangler.toml
           sed -i "s/database_name = \".*\"/database_name = \"${{ needs.setup.outputs.d1_db_name }}\"/" wrangler.toml
+
+          # Triggers keep derived tables in sync with *application* writes. A
+          # bulk restore is not an application write: the dump already carries
+          # the derived rows, so an armed trigger generates a second copy of
+          # them. 0049's game_mix compat triggers do exactly that — inserting a
+          # `game_mix` row rebuilds `game_mix_variant` from the legacy JSON
+          # mirror, and the dump's own `game_mix_variant` rows then collide on
+          # `game_mix_variant_mix_position_unique`. So disarm every trigger for
+          # the duration of the restore and re-arm it afterwards, leaving the
+          # dump as the single source of truth for seeded data.
+          #
+          # Read back from sqlite_master rather than re-running a migration:
+          # that captures exactly the triggers this DB has, so the step stays
+          # correct as migrations add or drop them.
+          bunx wrangler d1 execute "${{ needs.setup.outputs.d1_db_name }}" --remote --json \
+            --command="SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND sql IS NOT NULL ORDER BY name" \
+            > triggers.json
+          jq -r '.[0].results[] | "DROP TRIGGER IF EXISTS `" + .name + "`;"' triggers.json > drop-triggers.sql
+          jq -r '.[0].results[] | .sql + ";"' triggers.json > restore-triggers.sql
+          echo "Stashing $(wc -l < drop-triggers.sql) trigger(s) for the restore"
+
+          if [ -s drop-triggers.sql ]; then
+            bunx wrangler d1 execute "${{ needs.setup.outputs.d1_db_name }}" --remote --file=drop-triggers.sql
+          fi
+
           # Stash logic above ensures preview DB schema matches master, so the
           # seed must succeed cleanly. A failure here means the stash logic
           # missed something — fail the job so we notice instead of shipping
           # a preview with incomplete data.
           bunx wrangler d1 execute "${{ needs.setup.outputs.d1_db_name }}" --remote --file=dump.sql
+
+          if [ -s restore-triggers.sql ]; then
+            bunx wrangler d1 execute "${{ needs.setup.outputs.d1_db_name }}" --remote --file=restore-triggers.sql
+          fi
 
       - name: Restore and apply stashed migrations (new DB only)
         if: needs.d1-setup.outputs.is_new_db == 'true'

--- a/packages/db/src/__tests__/preview-seed-restore.test.ts
+++ b/packages/db/src/__tests__/preview-seed-restore.test.ts
@@ -34,11 +34,20 @@ if (isBun) {
  * (so nobody "simplifies" the trigger stash away), and stashing the triggers
  * around the restore makes the dump the single source of truth without
  * leaving the DB permanently trigger-less.
+ *
+ * Only the first case names 0049's compat triggers. When the contract
+ * migration drops the legacy `games` mirror they stop firing and that case
+ * stops throwing — the fix is to re-point it at whatever derived-table
+ * trigger remains (or delete this file once none do), NOT to conclude the
+ * stash is unnecessary. The stash guards the restore against triggers in
+ * general; every other case reads whatever triggers exist out of
+ * sqlite_master and never names 0049.
  */
 
 const MIGRATION_FILE_PATTERN = /^\d{4}_.+\.sql$/;
 const POSITION_UNIQUE_VIOLATION =
 	/UNIQUE constraint failed: game_mix_variant\.mix_id, game_mix_variant\.position/;
+const TRIGGER_ALREADY_EXISTS = /already exists/;
 const migrationsDirectory = fileURLToPath(
 	new URL("../migrations/", import.meta.url)
 );
@@ -82,6 +91,21 @@ const readTriggers = (db: Database): TriggerRow[] =>
 const dropTriggers = (db: Database, triggers: TriggerRow[]) => {
 	for (const trigger of triggers) {
 		db.exec(`DROP TRIGGER IF EXISTS \`${trigger.name}\`;`);
+	}
+};
+
+/**
+ * The workflow's re-arm file: `cat drop-triggers.sql restore-triggers.sql`.
+ *
+ * The drops are what make it idempotent. SQLite strips `IF NOT EXISTS` before
+ * storing DDL in sqlite_master, so the read-back CREATEs alone abort on the
+ * first surviving trigger — and `wrangler d1 execute --file` stops there,
+ * skipping every CREATE behind it.
+ */
+const rearmTriggers = (db: Database, triggers: TriggerRow[]) => {
+	dropTriggers(db, triggers);
+	for (const trigger of triggers) {
+		db.exec(`${trigger.sql};`);
 	}
 };
 
@@ -181,6 +205,29 @@ skipIfNotBun("preview seed restore (preview-deploy.yml)", () => {
 
 		replayProductionDump(db);
 		recreateTriggers(db, stashed);
+		expect(readTriggers(db)).toEqual(stashed);
+	});
+
+	it("does not survive a partial drop when the re-arm skips the drops", () => {
+		const stashed = readTriggers(db);
+		// Simulate a DROP batch that died halfway: half the triggers survive.
+		dropTriggers(db, stashed.slice(0, 6));
+
+		expect(() => recreateTriggers(db, stashed)).toThrow(TRIGGER_ALREADY_EXISTS);
+	});
+
+	it("re-arms every trigger from a partially dropped state", () => {
+		const stashed = readTriggers(db);
+		dropTriggers(db, stashed.slice(0, 6));
+
+		rearmTriggers(db, stashed);
+		expect(readTriggers(db)).toEqual(stashed);
+	});
+
+	it("re-arms idempotently when no trigger was dropped at all", () => {
+		const stashed = readTriggers(db);
+
+		rearmTriggers(db, stashed);
 		expect(readTriggers(db)).toEqual(stashed);
 	});
 

--- a/packages/db/src/__tests__/preview-seed-restore.test.ts
+++ b/packages/db/src/__tests__/preview-seed-restore.test.ts
@@ -1,0 +1,208 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// bun:sqlite is only available in Bun. CI has a dedicated `bun test` step for
+// migration files, while Vitest's Node projects intentionally skip the body.
+// biome-ignore lint/correctness/noUndeclaredVariables: Bun is a runtime global
+const isBun = typeof Bun !== "undefined";
+const skipIfNotBun = isBun ? describe : describe.skip;
+
+let Database: any = null;
+if (isBun) {
+	// @ts-expect-error -- bun:sqlite only exists in the Bun runtime.
+	// eslint-disable-next-line import/no-unresolved
+	const bunSqlite = require("bun:sqlite");
+	Database = bunSqlite.Database;
+}
+
+/**
+ * preview-deploy.yml seeds a brand-new preview D1 by applying every migration
+ * and then replaying a `--no-schema` dump of the production database into it.
+ *
+ * Triggers exist to keep derived tables in sync with *application* writes. A
+ * bulk restore is not an application write: the dump already carries the
+ * derived rows, so an armed trigger produces a second copy of them. That is
+ * not hypothetical — 0049's game_mix compat triggers rebuild
+ * `game_mix_variant` from the legacy JSON mirror on every `game_mix` insert,
+ * which collides with the dump's own junction rows and took the whole
+ * db-migrate job down the first time a preview DB was created after 0049
+ * reached production.
+ *
+ * These tests pin both halves of the workflow's fix: the collision is real
+ * (so nobody "simplifies" the trigger stash away), and stashing the triggers
+ * around the restore makes the dump the single source of truth without
+ * leaving the DB permanently trigger-less.
+ */
+
+const MIGRATION_FILE_PATTERN = /^\d{4}_.+\.sql$/;
+const POSITION_UNIQUE_VIOLATION =
+	/UNIQUE constraint failed: game_mix_variant\.mix_id, game_mix_variant\.position/;
+const migrationsDirectory = fileURLToPath(
+	new URL("../migrations/", import.meta.url)
+);
+
+const applyAsD1Migration = (db: Database, sql: string) => {
+	const statements = sql
+		.split("--> statement-breakpoint")
+		.map((statement) => statement.trim())
+		.filter(Boolean)
+		.filter((statement) => !statement.startsWith("PRAGMA foreign_keys="));
+	for (const statement of statements) {
+		db.exec(statement);
+	}
+};
+
+const applyCompleteMigrationHistory = (db: Database) => {
+	const filenames = readdirSync(migrationsDirectory)
+		.filter((filename) => MIGRATION_FILE_PATTERN.test(filename))
+		.toSorted();
+	for (const filename of filenames) {
+		applyAsD1Migration(
+			db,
+			readFileSync(join(migrationsDirectory, filename), "utf8")
+		);
+	}
+};
+
+interface TriggerRow {
+	name: string;
+	sql: string;
+}
+
+/** The exact query preview-deploy.yml runs to stash the triggers. */
+const readTriggers = (db: Database): TriggerRow[] =>
+	db
+		.query(
+			"SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND sql IS NOT NULL ORDER BY name"
+		)
+		.all() as TriggerRow[];
+
+const dropTriggers = (db: Database, triggers: TriggerRow[]) => {
+	for (const trigger of triggers) {
+		db.exec(`DROP TRIGGER IF EXISTS \`${trigger.name}\`;`);
+	}
+};
+
+const recreateTriggers = (db: Database, triggers: TriggerRow[]) => {
+	for (const trigger of triggers) {
+		db.exec(`${trigger.sql};`);
+	}
+};
+
+/**
+ * A production `--no-schema` dump, in the order `wrangler d1 export` writes it:
+ * `game_mix` (carrying the legacy JSON mirror) before `game_mix_variant`
+ * (carrying the authoritative junction rows production already normalized).
+ */
+const replayProductionDump = (db: Database) => {
+	db.exec("PRAGMA foreign_keys = OFF;");
+	db.exec(
+		`INSERT INTO user (id, name, email, email_verified, created_at, updated_at)
+			VALUES ('user-1', 'U', 'u@example.com', 1, 0, 0);`
+	);
+	db.exec(
+		`INSERT INTO game_group (id, user_id, label, created_at, updated_at)
+			VALUES ('group-1', 'user-1', 'Holdem', 0, 0);`
+	);
+	db.exec(
+		`INSERT INTO game_variant (id, user_id, label, group_id, sort_order, created_at, updated_at)
+			VALUES ('variant-1', 'user-1', 'NLH', 'group-1', 0, 0, 0),
+			       ('variant-2', 'user-1', 'PLO', 'group-1', 1, 0, 0);`
+	);
+	db.exec(
+		`INSERT INTO game_mix (id, user_id, label, games, created_at, updated_at)
+			VALUES ('mix-1', 'user-1', 'Mix', '["variant-1","variant-2"]', 0, 0);`
+	);
+	db.exec(
+		`INSERT INTO game_mix_variant (mix_id, variant_id, user_id, position)
+			VALUES ('mix-1', 'variant-1', 'user-1', 0),
+			       ('mix-1', 'variant-2', 'user-1', 1);`
+	);
+	db.exec("PRAGMA foreign_keys = ON;");
+};
+
+skipIfNotBun("preview seed restore (preview-deploy.yml)", () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		applyCompleteMigrationHistory(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("collides on game_mix_variant when the dump is replayed with triggers armed", () => {
+		expect(() => replayProductionDump(db)).toThrow(POSITION_UNIQUE_VIOLATION);
+	});
+
+	it("replays the dump cleanly once the triggers are stashed", () => {
+		dropTriggers(db, readTriggers(db));
+		expect(() => replayProductionDump(db)).not.toThrow();
+	});
+
+	it("keeps the dump's junction rows as the only ones, not the trigger's rebuild", () => {
+		const stashed = readTriggers(db);
+		dropTriggers(db, stashed);
+		replayProductionDump(db);
+		recreateTriggers(db, stashed);
+
+		expect(
+			db
+				.query(
+					"SELECT mix_id, variant_id, user_id, position FROM game_mix_variant ORDER BY position"
+				)
+				.all()
+		).toEqual([
+			{
+				mix_id: "mix-1",
+				variant_id: "variant-1",
+				user_id: "user-1",
+				position: 0,
+			},
+			{
+				mix_id: "mix-1",
+				variant_id: "variant-2",
+				user_id: "user-1",
+				position: 1,
+			},
+		]);
+	});
+
+	it("re-arms every stashed trigger, byte-identically", () => {
+		const stashed = readTriggers(db);
+		expect(stashed.length).toBeGreaterThan(0);
+
+		dropTriggers(db, stashed);
+		expect(readTriggers(db)).toEqual([]);
+
+		replayProductionDump(db);
+		recreateTriggers(db, stashed);
+		expect(readTriggers(db)).toEqual(stashed);
+	});
+
+	it("leaves the re-armed triggers deriving rows for real application writes", () => {
+		const stashed = readTriggers(db);
+		dropTriggers(db, stashed);
+		replayProductionDump(db);
+		recreateTriggers(db, stashed);
+
+		// A post-seed write is an application write again: the compat trigger
+		// must still mirror `games` into the junction.
+		db.exec(
+			`INSERT INTO game_mix (id, user_id, label, games, created_at, updated_at)
+				VALUES ('mix-2', 'user-1', 'Mix2', '["variant-2"]', 0, 0);`
+		);
+
+		expect(
+			db
+				.query(
+					"SELECT variant_id, position FROM game_mix_variant WHERE mix_id = 'mix-2'"
+				)
+				.all()
+		).toEqual([{ variant_id: "variant-2", position: 0 }]);
+	});
+});

--- a/packages/db/src/__tests__/preview-seed-restore.test.ts
+++ b/packages/db/src/__tests__/preview-seed-restore.test.ts
@@ -109,6 +109,15 @@ const rearmTriggers = (db: Database, triggers: TriggerRow[]) => {
 	}
 };
 
+/**
+ * A DROP batch that died halfway. Derived from the live count, never a
+ * literal: the contract migration in db-migrations.md leaves exactly six
+ * triggers, so a hard-coded `slice(0, 6)` would quietly become a FULL drop
+ * and both partial-drop cases would stop testing what they name.
+ */
+const halfOf = (triggers: TriggerRow[]): TriggerRow[] =>
+	triggers.slice(0, Math.floor(triggers.length / 2));
+
 const recreateTriggers = (db: Database, triggers: TriggerRow[]) => {
 	for (const trigger of triggers) {
 		db.exec(`${trigger.sql};`);
@@ -210,15 +219,14 @@ skipIfNotBun("preview seed restore (preview-deploy.yml)", () => {
 
 	it("does not survive a partial drop when the re-arm skips the drops", () => {
 		const stashed = readTriggers(db);
-		// Simulate a DROP batch that died halfway: half the triggers survive.
-		dropTriggers(db, stashed.slice(0, 6));
+		dropTriggers(db, halfOf(stashed));
 
 		expect(() => recreateTriggers(db, stashed)).toThrow(TRIGGER_ALREADY_EXISTS);
 	});
 
 	it("re-arms every trigger from a partially dropped state", () => {
 		const stashed = readTriggers(db);
-		dropTriggers(db, stashed.slice(0, 6));
+		dropTriggers(db, halfOf(stashed));
 
 		rearmTriggers(db, stashed);
 		expect(readTriggers(db)).toEqual(stashed);

--- a/packages/mcp/src/auth/__tests__/mcp-session.test.ts
+++ b/packages/mcp/src/auth/__tests__/mcp-session.test.ts
@@ -14,7 +14,9 @@ const USER = {
 const TOKEN = {
 	userId: "user-1",
 	scopes: "openid profile",
-	accessTokenExpiresAt: new Date(Date.UTC(2026, 7, 1)),
+	// Relative, not a fixed date: buildMcpSession rejects expired tokens, so a
+	// hard-coded timestamp turns the whole suite red once the clock passes it.
+	accessTokenExpiresAt: new Date(Date.now() + 3_600_000),
 };
 
 describe("buildMcpSession", () => {

--- a/scripts/check-rules.ts
+++ b/scripts/check-rules.ts
@@ -179,6 +179,62 @@ for (const check of CHECKS) {
 	}
 }
 
+/**
+ * bun:sqlite specs must be named in ci.yml's `bun test` step.
+ *
+ * Their bodies sit behind a `skipIfNotBun` guard, so Vitest's Node projects
+ * report them as skipped, not failed. A spec that is also missing from the
+ * dedicated `bun test` step therefore runs nowhere and reports green — a
+ * failure mode prose in .claude/rules/db-migrations.md cannot catch, which is
+ * exactly when AGENTS.md ("Procedure for adding a rule", step 5) calls for a
+ * check here. Expressed as a cross-file existence assertion rather than a
+ * banned pattern, so it does not fit the CHECKS table above.
+ */
+const BUN_SQLITE_STEP = "Test migrations with Bun SQLite";
+const BUN_SQLITE_SPEC_GLOB = "packages/db/src/__tests__/*.test.ts";
+const SPEC_TOKEN = /packages\/db\/src\/__tests__\/[^\s\\]+\.test\.ts/g;
+const REGEXP_SPECIALS = /[.+?^${}()|[\]]/g;
+
+const ciWorkflow = await readFile(".github/workflows/ci.yml", "utf8");
+const afterStepName = ciWorkflow.split(`- name: ${BUN_SQLITE_STEP}`)[1];
+const unlisted: string[] = [];
+
+if (afterStepName === undefined) {
+	unlisted.push(
+		`.github/workflows/ci.yml: step "${BUN_SQLITE_STEP}" not found — rename it here too`
+	);
+} else {
+	// Stop at the next step so a spec named in an unrelated step does not count.
+	const stepBody = afterStepName.split(/^\s*- name:/m)[0];
+	const listed = [...stepBody.matchAll(SPEC_TOKEN)].map(
+		(match) =>
+			new RegExp(
+				`^${match[0].replace(REGEXP_SPECIALS, "\\$&").replaceAll("*", "[^/]*")}$`
+			)
+	);
+	for await (const scannedPath of new Glob(BUN_SQLITE_SPEC_GLOB).scan(".")) {
+		const path = normalizeRulePath(scannedPath);
+		const text = await readFile(path, "utf8");
+		if (!text.includes("bun:sqlite")) {
+			continue;
+		}
+		if (!listed.some((pattern) => pattern.test(path))) {
+			unlisted.push(`${path}: not run by any project — add it to ci.yml`);
+		}
+	}
+}
+
+if (unlisted.length > 0) {
+	failed = true;
+	console.error(
+		`\ncheck-rules FAIL: bun:sqlite spec not listed in ci.yml's "${BUN_SQLITE_STEP}" step`
+	);
+	console.error("  rule: .claude/rules/db-migrations.md");
+	for (const hit of unlisted) {
+		console.error(`  ${hit}`);
+	}
+}
+
 if (failed) {
 	process.exit(1);
 }

--- a/scripts/check-rules.ts
+++ b/scripts/check-rules.ts
@@ -191,12 +191,16 @@ for (const check of CHECKS) {
  * banned pattern, so it does not fit the CHECKS table above.
  */
 const BUN_SQLITE_STEP = "Test migrations with Bun SQLite";
-// Every package, not just packages/db: AGENTS.md colocates tests next to the
-// code, so the next bun:sqlite spec plausibly lands in some other __tests__/.
-// `*` does not cross `/`, so a narrower glob would let such a spec escape both
-// this check and the `bun test` step — straight back to the silent-green hole.
-const BUN_SQLITE_SPEC_GLOB = "packages/**/__tests__/*.test.ts";
-const SPEC_TOKEN = /packages\/[^\s\\]+\.test\.ts/g;
+// Every workspace, not just packages/db: AGENTS.md colocates tests next to the
+// code, so the next bun:sqlite spec plausibly lands in some other __tests__/ —
+// apps/server's included. `*` does not cross `/`, so a narrower glob would let
+// such a spec escape both this check and the `bun test` step, which is the
+// silent-green hole this exists to close.
+const BUN_SQLITE_SPEC_GLOBS = [
+	"apps/**/__tests__/*.test.ts",
+	"packages/**/__tests__/*.test.ts",
+];
+const SPEC_TOKEN = /(?:apps|packages)\/[^\s\\]+\.test\.ts/g;
 const REGEXP_SPECIALS = /[.+?^${}()|[\]]/g;
 
 const ciWorkflow = await readFile(".github/workflows/ci.yml", "utf8");
@@ -216,17 +220,19 @@ if (afterStepName === undefined) {
 				`^${match[0].replace(REGEXP_SPECIALS, "\\$&").replaceAll("*", "[^/]*")}$`
 			)
 	);
-	for await (const scannedPath of new Glob(BUN_SQLITE_SPEC_GLOB).scan(".")) {
-		const path = normalizeRulePath(scannedPath);
-		if (IGNORED_DIRS.test(path)) {
-			continue;
-		}
-		const text = await readFile(path, "utf8");
-		if (!text.includes("bun:sqlite")) {
-			continue;
-		}
-		if (!listed.some((pattern) => pattern.test(path))) {
-			unlisted.push(`${path}: not run by any project — add it to ci.yml`);
+	for (const glob of BUN_SQLITE_SPEC_GLOBS) {
+		for await (const scannedPath of new Glob(glob).scan(".")) {
+			const path = normalizeRulePath(scannedPath);
+			if (IGNORED_DIRS.test(path)) {
+				continue;
+			}
+			const text = await readFile(path, "utf8");
+			if (!text.includes("bun:sqlite")) {
+				continue;
+			}
+			if (!listed.some((pattern) => pattern.test(path))) {
+				unlisted.push(`${path}: not run by any project — add it to ci.yml`);
+			}
 		}
 	}
 }

--- a/scripts/check-rules.ts
+++ b/scripts/check-rules.ts
@@ -191,8 +191,12 @@ for (const check of CHECKS) {
  * banned pattern, so it does not fit the CHECKS table above.
  */
 const BUN_SQLITE_STEP = "Test migrations with Bun SQLite";
-const BUN_SQLITE_SPEC_GLOB = "packages/db/src/__tests__/*.test.ts";
-const SPEC_TOKEN = /packages\/db\/src\/__tests__\/[^\s\\]+\.test\.ts/g;
+// Every package, not just packages/db: AGENTS.md colocates tests next to the
+// code, so the next bun:sqlite spec plausibly lands in some other __tests__/.
+// `*` does not cross `/`, so a narrower glob would let such a spec escape both
+// this check and the `bun test` step — straight back to the silent-green hole.
+const BUN_SQLITE_SPEC_GLOB = "packages/**/__tests__/*.test.ts";
+const SPEC_TOKEN = /packages\/[^\s\\]+\.test\.ts/g;
 const REGEXP_SPECIALS = /[.+?^${}()|[\]]/g;
 
 const ciWorkflow = await readFile(".github/workflows/ci.yml", "utf8");
@@ -214,6 +218,9 @@ if (afterStepName === undefined) {
 	);
 	for await (const scannedPath of new Glob(BUN_SQLITE_SPEC_GLOB).scan(".")) {
 		const path = normalizeRulePath(scannedPath);
+		if (IGNORED_DIRS.test(path)) {
+			continue;
+		}
 		const text = await readFile(path, "utf8");
 		if (!text.includes("bun:sqlite")) {
 			continue;


### PR DESCRIPTION
## 概要

新規プレビュー DB を作る PR の `db-migrate` が**必ず失敗する**状態になっていたのを直します。

```
UNIQUE constraint failed: game_mix_variant.mix_id, game_mix_variant.position
```

（実例: #581。マイグレーション 0001〜0050 はすべて ✅ で、落ちているのはその後の seed ステップです。）

## 原因

トリガは**アプリの書き込み**に対して派生テーブルを同期させるためのものです。バルクリストアはアプリの書き込みではありません — ダンプは派生行をすでに持っているので、トリガが武装したままだと同じ行が二重に作られます。

`preview-deploy.yml` の seed は、全マイグレーション適用済みのプレビュー DB に本番の `--no-schema` ダンプを流し込みます。ここで:

1. ダンプの `INSERT INTO game_mix ...` が 0049 の compat トリガを発火 → レガシー `games` JSON ミラーから `game_mix_variant` が再構築される
2. その後ダンプ自身の `INSERT INTO game_mix_variant ...` が同じ `(mix_id, position)` に衝突

`v3.4.0` で 0049 が本番に適用されるまでは本番ダンプに `game_mix_variant` の行が存在しなかったため顕在化していませんでした。preview-deploy の履歴上、`v3.4.0` 以降にプレビュー DB を新規作成したのは #581 が最初で、それ以前はすべて green です。

## 修正

seed の前後でトリガを退避します:

```sh
# sqlite_master から現在のトリガ DDL を読み出す
bunx wrangler d1 execute "$DB" --remote --json \
  --command="SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND sql IS NOT NULL ORDER BY name" > triggers.json
jq -r '.[0].results[] | "DROP TRIGGER IF EXISTS `" + .name + "`;"' triggers.json > drop-triggers.sql
jq -r '.[0].results[] | .sql + ";"'                                 triggers.json > restore-triggers.sql
# DROP → ダンプ投入 → 再作成
```

マイグレーションを再実行するのではなく **`sqlite_master` から読む**のがポイントです。その DB が実際に持つトリガをそのまま捕捉するので、今後マイグレーションでトリガが増減してもこのステップに手を入れる必要がありません（0049 を再実行する案は不可 — あのファイルは `DELETE FROM game_mix_variant` + ミラーからの backfill を含むので、ダンプの正の行を破壊します）。

## テスト

`packages/db/src/__tests__/preview-seed-restore.test.ts` を追加し、実 SQLite に全マイグレーションを適用したうえで両面を固定しました:

- トリガ武装のままダンプを再生すると **CI と同一のエラーメッセージで落ちる**（退避処理を「単純化」で消せないように）
- 退避すれば通る
- `game_mix_variant` に残るのは**ダンプの行だけ**でトリガの再構築結果ではない
- 全 12 トリガが**元の DDL のまま**再武装される
- 再武装後のトリガは**通常のアプリ書き込みに対しては従来どおり派生行を作る**

`bun:sqlite` が必要なため、`migration-*` と同様 `ci.yml` に明示列挙しています。列挙し忘れると Vitest 側では `skipIfNotBun` で黙ってスキップされるだけになるので、その理由もコメントで残しました。

`.claude/rules/db-migrations.md` にも節を追加しています（**トリガを足すときにワークフローを触る必要はない**という点を明記 — 特別扱いを書き足されると `sqlite_master` 方式の利点が失われるため）。

## 検証

```
bun test migration-*.test.ts preview-seed-restore.test.ts   ✅ 52 tests
vitest --project db                                         ✅ 635 tests
bun run lint / check-types / check:rules                     ✅
YAML パース（両ワークフロー）                                  ✅
```

本番相当の失敗をローカルの SQLite で再現し、同じエラーメッセージが出ることと修正で解消することを確認済みです。

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWBTSfsJyAQ7FvJxakBLQf)_