### PR TITLE
fix(ci): dev-deploy の seed でもトリガーを退避する

### DIFF
--- a/.claude/rules/db-migrations.md
+++ b/.claude/rules/db-migrations.md
@@ -135,21 +135,24 @@ numbered migration from an empty database and asserts the final trigger names an
 Keep this full-history guard intact and run it after touching these tables; `db:generate` reporting
 no schema changes does not verify manual triggers.
 
-## Triggers must not be armed while the preview DB is seeded
+## Triggers must not be armed while a DB is seeded from the master dump
 
 A trigger keeps a derived table in sync with **application writes**. Restoring a dump is not an
-application write: `preview-deploy.yml` seeds a brand-new preview D1 by applying every migration
-and then replaying a `--no-schema` export of production, which already contains the derived rows.
+application write: `preview-deploy.yml` (new preview DB) and `dev-deploy.yml` (every deploy — the
+dev DB is dropped and recreated each time) seed a brand-new D1 by applying every migration and then
+replaying a `--no-schema` export of production, which already contains the derived rows.
 An armed trigger derives them a second time — 0049's compat triggers rebuilt `game_mix_variant`
 from the legacy `games` mirror on each `game_mix` insert, and the dump's own junction rows then hit
-`UNIQUE constraint failed: game_mix_variant.mix_id, game_mix_variant.position`, taking `db-migrate`
-down for every PR that created a preview DB after 0049 reached production.
+`UNIQUE constraint failed: game_mix_variant.mix_id, game_mix_variant.position`, which D1 surfaces
+as the opaque `{"D1_RESET_DO":true}`. It took `db-migrate` down for every PR that created a preview
+DB after 0049 reached production, and — because the fix initially landed in `preview-deploy.yml`
+only — for every subsequent push to `dev` as well.
 
 The seed step therefore reads the live trigger DDL out of `sqlite_master`, drops every trigger,
 replays the dump, and recreates them — reading from `sqlite_master` rather than re-running a
 migration so it stays correct as migrations add or drop triggers. **Adding a trigger needs no
 workflow change; do not special-case one there.** What a new trigger does need is the awareness
-that seeded preview data comes from the dump, not from the trigger.
+that seeded data comes from the dump, not from the trigger.
 [`preview-seed-restore.test.ts`](../../packages/db/src/__tests__/preview-seed-restore.test.ts)
 pins both halves (the collision is real; stashing fixes it without leaving the DB trigger-less).
 It needs `bun:sqlite`, so like the `migration-*` specs it is listed explicitly in
@@ -157,6 +160,11 @@ It needs `bun:sqlite`, so like the `migration-*` specs it is listed explicitly i
 reports green, because `skipIfNotBun` makes Vitest skip it rather than fail. `bun run check:rules`
 enforces the listing (every `{apps,packages}/**/__tests__/*.test.ts` mentioning `bun:sqlite` must
 be named in that step), so this paragraph is documentation, not the guard.
+
+**Both seed steps are hand-copied siblings, so `check:rules` also asserts the stash itself**: any
+`.github/workflows/*.yml` containing the restore (`--file=dump.sql`) must carry all three halves —
+the `sqlite_master` read-back, `DROP TRIGGER IF EXISTS`, and the drops-then-creates
+`rearm-triggers.sql`. Prose alone did not keep the copies in sync; that is what the guard is for.
 
 ## Keeping the ledger from drifting again
 

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -105,8 +105,9 @@ jobs:
       - run: bun install --frozen-lockfile
 
       # Dev DB is recreated every deploy, so we always run the full
-      # stash → base-migrate → seed-from-master → restore → migrate-rest
-      # flow (mirrors preview-deploy.yml's `is_new_db == 'true'` path).
+      # stash → base-migrate → disarm-triggers → seed-from-master → re-arm →
+      # restore → migrate-rest flow (mirrors preview-deploy.yml's
+      # `is_new_db == 'true'` path).
       - name: Stash unreleased migrations
         working-directory: apps/server
         run: |
@@ -171,6 +172,62 @@ jobs:
 
           sed -i "s/database_id = \".*\"/database_id = \"${{ needs.d1-recreate.outputs.d1_database_id }}\"/" wrangler.toml
           sed -i "s/database_name = \".*\"/database_name = \"${D1_DB_NAME}\"/" wrangler.toml
+
+          # Triggers keep derived tables in sync with *application* writes. A
+          # bulk restore is not an application write: the dump already carries
+          # the derived rows, so an armed trigger generates a second copy of
+          # them. 0049's game_mix compat triggers do exactly that — inserting a
+          # `game_mix` row rebuilds `game_mix_variant` from the legacy JSON
+          # mirror, and the dump's own `game_mix_variant` rows then collide on
+          # `game_mix_variant_mix_position_unique`, which D1 surfaces as
+          # `{"D1_RESET_DO":true}`. So disarm every trigger for the duration of
+          # the restore and re-arm it afterwards, leaving the dump as the single
+          # source of truth for seeded data.
+          #
+          # Read back from sqlite_master rather than re-running a migration:
+          # that captures exactly the triggers this DB has, so the step stays
+          # correct as migrations add or drop them.
+          bunx wrangler d1 execute "${D1_DB_NAME}" --remote --json \
+            --command="SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND sql IS NOT NULL ORDER BY name" \
+            > triggers.json
+          jq -r '.[0].results[] | "DROP TRIGGER IF EXISTS `" + .name + "`;"' triggers.json > drop-triggers.sql
+          jq -r '.[0].results[] | .sql + ";"' triggers.json > restore-triggers.sql
+          # SQLite strips `IF NOT EXISTS` before storing DDL in sqlite_master,
+          # so the read-back CREATEs are NOT idempotent — re-running them over
+          # a surviving trigger aborts the file and every CREATE behind it is
+          # skipped. Prefix the drops so the re-arm converges from ANY state,
+          # including a DROP batch that only partially applied.
+          cat drop-triggers.sql restore-triggers.sql > rearm-triggers.sql
+          echo "Stashing $(wc -l < drop-triggers.sql) trigger(s) for the restore"
+
+          # Re-arm on the way out however we leave. Unlike preview, a later dev
+          # deploy does drop and recreate this database, so a trigger-less dev
+          # DB is not permanent — but it survives until the next push, and the
+          # very next step ("Restore and apply stashed migrations") runs its
+          # backfills against this data expecting the triggers to be armed.
+          #
+          # Both exits are decided explicitly: a failed seed keeps its own
+          # status (a half-seeded dev must not go green), and a failed re-arm
+          # fails the step even when the seed succeeded. Under `bash -e` a
+          # failing command in the handler already propagates, but saying it
+          # outright survives a shell without -e and names the consequence in
+          # the log.
+          restore_triggers() {
+            seed_status=$?
+            if [ -s rearm-triggers.sql ]; then
+              if ! bunx wrangler d1 execute "${D1_DB_NAME}" --remote --file=rearm-triggers.sql; then
+                echo "::error::failed to re-arm the stashed triggers — ${D1_DB_NAME} is left trigger-less"
+                exit 1
+              fi
+            fi
+            exit "$seed_status"
+          }
+          trap restore_triggers EXIT
+
+          if [ -s drop-triggers.sql ]; then
+            bunx wrangler d1 execute "${D1_DB_NAME}" --remote --file=drop-triggers.sql
+          fi
+
           bunx wrangler d1 execute "${D1_DB_NAME}" --remote --file=dump.sql
 
       - name: Restore and apply stashed migrations

--- a/packages/db/src/__tests__/preview-seed-restore.test.ts
+++ b/packages/db/src/__tests__/preview-seed-restore.test.ts
@@ -18,8 +18,12 @@ if (isBun) {
 }
 
 /**
- * preview-deploy.yml seeds a brand-new preview D1 by applying every migration
- * and then replaying a `--no-schema` dump of the production database into it.
+ * preview-deploy.yml (new preview DB) and dev-deploy.yml (every deploy — the
+ * dev DB is dropped and recreated each time) both seed a brand-new D1 by
+ * applying every migration and then replaying a `--no-schema` dump of the
+ * production database into it. The steps are hand-copied siblings, so these
+ * tests pin the shared semantics for both; `bun run check:rules` separately
+ * asserts that every workflow performing the restore carries the stash.
  *
  * Triggers exist to keep derived tables in sync with *application* writes. A
  * bulk restore is not an application write: the dump already carries the
@@ -30,7 +34,7 @@ if (isBun) {
  * db-migrate job down the first time a preview DB was created after 0049
  * reached production.
  *
- * These tests pin both halves of the workflow's fix: the collision is real
+ * These tests pin both halves of the workflows' fix: the collision is real
  * (so nobody "simplifies" the trigger stash away), and stashing the triggers
  * around the restore makes the dump the single source of truth without
  * leaving the DB permanently trigger-less.
@@ -80,7 +84,7 @@ interface TriggerRow {
 	sql: string;
 }
 
-/** The exact query preview-deploy.yml runs to stash the triggers. */
+/** The exact query the seed steps run to stash the triggers. */
 const readTriggers = (db: Database): TriggerRow[] =>
 	db
 		.query(
@@ -95,7 +99,7 @@ const dropTriggers = (db: Database, triggers: TriggerRow[]) => {
 };
 
 /**
- * The workflow's re-arm file: `cat drop-triggers.sql restore-triggers.sql`.
+ * The workflows' re-arm file: `cat drop-triggers.sql restore-triggers.sql`.
  *
  * The drops are what make it idempotent. SQLite strips `IF NOT EXISTS` before
  * storing DDL in sqlite_master, so the read-back CREATEs alone abort on the
@@ -156,7 +160,7 @@ const replayProductionDump = (db: Database) => {
 	db.exec("PRAGMA foreign_keys = ON;");
 };
 
-skipIfNotBun("preview seed restore (preview-deploy.yml)", () => {
+skipIfNotBun("seed restore (preview-deploy.yml, dev-deploy.yml)", () => {
 	let db: Database;
 
 	beforeEach(() => {

--- a/scripts/check-rules.ts
+++ b/scripts/check-rules.ts
@@ -248,6 +248,67 @@ if (unlisted.length > 0) {
 	}
 }
 
+/**
+ * Every workflow that seeds a D1 from a master-DB dump must stash the triggers
+ * around the restore.
+ *
+ * A trigger keeps a derived table in sync with *application* writes; a bulk
+ * restore is not one, so an armed trigger derives rows the dump already
+ * carries. 0049's game_mix compat triggers did exactly that and took
+ * db-migrate down with `{"D1_RESET_DO":true}`. preview-deploy.yml was fixed,
+ * dev-deploy.yml was not — its seed step is a hand-copied sibling ("mirrors
+ * preview-deploy.yml's `is_new_db == 'true'` path"), and a copy is precisely
+ * what prose cannot keep in sync. Matching on the restore itself rather than
+ * on a workflow allowlist means the next copy of this step is caught too.
+ *
+ * Each marker is a distinct half of the fix, so they are asserted separately:
+ * reading the live DDL back (not re-running a migration), dropping it, and
+ * re-arming from ANY state via a drops-then-creates file. A workflow that
+ * dropped without re-arming would leave the DB permanently trigger-less.
+ */
+const SEED_RESTORE_MARKER = "--file=dump.sql";
+const TRIGGER_STASH_MARKERS: { hint: string; marker: string }[] = [
+	{
+		marker: "FROM sqlite_master WHERE type = 'trigger'",
+		hint: "read the live trigger DDL back out of sqlite_master",
+	},
+	{ marker: "DROP TRIGGER IF EXISTS", hint: "drop them for the restore" },
+	{
+		marker: "rearm-triggers.sql",
+		hint: "re-arm from drops-then-creates so it converges from a partial drop",
+	},
+];
+
+const unstashed: string[] = [];
+// `dot: true` is load-bearing: Bun's Glob skips dot-directories by default, so
+// without it this scans .github/ into an empty set and reports green forever.
+for await (const scannedPath of new Glob("workflows/*.yml").scan({
+	cwd: ".github",
+	dot: true,
+})) {
+	const path = normalizeRulePath(`.github/${scannedPath}`);
+	const text = await readFile(path, "utf8");
+	if (!text.includes(SEED_RESTORE_MARKER)) {
+		continue;
+	}
+	for (const { marker, hint } of TRIGGER_STASH_MARKERS) {
+		if (!text.includes(marker)) {
+			unstashed.push(`${path}: missing \`${marker}\` — ${hint}`);
+		}
+	}
+}
+
+if (unstashed.length > 0) {
+	failed = true;
+	console.error(
+		`\ncheck-rules FAIL: D1 seed restore (\`${SEED_RESTORE_MARKER}\`) without the trigger stash`
+	);
+	console.error("  rule: .claude/rules/db-migrations.md");
+	for (const hit of unstashed) {
+		console.error(`  ${hit}`);
+	}
+}
+
 if (failed) {
 	process.exit(1);
 }


### PR DESCRIPTION
`Dev Deploy` の `db-migrate` が 2 回連続で失敗し、dev 環境が D1 再作成後に seed されていない状態になっていた件の修正です。

## 症状

[run #89](https://github.com/HIRO15254/sapphire2/actions/runs/30875783198) (#582 のマージ) と [run #90](https://github.com/HIRO15254/sapphire2/actions/runs/30886671567) (#581 のマージ) の `Seed dev database from master DB` ステップが、同じ箇所で失敗していました。

```
🌀 Executing on remote database sapphire2-db-dev (ba71bf57-…):
├ 🌀 Uploading ba71bf57-….sql
│ 🌀 Uploading complete.
✘ [ERROR] {"D1_RESET_DO":true}
```

`d1-recreate` が `sapphire2-db-dev` を drop / 再作成した後に seed が落ちるため、dev DB はベースマイグレーション適用済みでデータなし、`deploy-api` / `deploy-web` は skip されたままでした。

## 原因

armed のままのトリガーに対してダンプを流し込んでいたためです。

トリガーは派生テーブルを**アプリケーションの書き込み**に追従させるものですが、バルクリストアはアプリケーションの書き込みではありません。ダンプは既に派生行を持っているので、armed なトリガーはその 2 つ目のコピーを生成します。0049 の `game_mix` 互換トリガーがまさにこれで、`game_mix` 行の挿入がレガシー JSON ミラーから `game_mix_variant` を再生成し、ダンプ自身の junction 行と `game_mix_variant_mix_position_unique` で衝突します。D1 はこれを不透明な `{"D1_RESET_DO":true}` として返すため、ログからは原因が読めません。

#582 はこの問題を `preview-deploy.yml` にだけ修正していました。`dev-deploy.yml` の seed ステップは手でコピーされた兄弟（ジョブ内コメントにも "mirrors preview-deploy.yml's `is_new_db == 'true'` path" とある）で、トリガーの退避が入っていません。

タイミングも整合します。run #88 (`6d0ab7ba` = v3.4.0 のヘッド) までは成功しており、v3.4.0 の本番デプロイで master DB が 0049 に上がって実際の `game_mix_variant` 行を持った直後の run #89 から失敗し始めています。それ以前は衝突する行が master 側に存在しませんでした。

## 変更内容

### `dev-deploy.yml`

`preview-deploy.yml` と同じ read-back → drop → restore → re-arm を移植しました。

- トリガー DDL は `sqlite_master` から読み戻す（マイグレーションの再実行ではない）ので、マイグレーションがトリガーを追加・削除してもステップは正しいままです
- 再 arm は `cat drop-triggers.sql restore-triggers.sql` の drops-then-creates 形式。SQLite は `IF NOT EXISTS` を剥がして DDL を保存するため read-back した CREATE は冪等ではなく、drop を前置しないと部分適用状態から復帰できません
- 再 arm は `EXIT` trap で必ず実行します。seed の終了ステータスは保持し（半端に seed された dev を green にしない）、再 arm 自体が失敗したら seed が成功していてもステップを落とします

dev DB は次回デプロイで作り直されるためトリガーレス状態は preview と違って恒久的ではありませんが、直後の `Restore and apply stashed migrations` がトリガーの armed 前提でバックフィルを走らせるため、放置できません。

### `scripts/check-rules.ts`

散文では 2 つのコピーを同期できなかった（それがこの不具合そのもの）ので、機械チェックを追加しました。`--file=dump.sql` を含む `.github/workflows/*.yml` は、以下 3 つを全て持つことを要求します。

| マーカー | 意味 |
|---|---|
| `FROM sqlite_master WHERE type = 'trigger'` | 生きているトリガー DDL の読み戻し |
| `DROP TRIGGER IF EXISTS` | リストアのための退避 |
| `rearm-triggers.sql` | 部分 drop 状態からも収束する再 arm |

ワークフローの allowlist ではなくリストア自体にマッチさせているので、このステップが次にコピーされたときも捕まります。3 つを個別に assert しているのは、それぞれが修正の別の半分だからです（drop したまま再 arm しないワークフローは DB をトリガーレスにしてしまう）。

なお Bun の `Glob.scan` は既定でドットディレクトリを飛ばすため、`.github` を走査するには `dot: true` が必須でした。最初に書いたチェックはこれがなく、空集合を走査して green を返していました（同じサイレント green の失敗モードなのでコメントに残しています）。

### ドキュメント / テスト

- `.claude/rules/db-migrations.md`: 該当セクションを preview 専用の記述から両ワークフロー対応に更新し、`{"D1_RESET_DO":true}` として表面化することと、上記ガードの存在を明記
- `preview-seed-restore.test.ts`: テスト本体は両ワークフローで共有される SQL / トリガーのセマンティクスを pin しているので変更なし。doc コメントと `describe` 名だけを両対応に更新

## 動作確認

```
bun run lint            # Checked 1326 files. No fixes applied.
bun run check-types     # web / server / @sapphire2/mcp すべて exit 0
bun run check:rules     # all checks passed
bunx vitest run --project db   # 635 passed | 55 skipped
bun test packages/db/src/__tests__/migration-*.test.ts \
         packages/db/src/__tests__/preview-seed-restore.test.ts   # 55 pass, 0 fail
```

- 追加したガードが**先に red になること**を確認済み（`dev-deploy.yml` について欠けている 3 マーカーを個別に報告）→ ワークフロー修正後に green
- trap の終了ステータス分岐は 3 ケースを実際のシェルで検証: seed 成功 → 再 arm → exit 0 / seed 失敗 → 再 arm は実行され exit 1 / 再 arm 失敗 → seed 成功でも exit 1
- YAML パースと `bash -n` によるシェル構文チェック済み

このワークフローは push 時にしか動かないため、最終的な検証は `dev` へのマージ後の Dev Deploy 実行になります。

---
_Generated by [Claude Code](https://claude.ai/code/session_015itLHLiFK2o2gmFZiRk92v)_