### PR TITLE
feat(sessions): EV cash-out 未設定なら EV = 実収支として扱う

### DIFF
--- a/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
+++ b/apps/web/src/features/sessions/hooks/__tests__/use-sessions.test.ts
@@ -565,8 +565,19 @@ describe("pure helpers", () => {
 			const out = buildOptimisticItem(cashValues({ buyIn: 100, cashOut: 150 }));
 			expect(out.type).toBe("cash_game");
 			expect(out.profitLoss).toBe(50);
-			expect(out.evProfitLoss).toBeNull();
-			expect(out.evDiff).toBeNull();
+		});
+
+		it("falls back to the actual result for EV when no evCashOut is entered", () => {
+			const out = buildOptimisticItem(cashValues({ buyIn: 100, cashOut: 150 }));
+			expect(out.evProfitLoss).toBe(50);
+			expect(out.evDiff).toBe(0);
+		});
+
+		it("falls back to the actual loss for EV when no evCashOut is entered", () => {
+			const out = buildOptimisticItem(cashValues({ buyIn: 100, cashOut: 0 }));
+			expect(out.profitLoss).toBe(-100);
+			expect(out.evProfitLoss).toBe(-100);
+			expect(out.evDiff).toBe(0);
 		});
 
 		it("computes evProfitLoss and evDiff when evCashOut provided", () => {
@@ -575,6 +586,14 @@ describe("pure helpers", () => {
 			);
 			expect(out.evProfitLoss).toBe(100);
 			expect(out.evDiff).toBe(50);
+		});
+
+		it("treats an evCashOut of 0 as entered, not as missing", () => {
+			const out = buildOptimisticItem(
+				cashValues({ buyIn: 100, cashOut: 150, evCashOut: 0 })
+			);
+			expect(out.evProfitLoss).toBe(-100);
+			expect(out.evDiff).toBe(-150);
 		});
 
 		it("tournament branch leaves cash-specific fields null", () => {

--- a/apps/web/src/features/sessions/hooks/use-sessions.ts
+++ b/apps/web/src/features/sessions/hooks/use-sessions.ts
@@ -346,10 +346,13 @@ export function buildOptimisticItem(
 		item.evCashOut = newSession.evCashOut ?? null;
 		applyCashSnapshot(item, newSession);
 		item.profitLoss = newSession.cashOut - newSession.buyIn;
-		if (newSession.evCashOut !== undefined) {
-			item.evProfitLoss = newSession.evCashOut - newSession.buyIn;
-			item.evDiff = item.evProfitLoss - item.profitLoss;
-		}
+		// Mirrors the server's `resolveEvCashOut`: an omitted EV cash-out means
+		// the session ran exactly as expected, so EV is the actual result and the
+		// EV difference is 0. Leaving it null here would blank the EV line until
+		// the mutation settles and the server filled it back in.
+		item.evProfitLoss =
+			(newSession.evCashOut ?? newSession.cashOut) - newSession.buyIn;
+		item.evDiff = item.evProfitLoss - item.profitLoss;
 	} else {
 		item.tournamentBuyIn = newSession.tournamentBuyIn;
 		item.entryFee = newSession.entryFee ?? null;

--- a/apps/web/src/features/sessions/hooks/use-sessions.ts
+++ b/apps/web/src/features/sessions/hooks/use-sessions.ts
@@ -348,8 +348,9 @@ export function buildOptimisticItem(
 		item.profitLoss = newSession.cashOut - newSession.buyIn;
 		// Mirrors the server's `resolveEvCashOut`: an omitted EV cash-out means
 		// the session ran exactly as expected, so EV is the actual result and the
-		// EV difference is 0. Leaving it null here would blank the EV line until
-		// the mutation settles and the server filled it back in.
+		// EV difference is 0. Whether a row shows an EV line is decided by the raw
+		// `evCashOut` above, not by these two — they are kept identical to what the
+		// server will return so nothing shifts when the mutation settles.
 		item.evProfitLoss =
 			(newSession.evCashOut ?? newSession.cashOut) - newSession.buyIn;
 		item.evDiff = item.evProfitLoss - item.profitLoss;

--- a/apps/web/src/features/sessions/pages/session-detail-page/session-detail-page.tsx
+++ b/apps/web/src/features/sessions/pages/session-detail-page/session-detail-page.tsx
@@ -10,6 +10,7 @@ import {
 	buildSessionMetaRows,
 	buildTournamentRuleRows,
 	buildTournamentStatRows,
+	displayableEvProfitLoss,
 	getSessionGameName,
 	isLiveSession,
 } from "@/features/sessions/utils/session-display";
@@ -150,7 +151,7 @@ export function SessionDetailPage({ sessionId }: SessionDetailPageProps) {
 					) : undefined
 				}
 				currencyUnit={session.currencyUnit}
-				evProfitLoss={session.evProfitLoss}
+				evProfitLoss={displayableEvProfitLoss(session)}
 				profitLoss={session.profitLoss}
 			/>
 

--- a/apps/web/src/features/sessions/pages/session-detail-page/session-pl-hero/session-pl-hero.tsx
+++ b/apps/web/src/features/sessions/pages/session-detail-page/session-pl-hero/session-pl-hero.tsx
@@ -8,7 +8,10 @@ interface SessionPlHeroProps {
 	/** Optional result/stack chart rendered below the P&L, inside the same card. */
 	chart?: ReactNode;
 	currencyUnit: string | null;
-	/** EV-adjusted P&L (cash games with an EV cash-out); omitted otherwise. */
+	/**
+	 * EV-adjusted P&L, already gated by `displayableEvProfitLoss` — null for
+	 * tournaments and for cash games with no recorded EV cash-out.
+	 */
 	evProfitLoss?: number | null;
 	profitLoss: number | null;
 }

--- a/apps/web/src/features/sessions/pages/sessions-page/session-list-card/__tests__/session-list-card.test.tsx
+++ b/apps/web/src/features/sessions/pages/sessions-page/session-list-card/__tests__/session-list-card.test.tsx
@@ -20,6 +20,7 @@ const baseSession: SessionListCardItem = {
 	currencyUnit: null,
 	endedAt: null,
 	entryFee: null,
+	evCashOut: null,
 	evProfitLoss: null,
 	id: "s1",
 	placement: null,
@@ -176,7 +177,12 @@ describe("SessionListCard", () => {
 	});
 
 	it("shows the EV figure for a cash game with an EV record", async () => {
-		renderCard({ ...baseSession, currencyUnit: "$", evProfitLoss: 800 });
+		renderCard({
+			...baseSession,
+			currencyUnit: "$",
+			evCashOut: 2000,
+			evProfitLoss: 800,
+		});
 		await screen.findByText("1/2 NLH");
 		expect(screen.getByTestId("ev-result")).toHaveTextContent("EV +800 $");
 	});
@@ -187,20 +193,38 @@ describe("SessionListCard", () => {
 		expect(screen.queryByTestId("ev-result")).not.toBeInTheDocument();
 	});
 
+	it("omits the EV row when no EV cash-out was recorded, even though the server filled EV P&L in", () => {
+		// The server falls back to the actual result so the session counts in the
+		// EV statistics; the card must not print the same number twice.
+		renderCard({ ...baseSession, evCashOut: null, evProfitLoss: 1200 });
+		expect(screen.queryByTestId("ev-result")).not.toBeInTheDocument();
+	});
+
+	it("shows the EV row when an EV cash-out of 0 was recorded", async () => {
+		renderCard({
+			...baseSession,
+			currencyUnit: "$",
+			evCashOut: 0,
+			evProfitLoss: -2000,
+		});
+		await screen.findByText("1/2 NLH");
+		expect(screen.getByTestId("ev-result")).toHaveTextContent("EV -2,000 $");
+	});
+
 	it("colors a winning EV figure green", async () => {
-		renderCard({ ...baseSession, evProfitLoss: 800 });
+		renderCard({ ...baseSession, evCashOut: 2000, evProfitLoss: 800 });
 		await screen.findByText("1/2 NLH");
 		expect(screen.getByTestId("ev-result")).toHaveClass("text-green-600");
 	});
 
 	it("colors a losing EV figure red", async () => {
-		renderCard({ ...baseSession, evProfitLoss: -800 });
+		renderCard({ ...baseSession, evCashOut: 400, evProfitLoss: -800 });
 		await screen.findByText("1/2 NLH");
 		expect(screen.getByTestId("ev-result")).toHaveClass("text-red-600");
 	});
 
 	it("does not show an EV row for a tournament", async () => {
-		renderCard({ ...baseTournament, evProfitLoss: 800 });
+		renderCard({ ...baseTournament, evCashOut: 2000, evProfitLoss: 800 });
 		await screen.findByText("Sunday Major");
 		expect(screen.queryByTestId("ev-result")).not.toBeInTheDocument();
 	});

--- a/apps/web/src/features/sessions/pages/sessions-page/session-list-card/session-list-card.tsx
+++ b/apps/web/src/features/sessions/pages/sessions-page/session-list-card/session-list-card.tsx
@@ -29,6 +29,8 @@ export interface SessionListCardItem {
 	currencyUnit: string | null;
 	endedAt: string | null;
 	entryFee: number | null;
+	/** Raw EV cash-out — null means the user recorded none, so no EV row. */
+	evCashOut: number | null;
 	evProfitLoss: number | null;
 	id: string;
 	placement: number | null;

--- a/apps/web/src/features/sessions/pages/sessions-page/session-list/__tests__/session-list.test.tsx
+++ b/apps/web/src/features/sessions/pages/sessions-page/session-list/__tests__/session-list.test.tsx
@@ -20,6 +20,7 @@ function makeSession(
 		currencyUnit: null,
 		endedAt: null,
 		entryFee: null,
+		evCashOut: null,
 		evProfitLoss: null,
 		placement: null,
 		profitLoss: 0,

--- a/apps/web/src/features/sessions/utils/__tests__/session-display.test.ts
+++ b/apps/web/src/features/sessions/utils/__tests__/session-display.test.ts
@@ -5,6 +5,7 @@ import {
 	buildSessionMetaRows,
 	buildTournamentRuleRows,
 	buildTournamentStatRows,
+	displayableEvProfitLoss,
 	formatSessionDuration,
 	formatSessionEvDisplay,
 	formatSessionPlDisplay,
@@ -564,11 +565,46 @@ describe("formatTournamentResult", () => {
 	});
 });
 
+describe("displayableEvProfitLoss", () => {
+	const cash = {
+		type: "cash_game",
+		evCashOut: 1800,
+		evProfitLoss: 800,
+	};
+
+	it("returns the EV P&L when an EV cash-out was recorded", () => {
+		expect(displayableEvProfitLoss(cash)).toBe(800);
+	});
+
+	it("returns null when no EV cash-out was recorded", () => {
+		expect(
+			displayableEvProfitLoss({ ...cash, evCashOut: null, evProfitLoss: 1200 })
+		).toBeNull();
+	});
+
+	it("returns null for a tournament even with an EV cash-out", () => {
+		expect(displayableEvProfitLoss({ ...cash, type: "tournament" })).toBeNull();
+	});
+
+	it("treats an EV cash-out of 0 as recorded", () => {
+		expect(
+			displayableEvProfitLoss({ ...cash, evCashOut: 0, evProfitLoss: -1000 })
+		).toBe(-1000);
+	});
+
+	it("passes a null EV P&L through for an unfinished cash game", () => {
+		expect(
+			displayableEvProfitLoss({ ...cash, evCashOut: null, evProfitLoss: null })
+		).toBeNull();
+	});
+});
+
 describe("formatSessionEvDisplay", () => {
 	const cash = {
 		type: "cash_game",
 		currencyUnit: "$",
 		profitLoss: 1200,
+		evCashOut: 1800,
 		evProfitLoss: 800,
 		ringGameBlind2: 200,
 		tournamentBuyIn: null,
@@ -586,6 +622,26 @@ describe("formatSessionEvDisplay", () => {
 		expect(
 			formatSessionEvDisplay({ ...cash, evProfitLoss: null }, false)
 		).toBeNull();
+	});
+
+	it("returns null when no EV cash-out was recorded, even though the server filled EV P&L in", () => {
+		// The server falls back to the actual result so the session counts in the
+		// EV statistics; the row must not repeat that number as a second line.
+		expect(
+			formatSessionEvDisplay(
+				{ ...cash, evCashOut: null, evProfitLoss: 1200 },
+				false
+			)
+		).toBeNull();
+	});
+
+	it("shows the EV line when an EV cash-out of 0 was recorded", () => {
+		expect(
+			formatSessionEvDisplay(
+				{ ...cash, evCashOut: 0, evProfitLoss: -1000 },
+				false
+			)
+		).toBe("-1,000 $");
 	});
 
 	it("shows the currency EV P&L when the toggle is off", () => {

--- a/apps/web/src/features/sessions/utils/__tests__/share-session.test.ts
+++ b/apps/web/src/features/sessions/utils/__tests__/share-session.test.ts
@@ -26,6 +26,7 @@ function cashSession(
 		currencyUnit: "JPY",
 		endedAt: null,
 		entryFee: null,
+		evCashOut: null,
 		evProfitLoss: null,
 		placement: null,
 		prizeMoney: null,
@@ -98,8 +99,27 @@ describe("createSessionShareText", () => {
 		});
 
 		it("adds EV line when evProfitLoss is present", () => {
-			const text = createSessionShareText(cashSession({ evProfitLoss: 1200 }));
+			const text = createSessionShareText(
+				cashSession({ evCashOut: 16_200, evProfitLoss: 1200 })
+			);
 			expect(text).toContain("(EV: +1,200 JPY)");
+		});
+
+		it("omits the EV line when no EV cash-out was recorded", () => {
+			// The server falls back to the actual result, but the shared text must
+			// not repeat the same number as an EV addendum.
+			const text = createSessionShareText(
+				cashSession({ evCashOut: null, evProfitLoss: 5000 })
+			);
+			expect(text).not.toContain("EV:");
+		});
+
+		it("adds the EV line when an EV cash-out of 0 was recorded", () => {
+			const text = createSessionShareText(
+				cashSession({ evCashOut: 0, evProfitLoss: -10_000 })
+			);
+			// Compact formatting, same as every other amount in the shared text.
+			expect(text).toContain("(EV: -10k JPY)");
 		});
 
 		it("adds duration when both startedAt and endedAt are set", () => {

--- a/apps/web/src/features/sessions/utils/session-display.ts
+++ b/apps/web/src/features/sessions/utils/session-display.ts
@@ -391,15 +391,38 @@ export function formatSessionPlDisplay(
 }
 
 interface EvDisplayInput extends PlDisplayInput {
+	evCashOut: number | null;
 	evProfitLoss: number | null;
 }
 
 /**
+ * The EV figure a single session should display, or `null` when it must show
+ * none. This is the one place that decides it — the list card, the detail hero
+ * and the share text all read through it, so they cannot disagree.
+ *
+ * The gate is the raw `evCashOut`, not `evProfitLoss`. The server defines a
+ * cash game without a recorded EV cash-out as having run exactly as expected,
+ * so its `evProfitLoss` equals the actual result (`resolveEvCashOut`). That
+ * fallback is what puts those sessions into the EV statistics, but printing it
+ * per row would just repeat the P&L as a second identical line — so a row shows
+ * an EV figure only when the user actually recorded one. Live cash games always
+ * carry an `evCashOut`, so their EV line is unaffected.
+ */
+export function displayableEvProfitLoss(session: {
+	evCashOut: number | null;
+	evProfitLoss: number | null;
+	type: string;
+}): number | null {
+	if (session.type !== "cash_game" || session.evCashOut === null) {
+		return null;
+	}
+	return session.evProfitLoss;
+}
+
+/**
  * Secondary EV figure for a cash-game list row, honoring the BB/BI toggle.
- * Returns `null` for tournaments or when the session has no result yet, so the
- * result section omits the second line. Every finished cash game has an EV P&L:
- * a manual entry without an EV cash-out falls back to its actual result server
- * side (`resolveEvCashOut`), so the EV line reads the same as the P&L line.
+ * Returns `null` whenever {@link displayableEvProfitLoss} does, so the result
+ * section omits the second line.
  *
  * The realized P&L is always whole chips, but the EV can be fractional (live
  * all-in equity), so the value is rounded to the nearest integer before
@@ -410,8 +433,9 @@ export function formatSessionEvDisplay(
 	session: EvDisplayInput,
 	bbBiMode: boolean
 ): string | null {
-	if (session.type !== "cash_game" || session.evProfitLoss === null) {
+	const evProfitLoss = displayableEvProfitLoss(session);
+	if (evProfitLoss === null) {
 		return null;
 	}
-	return formatPlValue(Math.round(session.evProfitLoss), session, bbBiMode);
+	return formatPlValue(Math.round(evProfitLoss), session, bbBiMode);
 }

--- a/apps/web/src/features/sessions/utils/session-display.ts
+++ b/apps/web/src/features/sessions/utils/session-display.ts
@@ -405,8 +405,14 @@ interface EvDisplayInput extends PlDisplayInput {
  * so its `evProfitLoss` equals the actual result (`resolveEvCashOut`). That
  * fallback is what puts those sessions into the EV statistics, but printing it
  * per row would just repeat the P&L as a second identical line — so a row shows
- * an EV figure only when the user actually recorded one. Live cash games always
- * carry an `evCashOut`, so their EV line is unaffected.
+ * an EV figure only when the user actually recorded one.
+ *
+ * The rule is deliberately "the user recorded no EV cash-out", not "the EV
+ * difference is 0". A manual entry whose EV happened to match its result still
+ * shows its EV line, and a live cash game with no all-in logged keeps showing
+ * one too (the server always writes it an `evCashOut`) — there the app tracked
+ * EV throughout, so "EV difference was 0" is a real observation rather than an
+ * absence of information.
  */
 export function displayableEvProfitLoss(session: {
 	evCashOut: number | null;

--- a/apps/web/src/features/sessions/utils/session-display.ts
+++ b/apps/web/src/features/sessions/utils/session-display.ts
@@ -396,9 +396,10 @@ interface EvDisplayInput extends PlDisplayInput {
 
 /**
  * Secondary EV figure for a cash-game list row, honoring the BB/BI toggle.
- * Returns `null` for tournaments or when no EV cash-out was recorded, so the
- * result section omits the second line. Live cash games carry an EV P&L; manual
- * entries only have one when the user logged an EV cash-out.
+ * Returns `null` for tournaments or when the session has no result yet, so the
+ * result section omits the second line. Every finished cash game has an EV P&L:
+ * a manual entry without an EV cash-out falls back to its actual result server
+ * side (`resolveEvCashOut`), so the EV line reads the same as the P&L line.
  *
  * The realized P&L is always whole chips, but the EV can be fractional (live
  * all-in equity), so the value is rounded to the nearest integer before

--- a/apps/web/src/features/sessions/utils/share-session.ts
+++ b/apps/web/src/features/sessions/utils/share-session.ts
@@ -1,5 +1,8 @@
 import { formatCompactNumber } from "@/utils/format-number";
-import { formatSessionDuration } from "./session-display";
+import {
+	displayableEvProfitLoss,
+	formatSessionDuration,
+} from "./session-display";
 export interface ShareableSession {
 	beforeDeadline: boolean | null;
 	bountyPrizes: number | null;
@@ -8,6 +11,7 @@ export interface ShareableSession {
 	currencyUnit: string | null;
 	endedAt: string | null;
 	entryFee: number | null;
+	evCashOut: number | null;
 	evProfitLoss: number | null;
 	placement: number | null;
 	prizeMoney: number | null;
@@ -46,9 +50,10 @@ function buildProfitLossLine(
 		}
 	} else {
 		const duration = formatSessionDuration(session.startedAt, session.endedAt);
-		if (session.evProfitLoss !== null) {
-			const evSign = session.evProfitLoss >= 0 ? "+" : "";
-			const evAmount = formatCompactNumber(session.evProfitLoss);
+		const evProfitLoss = displayableEvProfitLoss(session);
+		if (evProfitLoss !== null) {
+			const evSign = evProfitLoss >= 0 ? "+" : "";
+			const evAmount = formatCompactNumber(evProfitLoss);
 			line += ` (EV: ${evSign}${evAmount} ${currencyUnit})`;
 		}
 		if (duration) {

--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -702,6 +702,83 @@ describe("session router input validation", () => {
 		});
 	});
 
+	describe("toProfitLossSeriesPoint falls back to the actual result when no EV cash-out is recorded", () => {
+		function row(overrides: Partial<ProfitLossSeriesRow>): ProfitLossSeriesRow {
+			return {
+				bountyPrizes: null,
+				breakMinutes: null,
+				buyIn: null,
+				cashOut: null,
+				chipPurchaseCost: 0,
+				chipRemoveTotal: null,
+				endedAt: null,
+				entryFee: null,
+				evCashOut: null,
+				id: "s1",
+				prizeMoney: null,
+				ringGameBlind2: null,
+				sessionDate: new Date(1_700_000_000_000),
+				startedAt: null,
+				tournamentBuyIn: null,
+				type: "cash_game",
+				...overrides,
+			};
+		}
+
+		it("reports evProfitLoss equal to profitLoss when evCashOut is null", () => {
+			const point = toProfitLossSeriesPoint(
+				row({ buyIn: 500, cashOut: 700, evCashOut: null })
+			);
+			expect(point.profitLoss).toBe(200);
+			expect(point.evProfitLoss).toBe(200);
+		});
+
+		it("keeps chipRemoveTotal in the fallback EV so it matches profitLoss exactly", () => {
+			const point = toProfitLossSeriesPoint(
+				row({ buyIn: 500, cashOut: 700, evCashOut: null, chipRemoveTotal: 100 })
+			);
+			expect(point.profitLoss).toBe(300);
+			expect(point.evProfitLoss).toBe(300);
+		});
+
+		it("reports a losing session's EV as the same loss", () => {
+			const point = toProfitLossSeriesPoint(
+				row({ buyIn: 500, cashOut: 0, evCashOut: null })
+			);
+			expect(point.profitLoss).toBe(-500);
+			expect(point.evProfitLoss).toBe(-500);
+		});
+
+		it("keeps evProfitLoss null when the cash session has no recorded result", () => {
+			const point = toProfitLossSeriesPoint(
+				row({ buyIn: null, cashOut: null, evCashOut: null })
+			);
+			expect(point.evProfitLoss).toBeNull();
+		});
+
+		it("keeps evProfitLoss null for a tournament", () => {
+			const point = toProfitLossSeriesPoint(
+				row({ type: "tournament", tournamentBuyIn: 100, prizeMoney: 500 })
+			);
+			expect(point.evProfitLoss).toBeNull();
+		});
+
+		it("still prefers a recorded evCashOut over the actual cash-out", () => {
+			const point = toProfitLossSeriesPoint(
+				row({ buyIn: 500, cashOut: 700, evCashOut: 650 })
+			);
+			expect(point.profitLoss).toBe(200);
+			expect(point.evProfitLoss).toBe(150);
+		});
+
+		it("treats an evCashOut of 0 as recorded, not as missing", () => {
+			const point = toProfitLossSeriesPoint(
+				row({ buyIn: 500, cashOut: 700, evCashOut: 0 })
+			);
+			expect(point.evProfitLoss).toBe(-500);
+		});
+	});
+
 	it("getById accepts {id}", () => {
 		const schema = (
 			appRouter.session.getById as unknown as {
@@ -2188,6 +2265,110 @@ describe("session joined ownership scoping", () => {
 			params.includes("user-1")
 		);
 		expect(ownerScopedJoins).toHaveLength(3);
+	});
+});
+
+describe("session.list EV falls back to the actual result without an EV cash-out", () => {
+	function listCaller(row: Record<string, unknown>) {
+		const { db } = createChainableMockDb({
+			select: {
+				game_session: [
+					{
+						id: "session-1",
+						type: "cash_game",
+						source: "manual",
+						buyIn: null,
+						cashOut: null,
+						evCashOut: null,
+						chipRemoveTotal: null,
+						...row,
+					},
+				],
+				session_chip_purchase: [],
+				session_blind_level: [],
+				session_to_session_tag: [],
+			},
+		});
+		return appRouter.createCaller({
+			session: { user: { id: "user-1" } },
+			db,
+		} as unknown as Parameters<typeof appRouter.createCaller>[0]);
+	}
+
+	it("reports evProfitLoss = profitLoss and evDiff = 0 when evCashOut is null", async () => {
+		const caller = listCaller({ buyIn: 500, cashOut: 700, evCashOut: null });
+
+		const { items } = await caller.session.list({});
+
+		expect(items[0]).toMatchObject({
+			profitLoss: 200,
+			evProfitLoss: 200,
+			evDiff: 0,
+		});
+	});
+
+	it("adds chipRemoveTotal to the fallback EV so evDiff stays 0", async () => {
+		const caller = listCaller({
+			buyIn: 500,
+			cashOut: 700,
+			evCashOut: null,
+			chipRemoveTotal: 100,
+		});
+
+		const { items } = await caller.session.list({});
+
+		expect(items[0]).toMatchObject({
+			profitLoss: 300,
+			evProfitLoss: 300,
+			evDiff: 0,
+		});
+	});
+
+	it("still prefers a recorded evCashOut", async () => {
+		const caller = listCaller({ buyIn: 500, cashOut: 700, evCashOut: 650 });
+
+		const { items } = await caller.session.list({});
+
+		expect(items[0]).toMatchObject({
+			profitLoss: 200,
+			evProfitLoss: 150,
+			evDiff: -50,
+		});
+	});
+
+	it("leaves evProfitLoss null when the cash session has no recorded result", async () => {
+		const caller = listCaller({ buyIn: null, cashOut: null, evCashOut: null });
+
+		const { items } = await caller.session.list({});
+
+		expect(items[0]).toMatchObject({
+			profitLoss: null,
+			evProfitLoss: null,
+			evDiff: null,
+		});
+	});
+
+	it("counts a cash session without an EV cash-out in the summary EV totals", async () => {
+		const caller = listCaller({ buyIn: 500, cashOut: 700, evCashOut: null });
+
+		const { summary } = await caller.session.list({});
+
+		expect(summary.totalEvProfitLoss).toBe(200);
+		expect(summary.totalEvDiff).toBe(0);
+	});
+
+	it("leaves the summary EV totals null when no cash session has a result", async () => {
+		const caller = listCaller({
+			type: "tournament",
+			buyIn: null,
+			cashOut: null,
+			evCashOut: null,
+		});
+
+		const { summary } = await caller.session.list({});
+
+		expect(summary.totalEvProfitLoss).toBeNull();
+		expect(summary.totalEvDiff).toBeNull();
 	});
 });
 

--- a/packages/api/src/__tests__/session.test.ts
+++ b/packages/api/src/__tests__/session.test.ts
@@ -12,6 +12,7 @@ import {
 	type ProfitLossSeriesRow,
 	parseSessionCursor,
 	resolveCashRuleSnapshot,
+	resolveEvCashOut,
 	selectInChunks,
 	sessionKeysetCondition,
 	toProfitLossSeriesPoint,
@@ -29,6 +30,28 @@ const SESSION_DATE_RE = /sessionDate/;
 const PLACEMENT_RE = /placement/;
 const PRIZE_MONEY_RE = /prizeMoney/;
 const TOURNAMENT_ID_RE = /tournamentId/;
+
+describe("resolveEvCashOut", () => {
+	it("returns the recorded EV cash-out when there is one", () => {
+		expect(resolveEvCashOut(650, 700)).toBe(650);
+	});
+
+	it("falls back to the actual cash-out when no EV cash-out was recorded", () => {
+		expect(resolveEvCashOut(null, 700)).toBe(700);
+	});
+
+	it("treats an EV cash-out of 0 as recorded, not as missing", () => {
+		expect(resolveEvCashOut(0, 700)).toBe(0);
+	});
+
+	it("returns null when there is no cash-out to fall back to", () => {
+		expect(resolveEvCashOut(null, null)).toBeNull();
+	});
+
+	it("still returns a recorded EV cash-out when the session has no cash-out", () => {
+		expect(resolveEvCashOut(650, null)).toBe(650);
+	});
+});
 
 describe("computeCashGamePL", () => {
 	it("returns cashOut - buyIn when no chips were removed early", () => {

--- a/packages/api/src/__tests__/stats.test.ts
+++ b/packages/api/src/__tests__/stats.test.ts
@@ -958,6 +958,89 @@ describe("fetchStatsRows variant mapping", () => {
 		expect(rows[0]?.evDiff).toBe(50);
 	});
 
+	it("falls back to the actual result when a cash_game row has no evCashOut", async () => {
+		const { db } = createChainableMockDb({
+			select: {
+				game_session: [
+					rawRow({
+						id: "cash-no-ev",
+						type: "cash_game",
+						buyIn: 500,
+						cashOut: 700,
+						evCashOut: null,
+					}),
+				],
+			},
+		});
+
+		const rows = await fetchStatsRows(db, "user-1", { normalized: false });
+		expect(rows[0]?.profitLoss).toBe(200);
+		expect(rows[0]?.evProfitLoss).toBe(200);
+		expect(rows[0]?.evDiff).toBe(0);
+	});
+
+	it("keeps chipRemoveTotal inside the fallback EV so evDiff stays 0", async () => {
+		const { db } = createChainableMockDb({
+			select: {
+				game_session: [
+					rawRow({
+						id: "cash-no-ev-chips",
+						type: "cash_game",
+						buyIn: 500,
+						cashOut: 600,
+						evCashOut: null,
+						chipRemoveTotal: 100,
+					}),
+				],
+			},
+		});
+
+		const rows = await fetchStatsRows(db, "user-1", { normalized: false });
+		expect(rows[0]?.profitLoss).toBe(200);
+		expect(rows[0]?.evProfitLoss).toBe(200);
+		expect(rows[0]?.evDiff).toBe(0);
+	});
+
+	it("leaves evProfitLoss null when a cash_game row has no recorded result", async () => {
+		const { db } = createChainableMockDb({
+			select: {
+				game_session: [
+					rawRow({
+						id: "cash-no-result",
+						type: "cash_game",
+						buyIn: null,
+						cashOut: null,
+						evCashOut: null,
+					}),
+				],
+			},
+		});
+
+		const rows = await fetchStatsRows(db, "user-1", { normalized: false });
+		expect(rows[0]?.evProfitLoss).toBeNull();
+		expect(rows[0]?.evDiff).toBeNull();
+	});
+
+	it("treats an evCashOut of 0 as recorded, not as missing", async () => {
+		const { db } = createChainableMockDb({
+			select: {
+				game_session: [
+					rawRow({
+						id: "cash-zero-ev",
+						type: "cash_game",
+						buyIn: 500,
+						cashOut: 700,
+						evCashOut: 0,
+					}),
+				],
+			},
+		});
+
+		const rows = await fetchStatsRows(db, "user-1", { normalized: false });
+		expect(rows[0]?.evProfitLoss).toBe(-500);
+		expect(rows[0]?.evDiff).toBe(-700);
+	});
+
 	it("treats a null chipRemoveTotal as 0 for a cash_game row's profitLoss", async () => {
 		const { db } = createChainableMockDb({
 			select: {

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -109,6 +109,24 @@ function computeCashGamePL(
 	return cashOut + chipRemoveTotal - buyIn;
 }
 
+/**
+ * The EV cash-out the EV P/L is computed from. Recording one is optional, and
+ * a session without it is defined to have run exactly as expected: EV falls
+ * back to the actual cash-out, so its EV P/L equals its real result and its EV
+ * difference is 0. Without the fallback those sessions dropped out of every EV
+ * figure entirely, which made the EV totals a sum over an unstated subset of
+ * the filtered sessions rather than over all of them.
+ *
+ * Returns null only when there is no cash-out either (an unfinished session),
+ * where no EV can be stated at all.
+ */
+export function resolveEvCashOut(
+	evCashOut: number | null,
+	cashOut: number | null
+): number | null {
+	return evCashOut ?? cashOut;
+}
+
 function computeTournamentPL(
 	tournamentBuyIn: number | null,
 	entryFee: number | null,
@@ -1179,10 +1197,11 @@ function accumulateEvMetrics(
 		evSessionCount: number;
 	}) => void
 ) {
-	if (s.type !== "cash_game" || s.evCashOut === null || s.buyIn === null) {
+	const evCashOut = resolveEvCashOut(s.evCashOut, s.cashOut);
+	if (s.type !== "cash_game" || evCashOut === null || s.buyIn === null) {
 		return;
 	}
-	const evPl = s.evCashOut + (s.chipRemoveTotal ?? 0) - s.buyIn;
+	const evPl = evCashOut + (s.chipRemoveTotal ?? 0) - s.buyIn;
 	update({
 		totalEvProfitLoss: current.totalEvProfitLoss + evPl,
 		totalEvDiff: current.totalEvDiff + (evPl - pl),
@@ -1633,12 +1652,13 @@ function computeCashStats(r: ProfitLossSeriesRow): CashGameStats {
 		return { profitLoss: 0, evProfitLoss: null, buyInTotal: null };
 	}
 	const chipRemoveTotal = r.chipRemoveTotal ?? 0;
+	const evCashOut = resolveEvCashOut(r.evCashOut, r.cashOut);
 	return {
 		profitLoss: computeCashGamePL(r.buyIn, r.cashOut, chipRemoveTotal),
 		evProfitLoss:
-			r.evCashOut === null
+			evCashOut === null
 				? null
-				: computeCashGamePL(r.buyIn, r.evCashOut, chipRemoveTotal),
+				: computeCashGamePL(r.buyIn, evCashOut, chipRemoveTotal),
 		buyInTotal: r.buyIn,
 	};
 }
@@ -1805,8 +1825,9 @@ function enrichItemWithPL<T extends ListItemRaw>(item: T) {
 	) {
 		const chipRemoveTotal = item.chipRemoveTotal ?? 0;
 		profitLoss = computeCashGamePL(item.buyIn, item.cashOut, chipRemoveTotal);
-		if (item.evCashOut !== null) {
-			evProfitLoss = item.evCashOut + chipRemoveTotal - item.buyIn;
+		const evCashOut = resolveEvCashOut(item.evCashOut, item.cashOut);
+		if (evCashOut !== null) {
+			evProfitLoss = evCashOut + chipRemoveTotal - item.buyIn;
 			evDiff = evProfitLoss - profitLoss;
 		}
 	} else if (item.type === "tournament") {

--- a/packages/api/src/routers/session.ts
+++ b/packages/api/src/routers/session.ts
@@ -118,8 +118,18 @@ function computeCashGamePL(
  * the filtered sessions rather than over all of them.
  *
  * Returns null only when there is no cash-out either (an unfinished session),
- * where no EV can be stated at all.
+ * where no EV can be stated at all — hence the overload: past a `cashOut !==
+ * null` guard the result is always a number, so callers inside such a guard do
+ * not carry a null branch that cannot run.
  */
+export function resolveEvCashOut(
+	evCashOut: number | null,
+	cashOut: number
+): number;
+export function resolveEvCashOut(
+	evCashOut: number | null,
+	cashOut: number | null
+): number | null;
 export function resolveEvCashOut(
 	evCashOut: number | null,
 	cashOut: number | null
@@ -1197,8 +1207,13 @@ function accumulateEvMetrics(
 		evSessionCount: number;
 	}) => void
 ) {
+	if (s.type !== "cash_game" || s.buyIn === null) {
+		return;
+	}
+	// Resolved only after the cash-game guard: the fallback is defined for a
+	// cash-game cash-out, and a tournament row's cashOut carries no EV meaning.
 	const evCashOut = resolveEvCashOut(s.evCashOut, s.cashOut);
-	if (s.type !== "cash_game" || evCashOut === null || s.buyIn === null) {
+	if (evCashOut === null) {
 		return;
 	}
 	const evPl = evCashOut + (s.chipRemoveTotal ?? 0) - s.buyIn;
@@ -1655,10 +1670,7 @@ function computeCashStats(r: ProfitLossSeriesRow): CashGameStats {
 	const evCashOut = resolveEvCashOut(r.evCashOut, r.cashOut);
 	return {
 		profitLoss: computeCashGamePL(r.buyIn, r.cashOut, chipRemoveTotal),
-		evProfitLoss:
-			evCashOut === null
-				? null
-				: computeCashGamePL(r.buyIn, evCashOut, chipRemoveTotal),
+		evProfitLoss: computeCashGamePL(r.buyIn, evCashOut, chipRemoveTotal),
 		buyInTotal: r.buyIn,
 	};
 }
@@ -1826,10 +1838,8 @@ function enrichItemWithPL<T extends ListItemRaw>(item: T) {
 		const chipRemoveTotal = item.chipRemoveTotal ?? 0;
 		profitLoss = computeCashGamePL(item.buyIn, item.cashOut, chipRemoveTotal);
 		const evCashOut = resolveEvCashOut(item.evCashOut, item.cashOut);
-		if (evCashOut !== null) {
-			evProfitLoss = evCashOut + chipRemoveTotal - item.buyIn;
-			evDiff = evProfitLoss - profitLoss;
-		}
+		evProfitLoss = evCashOut + chipRemoveTotal - item.buyIn;
+		evDiff = evProfitLoss - profitLoss;
 	} else if (item.type === "tournament") {
 		profitLoss = computeTournamentPL(
 			item.tournamentBuyIn,

--- a/packages/api/src/routers/stats.ts
+++ b/packages/api/src/routers/stats.ts
@@ -11,6 +11,7 @@ import {
 	computeTournamentPL,
 	fetchProfitLossSeries,
 	getSessionChipPurchaseMap,
+	resolveEvCashOut,
 	sumChipPurchaseCost,
 	validateEntityOwnership,
 } from "./session";
@@ -182,10 +183,11 @@ function mapStatsRow(
 			r.buyIn === null || r.cashOut === null
 				? 0
 				: computeCashGamePL(r.buyIn, r.cashOut, chipRemoveTotal);
+		const evCashOut = resolveEvCashOut(r.evCashOut, r.cashOut);
 		const evProfitLoss =
-			r.evCashOut === null || r.buyIn === null
+			evCashOut === null || r.buyIn === null
 				? null
-				: computeCashGamePL(r.buyIn, r.evCashOut, chipRemoveTotal);
+				: computeCashGamePL(r.buyIn, evCashOut, chipRemoveTotal);
 		const evDiff = evProfitLoss === null ? null : evProfitLoss - profitLoss;
 		return {
 			...base,


### PR DESCRIPTION
## 背景

EV cash-out は任意入力だが、未入力のキャッシュゲームは `evProfitLoss` が `null` になり、一覧・詳細・統計のあらゆる EV 指標から丸ごと除外されていた。そのため EV 合計はフィルタ対象のセッション全体ではなく「EV を入力したセッションだけ」の合計になっており、その母集団が画面上どこにも示されていなかった。

## 変更内容

### 1. 算出: EV 未入力は「想定どおりに終わった」= EV 差分 0

EV cash-out を実際の cash-out にフォールバックさせ、`evProfitLoss = profitLoss` / `evDiff = 0` とする。これによりそのセッションも EV 指標の母集団に入る。

- `packages/api/src/routers/session.ts`
  - 共通ヘルパー `resolveEvCashOut(evCashOut, cashOut)` を追加（`evCashOut ?? cashOut`）。cash-out 自体が無い未終了セッションは `null` を返す。`cashOut: number` を受けるオーバーロードを持たせ、cash-out 非 null が確定した呼び出し側に到達不能な null 分岐が残らないようにしている。
  - EV を算出する 3 箇所から参照: 一覧行の `enrichItemWithPL`、summary 集計の `accumulateEvMetrics`、P/L 系列の `computeCashStats`。
- `packages/api/src/routers/stats.ts` — `mapStatsRow` のキャッシュゲーム分岐も同ヘルパー経由に。
- `apps/web/src/features/sessions/hooks/use-sessions.ts` — 楽観的更新 `buildOptimisticItem` を同じ規則に合わせ、保存直後に EV 行が一瞬消える挙動をなくした。

### 2. 表示: EV 未入力の行では EV 行を出さない

上記フォールバックをそのまま表示すると、一覧カード・詳細ヒーロー・共有テキストで「+200 / EV +200」と同じ数字が 2 行並ぶ。集計の母集団は広げたまま、行レベル表示だけ抑制する。

- `apps/web/src/features/sessions/utils/session-display.ts` に `displayableEvProfitLoss` を追加し、判定を 1 箇所へ集約。`formatSessionEvDisplay`（一覧カード）・`share-session.ts`・詳細ページ → `SessionPlHero` への受け渡しがすべてここを通る。
- 判定は**生の `evCashOut`** で行う（`evDiff === 0` ではない）。EV を入力してたまたま実収支と一致したセッションでは EV 行を出したいし、「EV 未記録」と「EV が期待どおりだった」は表示上区別できた方がよいため。
- ライブセッションは `live-session-pl.ts` が `evCashOut = cashOut + totalEvDiff` を必ず埋めるので、EV 行は従来どおり表示される。

DB スキーマとプロシージャの入出力シグネチャは変更していないため、マイグレーションと MCP 側の登録変更は不要（`--project mcp` 緑）。

## 挙動の変化

### 算出値（API）

| ケース | 変更前 `evProfitLoss` / `evDiff` | 変更後 |
|---|---|---|
| cash-out あり・EV cash-out なし | `null` / `null`（EV 指標から除外） | 実収支 / `0` |
| cash-out あり・EV cash-out あり | 変更なし | 変更なし |
| EV cash-out = 0 | 「入力あり」として計算 | 変更なし（`??` なので 0 は入力扱い） |
| 未終了（cash-out なし） | `null` | `null` |
| トーナメント | `null` | `null` |

### 画面

- **統計**: EV 合計・EV 差分の母集団が全キャッシュゲームに広がる。EV 差分の合計値そのものは 0 加算なので不変だが、これまで EV 未入力のユーザーで `—` だった EV diff は常時 `±0` 表示になる。
- **P/L グラフ**: EV ラインが「EV を入力した回だけを積んだ累積」ではなく実収支ラインと同じセッション集合の累積になり、2 本の線が同じ母集団を表すようになる。
- **一覧カード / 詳細ヒーロー / 共有テキスト**: EV 未入力のキャッシュゲームでは EV 行が出ない（従来と同じ見た目）。EV を入力した行とライブセッションはこれまでどおり EV 行が出る。

## テスト

TDD で先に追加し、赤を確認してから実装した。

- `packages/api/src/__tests__/session.test.ts` — `resolveEvCashOut` の直接テスト（EV 指定 / 未指定 / 0 / cash-out なし）、`toProfitLossSeriesPoint` のフォールバック（利益 / 損失 / chipRemoveTotal 込み / 未終了 / トーナメント / EV 明示指定 / EV=0）、`session.list` の行 enrich と summary EV 合計。
- `packages/api/src/__tests__/stats.test.ts` — `fetchStatsRows` のフォールバック、chipRemoveTotal 込み、未終了、EV=0 境界。
- `apps/web/.../utils/__tests__/session-display.test.ts` — `displayableEvProfitLoss` の全分岐（EV あり / EV なし / トーナメント / EV=0 / 未終了）と `formatSessionEvDisplay` 経由の抑制。
- `apps/web/.../utils/__tests__/share-session.test.ts` — EV 未入力で EV 節が出ないこと、EV=0 では出ること。
- `apps/web/.../session-list-card/__tests__/session-list-card.test.tsx` — EV 未入力で `ev-result` が出ないこと、EV=0 では出ること。
- `apps/web/.../hooks/__tests__/use-sessions.test.ts` — `buildOptimisticItem` のフォールバック（勝ち / 負け / EV=0）。既存の「EV 未入力なら null」アサーションを新仕様に更新。

`--project api` / `web-node` / `web-dom` / `mcp` を全件実行して緑、`ultracite check`・`check-types`・`check:rules` も緑。